### PR TITLE
Changed fold_value_biases method to be able to handle multi-gpu. 

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1773,45 +1773,44 @@ class HookedTransformer(HookedRootModule):
         return state_dict
 
     def fold_value_biases(self, state_dict: Dict[str, torch.Tensor]):
-     """Fold the value biases into the output bias.
+        """Fold the value biases into the output bias.
 
-    Because attention patterns add up to 1, the value biases always have a constant effect on a
-    head's output. Further, as the outputs of each head in a layer add together, each head's
-    value bias has a constant effect on the *layer's* output, which can make it harder to
-    interpret the effect of any given head, and it doesn't matter which head a bias is
-    associated with. We can factor this all into a single output bias to the layer, and make it
-    easier to interpret the head's output. Formally, we take b_O_new = b_O_original +
-    sum_head(b_V_head @ W_O_head).
-     """
-     for layer in range(self.cfg.n_layers):
-        # Determine the device
-        device = state_dict[f"blocks.{layer}.attn.W_O"].device
+        Because attention patterns add up to 1, the value biases always have a constant effect on a
+        head's output. Further, as the outputs of each head in a layer add together, each head's
+        value bias has a constant effect on the *layer's* output, which can make it harder to
+        interpret the effect of any given head, and it doesn't matter which head a bias is
+        associated with. We can factor this all into a single output bias to the layer, and make it
+        easier to interpret the head's output. Formally, we take b_O_new = b_O_original +
+        sum_head(b_V_head @ W_O_head).
+        """
+        for layer in range(self.cfg.n_layers):
+            # Determine the device
+            device = state_dict[f"blocks.{layer}.attn.W_O"].device
 
-        # shape [head_index, d_head]
-        if self.cfg.n_key_value_heads is None:
-            b_V = state_dict[f"blocks.{layer}.attn.b_V"].to(device)
-        else:
-            b_V = state_dict[f"blocks.{layer}.attn._b_V"].to(device)
-            b_V = torch.repeat_interleave(
-                b_V, dim=0, repeats=self.cfg.n_heads // self.cfg.n_key_value_heads
-            )
+            # shape [head_index, d_head]
+            if self.cfg.n_key_value_heads is None:
+                b_V = state_dict[f"blocks.{layer}.attn.b_V"].to(device)
+            else:
+                b_V = state_dict[f"blocks.{layer}.attn._b_V"].to(device)
+                b_V = torch.repeat_interleave(
+                    b_V, dim=0, repeats=self.cfg.n_heads // self.cfg.n_key_value_heads
+                )
 
-        # [head_index, d_head, d_model]
-        W_O = state_dict[f"blocks.{layer}.attn.W_O"].to(device)
-        
-        # [d_model]
-        b_O_original = state_dict[f"blocks.{layer}.attn.b_O"].to(device)
-        folded_b_O = b_O_original + (b_V[:, :, None] * W_O).sum([0, 1])
+            # [head_index, d_head, d_model]
+            W_O = state_dict[f"blocks.{layer}.attn.W_O"].to(device)
 
-        state_dict[f"blocks.{layer}.attn.b_O"] = folded_b_O
-        if self.cfg.n_key_value_heads is None:
-            state_dict[f"blocks.{layer}.attn.b_V"] = torch.zeros_like(b_V)
-        else:
-            state_dict[f"blocks.{layer}.attn._b_V"] = torch.zeros_like(
-                state_dict[f"blocks.{layer}.attn._b_V"]
-            )
-     return state_dict
+            # [d_model]
+            b_O_original = state_dict[f"blocks.{layer}.attn.b_O"].to(device)
+            folded_b_O = b_O_original + (b_V[:, :, None] * W_O).sum([0, 1])
 
+            state_dict[f"blocks.{layer}.attn.b_O"] = folded_b_O
+            if self.cfg.n_key_value_heads is None:
+                state_dict[f"blocks.{layer}.attn.b_V"] = torch.zeros_like(b_V)
+            else:
+                state_dict[f"blocks.{layer}.attn._b_V"] = torch.zeros_like(
+                    state_dict[f"blocks.{layer}.attn._b_V"]
+                )
+        return state_dict
 
     def refactor_factored_attn_matrices(self, state_dict: Dict[str, torch.Tensor]):
         """Experimental method for managing queries, keys and values.


### PR DESCRIPTION
Changed fold_value_biases method to be able to handle multi-gpu. Send all layers to same device.

<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

When using hooked transformer in this way: 
model = HookedTransformer.from_pretrained("microsoft/Phi-3-mini-4k-instruct",cache_dir="/mnt/hdd1",device_map="auto")
I got an error saying:
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 an│
d cpu! See image below refering to the fold_value_biases method.
![Screenshot from 2024-08-07 13-07-23](https://github.com/user-attachments/assets/7aadfa4a-4bb5-45b0-8add-37399cbae943)
I thereafter changed the method so that all layers are on the same device. See below.
Before change:
![Screenshot from 2024-08-07 13-09-07](https://github.com/user-attachments/assets/8d0602ac-6ba4-4535-b706-038037c7739e)
And after change:
![Screenshot from 2024-08-07 13-10-26](https://github.com/user-attachments/assets/ba97070a-82fc-42c4-83d8-6990331e52eb)

And loading the model with device_map="auto" works after this but please double check that it works for more general cases that you can foresee. Thanks!

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x ] I have commented my code, particularly in hard-to-understand areas
- [ -] I have made corresponding changes to the documentation
- [ -] My changes generate no new warnings
- [ -] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->