### PR TITLE
Add Mixtral to `test_match_huggingface` test

### DIFF
--- a/tests/integration/test_match_huggingface.py
+++ b/tests/integration/test_match_huggingface.py
@@ -15,9 +15,7 @@ class TestMatchHuggingFace:
 
     # tests
     def test_compare_huggingface_mlp_match_local_implementation(self, model_name):
-        tl_model = HookedTransformer.from_pretrained_no_processing(
-            model_name, device="cpu"
-        )
+        tl_model = HookedTransformer.from_pretrained_no_processing(model_name, device="cpu")
         hf_model = AutoModelForCausalLM.from_pretrained(model_name, device_map="cpu")
         tensor_shape = (3, 5, tl_model.cfg.d_model)
         test_tensor = torch.randn(tensor_shape)
@@ -25,9 +23,7 @@ class TestMatchHuggingFace:
         for layer_n in range(len(tl_model.blocks)):
             tl_out = tl_model.blocks[layer_n].mlp(test_tensor)
             # hf_out = hf_model.transformer.h[layer_n].mlp(test_tensor)
-            hf_out, router_logits = hf_model.model.layers[layer_n].block_sparse_moe(
-                test_tensor
-            )
+            hf_out, router_logits = hf_model.model.layers[layer_n].block_sparse_moe(test_tensor)
 
             print(f"test: {tl_out[:2, :2, :2]=}")
             print(f"test: {hf_out[:2, :2, :2]=}")

--- a/tests/integration/test_match_huggingface.py
+++ b/tests/integration/test_match_huggingface.py
@@ -25,10 +25,6 @@ class TestMatchHuggingFace:
             # hf_out = hf_model.transformer.h[layer_n].mlp(test_tensor)
             hf_out, router_logits = hf_model.model.layers[layer_n].block_sparse_moe(test_tensor)
 
-            print(f"test: {tl_out[:2, :2, :2]=}")
-            print(f"test: {hf_out[:2, :2, :2]=}")
-            print(f"test: {(tl_out - hf_out)[:5, :5, :5]=}")
-            print(f"test: {torch.sum(tl_out - hf_out)=}")
             assert torch.sum(tl_out == hf_out) == math.prod(tensor_shape)
 
     # def test_compare_huggingface_attention_match_local_implementation(self, model_name):
@@ -50,6 +46,4 @@ class TestMatchHuggingFace:
     #         # hf_out, _ = hf_model.transformer.h[layer_n].attn(hidden_states=input)
     #         hf_out, _, _ = hf_model.model.layers[layer_n].self_attn(hidden_states=input)
     #
-    #         print(f"{tl_out[:2, :2, :2]=}")
-    #         print(f"{hf_out[:2, :2, :2]=}")
     #         assert torch.sum(tl_out == hf_out) == math.prod(tl_out.shape)

--- a/tests/integration/test_match_huggingface.py
+++ b/tests/integration/test_match_huggingface.py
@@ -9,37 +9,51 @@ from transformer_lens import HookedTransformer
 
 class TestMatchHuggingFace:
     # fixtures
-    @pytest.fixture(scope="class", params=["gpt2"])
+    @pytest.fixture(scope="class", params=["joelb/Mixtral-8x7B-1l"])
     def model_name(self, request):
         return request.param
 
     # tests
     def test_compare_huggingface_mlp_match_local_implementation(self, model_name):
-        tl_model = HookedTransformer.from_pretrained_no_processing(model_name, device="cpu")
+        tl_model = HookedTransformer.from_pretrained_no_processing(
+            model_name, device="cpu"
+        )
         hf_model = AutoModelForCausalLM.from_pretrained(model_name, device_map="cpu")
         tensor_shape = (3, 5, tl_model.cfg.d_model)
         test_tensor = torch.randn(tensor_shape)
 
         for layer_n in range(len(tl_model.blocks)):
             tl_out = tl_model.blocks[layer_n].mlp(test_tensor)
-            hf_out = hf_model.transformer.h[layer_n].mlp(test_tensor)
+            # hf_out = hf_model.transformer.h[layer_n].mlp(test_tensor)
+            hf_out, router_logits = hf_model.model.layers[layer_n].block_sparse_moe(
+                test_tensor
+            )
 
+            print(f"test: {tl_out[:2, :2, :2]=}")
+            print(f"test: {hf_out[:2, :2, :2]=}")
+            print(f"test: {(tl_out - hf_out)[:5, :5, :5]=}")
+            print(f"test: {torch.sum(tl_out - hf_out)=}")
             assert torch.sum(tl_out == hf_out) == math.prod(tensor_shape)
 
-    def test_compare_huggingface_attention_match_local_implementation(self, model_name):
-        tl_model = HookedTransformer.from_pretrained_no_processing(model_name, device="cpu")
-        hf_model = AutoModelForCausalLM.from_pretrained(model_name, device_map="cpu")
-        batch, pos, d_model = 3, 5, tl_model.cfg.d_model
-        input = torch.randn(batch, pos, d_model)
-
-        for layer_n in range(len(tl_model.blocks)):
-            tl_out = tl_model.blocks[layer_n].attn(
-                query_input=input,
-                key_input=input,
-                value_input=input,
-                past_kv_cache_entry=None,
-                attention_mask=None,
-            )
-            hf_out, _ = hf_model.transformer.h[layer_n].attn(hidden_states=input)
-
-            assert torch.sum(tl_out == hf_out) == math.prod(tl_out.shape)
+    # def test_compare_huggingface_attention_match_local_implementation(self, model_name):
+    #     tl_model = HookedTransformer.from_pretrained_no_processing(
+    #         model_name, device="cpu"
+    #     )
+    #     hf_model = AutoModelForCausalLM.from_pretrained(model_name, device_map="cpu")
+    #     batch, pos, d_model = 3, 5, tl_model.cfg.d_model
+    #     input = torch.randn(batch, pos, d_model)
+    #
+    #     for layer_n in range(len(tl_model.blocks)):
+    #         tl_out = tl_model.blocks[layer_n].attn(
+    #             query_input=input,
+    #             key_input=input,
+    #             value_input=input,
+    #             past_kv_cache_entry=None,
+    #             attention_mask=None,
+    #         )
+    #         # hf_out, _ = hf_model.transformer.h[layer_n].attn(hidden_states=input)
+    #         hf_out, _, _ = hf_model.model.layers[layer_n].self_attn(hidden_states=input)
+    #
+    #         print(f"{tl_out[:2, :2, :2]=}")
+    #         print(f"{hf_out[:2, :2, :2]=}")
+    #         assert torch.sum(tl_out == hf_out) == math.prod(tl_out.shape)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -155,9 +155,7 @@ class HookedTransformer(HookedRootModule):
         else:
             # If no tokenizer name is provided, we assume we're training on an algorithmic task and
             # will pass in tokens directly. In this case, we don't need a tokenizer.
-            assert (
-                self.cfg.d_vocab != -1
-            ), "Must provide a tokenizer if d_vocab is not provided"
+            assert self.cfg.d_vocab != -1, "Must provide a tokenizer if d_vocab is not provided"
             self.tokenizer = None
             if default_padding_side != "right":
                 logging.warning(
@@ -175,10 +173,7 @@ class HookedTransformer(HookedRootModule):
             self.hook_tokens = HookPoint()  # [batch, pos]
 
         self.blocks = nn.ModuleList(
-            [
-                TransformerBlock(self.cfg, block_index)
-                for block_index in range(self.cfg.n_layers)
-            ]
+            [TransformerBlock(self.cfg, block_index) for block_index in range(self.cfg.n_layers)]
         )
 
         if self.cfg.normalization_type == "RMS":
@@ -200,9 +195,7 @@ class HookedTransformer(HookedRootModule):
             # If it's None, don't create either layer
             pass
         else:
-            logging.warning(
-                "Invalid normalization_type passed in %s", self.cfg.normalization_type
-            )
+            logging.warning("Invalid normalization_type passed in %s", self.cfg.normalization_type)
         self.unembed = Unembed(self.cfg)
 
         if self.cfg.init_weights:
@@ -253,9 +246,7 @@ class HookedTransformer(HookedRootModule):
         self,
         input: Union[str, List[str], Int[torch.Tensor, "batch pos"]],
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[
-            Union[Literal["left", "right"], None]
-        ] = USE_DEFAULT_VALUE,
+        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
     ) -> Tuple[
         Float[torch.Tensor, "batch pos d_model"],  # residual
@@ -283,9 +274,7 @@ class HookedTransformer(HookedRootModule):
                 self.tokenizer is not None
             ), "Must provide a tokenizer if passing a string to the model"
             # This is only intended to support passing in a single string
-            tokens = self.to_tokens(
-                input, prepend_bos=prepend_bos, padding_side=padding_side
-            )
+            tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)
         else:
             tokens = input
         if len(tokens.shape) == 1:
@@ -294,18 +283,14 @@ class HookedTransformer(HookedRootModule):
         if tokens.device.type != self.cfg.device:
             tokens = tokens.to(devices.get_device_for_block_index(0, self.cfg))
 
-        if (
-            self.tokenizer and self.tokenizer.padding_side == "left"
-        ) or past_kv_cache is not None:
+        if (self.tokenizer and self.tokenizer.padding_side == "left") or past_kv_cache is not None:
             # If the padding side is left or we are using caching, we need to compute the attention
             # mask for the adjustment of absolute positional embeddings and attention masking so
             # that pad tokens are not attended.
 
             if prepend_bos is USE_DEFAULT_VALUE:
                 prepend_bos = self.cfg.default_prepend_bos
-            attention_mask = utils.get_attention_mask(
-                self.tokenizer, tokens, prepend_bos
-            )
+            attention_mask = utils.get_attention_mask(self.tokenizer, tokens, prepend_bos)
 
             if past_kv_cache is not None:
                 # past_kv_cache is not None, so we're doing caching.
@@ -378,18 +363,15 @@ class HookedTransformer(HookedRootModule):
         return_type: Literal["logits"],
         loss_per_token: bool = False,
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[
-            Union[Literal["left", "right"], None]
-        ] = USE_DEFAULT_VALUE,
+        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[
-            Float[torch.Tensor, "batch pos d_model"]
-        ] = None,
+        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
-    ) -> Loss: ...
+    ) -> Loss:
+        ...
 
     @overload
     def forward(
@@ -398,18 +380,15 @@ class HookedTransformer(HookedRootModule):
         return_type: Literal["loss"],
         loss_per_token: bool = False,
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[
-            Union[Literal["left", "right"], None]
-        ] = USE_DEFAULT_VALUE,
+        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[
-            Float[torch.Tensor, "batch pos d_model"]
-        ] = None,
+        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
-    ) -> Loss: ...
+    ) -> Loss:
+        ...
 
     @overload
     def forward(
@@ -418,18 +397,15 @@ class HookedTransformer(HookedRootModule):
         return_type: Literal["both"],
         loss_per_token: bool = False,
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[
-            Union[Literal["left", "right"], None]
-        ] = USE_DEFAULT_VALUE,
+        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[
-            Float[torch.Tensor, "batch pos d_model"]
-        ] = None,
+        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
-    ) -> Tuple[Float[torch.Tensor, "batch pos d_vocab"], Loss]: ...
+    ) -> Tuple[Float[torch.Tensor, "batch pos d_vocab"], Loss]:
+        ...
 
     @overload
     def forward(
@@ -438,18 +414,15 @@ class HookedTransformer(HookedRootModule):
         return_type: Literal[None],
         loss_per_token: bool = False,
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[
-            Union[Literal["left", "right"], None]
-        ] = USE_DEFAULT_VALUE,
+        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[
-            Float[torch.Tensor, "batch pos d_model"]
-        ] = None,
+        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     def forward(
         self,
@@ -465,9 +438,7 @@ class HookedTransformer(HookedRootModule):
         padding_side: Optional[Literal["left", "right"]] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[
-            Float[torch.Tensor, "batch pos d_model"]
-        ] = None,
+        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
@@ -579,9 +550,7 @@ class HookedTransformer(HookedRootModule):
                     residual,
                     # Cache contains a list of HookedTransformerKeyValueCache objects, one for each
                     # block
-                    past_kv_cache_entry=past_kv_cache[i]
-                    if past_kv_cache is not None
-                    else None,
+                    past_kv_cache_entry=past_kv_cache[i] if past_kv_cache is not None else None,
                     shortformer_pos_embed=shortformer_pos_embed,
                     attention_mask=attention_mask,
                 )  # [batch, pos, d_model]
@@ -628,12 +597,14 @@ class HookedTransformer(HookedRootModule):
     @overload
     def run_with_cache(
         self, *model_args, return_cache_object: Literal[True] = True, **kwargs
-    ) -> Tuple[Output, ActivationCache]: ...
+    ) -> Tuple[Output, ActivationCache]:
+        ...
 
     @overload
     def run_with_cache(
         self, *model_args, return_cache_object: Literal[False], **kwargs
-    ) -> Tuple[Output, Dict[str, torch.Tensor]]: ...
+    ) -> Tuple[Output, Dict[str, torch.Tensor]]:
+        ...
 
     def run_with_cache(
         self, *model_args, return_cache_object=True, remove_batch_dim=False, **kwargs
@@ -656,9 +627,7 @@ class HookedTransformer(HookedRootModule):
             *model_args, remove_batch_dim=remove_batch_dim, **kwargs
         )
         if return_cache_object:
-            cache = ActivationCache(
-                cache_dict, self, has_batch_dim=not remove_batch_dim
-            )
+            cache = ActivationCache(cache_dict, self, has_batch_dim=not remove_batch_dim)
             return out, cache
         else:
             return out, cache_dict
@@ -715,9 +684,7 @@ class HookedTransformer(HookedRootModule):
         self,
         input: Union[str, List[str]],
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[
-            Union[Literal["left", "right"], None]
-        ] = USE_DEFAULT_VALUE,
+        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
         move_to_device: bool = True,
         truncate: bool = True,
     ) -> Int[torch.Tensor, "batch pos"]:
@@ -753,18 +720,14 @@ class HookedTransformer(HookedRootModule):
         with utils.LocallyOverridenDefaults(
             self, prepend_bos=prepend_bos, padding_side=padding_side
         ):
-            assert (
-                self.tokenizer is not None
-            ), "Cannot use to_tokens without a tokenizer"
+            assert self.tokenizer is not None, "Cannot use to_tokens without a tokenizer"
             assert (
                 self.cfg.tokenizer_prepends_bos is not None
             ), "Set the tokenizer for the model by calling set_tokenizer"
 
             if self.cfg.default_prepend_bos and not self.cfg.tokenizer_prepends_bos:
                 # We want to prepend bos but the tokenizer doesn't automatically do it, so we add it manually
-                input = utils.get_input_with_manually_prepended_bos(
-                    self.tokenizer, input
-                )
+                input = utils.get_input_with_manually_prepended_bos(self.tokenizer, input)
 
             tokens = self.tokenizer(
                 input,
@@ -809,9 +772,7 @@ class HookedTransformer(HookedRootModule):
         # it's set, then tokenization is no longer invertible, and some tokens
         # with a bunch of whitespace get collapsed together
         if len(tokens.shape) == 2:
-            return self.tokenizer.batch_decode(
-                tokens, clean_up_tokenization_spaces=False
-            )
+            return self.tokenizer.batch_decode(tokens, clean_up_tokenization_spaces=False)
         elif len(tokens.shape) <= 1:
             return self.tokenizer.decode(tokens, clean_up_tokenization_spaces=False)
         else:
@@ -828,9 +789,7 @@ class HookedTransformer(HookedRootModule):
             list,
         ],
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[
-            Union[Literal["left", "right"], None]
-        ] = USE_DEFAULT_VALUE,
+        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
     ) -> Union[List[str], List[List[str]]]:
         """Map text, a list of text or tokens to a list of tokens as strings.
 
@@ -871,16 +830,14 @@ class HookedTransformer(HookedRootModule):
             if isinstance(input, list):
                 return list(
                     map(
-                        lambda tokens: self.to_str_tokens(
-                            tokens, prepend_bos, padding_side
-                        ),
+                        lambda tokens: self.to_str_tokens(tokens, prepend_bos, padding_side),
                         input,
                     )
                 )  # type: ignore
             elif isinstance(input, str):
-                tokens = self.to_tokens(
-                    input, prepend_bos=prepend_bos, padding_side=padding_side
-                )[0]
+                tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)[
+                    0
+                ]
                 # Gemma tokenizer expects a batch dimension
                 if "gemma" in self.tokenizer.name_or_path and tokens.ndim == 1:
                     tokens = tokens.unsqueeze(1)
@@ -904,9 +861,7 @@ class HookedTransformer(HookedRootModule):
                 ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
             else:
                 raise ValueError(f"Invalid input type to to_str_tokens: {type(input)}")
-            str_tokens = self.tokenizer.batch_decode(
-                tokens, clean_up_tokenization_spaces=False
-            )
+            str_tokens = self.tokenizer.batch_decode(tokens, clean_up_tokenization_spaces=False)
             return str_tokens
 
     def to_single_token(self, string):
@@ -931,14 +886,10 @@ class HookedTransformer(HookedRootModule):
     def get_token_position(
         self,
         single_token: Union[str, int],
-        input: Union[
-            str, Union[Float[torch.Tensor, "pos"], Float[torch.Tensor, "1 pos"]]
-        ],
+        input: Union[str, Union[Float[torch.Tensor, "pos"], Float[torch.Tensor, "1 pos"]]],
         mode="first",
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[
-            Union[Literal["left", "right"], None]
-        ] = USE_DEFAULT_VALUE,
+        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
     ):
         """Get the position of a single_token in a string or sequence of tokens.
 
@@ -969,9 +920,7 @@ class HookedTransformer(HookedRootModule):
         """
         if isinstance(input, str):
             # If the input is a string, convert to tensor
-            tokens = self.to_tokens(
-                input, prepend_bos=prepend_bos, padding_side=padding_side
-            )
+            tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)
         else:
             tokens = input
 
@@ -988,9 +937,7 @@ class HookedTransformer(HookedRootModule):
         elif isinstance(single_token, torch.Tensor):
             single_token = single_token.item()
 
-        indices = torch.arange(len(tokens), device=tokens.device)[
-            tokens == single_token
-        ]
+        indices = torch.arange(len(tokens), device=tokens.device)[tokens == single_token]
         assert len(indices) > 0, "The token does not occur in the prompt"
         if mode == "first":
             return indices[0].item()
@@ -1082,12 +1029,8 @@ class HookedTransformer(HookedRootModule):
             self.pos_embed.to(devices.get_device_for_block_index(0, self.cfg))
             self.hook_pos_embed.to(devices.get_device_for_block_index(0, self.cfg))
         if hasattr(self, "ln_final"):
-            self.ln_final.to(
-                devices.get_device_for_block_index(self.cfg.n_layers - 1, self.cfg)
-            )
-        self.unembed.to(
-            devices.get_device_for_block_index(self.cfg.n_layers - 1, self.cfg)
-        )
+            self.ln_final.to(devices.get_device_for_block_index(self.cfg.n_layers - 1, self.cfg))
+        self.unembed.to(devices.get_device_for_block_index(self.cfg.n_layers - 1, self.cfg))
         for i, block in enumerate(self.blocks):
             block.to(devices.get_device_for_block_index(i, self.cfg))
 
@@ -1259,8 +1202,7 @@ class HookedTransformer(HookedRootModule):
             quant_method = qc.get("quant_method", "")
             assert not load_in_8bit, "8-bit quantization is not supported"
             assert not (
-                load_in_4bit
-                and (version.parse(torch.__version__) < version.parse("2.1.1"))
+                load_in_4bit and (version.parse(torch.__version__) < version.parse("2.1.1"))
             ), "Quantization is only supported for torch versions >= 2.1.1"
             assert not (
                 load_in_4bit and ("llama" not in model_name.lower())
@@ -1284,9 +1226,7 @@ class HookedTransformer(HookedRootModule):
             (from_pretrained_kwargs.get("torch_dtype", None) == torch.float16)
             or dtype == torch.float16
         ) and device in ["cpu", None]:
-            logging.warning(
-                "float16 models may not work on CPU. Consider using a GPU or bfloat16."
-            )
+            logging.warning("float16 models may not work on CPU. Consider using a GPU or bfloat16.")
 
         # Get the model name used in HuggingFace, rather than the alias.
         official_model_name = loading.get_official_model_name(model_name)
@@ -1483,13 +1423,9 @@ class HookedTransformer(HookedRootModule):
         for name, param in self.named_parameters():
             if "W_" in name:
                 if dist_type == "uniform":
-                    init_kaiming_uniform_(
-                        param, gain=gain, nonlinearity="relu", mode="fan_in"
-                    )
+                    init_kaiming_uniform_(param, gain=gain, nonlinearity="relu", mode="fan_in")
                 elif dist_type == "normal":
-                    init_kaiming_normal_(
-                        param, gain=gain, nonlinearity="relu", mode="fan_in"
-                    )
+                    init_kaiming_normal_(param, gain=gain, nonlinearity="relu", mode="fan_in")
 
     def _init_weights_muP(self, dist_type="uniform"):
         """
@@ -1642,9 +1578,7 @@ class HookedTransformer(HookedRootModule):
             # the bias, we use the W_ matrix to map it to the hidden space of the layer, so we need
             # to sum along axis -2, which is the residual stream space axis.
             if fold_biases:
-                state_dict[f"blocks.{l}.attn.b_Q"] = state_dict[
-                    f"blocks.{l}.attn.b_Q"
-                ] + (
+                state_dict[f"blocks.{l}.attn.b_Q"] = state_dict[f"blocks.{l}.attn.b_Q"] + (
                     state_dict[f"blocks.{l}.attn.W_Q"]
                     * state_dict[f"blocks.{l}.ln1.b"][None, :, None]
                 ).sum(-2)
@@ -1653,18 +1587,21 @@ class HookedTransformer(HookedRootModule):
                 ] + (
                     state_dict[f"blocks.{l}.attn.{gqa}W_K"]
                     * state_dict[f"blocks.{l}.ln1.b"][None, :, None]
-                ).sum(-2)
+                ).sum(
+                    -2
+                )
                 state_dict[f"blocks.{l}.attn.{gqa}b_V"] = state_dict[
                     f"blocks.{l}.attn.{gqa}b_V"
                 ] + (
                     state_dict[f"blocks.{l}.attn.{gqa}W_V"]
                     * state_dict[f"blocks.{l}.ln1.b"][None, :, None]
-                ).sum(-2)
+                ).sum(
+                    -2
+                )
                 del state_dict[f"blocks.{l}.ln1.b"]
 
             state_dict[f"blocks.{l}.attn.W_Q"] = (
-                state_dict[f"blocks.{l}.attn.W_Q"]
-                * state_dict[f"blocks.{l}.ln1.w"][None, :, None]
+                state_dict[f"blocks.{l}.attn.W_Q"] * state_dict[f"blocks.{l}.ln1.w"][None, :, None]
             )
             state_dict[f"blocks.{l}.attn.{gqa}W_K"] = (
                 state_dict[f"blocks.{l}.attn.{gqa}W_K"]
@@ -1701,17 +1638,14 @@ class HookedTransformer(HookedRootModule):
             # Fold ln2 into MLP
             if not self.cfg.attn_only:
                 if fold_biases:
-                    state_dict[f"blocks.{l}.mlp.b_in"] = state_dict[
-                        f"blocks.{l}.mlp.b_in"
-                    ] + (
+                    state_dict[f"blocks.{l}.mlp.b_in"] = state_dict[f"blocks.{l}.mlp.b_in"] + (
                         state_dict[f"blocks.{l}.mlp.W_in"]
                         * state_dict[f"blocks.{l}.ln2.b"][:, None]
                     ).sum(-2)
                     del state_dict[f"blocks.{l}.ln2.b"]
 
                 state_dict[f"blocks.{l}.mlp.W_in"] = (
-                    state_dict[f"blocks.{l}.mlp.W_in"]
-                    * state_dict[f"blocks.{l}.ln2.w"][:, None]
+                    state_dict[f"blocks.{l}.mlp.W_in"] * state_dict[f"blocks.{l}.ln2.w"][:, None]
                 )
 
                 if self.cfg.gated_mlp:
@@ -1739,7 +1673,9 @@ class HookedTransformer(HookedRootModule):
                         ] + (
                             state_dict[f"blocks.{l}.mlp.W_out"]
                             * state_dict[f"blocks.{l}.mlp.ln.b"][:, None]
-                        ).sum(-2)
+                        ).sum(
+                            -2
+                        )
 
                         del state_dict[f"blocks.{l}.mlp.ln.b"]
 
@@ -1767,9 +1703,7 @@ class HookedTransformer(HookedRootModule):
             ).sum(dim=-2)
             del state_dict[f"ln_final.b"]
 
-        state_dict[f"unembed.W_U"] = (
-            state_dict[f"unembed.W_U"] * state_dict[f"ln_final.w"][:, None]
-        )
+        state_dict[f"unembed.W_U"] = state_dict[f"unembed.W_U"] * state_dict[f"ln_final.w"][:, None]
         del state_dict[f"ln_final.w"]
 
         if center_weights:
@@ -1787,30 +1721,28 @@ class HookedTransformer(HookedRootModule):
         W_out. This is done by subtracting the mean of the weights from the weights themselves. This
         is done in-place. See fold_layer_norm for more details.
         """
-        state_dict["embed.W_E"] = state_dict["embed.W_E"] - state_dict[
-            "embed.W_E"
-        ].mean(-1, keepdim=True)
+        state_dict["embed.W_E"] = state_dict["embed.W_E"] - state_dict["embed.W_E"].mean(
+            -1, keepdim=True
+        )
         if self.cfg.positional_embedding_type != "rotary":
             state_dict["pos_embed.W_pos"] = state_dict["pos_embed.W_pos"] - state_dict[
                 "pos_embed.W_pos"
             ].mean(-1, keepdim=True)
         for l in range(self.cfg.n_layers):
-            state_dict[f"blocks.{l}.attn.W_O"] = state_dict[
+            state_dict[f"blocks.{l}.attn.W_O"] = state_dict[f"blocks.{l}.attn.W_O"] - state_dict[
                 f"blocks.{l}.attn.W_O"
-            ] - state_dict[f"blocks.{l}.attn.W_O"].mean(
+            ].mean(
                 -1, keepdim=True
             )  # W_O is [head_index, d_model, d_head]
             state_dict[f"blocks.{l}.attn.b_O"] = (
-                state_dict[f"blocks.{l}.attn.b_O"]
-                - state_dict[f"blocks.{l}.attn.b_O"].mean()
+                state_dict[f"blocks.{l}.attn.b_O"] - state_dict[f"blocks.{l}.attn.b_O"].mean()
             )  # b_O is [d_model]
             if not self.cfg.attn_only:
                 state_dict[f"blocks.{l}.mlp.W_out"] = state_dict[
                     f"blocks.{l}.mlp.W_out"
                 ] - state_dict[f"blocks.{l}.mlp.W_out"].mean(-1, keepdim=True)
                 state_dict[f"blocks.{l}.mlp.b_out"] = (
-                    state_dict[f"blocks.{l}.mlp.b_out"]
-                    - state_dict[f"blocks.{l}.mlp.b_out"].mean()
+                    state_dict[f"blocks.{l}.mlp.b_out"] - state_dict[f"blocks.{l}.mlp.b_out"].mean()
                 )
         return state_dict
 
@@ -1823,12 +1755,10 @@ class HookedTransformer(HookedRootModule):
         how components contribute to the logits, we'll be less misled by components that just add
         something to every logit.
         """
-        state_dict["unembed.W_U"] = state_dict["unembed.W_U"] - state_dict[
-            "unembed.W_U"
-        ].mean(-1, keepdim=True)
-        state_dict["unembed.b_U"] = (
-            state_dict["unembed.b_U"] - state_dict["unembed.b_U"].mean()
+        state_dict["unembed.W_U"] = state_dict["unembed.W_U"] - state_dict["unembed.W_U"].mean(
+            -1, keepdim=True
         )
+        state_dict["unembed.b_U"] = state_dict["unembed.b_U"] - state_dict["unembed.b_U"].mean()
         return state_dict
 
     def fold_value_biases(self, state_dict: Dict[str, torch.Tensor]):
@@ -2105,9 +2035,7 @@ class HookedTransformer(HookedRootModule):
                 assert (
                     self.tokenizer is not None
                 ), "Must provide a tokenizer if passing a string to the model"
-                tokens = self.to_tokens(
-                    input, prepend_bos=prepend_bos, padding_side=padding_side
-                )
+                tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)
             else:
                 tokens = input
 
@@ -2133,11 +2061,12 @@ class HookedTransformer(HookedRootModule):
             assert self.tokenizer is not None
             if stop_at_eos:
                 tokenizer_has_eos_token = (
-                    self.tokenizer is not None
-                    and self.tokenizer.eos_token_id is not None
+                    self.tokenizer is not None and self.tokenizer.eos_token_id is not None
                 )
                 if eos_token_id is None:
-                    assert tokenizer_has_eos_token, "Must pass a eos_token_id if stop_at_eos is True and tokenizer is None or has no eos_token_id"
+                    assert (
+                        tokenizer_has_eos_token
+                    ), "Must pass a eos_token_id if stop_at_eos is True and tokenizer is None or has no eos_token_id"
 
                     eos_token_id = self.tokenizer.eos_token_id
 
@@ -2148,15 +2077,11 @@ class HookedTransformer(HookedRootModule):
                     # eos_token_id is a Sequence (e.g. list or tuple)
                     stop_tokens = eos_token_id
                     eos_token_for_padding = (
-                        self.tokenizer.eos_token_id
-                        if tokenizer_has_eos_token
-                        else eos_token_id[0]
+                        self.tokenizer.eos_token_id if tokenizer_has_eos_token else eos_token_id[0]
                     )
 
             # An array to track which sequences in the batch have finished.
-            finished_sequences = torch.zeros(
-                batch_size, dtype=torch.bool, device=self.cfg.device
-            )
+            finished_sequences = torch.zeros(batch_size, dtype=torch.bool, device=self.cfg.device)
 
             # Currently nothing in HookedTransformer changes with eval, but this is here in case
             # that changes in the future.
@@ -2383,9 +2308,7 @@ class HookedTransformer(HookedRootModule):
             if include_mlp_biases:
                 accumulated_bias += self.blocks[i].mlp.b_out
         if mlp_input:
-            assert (
-                layer < self.cfg.n_layers
-            ), "Cannot include attn_bias from beyond the final layer"
+            assert layer < self.cfg.n_layers, "Cannot include attn_bias from beyond the final layer"
             accumulated_bias += self.blocks[layer].attn.b_O
         return accumulated_bias
 
@@ -2419,20 +2342,14 @@ class HookedTransformer(HookedRootModule):
         # layer than the left head.
         mask = (
             torch.arange(self.cfg.n_layers, device=self.cfg.device)[:, None, None, None]
-            < torch.arange(self.cfg.n_layers, device=self.cfg.device)[
-                None, None, :, None
-            ]
+            < torch.arange(self.cfg.n_layers, device=self.cfg.device)[None, None, :, None]
         )
         scores = torch.where(mask, scores, torch.zeros_like(scores))
         return scores
 
     def all_head_labels(self):
         """Returns a list of all head names in the model."""
-        return [
-            f"L{l}H{h}"
-            for l in range(self.cfg.n_layers)
-            for h in range(self.cfg.n_heads)
-        ]
+        return [f"L{l}H{h}" for l in range(self.cfg.n_layers) for h in range(self.cfg.n_heads)]
 
     def load_sample_training_dataset(self, **kwargs):
         """Load Sample Training Dataset.

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1649,7 +1649,6 @@ class HookedTransformer(HookedRootModule):
                 )
 
                 if self.cfg.gated_mlp:
-                    print("folding in ln to W_gate")
                     state_dict[f"blocks.{l}.mlp.W_gate"] = (
                         state_dict[f"blocks.{l}.mlp.W_gate"]
                         * state_dict[f"blocks.{l}.ln2.w"][:, None]

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -155,7 +155,9 @@ class HookedTransformer(HookedRootModule):
         else:
             # If no tokenizer name is provided, we assume we're training on an algorithmic task and
             # will pass in tokens directly. In this case, we don't need a tokenizer.
-            assert self.cfg.d_vocab != -1, "Must provide a tokenizer if d_vocab is not provided"
+            assert (
+                self.cfg.d_vocab != -1
+            ), "Must provide a tokenizer if d_vocab is not provided"
             self.tokenizer = None
             if default_padding_side != "right":
                 logging.warning(
@@ -173,7 +175,10 @@ class HookedTransformer(HookedRootModule):
             self.hook_tokens = HookPoint()  # [batch, pos]
 
         self.blocks = nn.ModuleList(
-            [TransformerBlock(self.cfg, block_index) for block_index in range(self.cfg.n_layers)]
+            [
+                TransformerBlock(self.cfg, block_index)
+                for block_index in range(self.cfg.n_layers)
+            ]
         )
 
         if self.cfg.normalization_type == "RMS":
@@ -195,7 +200,9 @@ class HookedTransformer(HookedRootModule):
             # If it's None, don't create either layer
             pass
         else:
-            logging.warning("Invalid normalization_type passed in %s", self.cfg.normalization_type)
+            logging.warning(
+                "Invalid normalization_type passed in %s", self.cfg.normalization_type
+            )
         self.unembed = Unembed(self.cfg)
 
         if self.cfg.init_weights:
@@ -246,7 +253,9 @@ class HookedTransformer(HookedRootModule):
         self,
         input: Union[str, List[str], Int[torch.Tensor, "batch pos"]],
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
+        padding_side: Optional[
+            Union[Literal["left", "right"], None]
+        ] = USE_DEFAULT_VALUE,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
     ) -> Tuple[
         Float[torch.Tensor, "batch pos d_model"],  # residual
@@ -274,7 +283,9 @@ class HookedTransformer(HookedRootModule):
                 self.tokenizer is not None
             ), "Must provide a tokenizer if passing a string to the model"
             # This is only intended to support passing in a single string
-            tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)
+            tokens = self.to_tokens(
+                input, prepend_bos=prepend_bos, padding_side=padding_side
+            )
         else:
             tokens = input
         if len(tokens.shape) == 1:
@@ -283,14 +294,18 @@ class HookedTransformer(HookedRootModule):
         if tokens.device.type != self.cfg.device:
             tokens = tokens.to(devices.get_device_for_block_index(0, self.cfg))
 
-        if (self.tokenizer and self.tokenizer.padding_side == "left") or past_kv_cache is not None:
+        if (
+            self.tokenizer and self.tokenizer.padding_side == "left"
+        ) or past_kv_cache is not None:
             # If the padding side is left or we are using caching, we need to compute the attention
             # mask for the adjustment of absolute positional embeddings and attention masking so
             # that pad tokens are not attended.
 
             if prepend_bos is USE_DEFAULT_VALUE:
                 prepend_bos = self.cfg.default_prepend_bos
-            attention_mask = utils.get_attention_mask(self.tokenizer, tokens, prepend_bos)
+            attention_mask = utils.get_attention_mask(
+                self.tokenizer, tokens, prepend_bos
+            )
 
             if past_kv_cache is not None:
                 # past_kv_cache is not None, so we're doing caching.
@@ -363,15 +378,18 @@ class HookedTransformer(HookedRootModule):
         return_type: Literal["logits"],
         loss_per_token: bool = False,
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
+        padding_side: Optional[
+            Union[Literal["left", "right"], None]
+        ] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
+        shortformer_pos_embed: Optional[
+            Float[torch.Tensor, "batch pos d_model"]
+        ] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
-    ) -> Loss:
-        ...
+    ) -> Loss: ...
 
     @overload
     def forward(
@@ -380,15 +398,18 @@ class HookedTransformer(HookedRootModule):
         return_type: Literal["loss"],
         loss_per_token: bool = False,
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
+        padding_side: Optional[
+            Union[Literal["left", "right"], None]
+        ] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
+        shortformer_pos_embed: Optional[
+            Float[torch.Tensor, "batch pos d_model"]
+        ] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
-    ) -> Loss:
-        ...
+    ) -> Loss: ...
 
     @overload
     def forward(
@@ -397,15 +418,18 @@ class HookedTransformer(HookedRootModule):
         return_type: Literal["both"],
         loss_per_token: bool = False,
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
+        padding_side: Optional[
+            Union[Literal["left", "right"], None]
+        ] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
+        shortformer_pos_embed: Optional[
+            Float[torch.Tensor, "batch pos d_model"]
+        ] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
-    ) -> Tuple[Float[torch.Tensor, "batch pos d_vocab"], Loss]:
-        ...
+    ) -> Tuple[Float[torch.Tensor, "batch pos d_vocab"], Loss]: ...
 
     @overload
     def forward(
@@ -414,15 +438,18 @@ class HookedTransformer(HookedRootModule):
         return_type: Literal[None],
         loss_per_token: bool = False,
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
+        padding_side: Optional[
+            Union[Literal["left", "right"], None]
+        ] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
+        shortformer_pos_embed: Optional[
+            Float[torch.Tensor, "batch pos d_model"]
+        ] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     def forward(
         self,
@@ -438,7 +465,9 @@ class HookedTransformer(HookedRootModule):
         padding_side: Optional[Literal["left", "right"]] = USE_DEFAULT_VALUE,
         start_at_layer: Optional[int] = None,
         tokens: Optional[Int[torch.Tensor, "batch pos"]] = None,
-        shortformer_pos_embed: Optional[Float[torch.Tensor, "batch pos d_model"]] = None,
+        shortformer_pos_embed: Optional[
+            Float[torch.Tensor, "batch pos d_model"]
+        ] = None,
         attention_mask: Optional[torch.Tensor] = None,  # [batch pos]
         stop_at_layer: Optional[int] = None,
         past_kv_cache: Optional[HookedTransformerKeyValueCache] = None,
@@ -550,7 +579,9 @@ class HookedTransformer(HookedRootModule):
                     residual,
                     # Cache contains a list of HookedTransformerKeyValueCache objects, one for each
                     # block
-                    past_kv_cache_entry=past_kv_cache[i] if past_kv_cache is not None else None,
+                    past_kv_cache_entry=past_kv_cache[i]
+                    if past_kv_cache is not None
+                    else None,
                     shortformer_pos_embed=shortformer_pos_embed,
                     attention_mask=attention_mask,
                 )  # [batch, pos, d_model]
@@ -597,14 +628,12 @@ class HookedTransformer(HookedRootModule):
     @overload
     def run_with_cache(
         self, *model_args, return_cache_object: Literal[True] = True, **kwargs
-    ) -> Tuple[Output, ActivationCache]:
-        ...
+    ) -> Tuple[Output, ActivationCache]: ...
 
     @overload
     def run_with_cache(
         self, *model_args, return_cache_object: Literal[False], **kwargs
-    ) -> Tuple[Output, Dict[str, torch.Tensor]]:
-        ...
+    ) -> Tuple[Output, Dict[str, torch.Tensor]]: ...
 
     def run_with_cache(
         self, *model_args, return_cache_object=True, remove_batch_dim=False, **kwargs
@@ -627,7 +656,9 @@ class HookedTransformer(HookedRootModule):
             *model_args, remove_batch_dim=remove_batch_dim, **kwargs
         )
         if return_cache_object:
-            cache = ActivationCache(cache_dict, self, has_batch_dim=not remove_batch_dim)
+            cache = ActivationCache(
+                cache_dict, self, has_batch_dim=not remove_batch_dim
+            )
             return out, cache
         else:
             return out, cache_dict
@@ -684,7 +715,9 @@ class HookedTransformer(HookedRootModule):
         self,
         input: Union[str, List[str]],
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
+        padding_side: Optional[
+            Union[Literal["left", "right"], None]
+        ] = USE_DEFAULT_VALUE,
         move_to_device: bool = True,
         truncate: bool = True,
     ) -> Int[torch.Tensor, "batch pos"]:
@@ -720,14 +753,18 @@ class HookedTransformer(HookedRootModule):
         with utils.LocallyOverridenDefaults(
             self, prepend_bos=prepend_bos, padding_side=padding_side
         ):
-            assert self.tokenizer is not None, "Cannot use to_tokens without a tokenizer"
+            assert (
+                self.tokenizer is not None
+            ), "Cannot use to_tokens without a tokenizer"
             assert (
                 self.cfg.tokenizer_prepends_bos is not None
             ), "Set the tokenizer for the model by calling set_tokenizer"
 
             if self.cfg.default_prepend_bos and not self.cfg.tokenizer_prepends_bos:
                 # We want to prepend bos but the tokenizer doesn't automatically do it, so we add it manually
-                input = utils.get_input_with_manually_prepended_bos(self.tokenizer, input)
+                input = utils.get_input_with_manually_prepended_bos(
+                    self.tokenizer, input
+                )
 
             tokens = self.tokenizer(
                 input,
@@ -772,7 +809,9 @@ class HookedTransformer(HookedRootModule):
         # it's set, then tokenization is no longer invertible, and some tokens
         # with a bunch of whitespace get collapsed together
         if len(tokens.shape) == 2:
-            return self.tokenizer.batch_decode(tokens, clean_up_tokenization_spaces=False)
+            return self.tokenizer.batch_decode(
+                tokens, clean_up_tokenization_spaces=False
+            )
         elif len(tokens.shape) <= 1:
             return self.tokenizer.decode(tokens, clean_up_tokenization_spaces=False)
         else:
@@ -789,7 +828,9 @@ class HookedTransformer(HookedRootModule):
             list,
         ],
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
+        padding_side: Optional[
+            Union[Literal["left", "right"], None]
+        ] = USE_DEFAULT_VALUE,
     ) -> Union[List[str], List[List[str]]]:
         """Map text, a list of text or tokens to a list of tokens as strings.
 
@@ -830,14 +871,16 @@ class HookedTransformer(HookedRootModule):
             if isinstance(input, list):
                 return list(
                     map(
-                        lambda tokens: self.to_str_tokens(tokens, prepend_bos, padding_side),
+                        lambda tokens: self.to_str_tokens(
+                            tokens, prepend_bos, padding_side
+                        ),
                         input,
                     )
                 )  # type: ignore
             elif isinstance(input, str):
-                tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)[
-                    0
-                ]
+                tokens = self.to_tokens(
+                    input, prepend_bos=prepend_bos, padding_side=padding_side
+                )[0]
                 # Gemma tokenizer expects a batch dimension
                 if "gemma" in self.tokenizer.name_or_path and tokens.ndim == 1:
                     tokens = tokens.unsqueeze(1)
@@ -861,7 +904,9 @@ class HookedTransformer(HookedRootModule):
                 ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
             else:
                 raise ValueError(f"Invalid input type to to_str_tokens: {type(input)}")
-            str_tokens = self.tokenizer.batch_decode(tokens, clean_up_tokenization_spaces=False)
+            str_tokens = self.tokenizer.batch_decode(
+                tokens, clean_up_tokenization_spaces=False
+            )
             return str_tokens
 
     def to_single_token(self, string):
@@ -886,10 +931,14 @@ class HookedTransformer(HookedRootModule):
     def get_token_position(
         self,
         single_token: Union[str, int],
-        input: Union[str, Union[Float[torch.Tensor, "pos"], Float[torch.Tensor, "1 pos"]]],
+        input: Union[
+            str, Union[Float[torch.Tensor, "pos"], Float[torch.Tensor, "1 pos"]]
+        ],
         mode="first",
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[Union[Literal["left", "right"], None]] = USE_DEFAULT_VALUE,
+        padding_side: Optional[
+            Union[Literal["left", "right"], None]
+        ] = USE_DEFAULT_VALUE,
     ):
         """Get the position of a single_token in a string or sequence of tokens.
 
@@ -920,7 +969,9 @@ class HookedTransformer(HookedRootModule):
         """
         if isinstance(input, str):
             # If the input is a string, convert to tensor
-            tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)
+            tokens = self.to_tokens(
+                input, prepend_bos=prepend_bos, padding_side=padding_side
+            )
         else:
             tokens = input
 
@@ -937,7 +988,9 @@ class HookedTransformer(HookedRootModule):
         elif isinstance(single_token, torch.Tensor):
             single_token = single_token.item()
 
-        indices = torch.arange(len(tokens), device=tokens.device)[tokens == single_token]
+        indices = torch.arange(len(tokens), device=tokens.device)[
+            tokens == single_token
+        ]
         assert len(indices) > 0, "The token does not occur in the prompt"
         if mode == "first":
             return indices[0].item()
@@ -1029,8 +1082,12 @@ class HookedTransformer(HookedRootModule):
             self.pos_embed.to(devices.get_device_for_block_index(0, self.cfg))
             self.hook_pos_embed.to(devices.get_device_for_block_index(0, self.cfg))
         if hasattr(self, "ln_final"):
-            self.ln_final.to(devices.get_device_for_block_index(self.cfg.n_layers - 1, self.cfg))
-        self.unembed.to(devices.get_device_for_block_index(self.cfg.n_layers - 1, self.cfg))
+            self.ln_final.to(
+                devices.get_device_for_block_index(self.cfg.n_layers - 1, self.cfg)
+            )
+        self.unembed.to(
+            devices.get_device_for_block_index(self.cfg.n_layers - 1, self.cfg)
+        )
         for i, block in enumerate(self.blocks):
             block.to(devices.get_device_for_block_index(i, self.cfg))
 
@@ -1202,7 +1259,8 @@ class HookedTransformer(HookedRootModule):
             quant_method = qc.get("quant_method", "")
             assert not load_in_8bit, "8-bit quantization is not supported"
             assert not (
-                load_in_4bit and (version.parse(torch.__version__) < version.parse("2.1.1"))
+                load_in_4bit
+                and (version.parse(torch.__version__) < version.parse("2.1.1"))
             ), "Quantization is only supported for torch versions >= 2.1.1"
             assert not (
                 load_in_4bit and ("llama" not in model_name.lower())
@@ -1226,7 +1284,9 @@ class HookedTransformer(HookedRootModule):
             (from_pretrained_kwargs.get("torch_dtype", None) == torch.float16)
             or dtype == torch.float16
         ) and device in ["cpu", None]:
-            logging.warning("float16 models may not work on CPU. Consider using a GPU or bfloat16.")
+            logging.warning(
+                "float16 models may not work on CPU. Consider using a GPU or bfloat16."
+            )
 
         # Get the model name used in HuggingFace, rather than the alias.
         official_model_name = loading.get_official_model_name(model_name)
@@ -1423,9 +1483,13 @@ class HookedTransformer(HookedRootModule):
         for name, param in self.named_parameters():
             if "W_" in name:
                 if dist_type == "uniform":
-                    init_kaiming_uniform_(param, gain=gain, nonlinearity="relu", mode="fan_in")
+                    init_kaiming_uniform_(
+                        param, gain=gain, nonlinearity="relu", mode="fan_in"
+                    )
                 elif dist_type == "normal":
-                    init_kaiming_normal_(param, gain=gain, nonlinearity="relu", mode="fan_in")
+                    init_kaiming_normal_(
+                        param, gain=gain, nonlinearity="relu", mode="fan_in"
+                    )
 
     def _init_weights_muP(self, dist_type="uniform"):
         """
@@ -1578,7 +1642,9 @@ class HookedTransformer(HookedRootModule):
             # the bias, we use the W_ matrix to map it to the hidden space of the layer, so we need
             # to sum along axis -2, which is the residual stream space axis.
             if fold_biases:
-                state_dict[f"blocks.{l}.attn.b_Q"] = state_dict[f"blocks.{l}.attn.b_Q"] + (
+                state_dict[f"blocks.{l}.attn.b_Q"] = state_dict[
+                    f"blocks.{l}.attn.b_Q"
+                ] + (
                     state_dict[f"blocks.{l}.attn.W_Q"]
                     * state_dict[f"blocks.{l}.ln1.b"][None, :, None]
                 ).sum(-2)
@@ -1587,21 +1653,18 @@ class HookedTransformer(HookedRootModule):
                 ] + (
                     state_dict[f"blocks.{l}.attn.{gqa}W_K"]
                     * state_dict[f"blocks.{l}.ln1.b"][None, :, None]
-                ).sum(
-                    -2
-                )
+                ).sum(-2)
                 state_dict[f"blocks.{l}.attn.{gqa}b_V"] = state_dict[
                     f"blocks.{l}.attn.{gqa}b_V"
                 ] + (
                     state_dict[f"blocks.{l}.attn.{gqa}W_V"]
                     * state_dict[f"blocks.{l}.ln1.b"][None, :, None]
-                ).sum(
-                    -2
-                )
+                ).sum(-2)
                 del state_dict[f"blocks.{l}.ln1.b"]
 
             state_dict[f"blocks.{l}.attn.W_Q"] = (
-                state_dict[f"blocks.{l}.attn.W_Q"] * state_dict[f"blocks.{l}.ln1.w"][None, :, None]
+                state_dict[f"blocks.{l}.attn.W_Q"]
+                * state_dict[f"blocks.{l}.ln1.w"][None, :, None]
             )
             state_dict[f"blocks.{l}.attn.{gqa}W_K"] = (
                 state_dict[f"blocks.{l}.attn.{gqa}W_K"]
@@ -1638,17 +1701,21 @@ class HookedTransformer(HookedRootModule):
             # Fold ln2 into MLP
             if not self.cfg.attn_only:
                 if fold_biases:
-                    state_dict[f"blocks.{l}.mlp.b_in"] = state_dict[f"blocks.{l}.mlp.b_in"] + (
+                    state_dict[f"blocks.{l}.mlp.b_in"] = state_dict[
+                        f"blocks.{l}.mlp.b_in"
+                    ] + (
                         state_dict[f"blocks.{l}.mlp.W_in"]
                         * state_dict[f"blocks.{l}.ln2.b"][:, None]
                     ).sum(-2)
                     del state_dict[f"blocks.{l}.ln2.b"]
 
                 state_dict[f"blocks.{l}.mlp.W_in"] = (
-                    state_dict[f"blocks.{l}.mlp.W_in"] * state_dict[f"blocks.{l}.ln2.w"][:, None]
+                    state_dict[f"blocks.{l}.mlp.W_in"]
+                    * state_dict[f"blocks.{l}.ln2.w"][:, None]
                 )
 
                 if self.cfg.gated_mlp:
+                    print("folding in ln to W_gate")
                     state_dict[f"blocks.{l}.mlp.W_gate"] = (
                         state_dict[f"blocks.{l}.mlp.W_gate"]
                         * state_dict[f"blocks.{l}.ln2.w"][:, None]
@@ -1672,9 +1739,7 @@ class HookedTransformer(HookedRootModule):
                         ] + (
                             state_dict[f"blocks.{l}.mlp.W_out"]
                             * state_dict[f"blocks.{l}.mlp.ln.b"][:, None]
-                        ).sum(
-                            -2
-                        )
+                        ).sum(-2)
 
                         del state_dict[f"blocks.{l}.mlp.ln.b"]
 
@@ -1702,7 +1767,9 @@ class HookedTransformer(HookedRootModule):
             ).sum(dim=-2)
             del state_dict[f"ln_final.b"]
 
-        state_dict[f"unembed.W_U"] = state_dict[f"unembed.W_U"] * state_dict[f"ln_final.w"][:, None]
+        state_dict[f"unembed.W_U"] = (
+            state_dict[f"unembed.W_U"] * state_dict[f"ln_final.w"][:, None]
+        )
         del state_dict[f"ln_final.w"]
 
         if center_weights:
@@ -1720,28 +1787,30 @@ class HookedTransformer(HookedRootModule):
         W_out. This is done by subtracting the mean of the weights from the weights themselves. This
         is done in-place. See fold_layer_norm for more details.
         """
-        state_dict["embed.W_E"] = state_dict["embed.W_E"] - state_dict["embed.W_E"].mean(
-            -1, keepdim=True
-        )
+        state_dict["embed.W_E"] = state_dict["embed.W_E"] - state_dict[
+            "embed.W_E"
+        ].mean(-1, keepdim=True)
         if self.cfg.positional_embedding_type != "rotary":
             state_dict["pos_embed.W_pos"] = state_dict["pos_embed.W_pos"] - state_dict[
                 "pos_embed.W_pos"
             ].mean(-1, keepdim=True)
         for l in range(self.cfg.n_layers):
-            state_dict[f"blocks.{l}.attn.W_O"] = state_dict[f"blocks.{l}.attn.W_O"] - state_dict[
+            state_dict[f"blocks.{l}.attn.W_O"] = state_dict[
                 f"blocks.{l}.attn.W_O"
-            ].mean(
+            ] - state_dict[f"blocks.{l}.attn.W_O"].mean(
                 -1, keepdim=True
             )  # W_O is [head_index, d_model, d_head]
             state_dict[f"blocks.{l}.attn.b_O"] = (
-                state_dict[f"blocks.{l}.attn.b_O"] - state_dict[f"blocks.{l}.attn.b_O"].mean()
+                state_dict[f"blocks.{l}.attn.b_O"]
+                - state_dict[f"blocks.{l}.attn.b_O"].mean()
             )  # b_O is [d_model]
             if not self.cfg.attn_only:
                 state_dict[f"blocks.{l}.mlp.W_out"] = state_dict[
                     f"blocks.{l}.mlp.W_out"
                 ] - state_dict[f"blocks.{l}.mlp.W_out"].mean(-1, keepdim=True)
                 state_dict[f"blocks.{l}.mlp.b_out"] = (
-                    state_dict[f"blocks.{l}.mlp.b_out"] - state_dict[f"blocks.{l}.mlp.b_out"].mean()
+                    state_dict[f"blocks.{l}.mlp.b_out"]
+                    - state_dict[f"blocks.{l}.mlp.b_out"].mean()
                 )
         return state_dict
 
@@ -1754,10 +1823,12 @@ class HookedTransformer(HookedRootModule):
         how components contribute to the logits, we'll be less misled by components that just add
         something to every logit.
         """
-        state_dict["unembed.W_U"] = state_dict["unembed.W_U"] - state_dict["unembed.W_U"].mean(
-            -1, keepdim=True
+        state_dict["unembed.W_U"] = state_dict["unembed.W_U"] - state_dict[
+            "unembed.W_U"
+        ].mean(-1, keepdim=True)
+        state_dict["unembed.b_U"] = (
+            state_dict["unembed.b_U"] - state_dict["unembed.b_U"].mean()
         )
-        state_dict["unembed.b_U"] = state_dict["unembed.b_U"] - state_dict["unembed.b_U"].mean()
         return state_dict
 
     def fold_value_biases(self, state_dict: Dict[str, torch.Tensor]):
@@ -2034,7 +2105,9 @@ class HookedTransformer(HookedRootModule):
                 assert (
                     self.tokenizer is not None
                 ), "Must provide a tokenizer if passing a string to the model"
-                tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)
+                tokens = self.to_tokens(
+                    input, prepend_bos=prepend_bos, padding_side=padding_side
+                )
             else:
                 tokens = input
 
@@ -2060,12 +2133,11 @@ class HookedTransformer(HookedRootModule):
             assert self.tokenizer is not None
             if stop_at_eos:
                 tokenizer_has_eos_token = (
-                    self.tokenizer is not None and self.tokenizer.eos_token_id is not None
+                    self.tokenizer is not None
+                    and self.tokenizer.eos_token_id is not None
                 )
                 if eos_token_id is None:
-                    assert (
-                        tokenizer_has_eos_token
-                    ), "Must pass a eos_token_id if stop_at_eos is True and tokenizer is None or has no eos_token_id"
+                    assert tokenizer_has_eos_token, "Must pass a eos_token_id if stop_at_eos is True and tokenizer is None or has no eos_token_id"
 
                     eos_token_id = self.tokenizer.eos_token_id
 
@@ -2076,11 +2148,15 @@ class HookedTransformer(HookedRootModule):
                     # eos_token_id is a Sequence (e.g. list or tuple)
                     stop_tokens = eos_token_id
                     eos_token_for_padding = (
-                        self.tokenizer.eos_token_id if tokenizer_has_eos_token else eos_token_id[0]
+                        self.tokenizer.eos_token_id
+                        if tokenizer_has_eos_token
+                        else eos_token_id[0]
                     )
 
             # An array to track which sequences in the batch have finished.
-            finished_sequences = torch.zeros(batch_size, dtype=torch.bool, device=self.cfg.device)
+            finished_sequences = torch.zeros(
+                batch_size, dtype=torch.bool, device=self.cfg.device
+            )
 
             # Currently nothing in HookedTransformer changes with eval, but this is here in case
             # that changes in the future.
@@ -2307,7 +2383,9 @@ class HookedTransformer(HookedRootModule):
             if include_mlp_biases:
                 accumulated_bias += self.blocks[i].mlp.b_out
         if mlp_input:
-            assert layer < self.cfg.n_layers, "Cannot include attn_bias from beyond the final layer"
+            assert (
+                layer < self.cfg.n_layers
+            ), "Cannot include attn_bias from beyond the final layer"
             accumulated_bias += self.blocks[layer].attn.b_O
         return accumulated_bias
 
@@ -2341,14 +2419,20 @@ class HookedTransformer(HookedRootModule):
         # layer than the left head.
         mask = (
             torch.arange(self.cfg.n_layers, device=self.cfg.device)[:, None, None, None]
-            < torch.arange(self.cfg.n_layers, device=self.cfg.device)[None, None, :, None]
+            < torch.arange(self.cfg.n_layers, device=self.cfg.device)[
+                None, None, :, None
+            ]
         )
         scores = torch.where(mask, scores, torch.zeros_like(scores))
         return scores
 
     def all_head_labels(self):
         """Returns a list of all head names in the model."""
-        return [f"L{l}H{h}" for l in range(self.cfg.n_layers) for h in range(self.cfg.n_heads)]
+        return [
+            f"L{l}H{h}"
+            for l in range(self.cfg.n_layers)
+            for h in range(self.cfg.n_heads)
+        ]
 
     def load_sample_training_dataset(self, **kwargs):
         """Load Sample Training Dataset.

--- a/transformer_lens/components/gated_mlp.py
+++ b/transformer_lens/components/gated_mlp.py
@@ -46,24 +46,18 @@ class GatedMLP(nn.Module):
 
         if self.cfg.load_in_4bit:
             nq = int((self.cfg.d_model * self.cfg.d_mlp) / 2)
-            self.W_in = Params4bit(
-                torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False
-            )
-            self.W_gate = Params4bit(
-                torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False
-            )
-            self.W_out = Params4bit(
-                torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False
-            )
+            self.W_in = Params4bit(torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False)
+            self.W_gate = Params4bit(torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False)
+            self.W_out = Params4bit(torch.empty(nq, 1, dtype=torch.uint8), requires_grad=False)
         else:
             self.W_in = nn.Parameter(
-                torch.empty(self.cfg.d_model, self.cfg.d_mlp, dtype=self.cfg.dtype)
+                torch.empty(self.cfg.d_mlp, self.cfg.d_model, dtype=self.cfg.dtype)
             )
             self.W_gate = nn.Parameter(
-                torch.empty(self.cfg.d_model, self.cfg.d_mlp, dtype=self.cfg.dtype)
+                torch.empty(self.cfg.d_mlp, self.cfg.d_model, dtype=self.cfg.dtype)
             )
             self.W_out = nn.Parameter(
-                torch.empty(self.cfg.d_mlp, self.cfg.d_model, dtype=self.cfg.dtype)
+                torch.empty(self.cfg.d_model, self.cfg.d_mlp, dtype=self.cfg.dtype)
             )
 
         self.b_in = nn.Parameter(torch.zeros(self.cfg.d_mlp, dtype=self.cfg.dtype))
@@ -104,9 +98,7 @@ class GatedMLP(nn.Module):
         # Technically, all these einsums could be done with a single matmul, but this is more readable.
         if self.cfg.load_in_4bit:
             pre_act = self.hook_pre(
-                bnb.matmul_4bit(
-                    x, self.W_gate.t(), bias=None, quant_state=self.W_gate.quant_state
-                )
+                bnb.matmul_4bit(x, self.W_gate.t(), bias=None, quant_state=self.W_gate.quant_state)
             )
         else:
             pre_act = self.hook_pre(
@@ -120,9 +112,7 @@ class GatedMLP(nn.Module):
         if self.cfg.act_fn is not None and not self.cfg.act_fn.endswith("_ln"):
             if self.cfg.load_in_4bit:
                 pre_linear = self.hook_pre_linear(
-                    bnb.matmul_4bit(
-                        x, self.W_in.t(), bias=None, quant_state=self.W_in.quant_state
-                    )
+                    bnb.matmul_4bit(x, self.W_in.t(), bias=None, quant_state=self.W_in.quant_state)
                 )
             else:
                 pre_linear = self.hook_pre_linear(

--- a/transformer_lens/components/gated_mlp.py
+++ b/transformer_lens/components/gated_mlp.py
@@ -130,8 +130,6 @@ class GatedMLP(nn.Module):
             mid_act = self.hook_mid(self.act_fn(pre_act))  # [batch, pos, d_mlp]
             post_act = self.hook_post(self.ln(mid_act))
 
-        # print(f"tl: {post_act[:2, :2, :2]=}")
-
         if self.cfg.load_in_4bit:
             return bnb.matmul_4bit(
                 post_act, self.W_out.t(), bias=None, quant_state=self.W_out.quant_state

--- a/transformer_lens/components/moe.py
+++ b/transformer_lens/components/moe.py
@@ -3,12 +3,13 @@ from typing import Dict, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from fancy_einsum import einsum
 from jaxtyping import Float
 
 from transformer_lens.components import MLP, GatedMLP
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
+
+global_cache = {}
 
 
 class MoE(nn.Module):
@@ -50,6 +51,8 @@ class MoE(nn.Module):
         router_logits = router_logits.view(
             x.shape[0] * x.shape[1], self.cfg.num_experts
         )
+        print("tl")
+        print("router_logits", str(router_logits[0, 0].item()))
         routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
 
         routing_weights, expert_indices = torch.topk(
@@ -57,9 +60,8 @@ class MoE(nn.Module):
         )
         routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
         routing_weights = routing_weights.to(x.dtype)
-        routing_weights = self.hook_expert_weights(
-            routing_weights
-        )  # F.softmax(weights, dim=-1))
+        print("routing_weights", str(routing_weights[0, 0].item()))
+        routing_weights = self.hook_expert_weights(routing_weights)
         expert_indices = self.hook_expert_indices(expert_indices)
         expert_mask = F.one_hot(
             expert_indices, num_classes=self.cfg.num_experts
@@ -71,16 +73,46 @@ class MoE(nn.Module):
         hidden_states = x.view(-1, self.cfg.d_model)
         for i, expert_mlp in enumerate(self.experts):
             # find the batch, pos, and expert indices which use this expert
+            print(f"{i=}")
+
+            if i == 0:
+                print(
+                    "W_gate",
+                    str(expert_mlp.W_gate[0, 0].item()),
+                    expert_mlp.W_gate.dtype,
+                )
+                print("W_in", str(expert_mlp.W_in[0, 0].item()), expert_mlp.W_in.dtype)
+                print(
+                    "W_out", str(expert_mlp.W_out[0, 0].item()), expert_mlp.W_out.dtype
+                )
             idx, top_x = torch.where(expert_mask[i])
+            if top_x.shape[0] == 0:
+                continue
 
             current_state = hidden_states[None, top_x].reshape(-1, self.cfg.d_model)
+            print("current_state", str(current_state[0, 0].item()))  # Exact
 
-            expert_hidden_state = expert_mlp.act_fn(
-                F.linear(current_state, expert_mlp.W_gate.T)
-            ) * F.linear(current_state, expert_mlp.W_in.T)
+            expert_gate = F.linear(current_state, expert_mlp.W_gate.T)
+            global_cache["hidden_states"] = current_state
+            global_cache["w1"] = expert_mlp.W_gate.T
+            global_cache["expert_gate"] = expert_gate
+            print("expert_gate", str(expert_gate[0, 0].item()))
+            expert_gate_act = expert_mlp.act_fn(expert_gate)
+            print("expert_gate_act", str(expert_gate_act[0, 0].item()))
+            expert_in = F.linear(current_state, expert_mlp.W_in.T)
+            global_cache["w3"] = expert_mlp.W_in.T
+            global_cache["expert_in"] = expert_in
+            print("expert_in", str(expert_in[0, 0].item()))
+            expert_hidden_state = expert_gate_act * expert_in
+            print("expert_hidden_state", str(expert_hidden_state[0, 0].item()))
             expert_output = F.linear(expert_hidden_state, expert_mlp.W_out.T)
 
             current_hidden_states = expert_output * routing_weights[top_x, idx, None]
+            print("expert_output", str(expert_output[0, 0].item()))  # XXX
+            print(
+                "routing_weight", str(routing_weights[top_x, idx, None][0, 0].item())
+            )  # Exact
+            print("current_hidden_states", str(current_hidden_states[0, 0].item()))
 
             results.index_add_(0, top_x, current_hidden_states.to(x.dtype))
 

--- a/transformer_lens/components/moe.py
+++ b/transformer_lens/components/moe.py
@@ -9,8 +9,6 @@ from transformer_lens.components import MLP, GatedMLP
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
 
-global_cache = {}
-
 
 class MoE(nn.Module):
     def __init__(self, cfg: Union[Dict, HookedTransformerConfig]):
@@ -45,14 +43,11 @@ class MoE(nn.Module):
     ) -> Float[torch.Tensor, "batch pos d_model"]:
         router_logits = F.linear(x, self.W_gate.T)
         router_logits = router_logits.view(x.shape[0] * x.shape[1], self.cfg.num_experts)
-        print("tl")
-        print("router_logits", str(router_logits[0, 0].item()))
         routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
 
         routing_weights, expert_indices = torch.topk(routing_weights, self.experts_per_token)
         routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
         routing_weights = routing_weights.to(x.dtype)
-        print("routing_weights", str(routing_weights[0, 0].item()))
         routing_weights = self.hook_expert_weights(routing_weights)
         expert_indices = self.hook_expert_indices(expert_indices)
         expert_mask = F.one_hot(expert_indices, num_classes=self.cfg.num_experts).permute(2, 1, 0)
@@ -60,43 +55,19 @@ class MoE(nn.Module):
         results = torch.zeros(x.shape[0] * x.shape[1], self.cfg.d_model, device=x.device)
         hidden_states = x.view(-1, self.cfg.d_model)
         for i, expert_mlp in enumerate(self.experts):
-            # find the batch, pos, and expert indices which use this expert
-            print(f"{i=}")
-
-            if i == 0:
-                print(
-                    "W_gate",
-                    str(expert_mlp.W_gate[0, 0].item()),
-                    expert_mlp.W_gate.dtype,
-                )
-                print("W_in", str(expert_mlp.W_in[0, 0].item()), expert_mlp.W_in.dtype)
-                print("W_out", str(expert_mlp.W_out[0, 0].item()), expert_mlp.W_out.dtype)
             idx, top_x = torch.where(expert_mask[i])
             if top_x.shape[0] == 0:
                 continue
 
             current_state = hidden_states[None, top_x].reshape(-1, self.cfg.d_model)
-            print("current_state", str(current_state[0, 0].item()))  # Exact
 
             expert_gate = F.linear(current_state, expert_mlp.W_gate)
-            global_cache["hidden_states"] = current_state
-            global_cache["w1"] = expert_mlp.W_gate
-            global_cache["expert_gate"] = expert_gate
-            print("expert_gate", str(expert_gate[0, 0].item()))
             expert_gate_act = expert_mlp.act_fn(expert_gate)
-            print("expert_gate_act", str(expert_gate_act[0, 0].item()))
             expert_in = F.linear(current_state, expert_mlp.W_in)
-            global_cache["w3"] = expert_mlp.W_in
-            global_cache["expert_in"] = expert_in
-            print("expert_in", str(expert_in[0, 0].item()))
             expert_hidden_state = expert_gate_act * expert_in
-            print("expert_hidden_state", str(expert_hidden_state[0, 0].item()))
             expert_output = F.linear(expert_hidden_state, expert_mlp.W_out)
 
             current_hidden_states = expert_output * routing_weights[top_x, idx, None]
-            print("expert_output", str(expert_output[0, 0].item()))  # XXX
-            print("routing_weight", str(routing_weights[top_x, idx, None][0, 0].item()))  # Exact
-            print("current_hidden_states", str(current_hidden_states[0, 0].item()))
 
             results.index_add_(0, top_x, current_hidden_states.to(x.dtype))
 

--- a/transformer_lens/components/moe.py
+++ b/transformer_lens/components/moe.py
@@ -18,12 +18,8 @@ class MoE(nn.Module):
         self.cfg = HookedTransformerConfig.unwrap(cfg)
 
         # Ensure that num_experts and experts_per_token are specified and non-zero
-        assert (
-            self.cfg.num_experts is not None
-        ), "num_experts must be specified for MoE layer"
-        assert (
-            self.cfg.experts_per_token
-        ), "experts_per_token must be specified for MoE layer"
+        assert self.cfg.num_experts is not None, "num_experts must be specified for MoE layer"
+        assert self.cfg.experts_per_token, "experts_per_token must be specified for MoE layer"
         self.experts_per_token: int = self.cfg.experts_per_token
         assert (
             self.cfg.experts_per_token <= self.cfg.num_experts
@@ -48,28 +44,20 @@ class MoE(nn.Module):
         self, x: Float[torch.Tensor, "batch pos d_model"]
     ) -> Float[torch.Tensor, "batch pos d_model"]:
         router_logits = F.linear(x, self.W_gate.T)
-        router_logits = router_logits.view(
-            x.shape[0] * x.shape[1], self.cfg.num_experts
-        )
+        router_logits = router_logits.view(x.shape[0] * x.shape[1], self.cfg.num_experts)
         print("tl")
         print("router_logits", str(router_logits[0, 0].item()))
         routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
 
-        routing_weights, expert_indices = torch.topk(
-            routing_weights, self.experts_per_token
-        )
+        routing_weights, expert_indices = torch.topk(routing_weights, self.experts_per_token)
         routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
         routing_weights = routing_weights.to(x.dtype)
         print("routing_weights", str(routing_weights[0, 0].item()))
         routing_weights = self.hook_expert_weights(routing_weights)
         expert_indices = self.hook_expert_indices(expert_indices)
-        expert_mask = F.one_hot(
-            expert_indices, num_classes=self.cfg.num_experts
-        ).permute(2, 1, 0)
+        expert_mask = F.one_hot(expert_indices, num_classes=self.cfg.num_experts).permute(2, 1, 0)
 
-        results = torch.zeros(
-            x.shape[0] * x.shape[1], self.cfg.d_model, device=x.device
-        )
+        results = torch.zeros(x.shape[0] * x.shape[1], self.cfg.d_model, device=x.device)
         hidden_states = x.view(-1, self.cfg.d_model)
         for i, expert_mlp in enumerate(self.experts):
             # find the batch, pos, and expert indices which use this expert
@@ -82,9 +70,7 @@ class MoE(nn.Module):
                     expert_mlp.W_gate.dtype,
                 )
                 print("W_in", str(expert_mlp.W_in[0, 0].item()), expert_mlp.W_in.dtype)
-                print(
-                    "W_out", str(expert_mlp.W_out[0, 0].item()), expert_mlp.W_out.dtype
-                )
+                print("W_out", str(expert_mlp.W_out[0, 0].item()), expert_mlp.W_out.dtype)
             idx, top_x = torch.where(expert_mask[i])
             if top_x.shape[0] == 0:
                 continue
@@ -92,26 +78,24 @@ class MoE(nn.Module):
             current_state = hidden_states[None, top_x].reshape(-1, self.cfg.d_model)
             print("current_state", str(current_state[0, 0].item()))  # Exact
 
-            expert_gate = F.linear(current_state, expert_mlp.W_gate.T)
+            expert_gate = F.linear(current_state, expert_mlp.W_gate)
             global_cache["hidden_states"] = current_state
-            global_cache["w1"] = expert_mlp.W_gate.T
+            global_cache["w1"] = expert_mlp.W_gate
             global_cache["expert_gate"] = expert_gate
             print("expert_gate", str(expert_gate[0, 0].item()))
             expert_gate_act = expert_mlp.act_fn(expert_gate)
             print("expert_gate_act", str(expert_gate_act[0, 0].item()))
-            expert_in = F.linear(current_state, expert_mlp.W_in.T)
-            global_cache["w3"] = expert_mlp.W_in.T
+            expert_in = F.linear(current_state, expert_mlp.W_in)
+            global_cache["w3"] = expert_mlp.W_in
             global_cache["expert_in"] = expert_in
             print("expert_in", str(expert_in[0, 0].item()))
             expert_hidden_state = expert_gate_act * expert_in
             print("expert_hidden_state", str(expert_hidden_state[0, 0].item()))
-            expert_output = F.linear(expert_hidden_state, expert_mlp.W_out.T)
+            expert_output = F.linear(expert_hidden_state, expert_mlp.W_out)
 
             current_hidden_states = expert_output * routing_weights[top_x, idx, None]
             print("expert_output", str(expert_output[0, 0].item()))  # XXX
-            print(
-                "routing_weight", str(routing_weights[top_x, idx, None][0, 0].item())
-            )  # Exact
+            print("routing_weight", str(routing_weights[top_x, idx, None][0, 0].item()))  # Exact
             print("current_hidden_states", str(current_hidden_states[0, 0].item()))
 
             results.index_add_(0, top_x, current_hidden_states.to(x.dtype))

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -175,6 +175,7 @@ OFFICIAL_MODEL_NAMES = [
     "mistralai/Mistral-7B-Instruct-v0.1",
     "mistralai/Mixtral-8x7B-v0.1",
     "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "joelb/Mixtral-8x7B-1l",
     "bigscience/bloom-560m",
     "bigscience/bloom-1b1",
     "bigscience/bloom-1b7",
@@ -710,6 +711,8 @@ def convert_hf_model_config(model_name: str, **kwargs):
             **kwargs,
         )
         architecture = hf_config.architectures[0]
+        if official_model_name == "joelb/Mixtral-8x7B-1l":
+            architecture = "MixtralForCausalLM"
 
     if official_model_name.startswith(
         ("llama-7b", "meta-llama/Llama-2-7b")

--- a/transformer_lens/pretrained/weight_conversions/mixtral.py
+++ b/transformer_lens/pretrained/weight_conversions/mixtral.py
@@ -56,14 +56,14 @@ def convert_mixtral_weights(mixtral, cfg: HookedTransformerConfig):
         # See https://github.com/mistralai/mistral-inference/blob/8598cf582091a596671be31990448e0620017851/mistral/model.py#L128 for reference
         for e in range(cfg.num_experts):
             state_dict[f"blocks.{l}.mlp.experts.{e}.W_in"] = (
-                mixtral.model.layers[l].block_sparse_moe.experts[e].w3.weight.T
+                mixtral.model.layers[l].block_sparse_moe.experts[e].w3.weight
             )
             state_dict[f"blocks.{l}.mlp.experts.{e}.W_gate"] = (
-                mixtral.model.layers[l].block_sparse_moe.experts[e].w1.weight.T
+                mixtral.model.layers[l].block_sparse_moe.experts[e].w1.weight
             )
             state_dict[f"blocks.{l}.mlp.experts.{e}.b_in"] = torch.zeros(cfg.d_mlp, dtype=cfg.dtype)
             state_dict[f"blocks.{l}.mlp.experts.{e}.W_out"] = (
-                mixtral.model.layers[l].block_sparse_moe.experts[e].w2.weight.T
+                mixtral.model.layers[l].block_sparse_moe.experts[e].w2.weight
             )
             state_dict[f"blocks.{l}.mlp.experts.{e}.b_out"] = torch.zeros(
                 cfg.d_model, dtype=cfg.dtype


### PR DESCRIPTION
# Description

This PR is a demonstration / for discussion. I've extended the existing `test_match_huggingface` test, adding a Mixtral test. As implemented, I'm sure this breaks other things, but this PR is really just intended more as a proof-of-concept and a demonstration of an unexpected difficulty making it work ((2) below).

A few things of note:
1. GPT2 and Mixtral don't use the same names in `transformers` so I had to remove GPT2 from the test. (See the commented out `hf_out` lines). This is easily fixed by not parametrizing the test but probably leads to some duplicated code.
2. I had to change `W_in`, `W_gate`, and `W_out` to be the transpose of how they were previously represented. See https://stackoverflow.com/q/78745180/383958 for reasoning.
3. I had to rewrite most of `forward` to get tests to pass. I think there was an actual difference in logic compared to Mixtral but I'm not entirely sure.
4. The test uses a model I made (see [script demonstrating](https://gist.github.com/joelburget/81ce38c42264655bf8b2fcfa2497a239) how), which just contains the first layer of Mixtral-7B. This makes it possible to actually run the test on a laptop.

## Type of change

Testing / discussion. This is a follow-up to #570 / #641.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility