### PR TITLE
removed einsum causing error when use_atten_result is enabled

### DIFF
--- a/tests/unit/test_use_attn_result.py
+++ b/tests/unit/test_use_attn_result.py
@@ -1,0 +1,73 @@
+import torch
+
+from transformer_lens import HookedTransformer
+from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
+
+
+def test_atten_result_normal_attn_correct():
+    """Verifies that the attn_result flag does not change the output for models with normal attention."""
+    d_model = 128
+    d_head = 8
+    n_heads = 16
+    n_ctx = 128
+    n_layers = 1
+    d_vocab = 10
+
+    cfg = HookedTransformerConfig(
+        d_model=d_model,
+        d_head=d_head,
+        n_heads=n_heads,
+        n_ctx=n_ctx,
+        n_layers=n_layers,
+        attn_only=True,
+        d_vocab=d_vocab,
+    )
+
+    model = HookedTransformer(cfg)
+    assert model.cfg.use_split_qkv_input is False
+
+    x = torch.arange(1, 9).unsqueeze(0)
+    normal_output = model(x)
+
+    model.set_use_attn_result(True)
+    assert model.cfg.use_attn_result  is True
+
+    split_output = model(x)
+
+    assert torch.allclose(normal_output, split_output, atol=1e-6)
+
+
+def test_atten_result_grouped_query_attn_correct():
+    """Verifies that the atten_result flag does not change the output for models with grouped query attention."""
+
+    d_model = 128
+    d_head = 8
+    n_heads = 16
+    n_ctx = 128
+    n_key_value_heads = 2
+    n_layers = 1
+    d_vocab = 10
+
+    cfg = HookedTransformerConfig(
+        d_model=d_model,
+        d_head=d_head,
+        n_heads=n_heads,
+        n_ctx=n_ctx,
+        n_key_value_heads=n_key_value_heads,
+        n_layers=n_layers,
+        attn_only=True,
+        d_vocab=d_vocab,
+    )
+
+    model = HookedTransformer(cfg)
+    assert model.cfg.use_split_qkv_input is False
+
+    x = torch.arange(1, 9).unsqueeze(0)
+    normal_output = model(x)
+
+    model.set_use_attn_result(True)
+    assert model.cfg.use_attn_result is True
+
+    split_output = model(x)
+
+    assert torch.allclose(normal_output, split_output, atol=1e-6)

--- a/tests/unit/test_use_attn_result.py
+++ b/tests/unit/test_use_attn_result.py
@@ -30,7 +30,7 @@ def test_atten_result_normal_attn_correct():
     normal_output = model(x)
 
     model.set_use_attn_result(True)
-    assert model.cfg.use_attn_result  is True
+    assert model.cfg.use_attn_result is True
 
     split_output = model(x)
 

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -2,7 +2,6 @@ from abc import ABC
 from typing import Dict, Optional, Tuple, Union
 
 import einops
-from fancy_einsum import einsum
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -2,6 +2,7 @@ from abc import ABC
 from typing import Dict, Optional, Tuple, Union
 
 import einops
+from fancy_einsum import einsum
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -302,11 +303,8 @@ class AbstractAttention(ABC, nn.Module):
                 input = einops.rearrange(
                     z, "batch pos head_index d_head -> batch pos (head_index d_head)"
                 )
-                result = self.hook_result(F.linear(input, w))  # [batch, pos, head_index, d_model]
-            out = (
-                einops.reduce(result, "batch position index model->batch position model", "sum")
-                + self.b_O
-            )  # [batch, pos, d_model]
+                result = self.hook_result(F.linear(input, w))  # [batch, pos, d_model]
+            out = result + self.b_O
         return out
 
     def calculate_qkv_matrices(


### PR DESCRIPTION
# Description



Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #659 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

| Before | After |
| ------ | ----- |
| <img width="900" alt="Screenshot 2024-07-08 at 12 59 00 PM" src="https://github.com/TransformerLensOrg/TransformerLens/assets/40397426/a3a64899-47f4-4074-b9f5-4edcc24dbfce"> | <img width="900" alt="Screenshot 2024-07-08 at 12 59 40 PM" src="https://github.com/TransformerLensOrg/TransformerLens/assets/40397426/75e3de97-ebe0-4a7a-837f-dcdbeafa923f"> |

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have not rewritten tests relating to key interfaces which would affect backward compatibility
