### PR TITLE
Support for T5 models

### DIFF
--- a/tests/acceptance/test_hooked_encoder_decoder.py
+++ b/tests/acceptance/test_hooked_encoder_decoder.py
@@ -1,0 +1,366 @@
+import pytest
+import torch
+from jaxtyping import Float
+from torch.testing import assert_close
+
+from transformers import AutoTokenizer, T5ForConditionalGeneration
+
+from transformer_lens import HookedEncoderDecoder
+
+MODEL_NAME = "t5-small"
+
+
+@pytest.fixture(scope="module")
+def our_model():
+    return HookedEncoderDecoder.from_pretrained(MODEL_NAME, device="cpu")
+
+
+@pytest.fixture(scope="module")
+def huggingface_model():
+    return T5ForConditionalGeneration.from_pretrained(MODEL_NAME).eval()
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    return AutoTokenizer.from_pretrained(MODEL_NAME)
+
+
+@pytest.fixture
+def hello_world_tokens(tokenizer):
+    return tokenizer("Hello, world!", return_tensors="pt")["input_ids"]
+
+
+@pytest.fixture
+def decoder_input_ids(tokenizer):
+    return torch.LongTensor([[tokenizer.pad_token_id]])
+
+
+def test_full_model(our_model, huggingface_model, tokenizer, decoder_input_ids):
+    sequences = ["Hello, world!", "this is another sequence of tokens"]
+
+    tokenized = tokenizer(sequences, return_tensors="pt", padding=True)
+    decoder_ids = torch.stack([decoder_input_ids[0]] * len(sequences), dim=0)
+    input_ids = tokenized["input_ids"]
+
+    attention_mask = tokenized["attention_mask"]
+
+    huggingface_model_out = huggingface_model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        decoder_input_ids=decoder_ids,
+    ).logits
+    our_model_out = our_model(
+        input_ids,
+        decoder_input=decoder_ids,
+        one_zero_attention_mask=attention_mask,
+    )
+    assert_close(huggingface_model_out, our_model_out, rtol=1.3e-6, atol=4e-5)
+
+
+def test_encoder(our_model, huggingface_model, hello_world_tokens):
+    our_embeds = our_model.embed(hello_world_tokens)
+    pos_bias = our_model.encoder[0].attn.compute_relative_attention_bias(
+        hello_world_tokens.shape[1], hello_world_tokens.shape[1]
+    )
+
+    for our_layer in our_model.encoder:
+        our_embeds = our_layer(resid_pre=our_embeds, position_bias=pos_bias)
+
+    our_encoder_out = our_model.encoder_final_ln(our_embeds)
+
+    huggingface_encoder_out = huggingface_model.encoder(
+        hello_world_tokens
+    ).last_hidden_state
+
+    assert_close(our_encoder_out, huggingface_encoder_out, rtol=1.3e-6, atol=4e-5)
+
+
+def test_decoder(our_model, huggingface_model, hello_world_tokens, decoder_input_ids):
+    encoder_hidden = huggingface_model.encoder(hello_world_tokens)[0]
+
+    embeds = our_model.embed(decoder_input_ids)
+    pos_bias = our_model.decoder[0].attn.compute_relative_attention_bias(
+        decoder_input_ids.shape[1], decoder_input_ids.shape[1]
+    )
+    for layer in our_model.decoder:
+        embeds = layer(
+            embeds, encoder_hidden_states=encoder_hidden, position_bias=pos_bias
+        )
+
+    our_decoder_out = our_model.decoder_final_ln(embeds)
+    hf_decoder_out = huggingface_model.decoder(
+        decoder_input_ids, encoder_hidden_states=encoder_hidden
+    )[0]
+
+    assert_close(our_decoder_out, hf_decoder_out, rtol=1.3e-6, atol=4e-5)
+
+
+def test_embed_one_sentence(our_model, huggingface_model, hello_world_tokens):
+    huggingface_embed = huggingface_model.encoder.embed_tokens
+    our_embed = our_model.embed
+
+    huggingface_embed_out = huggingface_embed(hello_world_tokens)[0]
+    our_embed_out = our_embed(hello_world_tokens).squeeze(0)
+    assert_close(huggingface_embed_out, our_embed_out)
+
+
+def test_relative_attention_bias(our_model, huggingface_model, hello_world_tokens):
+    # it is used only in self attention of first layer of encoder
+    huggingface_embed = huggingface_model.encoder.embed_tokens
+    huggingface_attn = huggingface_model.encoder.block[0].layer[0].SelfAttention
+    our_attn = our_model.encoder[0].attn
+
+    assert huggingface_attn.has_relative_attention_bias
+    assert our_attn.has_relative_attention_bias
+    assert (
+        our_attn.relative_attention_num_buckets
+        == huggingface_attn.relative_attention_num_buckets
+    )
+    assert (
+        our_attn.relative_attention_max_distance
+        == huggingface_attn.relative_attention_max_distance
+    )
+    assert_close(
+        our_attn.rel_pos_bias.weight, huggingface_attn.relative_attention_bias.weight
+    )
+
+    input_len = hello_world_tokens.shape[1]
+    our_bias = our_attn.compute_relative_attention_bias(input_len, input_len)
+    hf_bias = huggingface_attn.compute_bias(input_len, input_len)
+    assert_close(our_bias, hf_bias, rtol=1e-5, atol=1e-5)
+
+    embed_out = huggingface_embed(hello_world_tokens)
+
+    huggingface_attn_out = huggingface_attn(embed_out)[0]
+    our_attn_out = our_attn(embed_out, embed_out, embed_out, position_bias=our_bias)
+
+    assert_close(our_attn_out, huggingface_attn_out, rtol=7e-4, atol=1e-5)
+
+
+def test_relative_attention_layer(our_model, huggingface_model, hello_world_tokens):
+    # it is used only in self attention of first layer of encoder
+    hf_block = huggingface_model.encoder.block[0].layer[0]
+    our_block = our_model.encoder[0]
+    resid = huggingface_model.encoder.embed_tokens(hello_world_tokens)
+
+    input_len = hello_world_tokens.shape[1]
+    our_bias = our_block.attn.compute_relative_attention_bias(input_len, input_len)
+    resid_norm = our_block.ln1(resid)
+    our_out = resid + our_block.attn(
+        resid_norm, resid_norm, resid_norm, position_bias=our_bias
+    )
+
+    hf_out = hf_block(resid)[0]
+    assert_close(our_out, hf_out, rtol=1.3e-6, atol=4e-5)
+
+
+def test_attention(our_model, huggingface_model, hello_world_tokens):
+    huggingface_embed = huggingface_model.encoder.embed_tokens
+    huggingface_attn = huggingface_model.encoder.block[1].layer[0].SelfAttention
+
+    embed_out = huggingface_embed(hello_world_tokens)
+    our_attn = our_model.encoder[1].attn
+
+    our_attn_out = our_attn(embed_out, embed_out, embed_out)
+    huggingface_attn_out = huggingface_attn(embed_out)[0]
+
+    assert_close(our_attn_out, huggingface_attn_out, rtol=2e-4, atol=1e-5)
+
+
+def test_decoder_attention(our_model, huggingface_model, hello_world_tokens):
+    huggingface_embed = huggingface_model.decoder.embed_tokens
+    huggingface_attn = huggingface_model.decoder.block[1].layer[0].SelfAttention
+
+    embed_out = huggingface_embed(hello_world_tokens)
+    our_attn = our_model.decoder[1].attn
+
+    our_attn_out = our_attn(embed_out, embed_out, embed_out)
+    huggingface_attn_out = huggingface_attn(embed_out)[0]
+    assert_close(our_attn_out, huggingface_attn_out, rtol=3e-4, atol=1e-5)
+
+
+def test_attention_layer(our_model, huggingface_model, hello_world_tokens):
+    huggingface_embed = huggingface_model.encoder.embed_tokens
+    huggingface_attn = huggingface_model.encoder.block[1].layer[0]
+
+    embed_out = huggingface_embed(hello_world_tokens)
+    our_attn = our_model.encoder[1].attn
+    norm_embed = our_model.encoder[1].ln1(embed_out)
+    our_attn_out = our_attn(norm_embed, norm_embed, norm_embed) + embed_out
+
+    huggingface_attn_out = huggingface_attn(embed_out)[0]
+    assert_close(our_attn_out, huggingface_attn_out, rtol=2e-4, atol=1e-5)
+
+
+def test_decoder_attention_layer(our_model, huggingface_model, hello_world_tokens):
+    huggingface_embed = huggingface_model.decoder.embed_tokens
+    huggingface_attn = huggingface_model.decoder.block[1].layer[0]
+
+    embed_out = huggingface_embed(hello_world_tokens)
+    our_attn = our_model.decoder[1].attn
+    norm_embed = our_model.decoder[1].ln1(embed_out)
+    our_attn_out = our_attn(norm_embed, norm_embed, norm_embed) + embed_out
+
+    huggingface_attn_out = huggingface_attn(embed_out)[0]
+    assert_close(our_attn_out, huggingface_attn_out, rtol=3e-4, atol=1e-5)
+
+
+def test_cross_attention(
+    our_model, huggingface_model, hello_world_tokens, decoder_input_ids
+):
+    encoder_hidden = huggingface_model.encoder(hello_world_tokens).last_hidden_state
+    decoder_hidden = huggingface_model.decoder.embed_tokens(decoder_input_ids)
+
+    huggingface_cross_attn = huggingface_model.decoder.block[0].layer[1].EncDecAttention
+    our_cross_attn = our_model.decoder[0].cross_attn
+
+    our_cross_attn_out = our_cross_attn(decoder_hidden, encoder_hidden, encoder_hidden)
+    huggingface_cross_attn_out = huggingface_cross_attn(
+        decoder_hidden, key_value_states=encoder_hidden
+    )[0]
+    assert_close(our_cross_attn_out, huggingface_cross_attn_out, rtol=2e-4, atol=1e-5)
+
+
+def test_cross_attention_layer(
+    our_model, huggingface_model, hello_world_tokens, decoder_input_ids
+):
+    encoder_hidden = huggingface_model.encoder(hello_world_tokens).last_hidden_state
+    decoder_hidden = huggingface_model.decoder.embed_tokens(decoder_input_ids)
+
+    hf_layer = huggingface_model.decoder.block[0].layer[1]
+    our_layer = our_model.decoder[0]
+    # assert ln weights are the same
+    assert_close(hf_layer.layer_norm.weight, our_layer.ln2.w)
+
+    our_cross_attn_out = (
+        our_layer.cross_attn(
+            our_layer.ln2(decoder_hidden), encoder_hidden, encoder_hidden
+        )
+        + decoder_hidden
+    )
+    huggingface_cross_attn_out = hf_layer(
+        decoder_hidden, key_value_states=encoder_hidden
+    )[0]
+    assert_close(our_cross_attn_out, huggingface_cross_attn_out, rtol=2e-4, atol=1e-5)
+
+
+def test_encoder_block(our_model, huggingface_model, hello_world_tokens):
+    huggingface_embed = huggingface_model.encoder.embed_tokens
+    huggingface_block = huggingface_model.encoder.block[1]
+    our_block = our_model.encoder[1]
+
+    embed_out = huggingface_embed(hello_world_tokens)
+
+    hf_out = huggingface_block(embed_out)[0]
+    our_out = our_block(embed_out)
+
+    assert_close(our_out, hf_out, rtol=2e-4, atol=2e-5)
+
+
+def test_decoder_block(
+    our_model, huggingface_model, hello_world_tokens, decoder_input_ids
+):
+    huggingface_embed = huggingface_model.decoder.embed_tokens
+    huggingface_block = huggingface_model.decoder.block[1]
+    our_block = our_model.decoder[1]
+
+    encoder_hidden = huggingface_model.encoder(hello_world_tokens)[0]
+    decoder_hidden = huggingface_model.decoder.block[0](
+        huggingface_embed(decoder_input_ids)
+    )[0]
+
+    our_out = our_block(decoder_hidden, encoder_hidden_states=encoder_hidden)
+    hf_out = huggingface_block(decoder_hidden, encoder_hidden_states=encoder_hidden)[0]
+
+    assert_close(hf_out, our_out, rtol=2e-4, atol=2e-5)
+
+
+def test_layernorm(our_model, huggingface_model, hello_world_tokens):
+    huggingface_embed = huggingface_model.encoder.embed_tokens
+    huggingface_layernorm = huggingface_model.encoder.block[0].layer[0].layer_norm
+    our_layernorm = our_model.encoder[0].ln1
+
+    embed_out = huggingface_embed(hello_world_tokens)
+
+    our_layernorm_out = our_layernorm(embed_out)
+    huggingface_layernorm_out = huggingface_layernorm(embed_out)
+    assert_close(our_layernorm_out, huggingface_layernorm_out)
+
+
+def test_unembed(our_model, huggingface_model, hello_world_tokens):
+    huggingface_model_hidden = huggingface_model.decoder(
+        hello_world_tokens
+    ).last_hidden_state
+
+    our_model_logits = our_model.unembed(huggingface_model_hidden)
+    huggingface_model_logits = huggingface_model.lm_head(huggingface_model_hidden)
+
+    assert_close(our_model_logits, huggingface_model_logits, rtol=1.3e-3, atol=1e-5)
+
+
+def test_run_with_cache(our_model, hello_world_tokens, decoder_input_ids):
+    logits, cache = our_model.run_with_cache(
+        hello_world_tokens, decoder_input=decoder_input_ids
+    )
+
+    # check that an arbitrary subset of the keys exist and have the right shape
+    seq_len = 5
+    generated_len = 1
+    assert "hook_embed" in cache
+    assert cache["hook_embed"].shape == (1, seq_len, 512)
+    assert "encoder.1.attn.hook_v" in cache
+    assert cache["encoder.1.attn.hook_v"].shape == (1, seq_len, 8, 64)
+    assert "encoder.3.attn.hook_attn_scores" in cache
+    assert cache["encoder.3.attn.hook_attn_scores"].shape == (1, 8, seq_len, seq_len)
+    assert "decoder.0.cross_attn.hook_k" in cache
+    assert cache["decoder.0.cross_attn.hook_attn_scores"].shape == (
+        1,
+        8,
+        generated_len,
+        seq_len,
+    )
+    assert "decoder.3.hook_resid_post" in cache
+    assert cache["decoder.3.hook_resid_post"].shape == (1, generated_len, 512)
+
+
+def test_from_pretrained_revision():
+    """
+    Check that the from_pretrained parameter `revision` (= git version) works
+    """
+
+    _ = HookedEncoderDecoder.from_pretrained(MODEL_NAME, revision="main")
+
+    try:
+        _ = HookedEncoderDecoder.from_pretrained(
+            MODEL_NAME, revision="inexistent_branch_name"
+        )
+    except:
+        pass
+    else:
+        raise AssertionError("Should have raised an error")
+
+
+def test_predictions(our_model, huggingface_model, tokenizer, decoder_input_ids):
+    input_ids = tokenizer(
+        "My name is Wolfgang and I live in Berlin", return_tensors="pt"
+    )["input_ids"]
+
+    def get_predictions(logits: Float[torch.Tensor, "batch pos d_vocab"]):
+        predicted_tokens = logits[0].argmax(dim=-1)
+        return tokenizer.batch_decode(predicted_tokens)
+
+    our_model_logits = our_model(input_ids, decoder_input=decoder_input_ids)
+    our_prediction = get_predictions(our_model_logits)
+
+    huggingface_model_logits = huggingface_model(
+        input_ids, decoder_input_ids=decoder_input_ids
+    ).logits
+    huggingface_prediction = get_predictions(huggingface_model_logits)
+
+    assert our_prediction == huggingface_prediction
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires a CUDA device")
+def test_cuda(hello_world_tokens, decoder_input_ids):
+    model = HookedEncoderDecoder.from_pretrained(MODEL_NAME)
+    model(hello_world_tokens, decoder_input=decoder_input_ids.cuda())

--- a/transformer_lens/HookedEncoderDecoder.py
+++ b/transformer_lens/HookedEncoderDecoder.py
@@ -1,0 +1,455 @@
+"""Hooked EncoderDecoder
+
+Contains a T5 style model. This is separate from :class:`transformer_lens.HookedTransformer`
+because it has a significantly different architecture to e.g. GPT style transformers.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union, cast, overload
+
+import torch
+from einops import repeat
+from jaxtyping import Float, Int
+from torch import nn
+from transformers import AutoTokenizer
+from typing_extensions import Literal
+
+import transformer_lens.loading_from_pretrained as loading
+from transformer_lens.ActivationCache import ActivationCache
+from transformer_lens.components import (
+    Embed,
+    Unembed,
+    T5DecoderBlock,
+    T5EncoderBlock,
+    T5LayerNorm,
+)
+from transformer_lens.FactoredMatrix import FactoredMatrix
+from transformer_lens.hook_points import HookedRootModule, HookPoint
+from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
+from transformer_lens.utilities import devices
+
+
+class HookedEncoderDecoder(HookedRootModule):
+    """
+    This class implements a T5 encoder-decoder using the components in ./components.py, with HookPoints on every interesting activation. It inherits from HookedRootModule.
+
+    Limitations:
+    - Also note that model does not include dropouts, which may lead to inconsistent results from training or fine-tuning.
+
+    Like HookedTransformer, it can have a pretrained Transformer's weights loaded via `.from_pretrained`. There are a few features you might know from HookedTransformer which are not yet supported:
+        - There is no preprocessing (e.g. LayerNorm folding) when loading a pretrained model
+        - The model only accepts tokens as inputs, and not strings, or lists of strings
+    """
+
+    def __init__(self, cfg, tokenizer=None, move_to_device=True, **kwargs):
+        super().__init__()
+        if isinstance(cfg, Dict):
+            cfg = HookedTransformerConfig(**cfg)
+        elif isinstance(cfg, str):
+            raise ValueError(
+                "Please pass in a config dictionary or HookedTransformerConfig object. If you want to load a pretrained model, use HookedEncoderDecoder.from_pretrained() instead."
+            )
+        self.cfg = cfg
+
+        assert (
+            self.cfg.n_devices == 1
+        ), "Multiple devices not supported for HookedEncoderDecoder"
+        if tokenizer is not None:
+            self.tokenizer = tokenizer
+        elif self.cfg.tokenizer_name is not None:
+            huggingface_token = os.environ.get("HF_TOKEN", None)
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                self.cfg.tokenizer_name,
+                token=huggingface_token,
+            )
+        else:
+            self.tokenizer = None
+
+        if self.cfg.d_vocab == -1:
+            # If we have a tokenizer, vocab size can be inferred from it.
+            assert (
+                self.tokenizer is not None
+            ), "Must provide a tokenizer if d_vocab is not provided"
+            self.cfg.d_vocab = max(self.tokenizer.vocab.values()) + 1
+        if self.cfg.d_vocab_out == -1:
+            self.cfg.d_vocab_out = self.cfg.d_vocab
+
+        self.embed = Embed(self.cfg)
+        self.encoder = nn.ModuleList(
+            [
+                T5EncoderBlock(self.cfg, num_layer)
+                for num_layer in range(self.cfg.n_layers)
+            ]
+        )
+        self.encoder_final_ln = T5LayerNorm(self.cfg)
+        self.decoder = nn.ModuleList(
+            [
+                T5DecoderBlock(self.cfg, num_layer)
+                for num_layer in range(self.cfg.n_layers)
+            ]
+        )
+        self.decoder_final_ln = T5LayerNorm(self.cfg)
+        # self.lm_head = nn.Linear(self.cfg.d_model, self.cfg.d_vocab_out)
+        self.unembed = Unembed(self.cfg)
+
+        self.hook_full_embed = HookPoint()
+
+        if move_to_device:
+            self.to(self.cfg.device)
+
+        self.setup()
+
+    @overload
+    def forward(
+        self,
+        input: Int[torch.Tensor, "batch pos"],
+        decoder_input: Int[torch.Tensor, "batch pos"],
+        return_type: Literal["logits"],
+        one_zero_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+    ) -> Float[torch.Tensor, "batch pos d_vocab"]: ...
+
+    @overload
+    def forward(
+        self,
+        input: Int[torch.Tensor, "batch pos"],
+        decoder_input: Int[torch.Tensor, "batch pos"],
+        return_type: Literal[None],
+        one_zero_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+    ) -> Optional[Float[torch.Tensor, "batch pos d_vocab"]]: ...
+
+    def forward(
+        self,
+        input: Int[torch.Tensor, "batch pos"],
+        decoder_input: Int[torch.Tensor, "batch pos"],
+        return_type: Optional[str] = "logits",
+        one_zero_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+    ) -> Optional[Float[torch.Tensor, "batch pos d_vocab"]]:
+        """Input must be a batch of tokens. Strings and lists of strings are not yet supported.
+
+        return_type Optional[str]: The type of output to return. Can be one of: None (return nothing, don't calculate logits), or 'logits' (return logits).
+
+        token_type_ids Optional[torch.Tensor]: Binary ids indicating whether a token belongs to sequence A or B. For example, for two sentences: "[CLS] Sentence A [SEP] Sentence B [SEP]", token_type_ids would be [0, 0, ..., 0, 1, ..., 1, 1]. `0` represents tokens from Sentence A, `1` from Sentence B. If not provided, BERT assumes a single sequence input. Typically, shape is (batch_size, sequence_length).
+
+        one_zero_attention_mask: Optional[torch.Tensor]: A binary mask which indicates which tokens should be attended to (1) and which should be ignored (0). Primarily used for padding variable-length sentences in a batch. For instance, in a batch with sentences of differing lengths, shorter sentences are padded with 0s on the right. If not provided, the model assumes all tokens should be attended to.
+        """
+
+        tokens = input
+
+        if tokens.device.type != self.cfg.device:
+            tokens = tokens.to(self.cfg.device)
+            if one_zero_attention_mask is not None:
+                one_zero_attention_mask = one_zero_attention_mask.to(self.cfg.device)
+
+        resid = self.hook_full_embed(self.embed(tokens))
+
+        large_negative_number = -torch.inf
+        mask = (
+            repeat(1 - one_zero_attention_mask, "batch pos -> batch 1 1 pos")
+            if one_zero_attention_mask is not None
+            else None
+        )
+
+        for encoder_block in self.encoder:
+            resid = encoder_block(resid)
+
+        resid = self.encoder_final_ln(resid)
+
+        decoder_resid = self.embed(decoder_input)
+
+        for decoder_block in self.decoder:
+            decoder_resid = decoder_block(decoder_resid, resid)
+
+        decoder_resid = self.decoder_final_ln(decoder_resid)
+        if return_type is None:
+            return None
+
+        logits = self.unembed(decoder_resid)
+        return logits
+
+    @overload
+    def run_with_cache(
+        self, *model_args, return_cache_object: Literal[True] = True, **kwargs
+    ) -> Tuple[Float[torch.Tensor, "batch pos d_vocab"], ActivationCache]: ...
+
+    @overload
+    def run_with_cache(
+        self, *model_args, return_cache_object: Literal[False], **kwargs
+    ) -> Tuple[Float[torch.Tensor, "batch pos d_vocab"], Dict[str, torch.Tensor]]: ...
+
+    def run_with_cache(
+        self,
+        *model_args,
+        return_cache_object: bool = True,
+        remove_batch_dim: bool = False,
+        **kwargs,
+    ) -> Tuple[
+        Float[torch.Tensor, "batch pos d_vocab"],
+        Union[ActivationCache, Dict[str, torch.Tensor]],
+    ]:
+        """
+        Wrapper around run_with_cache in HookedRootModule. If return_cache_object is True, this will return an ActivationCache object, with a bunch of useful HookedTransformer specific methods, otherwise it will return a dictionary of activations as in HookedRootModule. This function was copied directly from HookedTransformer.
+        """
+        out, cache_dict = super().run_with_cache(
+            *model_args, remove_batch_dim=remove_batch_dim, **kwargs
+        )
+        if return_cache_object:
+            cache = ActivationCache(
+                cache_dict, self, has_batch_dim=not remove_batch_dim
+            )
+            return out, cache
+        else:
+            return out, cache_dict
+
+    def to(  # type: ignore
+        self,
+        device_or_dtype: Union[torch.device, str, torch.dtype],
+        print_details: bool = True,
+    ):
+        return devices.move_to_and_update_config(self, device_or_dtype, print_details)
+
+    def cuda(self):
+        # Wrapper around cuda that also changes self.cfg.device
+        return self.to("cuda")
+
+    def cpu(self):
+        # Wrapper around cuda that also changes self.cfg.device
+        return self.to("cpu")
+
+    def mps(self):
+        # Wrapper around cuda that also changes self.cfg.device
+        return self.to("mps")
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name: str,
+        checkpoint_index: Optional[int] = None,
+        checkpoint_value: Optional[int] = None,
+        hf_model=None,
+        device: Optional[str] = None,
+        tokenizer=None,
+        move_to_device=True,
+        dtype=torch.float32,
+        **from_pretrained_kwargs,
+    ) -> HookedEncoderDecoder:
+        """Loads in the pretrained weights from huggingface. Currently supports loading weight from HuggingFace BertForMaskedLM. Unlike HookedTransformer, this does not yet do any preprocessing on the model."""
+        logging.warning(
+            "Support for T5 in TransformerLens is currently experimental, until such a time when it has feature "
+            "parity with HookedTransformer and has been tested on real research tasks. Until then, backward "
+            "compatibility is not guaranteed. Please see the docs for information on the limitations of the current "
+            "implementation."
+            "\n"
+            "If using BERT for interpretability research, keep in mind that BERT has some significant architectural "
+            "differences to GPT. For example, LayerNorms are applied *after* the attention and MLP components, meaning "
+            "that the last LayerNorm in a block cannot be folded."
+        )
+
+        assert not (
+            from_pretrained_kwargs.get("load_in_8bit", False)
+            or from_pretrained_kwargs.get("load_in_4bit", False)
+        ), "Quantization not supported"
+
+        if "torch_dtype" in from_pretrained_kwargs:
+            dtype = from_pretrained_kwargs["torch_dtype"]
+
+        name_or_path = (
+            model_name
+            if Path(model_name).exists
+            else loading.get_official_model_name(model_name)
+        )
+
+        cfg = loading.get_pretrained_model_config(
+            name_or_path,
+            checkpoint_index=checkpoint_index,
+            checkpoint_value=checkpoint_value,
+            fold_ln=False,
+            device=device,
+            n_devices=1,
+            dtype=dtype,
+            **from_pretrained_kwargs,
+        )
+
+        state_dict = loading.get_pretrained_state_dict(
+            name_or_path, cfg, hf_model, dtype=dtype, **from_pretrained_kwargs
+        )
+
+        model = cls(cfg, tokenizer, move_to_device=False)
+
+        model.load_state_dict(state_dict, strict=False)
+
+        if move_to_device:
+            model.to(cfg.device)
+
+        print(f"Loaded pretrained model {model_name} into HookedTransformer")
+
+        return model
+
+    @property
+    def W_U(self) -> Float[torch.Tensor, "d_model d_vocab"]:
+        """
+        Convenience to get the unembedding matrix (ie the linear map from the final residual stream to the output logits)
+        """
+        return self.unembed.W_U
+
+    @property
+    def b_U(self) -> Float[torch.Tensor, "d_vocab"]:
+        """
+        Convenience to get the unembedding bias
+        """
+        return self.unembed.b_U
+
+    @property
+    def W_E(self) -> Float[torch.Tensor, "d_vocab d_model"]:
+        """
+        Convenience to get the embedding matrix
+        """
+        return self.embed.embed.W_E
+
+    @property
+    def W_pos(self) -> Float[torch.Tensor, "n_ctx d_model"]:
+        """
+        Convenience function to get the positional embedding. Only works on models with absolute positional embeddings!
+        """
+        return self.embed.pos_embed.W_pos
+
+    @property
+    def W_E_pos(self) -> Float[torch.Tensor, "d_vocab+n_ctx d_model"]:
+        """
+        Concatenated W_E and W_pos. Used as a full (overcomplete) basis of the input space, useful for full QK and full OV circuits.
+        """
+        return torch.cat([self.W_E, self.W_pos], dim=0)
+
+    @property
+    def W_K(self) -> Float[torch.Tensor, "n_layers n_heads d_model d_head"]:
+        """Stacks the key weights across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).attn.W_K for block in self.encoder]
+            + [cast(T5DecoderBlock, block).attn.W_K for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def W_Q(self) -> Float[torch.Tensor, "n_layers n_heads d_model d_head"]:
+        """Stacks the query weights across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).attn.W_Q for block in self.encoder]
+            + [cast(T5DecoderBlock, block).attn.W_Q for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def W_V(self) -> Float[torch.Tensor, "n_layers n_heads d_model d_head"]:
+        """Stacks the value weights across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).attn.W_V for block in self.encoder]
+            + [cast(T5DecoderBlock, block).attn.W_V for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def W_O(self) -> Float[torch.Tensor, "n_layers n_heads d_head d_model"]:
+        """Stacks the attn output weights across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).attn.W_O for block in self.encoder]
+            + [cast(T5DecoderBlock, block).attn.W_O for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def W_in(self) -> Float[torch.Tensor, "n_layers d_model d_mlp"]:
+        """Stacks the MLP input weights across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).mlp.W_in for block in self.encoder]
+            + [cast(T5DecoderBlock, block).mlp.W_in for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def W_out(self) -> Float[torch.Tensor, "n_layers d_mlp d_model"]:
+        """Stacks the MLP output weights across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).mlp.W_out for block in self.encoder]
+            + [cast(T5DecoderBlock, block).mlp.W_out for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def b_K(self) -> Float[torch.Tensor, "n_layers n_heads d_head"]:
+        """Stacks the key biases across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).attn.b_K for block in self.encoder]
+            + [cast(T5DecoderBlock, block).attn.b_K for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def b_Q(self) -> Float[torch.Tensor, "n_layers n_heads d_head"]:
+        """Stacks the query biases across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).attn.b_Q for block in self.encoder]
+            + [cast(T5DecoderBlock, block).attn.b_Q for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def b_V(self) -> Float[torch.Tensor, "n_layers n_heads d_head"]:
+        """Stacks the value biases across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).attn.b_V for block in self.encoder]
+            + [cast(T5DecoderBlock, block).attn.b_V for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def b_O(self) -> Float[torch.Tensor, "n_layers d_model"]:
+        """Stacks the attn output biases across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).attn.b_O for block in self.encoder]
+            + [cast(T5DecoderBlock, block).attn.b_O for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def b_in(self) -> Float[torch.Tensor, "n_layers d_mlp"]:
+        """Stacks the MLP input biases across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).mlp.b_in for block in self.encoder]
+            + [cast(T5DecoderBlock, block).mlp.b_in for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def b_out(self) -> Float[torch.Tensor, "n_layers d_model"]:
+        """Stacks the MLP output biases across all layers"""
+        return torch.stack(
+            [cast(T5EncoderBlock, block).mlp.b_out for block in self.encoder]
+            + [cast(T5DecoderBlock, block).mlp.b_out for block in self.decoder],
+            dim=0,
+        )
+
+    @property
+    def QK(self) -> FactoredMatrix:  # [n_layers, n_heads, d_model, d_model]
+        """Returns a FactoredMatrix object with the product of the Q and K matrices for each layer and head.
+        Useful for visualizing attention patterns."""
+        return FactoredMatrix(self.W_Q, self.W_K.transpose(-2, -1))
+
+    @property
+    def OV(self) -> FactoredMatrix:  # [n_layers, n_heads, d_model, d_model]
+        """Returns a FactoredMatrix object with the product of the O and V matrices for each layer and head."""
+        return FactoredMatrix(self.W_V, self.W_O)
+
+    def all_head_labels(self) -> List[str]:
+        """Returns a list of strings with the format "L{l}H{h}", where l is the layer index and h is the head index."""
+        return [
+            f"EL{l}H{h}"
+            for l in range(self.cfg.n_layers)
+            for h in range(self.cfg.n_heads)
+        ] + [
+            f"DL{l}H{h}"
+            for l in range(self.cfg.n_layers)
+            for h in range(self.cfg.n_heads)
+        ]

--- a/transformer_lens/HookedEncoderDecoder.py
+++ b/transformer_lens/HookedEncoderDecoder.py
@@ -112,9 +112,8 @@ class HookedEncoderDecoder(HookedRootModule):
         one_zero_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
     ) -> Optional[Float[torch.Tensor, "batch decoder_pos d_vocab"]]:
         """Input must be a batch of tokens. Strings and lists of strings are not yet supported.
-
+        decoder_input: Int[torch.Tensor, "batch decoder_pos"]: The input to the decoder. This is the sequence of tokens that the model will generate, usually with a start token at the beginning
         return_type Optional[str]: The type of output to return. Can be one of: None (return nothing, don't calculate logits), or 'logits' (return logits).
-
         one_zero_attention_mask: Optional[torch.Tensor]: A binary mask which indicates which tokens should be attended to (1) and which should be ignored (0). Primarily used for padding variable-length sentences in a batch. For instance, in a batch with sentences of differing lengths, shorter sentences are padded with 0s on the right. If not provided, the model assumes all tokens should be attended to.
         """
 
@@ -243,9 +242,9 @@ class HookedEncoderDecoder(HookedRootModule):
             "compatibility is not guaranteed. Please see the docs for information on the limitations of the current "
             "implementation."
             "\n"
-            "If using BERT for interpretability research, keep in mind that BERT has some significant architectural "
-            "differences to GPT. For example, LayerNorms are applied *after* the attention and MLP components, meaning "
-            "that the last LayerNorm in a block cannot be folded."
+            "If using T5 for interpretability research, keep in mind that T5 has some significant architectural "
+            "differences to GPT. The major one is that T5 is an Encoder-Decoder model"
+            "Also, it uses relative positional embeddings, different types of Attention (without bias) and LayerNorm"
         )
 
         assert not (

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -159,6 +159,11 @@ class HookedTransformerConfig:
             must also be set. Set to None if not using MoE.
         experts_per_token (int, *optional*): The number of experts to use for each pass in the MoE layer. If set,
             num_experts must also be set. Set to None if not using MoE.
+        relative_attention_max_distance (int, *optional*): The maximum distance between tokens for relative
+            attention. If set, relative_attention_num_buckets must also be set.Only used in EncoderDecoder models, like T5.
+        relative_attention_num_buckets (int, *optional*): The number of buckets to use for relative attention.
+            If set, relative_attention_max_distance must also be set.Only used in EncoderDecoder models, like T5.
+        decoder_start_token_id (int, *optional*): The start token id for the decoder. Only used in EncoderDecoder models, like T5.
     """
 
     n_layers: int
@@ -214,6 +219,9 @@ class HookedTransformerConfig:
     load_in_4bit: bool = False
     num_experts: Optional[int] = None
     experts_per_token: Optional[int] = None
+    relative_attention_max_distance: Optional[int] = None
+    relative_attention_num_buckets: Optional[int] = None
+    decoder_start_token_id: Optional[int] = None
 
     def __post_init__(self):
         if self.n_heads == -1:

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -164,6 +164,7 @@ class HookedTransformerConfig:
         relative_attention_num_buckets (int, *optional*): The number of buckets to use for relative attention.
             If set, relative_attention_max_distance must also be set.Only used in EncoderDecoder models, like T5.
         decoder_start_token_id (int, *optional*): The start token id for the decoder. Only used in EncoderDecoder models, like T5.
+        tie_word_embeddings (bool): Whether to tie the word embeddings and the output layer weights. Defaults to False. Only used in EncoderDecoder (T5) by now.
     """
 
     n_layers: int
@@ -222,6 +223,7 @@ class HookedTransformerConfig:
     relative_attention_max_distance: Optional[int] = None
     relative_attention_num_buckets: Optional[int] = None
     decoder_start_token_id: Optional[int] = None
+    tie_word_embeddings: bool = False
 
     def __post_init__(self):
         if self.n_heads == -1:

--- a/transformer_lens/__init__.py
+++ b/transformer_lens/__init__.py
@@ -15,6 +15,7 @@ from .HookedSAE import HookedSAE
 from .HookedSAETransformer import HookedSAETransformer
 from .SVDInterpreter import SVDInterpreter
 from .HookedEncoder import HookedEncoder
+from .HookedEncoderDecoder import HookedEncoderDecoder
 from . import head_detector
 from . import loading_from_pretrained as loading
 from . import patching

--- a/transformer_lens/components.py
+++ b/transformer_lens/components.py
@@ -531,6 +531,10 @@ class AbstractAttention(ABC, nn.Module):
             # ALiBi bias wil be constructed on the first forward pass.
             # Note: While computationally efficient, initializing an bias with max n_ctx (16, 1024, 1024) of float32 will occupy ~256MiB of contiguous GPU memory, which may not be optimal for memory usage.
             self.alibi = None
+        elif self.cfg.positional_embedding_type == "relative_positional_bias":
+            # will be overwritten by the child T5Attention class
+            self.has_relative_attention_bias = False
+
 
     @property
     def OV(self) -> FactoredMatrix:
@@ -564,18 +568,19 @@ class AbstractAttention(ABC, nn.Module):
             Float[torch.Tensor, "batch pos head_index d_model"],
         ],
         key_input: Union[
-            Float[torch.Tensor, "batch pos d_model"],
-            Float[torch.Tensor, "batch pos head_index d_model"],
-            Float[torch.Tensor, "batch pos kv_head_index d_model"],
+            Float[torch.Tensor, "batch kv_pos d_model"],
+            Float[torch.Tensor, "batch kv_pos head_index d_model"],
+            Float[torch.Tensor, "batch kv_pos kv_head_index d_model"],
         ],
         value_input: Union[
-            Float[torch.Tensor, "batch pos d_model"],
-            Float[torch.Tensor, "batch pos head_index d_model"],
-            Float[torch.Tensor, "batch pos kv_head_index d_model"],
+            Float[torch.Tensor, "batch kv_pos d_model"],
+            Float[torch.Tensor, "batch kv_pos head_index d_model"],
+            Float[torch.Tensor, "batch kv_pos kv_head_index d_model"],
         ],
         past_kv_cache_entry: Optional[HookedTransformerKeyValueCacheEntry] = None,
-        additive_attention_mask: Optional[Float[torch.Tensor, "batch 1 1 pos"]] = None,
+        additive_attention_mask: Optional[Float[torch.Tensor, "batch 1 1 kv_pos"]] = None,
         attention_mask: Optional[Int[torch.Tensor, "batch offset_pos"]] = None,
+        position_bias: Optional[Float[torch.Tensor, "1 head_index pos kv_pos"]] = None
     ) -> Float[torch.Tensor, "batch pos d_model"]:
         """
         shortformer_pos_embed is only used if self.cfg.positional_embedding_type == "shortformer", else defaults to None and is irrelevant. See HookedTransformerConfig for more details
@@ -621,6 +626,19 @@ class AbstractAttention(ABC, nn.Module):
             attn_scores += self.alibi[
                 :, :query_ctx, :key_ctx
             ]  # [batch, head_index, query_pos, key_pos]
+        elif self.cfg.positional_embedding_type == "relative_positional_bias":
+            if position_bias is None:
+                if self.has_relative_attention_bias:
+                    raise ValueError("Positional bias is required for relative_positional_bias")
+                else:
+                    position_bias = torch.zeros(
+                        1, self.cfg.n_heads,
+                        attn_scores.shape[2],
+                        attn_scores.shape[3],
+                        device=attn_scores.device,
+                    )
+                    
+            attn_scores += position_bias
 
         if self.cfg.attention_dir == "causal":
             # If causal attention, we mask it to only attend backwards. If bidirectional, we don't mask.
@@ -696,17 +714,17 @@ class AbstractAttention(ABC, nn.Module):
             Float[torch.Tensor, "batch pos head_index d_model"],
         ],
         key_input: Union[
-            Float[torch.Tensor, "batch pos d_model"],
-            Float[torch.Tensor, "batch pos head_index d_model"],
+            Float[torch.Tensor, "batch kv_pos d_model"],
+            Float[torch.Tensor, "batch kv_pos head_index d_model"],
         ],
         value_input: Union[
-            Float[torch.Tensor, "batch pos d_model"],
-            Float[torch.Tensor, "batch pos head_index d_model"],
+            Float[torch.Tensor, "batch kv_pos d_model"],
+            Float[torch.Tensor, "batch kv_pos head_index d_model"],
         ],
     ) -> Tuple[
         Float[torch.Tensor, "batch pos head_index d_head"],
-        Float[torch.Tensor, "batch pos head_index d_head"],
-        Float[torch.Tensor, "batch pos head_index d_head"],
+        Float[torch.Tensor, "batch kv_pos head_index d_head"],
+        Float[torch.Tensor, "batch kv_pos head_index d_head"],
     ]:
         if self.cfg.use_split_qkv_input or self.cfg.use_attn_in:
             qkv_einops_string = "batch pos head_index d_model"

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -7,12 +7,18 @@ import dataclasses
 import logging
 import os
 import re
+from pathlib import Path
 from typing import Dict, Optional, Union, cast
 
 import einops
 import torch
 from huggingface_hub import HfApi
-from transformers import AutoConfig, AutoModelForCausalLM, BertForPreTraining
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    BertForPreTraining,
+    T5ForConditionalGeneration,
+)
 
 import transformer_lens.utils as utils
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
@@ -654,7 +660,12 @@ def convert_hf_model_config(model_name: str, **kwargs):
     Takes the official_model_name as an input.
     """
     # In case the user passed in an alias
-    official_model_name = get_official_model_name(model_name)
+    if (Path(model_name) / "config.json").exists():
+        logging.info("Loading model config from local directory")
+        official_model_name = model_name
+    else:
+        official_model_name = get_official_model_name(model_name)
+    
     # Load HuggingFace model config
     if "llama" in official_model_name.lower():
         architecture = "LlamaForCausalLM"
@@ -1141,6 +1152,22 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "gated_mlp": True,
             "final_rms": True,
         }
+    elif architecture == "T5ForConditionalGeneration":
+        cfg_dict = {
+            "d_model": hf_config.d_model,
+            "d_head": hf_config.d_kv,
+            "n_heads": hf_config.num_heads,
+            "d_mlp": hf_config.d_ff,
+            "d_vocab": hf_config.vocab_size,
+            "n_layers": hf_config.num_layers,
+            "n_ctx": hf_config.max_length,
+            "eps": hf_config.layer_norm_epsilon,
+            "act_fn": hf_config.feed_forward_proj,
+            "relative_attention_max_distance": hf_config.relative_attention_max_distance,
+            "relative_attention_num_buckets": hf_config.relative_attention_num_buckets,
+            "decoder_start_token_id": hf_config.decoder_start_token_id,
+            "attention_dir": "bidirectional",
+        }
     else:
         raise NotImplementedError(f"{architecture} is not currently supported.")
     # All of these models use LayerNorm
@@ -1237,7 +1264,12 @@ def get_pretrained_model_config(
             Also given to other HuggingFace functions when compatible.
 
     """
-    official_model_name = get_official_model_name(model_name)
+    if Path(model_name).exists():
+        # If the model_name is a path, it's a local model
+        cfg_dict = convert_hf_model_config(model_name, **kwargs)
+        official_model_name = model_name
+    else:
+        official_model_name = get_official_model_name(model_name)
     if (
         official_model_name.startswith("NeelNanda")
         or official_model_name.startswith("ArthurConmy")
@@ -1393,7 +1425,11 @@ def get_pretrained_state_dict(
     if "torch_dtype" in kwargs:
         dtype = kwargs["torch_dtype"]
         del kwargs["torch_dtype"]
-    official_model_name = get_official_model_name(official_model_name)
+    if Path(official_model_name).exists():
+        official_model_name = str(Path(official_model_name).resolve())
+        logging.info(f"Loading model from local path {official_model_name}")
+    else:
+        official_model_name = get_official_model_name(official_model_name)
     if official_model_name.startswith(NEED_REMOTE_CODE_MODELS) and not kwargs.get(
         "trust_remote_code", False
     ):
@@ -1459,6 +1495,13 @@ def get_pretrained_state_dict(
                     token=huggingface_token,
                     **kwargs,
                 )
+            elif "t5" in official_model_name:
+                hf_model = T5ForConditionalGeneration.from_pretrained(
+                    official_model_name,
+                    torch_dtype=dtype,
+                    token=huggingface_token,
+                    **kwargs,
+                )
             else:
                 hf_model = AutoModelForCausalLM.from_pretrained(
                     official_model_name,
@@ -1486,6 +1529,8 @@ def get_pretrained_state_dict(
             state_dict = convert_llama_weights(hf_model, cfg)
         elif cfg.original_architecture == "BertForMaskedLM":
             state_dict = convert_bert_weights(hf_model, cfg)
+        elif cfg.original_architecture == "T5ForConditionalGeneration":
+            state_dict = convert_t5_weights(hf_model, cfg)
         elif cfg.original_architecture == "MistralForCausalLM":
             state_dict = convert_mistral_weights(hf_model, cfg)
         elif cfg.original_architecture == "MixtralForCausalLM":
@@ -2411,6 +2456,104 @@ def convert_bert_weights(bert, cfg: HookedTransformerConfig):
     state_dict["unembed.W_U"] = embeddings.word_embeddings.weight.T
     # "unembed.W_U": mlm_head.decoder.weight.T,
     state_dict["unembed.b_U"] = mlm_head.bias
+
+    return state_dict
+
+
+def convert_t5_weights(t5, cfg: HookedTransformerConfig):
+    state_dict = {
+        "embed.W_E": t5.encoder.embed_tokens.weight,
+        "unembed.W_U":  t5.encoder.embed_tokens.weight.T,
+        "encoder.0.rel_pos_bias.weight": t5.encoder.block[0].layer[0].SelfAttention.relative_attention_bias
+    }
+
+
+    for l in range(cfg.n_layers):
+        block = t5.encoder.block[l]
+        state_dict[f"encoder.{l}.attn.W_Q"] = einops.rearrange(
+            block.layer[0].SelfAttention.q.weight, "(i h) m -> i m h", i=cfg.n_heads
+        )
+        state_dict[f"encoder.{l}.attn.W_K"] = einops.rearrange(
+            block.layer[0].SelfAttention.k.weight, "(i h) m -> i m h", i=cfg.n_heads
+        )
+
+        state_dict[f"encoder.{l}.attn.W_V"] = einops.rearrange(
+            block.layer[0].SelfAttention.v.weight, "(i h) m -> i m h", i=cfg.n_heads
+        )
+
+        state_dict[f"encoder.{l}.attn.W_O"] = einops.rearrange(
+            block.layer[0].SelfAttention.o.weight,
+            "m (i h) -> i h m",
+            i=cfg.n_heads,
+        )
+        state_dict[f"encoder.{l}.ln1.w"] = block.layer[0].layer_norm.weight
+
+        # fixme DenseReluDense may be T5DenseGatedActDense instead
+        state_dict[f"encoder.{l}.mlp.W_in"] = einops.rearrange(
+            block.layer[1].DenseReluDense.wi.weight, "mlp model -> model mlp"
+        )
+
+        state_dict[f"encoder.{l}.mlp.W_out"] = einops.rearrange(
+            block.layer[1].DenseReluDense.wo.weight, "model mlp -> mlp model"
+        )
+        state_dict[f"encoder.{l}.ln2.w"] = block.layer[1].layer_norm.weight
+
+    state_dict["encoder_final_ln.w"] = t5.encoder.final_layer_norm.weight
+
+    state_dict["decoder.0.rel_pos_bias.weight"] = (
+        t5.decoder.block[0].layer[0].SelfAttention.relative_attention_bias
+    )
+
+    for l in range(cfg.n_layers):
+        block = t5.decoder.block[l]
+        state_dict[f"decoder.{l}.attn.W_Q"] = einops.rearrange(
+            block.layer[0].SelfAttention.q.weight, "(i h) m -> i m h", i=cfg.n_heads
+        )
+
+        state_dict[f"decoder.{l}.attn.W_K"] = einops.rearrange(
+            block.layer[0].SelfAttention.k.weight, "(i h) m -> i m h", i=cfg.n_heads
+        )
+        state_dict[f"decoder.{l}.attn.W_V"] = einops.rearrange(
+            block.layer[0].SelfAttention.v.weight, "(i h) m -> i m h", i=cfg.n_heads
+        )
+
+        state_dict[f"decoder.{l}.attn.W_O"] = einops.rearrange(
+            block.layer[0].SelfAttention.o.weight,
+            "m (i h) -> i h m",
+            i=cfg.n_heads,
+        )
+
+        state_dict[f"decoder.{l}.attn_ln.w"] = block.layer[0].layer_norm.weight
+
+        state_dict[f"decoder.{l}.cross_attn.W_Q"] = einops.rearrange(
+            block.layer[1].EncDecAttention.q.weight, "(i h) m -> i m h", i=cfg.n_heads
+        )
+        
+        state_dict[f"decoder.{l}.cross_attn.W_K"] = einops.rearrange(
+            block.layer[1].EncDecAttention.k.weight, "(i h) m -> i m h", i=cfg.n_heads
+        )
+        
+        state_dict[f"decoder.{l}.cross_attn.W_V"] = einops.rearrange(
+            block.layer[1].EncDecAttention.v.weight, "(i h) m -> i m h", i=cfg.n_heads
+        )
+        state_dict[f"decoder.{l}.cross_attn.W_O"] = einops.rearrange(
+            block.layer[1].EncDecAttention.o.weight,
+            "m (i h) -> i h m",
+            i=cfg.n_heads,
+        )
+        state_dict[f"decoder.{l}.attn_ln.w"] = block.layer[1].layer_norm.weight
+
+        # fixme DenseReluDense may be T5DenseGatedActDense instead
+        state_dict[f"decoder.{l}.mlp.W_in"] = einops.rearrange(
+            block.layer[2].DenseReluDense.wi.weight, "mlp model -> model mlp"
+        )
+        state_dict[f"decoder.{l}.mlp.W_out"] = einops.rearrange(
+            block.layer[2].DenseReluDense.wo.weight, "model mlp -> mlp model"
+        )
+        state_dict[f"decoder.{l}.mlp_ln.w"] = block.layer[2].layer_norm.weight
+
+    state_dict["decoder_final_ln.w"] = t5.decoder.final_layer_norm.weight
+
 
     return state_dict
 

--- a/transformer_lens/utilities/devices.py
+++ b/transformer_lens/utilities/devices.py
@@ -45,7 +45,7 @@ def get_device_for_block_index(
 
 
 def move_to_and_update_config(
-    model: Union["transformer_lens.HookedTransformer", "transformer_lens.HookedEncoder"],
+    model: Union["transformer_lens.HookedTransformer", "transformer_lens.HookedEncoder", "transformer_lens.HookedEncoderDecoder"],
     device_or_dtype: Union[torch.device, str, torch.dtype],
     print_details=True,
 ):


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.
-->

Hey! 

I need support for EncoderDecoder (T5) models for my research, but unfortunately neither TransformerLens, neither nnsight had support for them.

This PR is mostly based on #276 and HuggingFace implementation of [T5](https://github.com/huggingface/transformers/blob/v4.41.0/src/transformers/models/t5/modeling_t5.py)

Hope that it is enough to get started with encoder-decoder arhitectures, and merge into the lib. I will continue work on this. 

Will be glad to receive any comments 
:)

Loading example 

```python
from transformer_lens.HookedEncoderDecoder import  HookedEncoderDecoder

path = "results/t5_scratch_adamw_eos_3lay_8head_512d_2048dff_3e-4_400ep/"

#you can load  local custom model or official T5 weights from HF
path = "t5-small" 

hooked_model = HookedEncoderDecoder.from_pretrained(model_name=path)
```

# Description
* added HookedEncoderDecoder class
* added T5LayerNorm, T5Attention, T5Block
* changed signature of AbstractAttention.forward 
from `pos` to `kv_pos` in keys and values associated fields. This was needed for CrossAttention support
*  add model_state_dict loading from pretrained model
* added support of loading models from **local folders** 
    See more in `transformer_lens/loading_from_pretrained.py:669,1276,1437`  Unsure about this one. I need this feature for my research purposes, don't know if this should go into release. (But i believe there's some people, who might find this useful too.

Fixes #258  
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

