### PR TITLE
fix: fixing broken backward hooks change

### DIFF
--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -297,12 +297,15 @@ class AbstractAttention(ABC, nn.Module):
             else:
                 w = einops.rearrange(
                     self.W_O,
-                    "head_index d_head d_model -> d_model (head_index d_head)",
+                    "head_index d_head d_model -> d_model head_index d_head",
                 )
-                input = einops.rearrange(
-                    z, "batch pos head_index d_head -> batch pos (head_index d_head)"
-                )
-                result = self.hook_result(F.linear(input, w))  # [batch, pos, head_index, d_model]
+                result = self.hook_result(
+                    einops.einsum(
+                        z,
+                        w,
+                        "... head_index d_head, d_model head_index d_head -> ... head_index d_model",
+                    )
+                )  # [batch, pos, head_index, d_model]
             out = (
                 einops.reduce(result, "batch position index model->batch position model", "sum")
                 + self.b_O

--- a/transformer_lens/hook_points.py
+++ b/transformer_lens/hook_points.py
@@ -117,7 +117,7 @@ class HookPoint(nn.Module):
             _internal_hooks = self._forward_hooks
             visible_hooks = self.fwd_hooks
         elif dir == "bwd":
-            pt_handle = self.register_backward_hook(full_hook)
+            pt_handle = self.register_full_backward_hook(full_hook)
             _internal_hooks = self._backward_hooks
             visible_hooks = self.bwd_hooks
         else:


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

This PR fixes a bug in v2.x.x of TransformerLens where backwards hooks were changed to use the deprecated and broken `register_backward_hook()` method instead of the correct `register_full_backward_hook()`. Before v2.x.x the correct method was used. The breaking change happened in #607, but it's not clear why this change was made.

This PR also adds a test which will not allow this regression to happen again.

Fixes #672

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->