### PR TITLE
Release 2.7

### DIFF
--- a/transformer_lens/HookedEncoder.py
+++ b/transformer_lens/HookedEncoder.py
@@ -255,7 +255,7 @@ class HookedEncoder(HookedRootModule):
         if move_to_device:
             model.to(cfg.device)
 
-        print(f"Loaded pretrained model {model_name} into HookedTransformer")
+        print(f"Loaded pretrained model {model_name} into HookedEncoder")
 
         return model
 

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1940,6 +1940,12 @@ class HookedTransformer(HookedRootModule):
         """
         self.cfg.use_attn_in = use_attn_in
 
+    def set_ungroup_grouped_query_attention(self, ungroup_grouped_query_attention: bool):
+        """
+        Toggles whether to ungroup the grouped key and value heads in models with grouped query attention (GQA).
+        """
+        self.cfg.ungroup_grouped_query_attention = ungroup_grouped_query_attention
+
     def process_weights_(
         self,
         fold_ln: bool = True,

--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -54,6 +54,8 @@ class HookedTransformerConfig:
             attention head separately, with a hook. Defaults to false to save memory
         use_attn_scale (bool): whether to scale the attention weights by
             1/sqrt(d_head)
+        ungroup_grouped_query_attention (bool): whether to ungroup key and value heads, for models that use
+            grouped query attention.
         attn_scale (float): The amount to divide attention scores by (if applicable). Defaults to
             sqrt(d_head)
         model_name (str): the name of the model, used to load
@@ -199,6 +201,7 @@ class HookedTransformerConfig:
     use_hook_mlp_in: bool = False
     use_attn_in: bool = False
     use_local_attn: bool = False
+    ungroup_grouped_query_attention: bool = False
     original_architecture: Optional[str] = None
     from_checkpoint: bool = False
     checkpoint_index: Optional[int] = None

--- a/transformer_lens/components/grouped_query_attention.py
+++ b/transformer_lens/components/grouped_query_attention.py
@@ -126,11 +126,16 @@ class GroupedQueryAttention(AbstractAttention):
         q = self.hook_q(
             attn_fn(query_input, self.W_Q, self.b_Q)
         )  # [batch, pos, head_index, d_head]
+
         k = self.hook_k(
-            attn_fn(key_input, self._W_K, self._b_K)
+            attn_fn(key_input, self.W_K, self.b_K)
+            if self.cfg.ungroup_grouped_query_attention
+            else attn_fn(key_input, self._W_K, self._b_K)
         )  # [batch, pos, head_index, d_head]
         v = self.hook_v(
-            attn_fn(value_input, self._W_V, self._b_V)
+            attn_fn(value_input, self.W_V, self.b_V)
+            if self.cfg.ungroup_grouped_query_attention
+            else attn_fn(value_input, self._W_V, self._b_V)
         )  # [batch, pos, head_index, d_head]
         return q, k, v
 
@@ -149,7 +154,8 @@ class GroupedQueryAttention(AbstractAttention):
         Returns:
             Float[torch.Tensor, "batch head_index query_pos key_pos"]: The attention scores.
         """
-        k = torch.repeat_interleave(k, dim=2, repeats=self.repeat_kv_heads)
+        if not self.cfg.ungroup_grouped_query_attention:
+            k = torch.repeat_interleave(k, dim=2, repeats=self.repeat_kv_heads)
         return super().calculate_attention_scores(q, k)
 
     def calculate_z_scores(
@@ -167,5 +173,6 @@ class GroupedQueryAttention(AbstractAttention):
         Returns:
             Float[torch.Tensor, "batch head_index query_pos key_pos"]: The z scores.
         """
-        v = torch.repeat_interleave(v, dim=2, repeats=self.repeat_kv_heads)
+        if not self.cfg.ungroup_grouped_query_attention:
+            v = torch.repeat_interleave(v, dim=2, repeats=self.repeat_kv_heads)
         return super().calculate_z_scores(v, pattern)

--- a/transformer_lens/components/transformer_block.py
+++ b/transformer_lens/components/transformer_block.py
@@ -136,6 +136,7 @@ class TransformerBlock(nn.Module):
             n_kv_heads = (
                 self.cfg.n_key_value_heads
                 if self.cfg.n_key_value_heads is not None
+                and not self.cfg.ungroup_grouped_query_attention
                 else self.cfg.n_heads
             )
             query_input = self.hook_q_input(


### PR DESCRIPTION
* Redo of #713 (#722)

* adding option to ungroup gqa

* adding option to ungroup gqa

* updating gqa / rebasing

* Update HookedTransformerConfig.py

* formatting fix

* renaming ungroup_gqa option

* Add tests for ungroup_grouped_query_attention flag

---------




* fixed typo

---------

<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->