### PR TITLE
`from_pretrained` has correct return type (i.e. `HookedSAETransformer.from_pretrained` returns `HookedSAETransformer`)

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -10,7 +10,18 @@ a deeper understanding of the internal workings of transformers like GPT-2.
 """
 import logging
 import os
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union, cast, overload
+from typing import (
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 import einops
 import numpy as np
@@ -66,6 +77,8 @@ DTYPE_FROM_STRING = {
     "bfloat16": torch.bfloat16,
     "bf16": torch.bfloat16,
 }
+
+T = TypeVar("T", bound="HookedTransformer")
 
 
 class Output(NamedTuple):
@@ -1053,7 +1066,7 @@ class HookedTransformer(HookedRootModule):
 
     @classmethod
     def from_pretrained(
-        cls,
+        cls: Type[T],
         model_name: str,
         fold_ln: bool = True,
         center_writing_weights: bool = True,
@@ -1072,7 +1085,7 @@ class HookedTransformer(HookedRootModule):
         dtype="float32",
         first_n_layers: Optional[int] = None,
         **from_pretrained_kwargs,
-    ) -> "HookedTransformer":
+    ) -> T:
         """Load in a Pretrained Model.
 
         Load in pretrained model weights to the HookedTransformer format and optionally to do some


### PR DESCRIPTION
# Description

This changes the type signature of `from_pretrained`, so its return type is the generic type of the base class. For example, now when we use `HookedSAETransformer.from_pretrained`, the expected return type is `HookedSAETransformer` not `HookedTransformer`.

I changed this because in my [SAE intro material](https://colab.research.google.com/drive/1ePkM8oBHIEZ2kcqAiA3waeAmz8RSdHmq#scrollTo=47O2XjSCRm-9) I was having to explicitly type-annotate as `sae: HookedSAETransformer = HookedSAETransformer.from_pretrained(...)`, and so just changing the type signature seemed like the best option.