### PR TITLE
Ungrouping GQA

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1937,11 +1937,11 @@ class HookedTransformer(HookedRootModule):
         """
         self.cfg.use_attn_in = use_attn_in
 
-    def set_ungroup_gqa(self, ungroup_gqa: bool):
+    def set_ungroup_grouped_query_attention(self, ungroup_grouped_query_attention: bool):
         """
         Toggles whether to ungroup the grouped key and value heads in models with grouped query attention (GQA).
         """
-        self.cfg.ungroup_gqa = ungroup_gqa
+        self.cfg.ungroup_grouped_query_attention = ungroup_grouped_query_attention
 
     def process_weights_(
         self,

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1937,6 +1937,12 @@ class HookedTransformer(HookedRootModule):
         """
         self.cfg.use_attn_in = use_attn_in
 
+    def set_ungroup_gqa(self, ungroup_gqa: bool):
+        """
+        Toggles whether to ungroup the grouped key and value heads in models with grouped query attention (GQA).
+        """
+        self.cfg.ungroup_gqa = ungroup_gqa
+
     def process_weights_(
         self,
         fold_ln: bool = True,

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -243,6 +243,7 @@ class HookedTransformerConfig:
     use_normalization_before_and_after: bool = False
     attn_scores_soft_cap: float = -1.0
     output_logits_soft_cap: float = -1.0
+    ungroup_gqa: bool = False
 
     def __post_init__(self):
         if self.n_heads == -1:

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -246,7 +246,6 @@ class HookedTransformerConfig:
     use_normalization_before_and_after: bool = False
     attn_scores_soft_cap: float = -1.0
     output_logits_soft_cap: float = -1.0
-    ungroup_gqa: bool = False
 
     def __post_init__(self):
         if self.n_heads == -1:

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -54,6 +54,8 @@ class HookedTransformerConfig:
             attention head separately, with a hook. Defaults to false to save memory
         use_attn_scale (bool): whether to scale the attention weights by
             1/sqrt(d_head)
+        ungroup_gqa (bool): whether to ungroup key and value heads, for models that use
+            grouped query attention.
         attn_scale (float): The amount to divide attention scores by (if applicable). Defaults to
             sqrt(d_head)
         model_name (str): the name of the model, used to load
@@ -199,6 +201,7 @@ class HookedTransformerConfig:
     use_hook_mlp_in: bool = False
     use_attn_in: bool = False
     use_local_attn: bool = False
+    ungroup_gqa: bool = False
     original_architecture: Optional[str] = None
     from_checkpoint: bool = False
     checkpoint_index: Optional[int] = None
@@ -243,7 +246,6 @@ class HookedTransformerConfig:
     use_normalization_before_and_after: bool = False
     attn_scores_soft_cap: float = -1.0
     output_logits_soft_cap: float = -1.0
-    ungroup_gqa: bool = False
 
     def __post_init__(self):
         if self.n_heads == -1:

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -54,7 +54,7 @@ class HookedTransformerConfig:
             attention head separately, with a hook. Defaults to false to save memory
         use_attn_scale (bool): whether to scale the attention weights by
             1/sqrt(d_head)
-        ungroup_gqa (bool): whether to ungroup key and value heads, for models that use
+        ungroup_grouped_query_attention (bool): whether to ungroup key and value heads, for models that use
             grouped query attention.
         attn_scale (float): The amount to divide attention scores by (if applicable). Defaults to
             sqrt(d_head)
@@ -201,7 +201,7 @@ class HookedTransformerConfig:
     use_hook_mlp_in: bool = False
     use_attn_in: bool = False
     use_local_attn: bool = False
-    ungroup_gqa: bool = False
+    ungroup_grouped_query_attention: bool = False
     original_architecture: Optional[str] = None
     from_checkpoint: bool = False
     checkpoint_index: Optional[int] = None

--- a/transformer_lens/components/grouped_query_attention.py
+++ b/transformer_lens/components/grouped_query_attention.py
@@ -126,11 +126,12 @@ class GroupedQueryAttention(AbstractAttention):
         q = self.hook_q(
             attn_fn(query_input, self.W_Q, self.b_Q)
         )  # [batch, pos, head_index, d_head]
+
         k = self.hook_k(
-            attn_fn(key_input, self._W_K, self._b_K)
+            attn_fn(key_input, self.W_K, self.b_K) if self.cfg.ungroup_gqa else attn_fn(key_input, self._W_K, self._b_K)
         )  # [batch, pos, head_index, d_head]
         v = self.hook_v(
-            attn_fn(value_input, self._W_V, self._b_V)
+            attn_fn(value_input, self.W_V, self.b_V) if self.cfg.ungroup_gqa else attn_fn(value_input, self._W_V, self._b_V)
         )  # [batch, pos, head_index, d_head]
         return q, k, v
 
@@ -149,7 +150,8 @@ class GroupedQueryAttention(AbstractAttention):
         Returns:
             Float[torch.Tensor, "batch head_index query_pos key_pos"]: The attention scores.
         """
-        k = torch.repeat_interleave(k, dim=2, repeats=self.repeat_kv_heads)
+        if not self.cfg.ungroup_gqa:
+            k = torch.repeat_interleave(k, dim=2, repeats=self.repeat_kv_heads)
         return super().calculate_attention_scores(q, k)
 
     def calculate_z_scores(
@@ -167,5 +169,6 @@ class GroupedQueryAttention(AbstractAttention):
         Returns:
             Float[torch.Tensor, "batch head_index query_pos key_pos"]: The z scores.
         """
-        v = torch.repeat_interleave(v, dim=2, repeats=self.repeat_kv_heads)
+        if not self.cfg.ungroup_gqa:
+            v = torch.repeat_interleave(v, dim=2, repeats=self.repeat_kv_heads)
         return super().calculate_z_scores(v, pattern)

--- a/transformer_lens/components/grouped_query_attention.py
+++ b/transformer_lens/components/grouped_query_attention.py
@@ -129,12 +129,12 @@ class GroupedQueryAttention(AbstractAttention):
 
         k = self.hook_k(
             attn_fn(key_input, self.W_K, self.b_K)
-            if self.cfg.ungroup_gqa
+            if self.cfg.ungroup_grouped_query_attention
             else attn_fn(key_input, self._W_K, self._b_K)
         )  # [batch, pos, head_index, d_head]
         v = self.hook_v(
             attn_fn(value_input, self.W_V, self.b_V)
-            if self.cfg.ungroup_gqa
+            if self.cfg.ungroup_grouped_query_attention
             else attn_fn(value_input, self._W_V, self._b_V)
         )  # [batch, pos, head_index, d_head]
         return q, k, v
@@ -154,7 +154,7 @@ class GroupedQueryAttention(AbstractAttention):
         Returns:
             Float[torch.Tensor, "batch head_index query_pos key_pos"]: The attention scores.
         """
-        if not self.cfg.ungroup_gqa:
+        if not self.cfg.ungroup_grouped_query_attention:
             k = torch.repeat_interleave(k, dim=2, repeats=self.repeat_kv_heads)
         return super().calculate_attention_scores(q, k)
 
@@ -173,6 +173,6 @@ class GroupedQueryAttention(AbstractAttention):
         Returns:
             Float[torch.Tensor, "batch head_index query_pos key_pos"]: The z scores.
         """
-        if not self.cfg.ungroup_gqa:
+        if not self.cfg.ungroup_grouped_query_attention:
             v = torch.repeat_interleave(v, dim=2, repeats=self.repeat_kv_heads)
         return super().calculate_z_scores(v, pattern)

--- a/transformer_lens/components/grouped_query_attention.py
+++ b/transformer_lens/components/grouped_query_attention.py
@@ -128,10 +128,14 @@ class GroupedQueryAttention(AbstractAttention):
         )  # [batch, pos, head_index, d_head]
 
         k = self.hook_k(
-            attn_fn(key_input, self.W_K, self.b_K) if self.cfg.ungroup_gqa else attn_fn(key_input, self._W_K, self._b_K)
+            attn_fn(key_input, self.W_K, self.b_K)
+            if self.cfg.ungroup_gqa
+            else attn_fn(key_input, self._W_K, self._b_K)
         )  # [batch, pos, head_index, d_head]
         v = self.hook_v(
-            attn_fn(value_input, self.W_V, self.b_V) if self.cfg.ungroup_gqa else attn_fn(value_input, self._W_V, self._b_V)
+            attn_fn(value_input, self.W_V, self.b_V)
+            if self.cfg.ungroup_gqa
+            else attn_fn(value_input, self._W_V, self._b_V)
         )  # [batch, pos, head_index, d_head]
         return q, k, v
 

--- a/transformer_lens/components/transformer_block.py
+++ b/transformer_lens/components/transformer_block.py
@@ -135,7 +135,8 @@ class TransformerBlock(nn.Module):
         if self.cfg.use_split_qkv_input:
             n_kv_heads = (
                 self.cfg.n_key_value_heads
-                if self.cfg.n_key_value_heads is not None and not self.cfg.ungroup_gqa
+                if self.cfg.n_key_value_heads is not None
+                and not self.cfg.ungroup_grouped_query_attention
                 else self.cfg.n_heads
             )
             query_input = self.hook_q_input(

--- a/transformer_lens/components/transformer_block.py
+++ b/transformer_lens/components/transformer_block.py
@@ -135,7 +135,7 @@ class TransformerBlock(nn.Module):
         if self.cfg.use_split_qkv_input:
             n_kv_heads = (
                 self.cfg.n_key_value_heads
-                if self.cfg.n_key_value_heads is not None
+                if self.cfg.n_key_value_heads is not None and not self.cfg.ungroup_gqa
                 else self.cfg.n_heads
             )
             query_input = self.hook_q_input(


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description
**Background**: Normal attention layers have $N$ attention heads, each with unique query/key/value weights. In contrast, GQA has $N$ unique sets of query weights but only $M<N$ unique sets of key/value weights; thus, some of the key/value weights are shared across heads, improving efficiency. Currently, this means that while the dimensionality of `hook_k_input` and `hook_v_input` is `(batch, pos, N, d_model)` for most models, it is `(batch, pos, M, d_model)` for GQA models. This is a bit annoying if we want to edit the k/v inputs to each attention head separately, even though their weights are shared.

**Proposal**:  I have added an option, `cfg.ungroup_gqa` (default: `False`), which causes the input to be fed into `hook_k_input` and `hook_v_input` as `(batch, pos, N, d_model)`, instead of only expanding to this size later, at `calculate_attention_scores`  or `calculate_z_scores`. This loses the benefits of GQA, but it nice for interp.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility