### PR TITLE
Load state dict with assign to avoid OOMs

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1940,6 +1940,12 @@ class HookedTransformer(HookedRootModule):
         """
         self.cfg.use_attn_in = use_attn_in
 
+    def set_ungroup_grouped_query_attention(self, ungroup_grouped_query_attention: bool):
+        """
+        Toggles whether to ungroup the grouped key and value heads in models with grouped query attention (GQA).
+        """
+        self.cfg.ungroup_grouped_query_attention = ungroup_grouped_query_attention
+
     def process_weights_(
         self,
         fold_ln: bool = True,

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1570,7 +1570,7 @@ class HookedTransformer(HookedRootModule):
         if self.cfg.load_in_4bit or (version.parse(torch.__version__) >= version.parse("2.1.0")):
             # with quantization, parameters should be assigned
             # so that quantization settings are not lost
-            # Also, generally use `assign` if we're on a recent enough version, 
+            # Also, generally use `assign` if we're on a recent enough version,
             # to save memory.
             self.load_state_dict(state_dict, assign=True, strict=False)
         else:

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1516,7 +1516,7 @@ class HookedTransformer(HookedRootModule):
                 make it easier to interpret the head's output.
             refactor_factored_attn_matrices (bool, optional): Whether to convert the factored
                 matrices (W_Q & W_K, and W_O & W_V) to be "even". Defaults to False.
-            force_load_with_assign (bool, optional): Whether to load the state dict with 
+            force_load_with_assign (bool, optional): Whether to load the state dict with
                 `assign=True` if the torch version supports it. Can save on memory.
             model_name (str, optional): checks the model name for special cases of state dict
                 loading. Only used for Redwood 2L model currently.

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1567,9 +1567,11 @@ class HookedTransformer(HookedRootModule):
         if refactor_factored_attn_matrices:
             state_dict = self.refactor_factored_attn_matrices(state_dict)
 
-        if self.cfg.load_in_4bit:
+        if self.cfg.load_in_4bit or (version.parse(torch.__version__) >= version.parse("2.1.0")):
             # with quantization, parameters should be assigned
             # so that quantization settings are not lost
+            # Also, generally use `assign` if we're on a recent enough version, 
+            # to save memory.
             self.load_state_dict(state_dict, assign=True, strict=False)
         else:
             state_dict_keys = list(state_dict.keys())

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1060,6 +1060,7 @@ class HookedTransformer(HookedRootModule):
         center_writing_weights: bool = True,
         center_unembed: bool = True,
         refactor_factored_attn_matrices: bool = False,
+        force_load_with_assign: bool = False,
         checkpoint_index: Optional[int] = None,
         checkpoint_value: Optional[int] = None,
         hf_model: Optional[AutoModelForCausalLM] = None,
@@ -1151,6 +1152,8 @@ class HookedTransformer(HookedRootModule):
                 keepdim=True)``.
             refactor_factored_attn_matrices: Whether to convert the factored
                 matrices (W_Q & W_K, and W_O & W_V) to be "even". Defaults to False
+            force_load_with_assign: Whether to load the state dict with
+                `assign=True` if the torch version supports it. Can save on memory.
             checkpoint_index: If loading from a checkpoint, the index of
                 the checkpoint to load.
             checkpoint_value: If loading from a checkpoint, the value of
@@ -1315,6 +1318,7 @@ class HookedTransformer(HookedRootModule):
             center_unembed=center_unembed,
             fold_value_biases=fold_value_biases,
             refactor_factored_attn_matrices=refactor_factored_attn_matrices,
+            force_load_with_assign=force_load_with_assign,
         )
 
         if move_to_device:

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1060,7 +1060,6 @@ class HookedTransformer(HookedRootModule):
         center_writing_weights: bool = True,
         center_unembed: bool = True,
         refactor_factored_attn_matrices: bool = False,
-        force_load_with_assign: bool = False,
         checkpoint_index: Optional[int] = None,
         checkpoint_value: Optional[int] = None,
         hf_model: Optional[AutoModelForCausalLM] = None,
@@ -1152,8 +1151,6 @@ class HookedTransformer(HookedRootModule):
                 keepdim=True)``.
             refactor_factored_attn_matrices: Whether to convert the factored
                 matrices (W_Q & W_K, and W_O & W_V) to be "even". Defaults to False
-            force_load_with_assign: Whether to load the state dict with
-                `assign=True` if the torch version supports it. Can save on memory.
             checkpoint_index: If loading from a checkpoint, the index of
                 the checkpoint to load.
             checkpoint_value: If loading from a checkpoint, the value of
@@ -1318,7 +1315,6 @@ class HookedTransformer(HookedRootModule):
             center_unembed=center_unembed,
             fold_value_biases=fold_value_biases,
             refactor_factored_attn_matrices=refactor_factored_attn_matrices,
-            force_load_with_assign=force_load_with_assign,
         )
 
         if move_to_device:
@@ -1493,7 +1489,6 @@ class HookedTransformer(HookedRootModule):
         center_unembed: bool = True,
         fold_value_biases: bool = True,
         refactor_factored_attn_matrices: bool = False,
-        force_load_with_assign: bool = False,
     ):
         """Load & Process State Dict.
 
@@ -1520,8 +1515,6 @@ class HookedTransformer(HookedRootModule):
                 make it easier to interpret the head's output.
             refactor_factored_attn_matrices (bool, optional): Whether to convert the factored
                 matrices (W_Q & W_K, and W_O & W_V) to be "even". Defaults to False.
-            force_load_with_assign (bool, optional): Whether to load the state dict with
-                `assign=True` if the torch version supports it. Can save on memory.
             model_name (str, optional): checks the model name for special cases of state dict
                 loading. Only used for Redwood 2L model currently.
         """
@@ -1575,11 +1568,7 @@ class HookedTransformer(HookedRootModule):
         if refactor_factored_attn_matrices:
             state_dict = self.refactor_factored_attn_matrices(state_dict)
 
-        if self.cfg.load_in_4bit or (
-            # Allow users to force `assign` to save memory.
-            force_load_with_assign
-            and version.parse(torch.__version__) >= version.parse("2.1.0")
-        ):
+        if self.cfg.load_in_4bit or version.parse(torch.__version__) >= version.parse("2.1.0"):
             # with quantization, parameters should be assigned
             # so that quantization settings are not lost
             self.load_state_dict(state_dict, assign=True, strict=False)
@@ -2442,40 +2431,4 @@ class HookedTransformer(HookedRootModule):
         self,
         tokenize: bool = False,
         prepend_bos: Optional[Union[bool, None]] = USE_DEFAULT_VALUE,
-        padding_side: Optional[Literal["left", "right"]] = USE_DEFAULT_VALUE,
-    ) -> Union[str, Float[torch.Tensor, "1 pos"]]:
-        """Sample Data Point from Dataset.
-
-        Helper function to randomly sample a data point from self.dataset, a small dataset from the
-        data distribution the model was trained on.
-
-        Implicitly calls self.load_sample_training_dataset if it hasn't already been called. Only
-        works for pretrained models with an associated dataset. But you can manually replace
-        self.dataset with a dataset of your choice if you want.
-
-        Args:
-            tokenize (bool): Whether to return tokens (instead of text). Defaults to False. Note
-                that the returned tokens will be automatically truncated to the model's max context
-                size.
-            prepend_bos (bool, optional): Overrides self.cfg.default_prepend_bos. Whether to prepend
-                the BOS token to the input (applicable when input is a string). Defaults to None,
-                implying usage of self.cfg.default_prepend_bos (default is True unless specified
-                otherwise). Pass True or False to override the default.
-            padding_side (Union[Literal["left", "right"], None], optional): Overrides
-                self.tokenizer.padding_side. Specifies which side to pad when tokenizing multiple
-                strings of different lengths.
-        """
-        if self.dataset is None:
-            self.load_sample_training_dataset()
-        assert self.dataset is not None  # keep mypy happy
-        sample_dataset_size = len(self.dataset)
-        index = np.random.randint(0, sample_dataset_size)
-        if not tokenize:
-            return self.dataset[index]["text"]
-        else:
-            return self.to_tokens(
-                self.dataset[index]["text"],
-                prepend_bos=prepend_bos,
-                padding_side=padding_side,
-                truncate=True,
-            )
+  

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -54,6 +54,8 @@ class HookedTransformerConfig:
             attention head separately, with a hook. Defaults to false to save memory
         use_attn_scale (bool): whether to scale the attention weights by
             1/sqrt(d_head)
+        ungroup_grouped_query_attention (bool): whether to ungroup key and value heads, for models that use
+            grouped query attention.
         attn_scale (float): The amount to divide attention scores by (if applicable). Defaults to
             sqrt(d_head)
         model_name (str): the name of the model, used to load
@@ -199,6 +201,7 @@ class HookedTransformerConfig:
     use_hook_mlp_in: bool = False
     use_attn_in: bool = False
     use_local_attn: bool = False
+    ungroup_grouped_query_attention: bool = False
     original_architecture: Optional[str] = None
     from_checkpoint: bool = False
     checkpoint_index: Optional[int] = None

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -451,9 +451,7 @@ class AbstractAttention(ABC, nn.Module):
             )
 
         # Index back to front to ensure local attention works
-        final_mask = self.mask[
-            None, None, -query_ctx_length:, -key_ctx_length:
-        ].bool()  # [1, 1, pos, pos]
+        final_mask = self.mask[None, None, -query_ctx_length:, -key_ctx_length:]  # [1, 1, pos, pos]
         if attention_mask is not None:
             # Apply a causal mask to the attention scores considering the padding
             einsum_str = "batch head pos offset_pos, batch offset_pos -> batch head pos offset_pos"

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -451,7 +451,9 @@ class AbstractAttention(ABC, nn.Module):
             )
 
         # Index back to front to ensure local attention works
-        final_mask = self.mask[None, None, -query_ctx_length:, -key_ctx_length:]  # [1, 1, pos, pos]
+        final_mask = self.mask[
+            None, None, -query_ctx_length:, -key_ctx_length:
+        ].bool()  # [1, 1, pos, pos]
         if attention_mask is not None:
             # Apply a causal mask to the attention scores considering the padding
             einsum_str = "batch head pos offset_pos, batch offset_pos -> batch head pos offset_pos"

--- a/transformer_lens/components/grouped_query_attention.py
+++ b/transformer_lens/components/grouped_query_attention.py
@@ -126,11 +126,16 @@ class GroupedQueryAttention(AbstractAttention):
         q = self.hook_q(
             attn_fn(query_input, self.W_Q, self.b_Q)
         )  # [batch, pos, head_index, d_head]
+
         k = self.hook_k(
-            attn_fn(key_input, self._W_K, self._b_K)
+            attn_fn(key_input, self.W_K, self.b_K)
+            if self.cfg.ungroup_grouped_query_attention
+            else attn_fn(key_input, self._W_K, self._b_K)
         )  # [batch, pos, head_index, d_head]
         v = self.hook_v(
-            attn_fn(value_input, self._W_V, self._b_V)
+            attn_fn(value_input, self.W_V, self.b_V)
+            if self.cfg.ungroup_grouped_query_attention
+            else attn_fn(value_input, self._W_V, self._b_V)
         )  # [batch, pos, head_index, d_head]
         return q, k, v
 
@@ -149,7 +154,8 @@ class GroupedQueryAttention(AbstractAttention):
         Returns:
             Float[torch.Tensor, "batch head_index query_pos key_pos"]: The attention scores.
         """
-        k = torch.repeat_interleave(k, dim=2, repeats=self.repeat_kv_heads)
+        if not self.cfg.ungroup_grouped_query_attention:
+            k = torch.repeat_interleave(k, dim=2, repeats=self.repeat_kv_heads)
         return super().calculate_attention_scores(q, k)
 
     def calculate_z_scores(
@@ -167,5 +173,6 @@ class GroupedQueryAttention(AbstractAttention):
         Returns:
             Float[torch.Tensor, "batch head_index query_pos key_pos"]: The z scores.
         """
-        v = torch.repeat_interleave(v, dim=2, repeats=self.repeat_kv_heads)
+        if not self.cfg.ungroup_grouped_query_attention:
+            v = torch.repeat_interleave(v, dim=2, repeats=self.repeat_kv_heads)
         return super().calculate_z_scores(v, pattern)

--- a/transformer_lens/components/transformer_block.py
+++ b/transformer_lens/components/transformer_block.py
@@ -136,6 +136,7 @@ class TransformerBlock(nn.Module):
             n_kv_heads = (
                 self.cfg.n_key_value_heads
                 if self.cfg.n_key_value_heads is not None
+                and not self.cfg.ungroup_grouped_query_attention
                 else self.cfg.n_heads
             )
             query_input = self.hook_q_input(


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

I personally keep getting OOMs when trying to load llama3 8B. I narrowed down the offending code to `load_and_process_state_dict`, then realized Neel offered a suggestion in #480 that isn't implemented yet.

So, a simple change: always use `assign=True` (if the installed PyTorch version is recent enough).

Previously, tests broke because of a mismatch in the `dtype` of the state_dict mask and the default TL mask. Adding a cast fixes all tests.

Fixes #480. (issue)

## Type of change

Bug fix or new feature, depending on perspective. Should allow loading more models without needing a ton of memory.

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->