### PR TITLE
HookedTransformerConfig docs string: `weight_init_mode` => `init_mode`

### DIFF
--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -78,7 +78,7 @@ class HookedTransformerConfig:
             attention
         attn_types (List[str], *optional*): the types of attention to use for
             local attention
-        weight_init_mode (str): the initialization mode to use for the
+        init_mode (str): the initialization mode to use for the
             weights. Only relevant for custom models, ignored for pre-trained.
             We now support 'gpt2', 'xavier_uniform', 'xavier_normal', 'kaiming_uniform',
             'kaiming_normal'. MuP support to come. Defaults to 'gpt2'.
@@ -100,7 +100,7 @@ class HookedTransformerConfig:
             Used to set sources of randomness (Python, PyTorch and NumPy) and to initialize weights.
             Defaults to None. We recommend setting a seed, so your experiments are reproducible.
         initializer_range (float): The standard deviation of the normal used to
-            initialise the weights, initialized to 0.8 / sqrt(d_model). If weight_init_mode is
+            initialise the weights, initialized to 0.8 / sqrt(d_model). If init_mode is
             'xavier_uniform' or 'xavier_normal', this value is instead treated as the `gain` parameter for the weight
             initialisation (a constant factor to scale the weights by). Defaults to -1.0, which means not set.
         init_weights (bool): Whether to initialize the weights. Defaults to


### PR DESCRIPTION
It was never recently called `weight_init_mode`

# Description

Replace `weight_init_mode` with `init_mode` in the docstring of HookedTransformerConfig

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- ~I have added tests that prove my fix is effective or that my feature works~
- ~New and existing unit tests pass locally with my changes~
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
