### PR TITLE
allow user to force trust_remote_code=true via from_pretrained kwargs

### DIFF
--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1147,6 +1147,8 @@ def convert_hf_model_config(model_name: str, **kwargs):
     cfg_dict["original_architecture"] = architecture
     # The name such that AutoTokenizer.from_pretrained works
     cfg_dict["tokenizer_name"] = official_model_name
+    if kwargs.get("trust_remote_code", False):
+        cfg_dict["trust_remote_code"] = True
     return cfg_dict
 
 


### PR DESCRIPTION
# Description

A simple code change that allows you to force TL to use `trust_remote_code=True` in its configuration. This is particularly useful when you need to use an unreferenced model with a supported architecture that requires it (e.g., m-a-p/CT-LLM-Base).

## Type of change

- [x] New feature (non-breaking change which adds functionality)