### PR TITLE
Match Huggingface MLP implementation exactly.

### DIFF
--- a/tests/integration/test_match_huggingface.py
+++ b/tests/integration/test_match_huggingface.py
@@ -1,0 +1,17 @@
+import torch
+from transformers import AutoModelForCausalLM
+
+from transformer_lens import HookedTransformer
+
+
+class TestMatchHuggingFace:
+    def test_test_mlp_outputs_match(self):
+        tl_model = HookedTransformer.from_pretrained_no_processing("gpt2", device="cpu")
+        hf_model = AutoModelForCausalLM.from_pretrained("gpt2", device_map="cpu")
+        test_tensor = torch.randn((1, 1, tl_model.cfg.d_model))
+
+        for layer_n in range(len(tl_model.blocks)):
+            tl_out = tl_model.blocks[layer_n].mlp(test_tensor)
+            hf_out = hf_model.transformer.h[layer_n].mlp(test_tensor)
+
+            assert torch.sum(tl_out == hf_out) == tl_model.cfg.d_model

--- a/tests/integration/test_match_huggingface.py
+++ b/tests/integration/test_match_huggingface.py
@@ -1,3 +1,4 @@
+import math
 import torch
 import pytest
 from transformers import AutoModelForCausalLM
@@ -17,10 +18,11 @@ class TestMatchHuggingFace:
             model_name, device="cpu"
         )
         hf_model = AutoModelForCausalLM.from_pretrained(model_name, device_map="cpu")
-        test_tensor = torch.randn((2, 2, tl_model.cfg.d_model))
+        tensor_shape = (3, 5, tl_model.cfg.d_model)
+        test_tensor = torch.randn(tensor_shape)
 
         for layer_n in range(len(tl_model.blocks)):
             tl_out = tl_model.blocks[layer_n].mlp(test_tensor)
             hf_out = hf_model.transformer.h[layer_n].mlp(test_tensor)
 
-            assert torch.sum(tl_out == hf_out) == 2 * 2 * tl_model.cfg.d_model
+            assert torch.sum(tl_out == hf_out) == math.prod(tensor_shape)

--- a/tests/integration/test_match_huggingface.py
+++ b/tests/integration/test_match_huggingface.py
@@ -1,6 +1,7 @@
 import math
-import torch
+
 import pytest
+import torch
 from transformers import AutoModelForCausalLM
 
 from transformer_lens import HookedTransformer
@@ -14,9 +15,7 @@ class TestMatchHuggingFace:
 
     # tests
     def test_compare_huggingface_logits_match_local_implementation(self, model_name):
-        tl_model = HookedTransformer.from_pretrained_no_processing(
-            model_name, device="cpu"
-        )
+        tl_model = HookedTransformer.from_pretrained_no_processing(model_name, device="cpu")
         hf_model = AutoModelForCausalLM.from_pretrained(model_name, device_map="cpu")
         tensor_shape = (3, 5, tl_model.cfg.d_model)
         test_tensor = torch.randn(tensor_shape)

--- a/transformer_lens/components/mlp.py
+++ b/transformer_lens/components/mlp.py
@@ -13,8 +13,8 @@ from jaxtyping import Float
 from transformer_lens.components import LayerNorm, LayerNormPre
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
-from transformer_lens.utils import gelu_fast, gelu_new, solu
 from transformer_lens.utilities.addmm import batch_addmm
+from transformer_lens.utils import gelu_fast, gelu_new, solu
 
 
 # MLP Layers

--- a/transformer_lens/components/mlp.py
+++ b/transformer_lens/components/mlp.py
@@ -13,36 +13,7 @@ from jaxtyping import Float
 from transformer_lens.components import LayerNorm, LayerNormPre
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
-from transformer_lens.utils import gelu_fast, gelu_new, solu
-
-
-def vanilla_addmm(
-    input: Float[torch.Tensor, "... #o"],  # Must be broadcastable to "m o"
-    mat1: Float[torch.Tensor, "m n"],
-    mat2: Float[torch.Tensor, "n o"],
-) -> Float[torch.Tensor, "m o"]:
-    """Typechecked version of torch.addmm.
-
-    Note that both mat1 and mat2 *must* be 2d matrices.
-    """
-    return torch.addmm(input, mat1, mat2)
-
-
-def batch_addmm(
-    bias: Float[torch.Tensor, "... #d_out"],  # Must be broadcastable to "... d_out"
-    weight: Float[torch.Tensor, "d_in d_out"],
-    x: Float[torch.Tensor, "... d_in"],
-) -> Float[torch.Tensor, "... d_out"]:
-    """Fused add-multiply with support for batch dimensions.
-
-    Must match the Huggingface Conv1D implementation exactly.
-    https://github.com/huggingface/transformers/blob/9ba9369a2557e53a01378199a9839ec6e82d8bc7/src/transformers/pytorch_utils.py#L102-L106
-    """
-    n_output_features = weight.shape[-2]
-    size_out = x.size()[:-1] + (n_output_features,)
-    x = vanilla_addmm(bias, x.view(-1, x.size(-1)), weight)
-    x = x.view(size_out)
-    return x
+from transformer_lens.utils import gelu_fast, gelu_new, solu, batch_addmm
 
 
 # MLP Layers

--- a/transformer_lens/components/mlp.py
+++ b/transformer_lens/components/mlp.py
@@ -13,7 +13,8 @@ from jaxtyping import Float
 from transformer_lens.components import LayerNorm, LayerNormPre
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
-from transformer_lens.utils import gelu_fast, gelu_new, solu, batch_addmm
+from transformer_lens.utils import gelu_fast, gelu_new, solu
+from transformer_lens.utilities.addmm import batch_addmm
 
 
 # MLP Layers

--- a/transformer_lens/components/mlp.py
+++ b/transformer_lens/components/mlp.py
@@ -66,7 +66,7 @@ class MLP(nn.Module):
         # This is equivalent to (roughly) W_in @ x + b_in. It's important to
         # use a fused addmm to ensure it matches the Huggingface implementation
         # exactly.
-        pre_act = batch_addmm(self.b_in, self.W_in, x)  # [batch, pos, d_mlp]
+        pre_act = self.hook_pre(batch_addmm(self.b_in, self.W_in, x))  # [batch, pos, d_mlp]
         if self.cfg.act_fn is not None and not self.cfg.act_fn.endswith("_ln"):
             post_act = self.hook_post(self.act_fn(pre_act))  # [batch, pos, d_mlp]
         else:

--- a/transformer_lens/components/mlp.py
+++ b/transformer_lens/components/mlp.py
@@ -16,15 +16,31 @@ from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
 from transformer_lens.utils import gelu_fast, gelu_new, solu
 
 
-def addmm(bias, weight, x):
-    """Fused addmm.
+def vanilla_addmm(
+    input: Float[torch.Tensor, "... #o"],  # Must be broadcastable to "m o"
+    mat1: Float[torch.Tensor, "m n"],
+    mat2: Float[torch.Tensor, "n o"],
+) -> Float[torch.Tensor, "m o"]:
+    """Typechecked version of torch.addmm.
+
+    Note that both mat1 and mat2 *must* be 2d matrices.
+    """
+    return torch.addmm(input, mat1, mat2)
+
+
+def batch_addmm(
+    bias: Float[torch.Tensor, "... #d_out"],  # Must be broadcastable to "... d_out"
+    weight: Float[torch.Tensor, "d_in d_out"],
+    x: Float[torch.Tensor, "... d_in"],
+) -> Float[torch.Tensor, "... d_out"]:
+    """Fused add-multiply with support for batch dimensions.
 
     Must match the Huggingface Conv1D implementation exactly.
     https://github.com/huggingface/transformers/blob/9ba9369a2557e53a01378199a9839ec6e82d8bc7/src/transformers/pytorch_utils.py#L102-L106
     """
-    nf = weight.shape[1]
-    size_out = x.size()[:-1] + (nf,)
-    x = torch.addmm(bias, x.view(-1, x.size(-1)), weight)
+    n_output_features = weight.shape[-2]
+    size_out = x.size()[:-1] + (n_output_features,)
+    x = vanilla_addmm(bias, x.view(-1, x.size(-1)), weight)
     x = x.view(size_out)
     return x
 
@@ -78,10 +94,10 @@ class MLP(nn.Module):
         # This is equivalent to (roughly) W_in @ x + b_in. It's important to
         # use a fused addmm to ensure it matches the Huggingface implementation
         # exactly.
-        pre_act = addmm(self.b_in, self.W_in, x)  # [batch, pos, d_mlp]
+        pre_act = batch_addmm(self.b_in, self.W_in, x)  # [batch, pos, d_mlp]
         if self.cfg.act_fn is not None and not self.cfg.act_fn.endswith("_ln"):
             post_act = self.hook_post(self.act_fn(pre_act))  # [batch, pos, d_mlp]
         else:
             mid_act = self.hook_mid(self.act_fn(pre_act))  # [batch, pos, d_mlp]
             post_act = self.hook_post(self.ln(mid_act))
-        return addmm(self.b_out, self.W_out, post_act)
+        return batch_addmm(self.b_out, self.W_out, post_act)

--- a/transformer_lens/components/mlp.py
+++ b/transformer_lens/components/mlp.py
@@ -2,18 +2,31 @@
 
 This module contains all the component :class:`MLP`.
 """
+
 from typing import Callable, Dict, Union
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from fancy_einsum import einsum
 from jaxtyping import Float
 
 from transformer_lens.components import LayerNorm, LayerNormPre
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
 from transformer_lens.utils import gelu_fast, gelu_new, solu
+
+
+def addmm(bias, weight, x):
+    """Fused addmm.
+
+    Must match the Huggingface Conv1D implementation exactly.
+    https://github.com/huggingface/transformers/blob/9ba9369a2557e53a01378199a9839ec6e82d8bc7/src/transformers/pytorch_utils.py#L102-L106
+    """
+    nf = weight.shape[1]
+    size_out = x.size()[:-1] + (nf,)
+    x = torch.addmm(bias, x.view(-1, x.size(-1)), weight)
+    x = x.view(size_out)
+    return x
 
 
 # MLP Layers
@@ -62,20 +75,13 @@ class MLP(nn.Module):
     def forward(
         self, x: Float[torch.Tensor, "batch pos d_model"]
     ) -> Float[torch.Tensor, "batch pos d_model"]:
-        # Technically, all these einsums could be done with a single matmul, but this is more readable.
-        pre_act = self.hook_pre(
-            einsum("batch pos d_model, d_model d_mlp -> batch pos d_mlp", x, self.W_in) + self.b_in
-        )  # [batch, pos, d_mlp]
+        # This is equivalent to (roughly) W_in @ x + b_in. It's important to
+        # use a fused addmm to ensure it matches the Huggingface implementation
+        # exactly.
+        pre_act = addmm(self.b_in, self.W_in, x)  # [batch, pos, d_mlp]
         if self.cfg.act_fn is not None and not self.cfg.act_fn.endswith("_ln"):
             post_act = self.hook_post(self.act_fn(pre_act))  # [batch, pos, d_mlp]
         else:
             mid_act = self.hook_mid(self.act_fn(pre_act))  # [batch, pos, d_mlp]
             post_act = self.hook_post(self.ln(mid_act))
-        return (
-            einsum(
-                "batch pos d_mlp, d_mlp d_model -> batch pos d_model",
-                post_act,
-                self.W_out,
-            )
-            + self.b_out
-        )
+        return addmm(self.b_out, self.W_out, post_act)

--- a/transformer_lens/utilities/addmm.py
+++ b/transformer_lens/utilities/addmm.py
@@ -1,0 +1,31 @@
+import torch
+from jaxtyping import Float
+
+
+def vanilla_addmm(
+    input: Float[torch.Tensor, "... #o"],  # Must be broadcastable to "m o"
+    mat1: Float[torch.Tensor, "m n"],
+    mat2: Float[torch.Tensor, "n o"],
+) -> Float[torch.Tensor, "m o"]:
+    """Typechecked version of torch.addmm.
+
+    Note that both mat1 and mat2 *must* be 2d matrices.
+    """
+    return torch.addmm(input, mat1, mat2)
+
+
+def batch_addmm(
+    bias: Float[torch.Tensor, "... #d_out"],  # Must be broadcastable to "... d_out"
+    weight: Float[torch.Tensor, "d_in d_out"],
+    x: Float[torch.Tensor, "... d_in"],
+) -> Float[torch.Tensor, "... d_out"]:
+    """Fused add-multiply with support for batch dimensions.
+
+    Must match the Huggingface Conv1D implementation exactly.
+    https://github.com/huggingface/transformers/blob/9ba9369a2557e53a01378199a9839ec6e82d8bc7/src/transformers/pytorch_utils.py#L102-L106
+    """
+    n_output_features = weight.shape[-1]
+    size_out = x.size()[:-1] + (n_output_features,)
+    x = vanilla_addmm(bias, x.view(-1, x.size(-1)), weight)
+    x = x.view(size_out)
+    return x

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -1210,32 +1210,3 @@ try:
     pytest.mark.skip(test_prompt)
 except ModuleNotFoundError:
     pass  # disregard if pytest not in env
-
-
-def vanilla_addmm(
-    input: Float[torch.Tensor, "... #o"],  # Must be broadcastable to "m o"
-    mat1: Float[torch.Tensor, "m n"],
-    mat2: Float[torch.Tensor, "n o"],
-) -> Float[torch.Tensor, "m o"]:
-    """Typechecked version of torch.addmm.
-
-    Note that both mat1 and mat2 *must* be 2d matrices.
-    """
-    return torch.addmm(input, mat1, mat2)
-
-
-def batch_addmm(
-    bias: Float[torch.Tensor, "... #d_out"],  # Must be broadcastable to "... d_out"
-    weight: Float[torch.Tensor, "d_in d_out"],
-    x: Float[torch.Tensor, "... d_in"],
-) -> Float[torch.Tensor, "... d_out"]:
-    """Fused add-multiply with support for batch dimensions.
-
-    Must match the Huggingface Conv1D implementation exactly.
-    https://github.com/huggingface/transformers/blob/9ba9369a2557e53a01378199a9839ec6e82d8bc7/src/transformers/pytorch_utils.py#L102-L106
-    """
-    n_output_features = weight.shape[-1]
-    size_out = x.size()[:-1] + (n_output_features,)
-    x = vanilla_addmm(bias, x.view(-1, x.size(-1)), weight)
-    x = x.view(size_out)
-    return x

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -1234,7 +1234,7 @@ def batch_addmm(
     Must match the Huggingface Conv1D implementation exactly.
     https://github.com/huggingface/transformers/blob/9ba9369a2557e53a01378199a9839ec6e82d8bc7/src/transformers/pytorch_utils.py#L102-L106
     """
-    n_output_features = weight.shape[-2]
+    n_output_features = weight.shape[-1]
     size_out = x.size()[:-1] + (n_output_features,)
     x = vanilla_addmm(bias, x.view(-1, x.size(-1)), weight)
     x = x.view(size_out)

--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -1210,3 +1210,32 @@ try:
     pytest.mark.skip(test_prompt)
 except ModuleNotFoundError:
     pass  # disregard if pytest not in env
+
+
+def vanilla_addmm(
+    input: Float[torch.Tensor, "... #o"],  # Must be broadcastable to "m o"
+    mat1: Float[torch.Tensor, "m n"],
+    mat2: Float[torch.Tensor, "n o"],
+) -> Float[torch.Tensor, "m o"]:
+    """Typechecked version of torch.addmm.
+
+    Note that both mat1 and mat2 *must* be 2d matrices.
+    """
+    return torch.addmm(input, mat1, mat2)
+
+
+def batch_addmm(
+    bias: Float[torch.Tensor, "... #d_out"],  # Must be broadcastable to "... d_out"
+    weight: Float[torch.Tensor, "d_in d_out"],
+    x: Float[torch.Tensor, "... d_in"],
+) -> Float[torch.Tensor, "... d_out"]:
+    """Fused add-multiply with support for batch dimensions.
+
+    Must match the Huggingface Conv1D implementation exactly.
+    https://github.com/huggingface/transformers/blob/9ba9369a2557e53a01378199a9839ec6e82d8bc7/src/transformers/pytorch_utils.py#L102-L106
+    """
+    n_output_features = weight.shape[-2]
+    size_out = x.size()[:-1] + (n_output_features,)
+    x = vanilla_addmm(bias, x.view(-1, x.size(-1)), weight)
+    x = x.view(size_out)
+    return x


### PR DESCRIPTION
# Description

#570 has shown that there are small differences in outputs between the Huggingface implementation of models, which uses a fused add-multiply (this presumably matches the way the models were trained as well) and TransformerLens, which doesn't. It seems likely that with bigger models (e.g. Mixtral), these errors accumulate enough to be significant. This is my attempt to begin to fix the problem.

Note that we take a slight readability hit, but I believe this is worth it for correctness.

For now I've only applied this to the implemenation in `mlp.py`. There are several other places the same fix should probably be applied.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility