### PR TITLE
Fix typo in Main_Demo.ipynb

### DIFF
--- a/demos/Main_Demo.ipynb
+++ b/demos/Main_Demo.ipynb
@@ -534,7 +534,7 @@
                 "The IOI task is the task of identifying that a sentence like \"After John and Mary went to the store, Mary gave a bottle of milk to\" continues with \" John\" rather than \" Mary\" (ie, finding the indirect object), and Redwood Research have [an excellent paper studying the underlying circuit in GPT-2 Small](https://arxiv.org/abs/2211.00593).\n",
                 "\n",
                 "**[Activation patching](https://dynalist.io/d/n2ZWtnoYHrU1s4vnFSAQ519J#z=qeWBvs-R-taFfcCq-S_hgMqx)** is a technique from [Kevin Meng and David Bau's excellent ROME paper](https://rome.baulab.info/). The goal is to identify which model activations are important for completing a task. We do this by setting up a **clean prompt** and a **corrupted prompt** and a **metric** for performance on the task. We then pick a specific model activation, run the model on the corrupted prompt, but then *intervene* on that activation and patch in its value when run on the clean prompt. We then apply the metric, and see how much this patch has recovered the clean performance. \n",
-                "(See [a more detailed demonstration of activation patching here](https://colab.research.google.com/github.com/TransformerLensOrg/TransformerLens/blob/main/demos/Exploratory_Analysis_Demo.ipynb))"
+                "(See [a more detailed demonstration of activation patching here](https://colab.research.google.com/github/TransformerLensOrg/TransformerLens/blob/main/demos/Exploratory_Analysis_Demo.ipynb))"
             ]
         },
         {


### PR DESCRIPTION
Fixed typo in link to Exploratory_Analysis_Demo.ipynb so it opens properly in colab.


# Description

Fixed typo in link to Exploratory_Analysis_Demo.ipynb so it opens properly in colab. The original link had an errant ".com" resulting in a 403 when clicking and opening in Google Colab.

Fixes # (issue)

None.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Screenshots not applicable.

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

I have done any of the above but do not believe they apply.