### PR TITLE
Avoid warning in `utils.download_file_from_hf`

### DIFF
--- a/transformer_lens/utils.py
+++ b/transformer_lens/utils.py
@@ -59,7 +59,7 @@ def download_file_from_hf(
     )
 
     if file_path.endswith(".pth") or force_is_torch:
-        return torch.load(file_path, map_location="cpu")
+        return torch.load(file_path, map_location="cpu", weights_only=False)
     elif file_path.endswith(".json"):
         return json.load(open(file_path, "r"))
     else:


### PR DESCRIPTION
Add `weights_only=False` argument to `torch.load`. Starting in `torch=2.4.1`, `torch.load` prints a warning when the `weights_only` argument is not given.

The only issue here is that I get an issue if I use a version of `torch` earlier than `1.13`, and `transformer_lens` officially (according to `pyproject.toml` supports back to `1.10`. However, I couldn't use `transformer_lens` with `torch==1.10` without getting other errors, so maybe it isn't really supported anyway?

<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #714 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
    - This shouldn't be necessary since no new logic is added
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->