### PR TITLE
Fix Out bias not being summed in attention component when using 4 bit precision

### DIFF
--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -264,13 +264,16 @@ class AbstractAttention(ABC, nn.Module):
         if not self.cfg.use_attn_result:
             if self.cfg.load_in_4bit:
                 # call bitsandbytes method to dequantize and multiply
-                out = bnb.matmul_4bit(
-                    z.reshape(z.shape[0], z.shape[1], self.cfg.d_model),
-                    self.W_O.t(),
-                    # bias=self.W_O.t(),
-                    bias=None,
-                    quant_state=self.W_O.quant_state,
-                ) + self.b_O
+                out = (
+                    bnb.matmul_4bit(
+                        z.reshape(z.shape[0], z.shape[1], self.cfg.d_model),
+                        self.W_O.t(),
+                        # bias=self.W_O.t(),
+                        bias=None,
+                        quant_state=self.W_O.quant_state,
+                    )
+                    + self.b_O
+                )
             else:
                 w = einops.rearrange(
                     self.W_O, "head_index d_head d_model -> d_model (head_index d_head)"

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -270,8 +270,7 @@ class AbstractAttention(ABC, nn.Module):
                     # bias=self.W_O.t(),
                     bias=None,
                     quant_state=self.W_O.quant_state,
-                )
-                +self.b_O
+                ) + self.b_O
             else:
                 w = einops.rearrange(
                     self.W_O, "head_index d_head d_model -> d_model (head_index d_head)"


### PR DESCRIPTION
# Description

The attention component was not using `b_O` for models in 4 bit precision. It looked like it was, but the statement had no effect since it was in a new line, without using `\`, and not surrounded by parenthesis. I found this out by looking at the automatic inspections generated by Pycharm.

**This was caused by the black formatter.** I had to add extra parenthesis to avoid formatting warnings. I.e., just moving `+ self.b_O` to the line above will get automatically reverted when running black.

I haven't added tests for this change (AFAIK there are not tests for 4 bit precision).

![image](https://github.com/TransformerLensOrg/TransformerLens/assets/1159078/05d7ef63-50ae-4db5-ad5f-fbeca7eb955f)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have not rewritten tests relating to key interfaces which would affect backward compatibility