### PR TITLE
Remove einsum in logit_attrs in ActivationCache

### DIFF
--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -557,10 +557,8 @@ class ActivationCache:
             has_batch_dim=has_batch_dim,
         )
 
-        logit_attrs = einsum(
-            "... d_model, ... d_model -> ...", scaled_residual_stack, logit_directions
-        )
-
+        # Element-wise multiplication and sum over the d_model dimension
+        logit_attrs = (scaled_residual_stack * logit_directions).sum(dim=-1)
         return logit_attrs
 
     def decompose_resid(


### PR DESCRIPTION
# Description

There are known accuracy issues which are to some extent caused by the usage of einsum across large parts of the codebase. This PR removes one of these usages in the logic_attrs function in ActivationCache.py. There is no specific issue associated with this PR, although removing a lot of the einsum usages could help in removing implementation inaccuracies addressed in many issues. I have not added specific test cases for this change, but I ran all the models (except those that required authorization and the paid_cpu models) in the Colab_Compatibility notebook and have not run into any compatibility issues introduced by this change. Additionally, the changed part is executed 8 times across the unit and acceptance tests.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility