### PR TITLE
Move the HookedSAE / HookedSAETransformer warning to a less prominent…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,6 @@ A Library for Mechanistic Interpretability of Generative Language Models. Mainta
 [![Read the Docs
 Here](https://img.shields.io/badge/-Read%20the%20Docs%20Here-blue?style=for-the-badge&logo=Read-the-Docs&logoColor=white&link=https://TransformerLensOrg.github.io/TransformerLens/)](https://TransformerLensOrg.github.io/TransformerLens/)
 
-| :exclamation:  HookedSAETransformer Removed   |
-|-----------------------------------------------|
-
-Hooked SAE has been removed from TransformerLens 2.0. The functionality is being moved to
-[SAELens](http://github.com/jbloomAus/SAELens). For more information on this release, please see the
-accompanying
-[announcement](https://transformerlensorg.github.io/TransformerLens/content/news/release-2.0.html)
-for details on what's new, and the future of TransformerLens.
-
 This is a library for doing [mechanistic
 interpretability](https://distill.pub/2020/circuits/zoom-in/) of GPT-2 Style language models. The
 goal of mechanistic interpretability is to take a trained model and reverse engineer the algorithms
@@ -155,6 +146,15 @@ Please use issues for concrete discussions about the package, and Slack for high
 discussions about eg supporting important new use cases, or if you want to make substantial
 contributions to the library and want a maintainer's opinion. We'd also love for you to come and
 share your projects on the Slack!
+
+| :exclamation:  HookedSAETransformer Removed   |
+|-----------------------------------------------|
+
+Hooked SAE has been removed from TransformerLens in version 2.0. The functionality is being moved to
+[SAELens](http://github.com/jbloomAus/SAELens). For more information on this release, please see the
+accompanying
+[announcement](https://transformerlensorg.github.io/TransformerLens/content/news/release-2.0.html)
+for details on what's new, and the future of TransformerLens.
 
 ## Credits
 


### PR DESCRIPTION
… part of the README.

<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

I don't think that the change to `HookedSAE` impacts many users, so we should move it to a later part of the README, so that more important (e.g. quickstart stuff!) is near the top of the README.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

(Most of this is irrelevant since it's just a README change)

- [x] I have made corresponding changes to the documentation
