### PR TITLE
add n k v heads to model properties table

### DIFF
--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -101,7 +101,7 @@ def generate_model_table(_app: Optional[Any] = None):
     )
 
     # Convert to markdown (with a title)
-    df['n_key_value_heads'] = df['n_key_value_heads'].fillna(-1).astype(int).replace(-1, '')
+    df["n_key_value_heads"] = df["n_key_value_heads"].fillna(-1).astype(int).replace(-1, "")
     markdown_string = df.to_markdown()
     markdown_string = "# Model Properties Table\n\n" + markdown_string
 

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -90,6 +90,7 @@ def generate_model_table(_app: Optional[Any] = None):
         "d_vocab",
         "d_head",
         "d_mlp",
+        "n_key_value_heads",
     ]
     df = pd.DataFrame(
         {
@@ -100,6 +101,7 @@ def generate_model_table(_app: Optional[Any] = None):
     )
 
     # Convert to markdown (with a title)
+    df['n_key_value_heads'] = df['n_key_value_heads'].fillna(-1).astype(int).replace(-1, '')
     markdown_string = df.to_markdown()
     markdown_string = "# Model Properties Table\n\n" + markdown_string
 

--- a/tests/unit/test_make_docs.py
+++ b/tests/unit/test_make_docs.py
@@ -41,6 +41,9 @@ def test_get_property():
     d_mlp = get_property("d_mlp", "attn-only-1l")
     assert d_mlp == 2048
 
+    n_key_value_heads = get_property("n_key_value_heads", "attn-only-1l")
+    assert n_key_value_heads is None
+
     # Test an unknown property
     with pytest.raises(KeyError):
         get_property("unknown_property", "attn-only-1l")


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.
-->
# Description

Adds "n_kv_heads" to the Model Properties Table in the documentation. Some models use multi-query attention (which uses a single key and value head) or grouped-query attention (which uses multiple key and value heads, but less than the number of query heads). This change lets users easily see which models use these.

Fixes # https://github.com/TransformerLensOrg/TransformerLens/issues/522

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

**Before**

<img width="1728" alt="Screenshot 2024-05-27 at 5 10 05 PM" src="https://github.com/TransformerLensOrg/TransformerLens/assets/42191920/851ab7a5-2010-4c2c-b5ea-f8131d335d5c">

<img width="1728" alt="Screenshot 2024-05-27 at 5 10 18 PM" src="https://github.com/TransformerLensOrg/TransformerLens/assets/42191920/0d81fd7a-42b3-40cd-886d-50a72c108ee0">

**After**

<img width="1728" alt="Screenshot 2024-05-27 at 5 08 53 PM" src="https://github.com/TransformerLensOrg/TransformerLens/assets/42191920/ed86ea1e-881a-4ba6-9990-af230685cbba">

<img width="1728" alt="Screenshot 2024-05-27 at 5 09 09 PM" src="https://github.com/TransformerLensOrg/TransformerLens/assets/42191920/b907f9a4-9093-4851-b97c-fb6e0130e310">

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->