### PR TITLE
Add warning and halt execution for incorrect T5 model usage

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1220,6 +1220,8 @@ class HookedTransformer(HookedRootModule):
                 "right".
             first_n_layers: If specified, only load the first n layers of the model.
         """
+        if model_name.lower().startswith("t5"):
+            raise RuntimeError("Execution stopped: Please use HookedEncoderDecoder to load T5 models instead of HookedTransformer.")
 
         assert not (
             from_pretrained_kwargs.get("load_in_8bit", False)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1221,7 +1221,9 @@ class HookedTransformer(HookedRootModule):
             first_n_layers: If specified, only load the first n layers of the model.
         """
         if model_name.lower().startswith("t5"):
-            raise RuntimeError("Execution stopped: Please use HookedEncoderDecoder to load T5 models instead of HookedTransformer.")
+            raise RuntimeError(
+                "Execution stopped: Please use HookedEncoderDecoder to load T5 models instead of HookedTransformer."
+            )
 
         assert not (
             from_pretrained_kwargs.get("load_in_8bit", False)


### PR DESCRIPTION

# Description

Added a warning for users to load T5 models using HookedEncoderDecoder instead of HookedTransformer, and raised a RuntimeError to stop execution and prevent further incorrect usage.

Fixes #726 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->