### PR TITLE
Add support for Phi-3

### DIFF
--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -174,6 +174,7 @@ OFFICIAL_MODEL_NAMES = [
     "microsoft/phi-1",
     "microsoft/phi-1_5",
     "microsoft/phi-2",
+    "microsoft/Phi-3-mini-4k-instruct",
     "google/gemma-2b",
     "google/gemma-7b",
     "google/gemma-2b-it",
@@ -587,6 +588,7 @@ MODEL_ALIASES = {
     "microsoft/phi-1": ["phi-1"],
     "microsoft/phi-1_5": ["phi-1_5"],
     "microsoft/phi-2": ["phi-2"],
+    "microsoft/Phi-3-mini-4k-instruct": ["phi-3"],
     "google/gemma-2b": ["gemma-2b"],
     "google/gemma-7b": ["gemma-7b"],
     "google/gemma-2b-it": ["gemma-2b-it"],
@@ -615,6 +617,7 @@ NEED_REMOTE_CODE_MODELS = (
     "bigcode/santacoder",
     "Qwen/Qwen-",
     "microsoft/phi-2",
+    "microsoft/Phi-3-mini-4k-instruct",
 )
 
 
@@ -1096,6 +1099,28 @@ def convert_hf_model_config(model_name: str, **kwargs):
         }
         partial_rotary_factor = hf_config.partial_rotary_factor
         cfg_dict["rotary_dim"] = round(partial_rotary_factor * cfg_dict["d_head"])
+    elif architecture == "Phi3ForCausalLM":
+        # Architecture for microsoft/phi3 models
+        cfg_dict = {
+            "d_model": hf_config.hidden_size,
+            "d_head": hf_config.hidden_size // hf_config.num_attention_heads,
+            "n_heads": hf_config.num_attention_heads,
+            "d_mlp": hf_config.intermediate_size,
+            "n_layers": hf_config.num_hidden_layers,
+            "n_ctx": hf_config.max_position_embeddings,
+            "eps": hf_config.rms_norm_eps,
+            "d_vocab": hf_config.vocab_size,
+            "act_fn": hf_config.hidden_act,
+            "initializer_range": hf_config.initializer_range,
+            "normalization_type": "RMS",
+            "positional_embedding_type": "rotary",
+            "trust_remote_code": True,
+            "rotary_base": hf_config.rope_theta,
+            "use_attn_scale": True,
+            "gated_mlp": True,
+            "parallel_attn_mlp": False,
+            "rotary_dim": hf_config.hidden_size // hf_config.num_attention_heads,
+        }
 
     elif official_model_name.startswith("google/gemma-2b"):
         # Architecture for Gemma 2b and Gemma 2b Instruct models
@@ -1500,6 +1525,8 @@ def get_pretrained_state_dict(
             state_dict = convert_qwen2_weights(hf_model, cfg)
         elif cfg.original_architecture == "PhiForCausalLM":
             state_dict = convert_phi_weights(hf_model, cfg)
+        elif cfg.original_architecture == "Phi3ForCausalLM":
+            state_dict = convert_phi3_weights(hf_model, cfg)
         elif cfg.original_architecture == "GemmaForCausalLM":
             state_dict = convert_gemma_weights(hf_model, cfg)
         else:
@@ -2585,6 +2612,58 @@ def convert_phi_weights(phi, cfg: HookedTransformerConfig):
 
     state_dict["unembed.W_U"] = phi.lm_head.weight.T
     state_dict["unembed.b_U"] = phi.lm_head.bias
+
+    return state_dict
+
+
+def convert_phi3_weights(phi, cfg: HookedTransformerConfig):
+    state_dict = {}
+
+    state_dict["embed.W_E"] = phi.model.embed_tokens.weight
+
+    for l in range(cfg.n_layers):
+        state_dict[f"blocks.{l}.ln1.w"] = phi.model.layers[l].input_layernorm.weight
+        state_dict[f"blocks.{l}.ln1.b"] = torch.zeros(cfg.d_vocab, dtype=cfg.dtype)
+
+        W = phi.model.layers[l].self_attn.qkv_proj.weight
+        W_Q, W_K, W_V = torch.tensor_split(W, 3, dim=0)
+        W_Q = einops.rearrange(
+            W_Q, "(n_head d_head) d_model -> n_head d_model d_head", n_head=cfg.n_heads
+        )
+        W_K = einops.rearrange(
+            W_K, "(n_head d_head) d_model  -> n_head d_model d_head", n_head=cfg.n_heads
+        )
+        W_V = einops.rearrange(
+            W_V, "(n_head d_head) d_model  -> n_head d_model d_head", n_head=cfg.n_heads
+        )
+        state_dict[f"blocks.{l}.attn.W_Q"] = W_Q
+        state_dict[f"blocks.{l}.attn.b_Q"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.W_K"] = W_K
+        state_dict[f"blocks.{l}.attn.b_K"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+        state_dict[f"blocks.{l}.attn.W_V"] = W_V
+        state_dict[f"blocks.{l}.attn.b_V"] = torch.zeros(cfg.n_heads, cfg.d_head, dtype=cfg.dtype)
+
+        W_O = phi.model.layers[l].self_attn.o_proj.weight
+        W_O = einops.rearrange(
+            W_O, "d_model (n_head d_head) -> n_head d_head d_model", n_head=cfg.n_heads
+        )
+
+        state_dict[f"blocks.{l}.attn.W_O"] = W_O
+        state_dict[f"blocks.{l}.attn.b_O"] = torch.zeros(cfg.d_model, dtype=cfg.dtype)
+
+        state_dict[f"blocks.{l}.ln2.w"] = phi.model.layers[l].post_attention_layernorm.weight
+        state_dict[f"blocks.{l}.ln2.b"] = torch.zeros(cfg.d_vocab, dtype=cfg.dtype)
+
+        W = phi.model.layers[l].mlp.gate_up_proj.weight.T
+        W_gate, W_in = torch.tensor_split(W, 2, dim=1)
+        state_dict[f"blocks.{l}.mlp.W_in"] = W_in
+        state_dict[f"blocks.{l}.mlp.W_gate"] = W_gate
+        state_dict[f"blocks.{l}.mlp.W_out"] = phi.model.layers[l].mlp.down_proj.weight.T
+
+    state_dict["ln_final.w"] = phi.model.norm.weight
+
+    state_dict["unembed.W_U"] = phi.lm_head.weight.T
+    state_dict["unembed.b_U"] = torch.zeros(cfg.d_vocab, dtype=cfg.dtype)
 
     return state_dict
 


### PR DESCRIPTION
# Description

This pull request adds support for [Phi-3](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf), the latest open-weights model from Microsoft.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I have not rewritten tests relating to key interfaces which would affect backward compatibility

I have not written any new test as I've only added code to parse the config dictionary for Phi-3 and to convert Phi-3's weighs. No other part of TransformerLens has been modified.