### PR TITLE
Fix typo in `embed.py` docs

### DIFF
--- a/transformer_lens/components/embed.py
+++ b/transformer_lens/components/embed.py
@@ -1,6 +1,6 @@
 """Hooked Transformer Embed Component.
 
-This module contains all the component :class:`BertMLMHead`.
+This module contains all the component :class:`Embed`.
 """
 from typing import Dict, Union
 


### PR DESCRIPTION
This is not to do with BERT

# Checklist:

- [x] I have made corresponding changes to the documentation
