### PR TITLE
Adding RMSNorm to apply_ln_to_stack

### DIFF
--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -948,7 +948,7 @@ class ActivationCache:
         element and position, which is why we need to use the cached scale factors rather than just
         applying a new LayerNorm.
 
-        If the model does not use LayerNorm, it returns the residual stack unchanged.
+        If the model does not use LayerNorm or RMSNorm, it returns the residual stack unchanged.
 
         Args:
             residual_stack:
@@ -972,7 +972,7 @@ class ActivationCache:
                 Whether residual_stack has a batch dimension.
 
         """
-        if self.model.cfg.normalization_type not in ["LN", "LNPre"]:
+        if self.model.cfg.normalization_type not in ["LN", "LNPre", "RMS", "RMSPre"]:
             # The model does not use LayerNorm, so we don't need to do anything.
             return residual_stack
         if not isinstance(pos_slice, Slice):

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -988,8 +988,9 @@ class ActivationCache:
             # Apply batch slice to the stack
             residual_stack = batch_slice.apply(residual_stack, dim=1)
 
-        # Center the stack
-        residual_stack = residual_stack - residual_stack.mean(dim=-1, keepdim=True)
+        # Center the stack onlny if the model uses LayerNorm
+        if self.model.cfg.normalization_type in ["LN", "LNPre"]:
+            residual_stack = residual_stack - residual_stack.mean(dim=-1, keepdim=True)
 
         if layer == self.model.cfg.n_layers or layer is None:
             scale = self["ln_final.hook_scale"]


### PR DESCRIPTION
# Description

Adding support to RMSNorm in the apply_ln_to_stack function. It should be supported by: https://github.com/TransformerLensOrg/TransformerLens/pull/489

Fixes #472 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility