### PR TITLE
Remove einsum in compute_head_results in ActivationCache

### DIFF
--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -666,14 +666,21 @@ class ActivationCache:
         if "blocks.0.attn.hook_result" in self.cache_dict:
             logging.warning("Tried to compute head results when they were already cached")
             return
-        for l in range(self.model.cfg.n_layers):
+        for layer in range(self.model.cfg.n_layers):
             # Note that we haven't enabled set item on this object so we need to edit the underlying
             # cache_dict directly.
-            self.cache_dict[f"blocks.{l}.attn.hook_result"] = einsum(
-                "... head_index d_head, head_index d_head d_model -> ... head_index d_model",
-                self[("z", l, "attn")],
-                self.model.blocks[l].attn.W_O,
+
+            # Add singleton dimension to match W_O's shape for broadcasting
+            z = einops.rearrange(
+                self[("z", layer, "attn")],
+                "... head_index d_head -> ... head_index d_head 1",
             )
+
+            # Element-wise multiplication of z and W_O (with shape [head_index, d_head, d_model])
+            result = z * self.model.blocks[layer].attn.W_O
+
+            # Sum over d_head to get the contribution of each head to the residual stream
+            self.cache_dict[f"blocks.{layer}.attn.hook_result"] = result.sum(dim=-2)
 
     def stack_head_results(
         self,

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 import einops
 import numpy as np
 import torch
-from fancy_einsum import einsum
 from jaxtyping import Float, Int
 from typing_extensions import Literal
 


### PR DESCRIPTION
# Description

There are known accuracy issues which are to some extent caused by the usage of einsum across large parts of the codebase. This PR removes one of these usages in the compute_head_results function in ActivationCache.py. There is no specific issue associated with this PR, although removing a lot of the einsum usages could help in removing implementation inaccuracies addressed in many issues. I have not added specific test cases for this change, but I ran all the models (except those that required authorization and the paid_cpu models) in the Colab_Compatibility notebook and have not run into any compatibility issues introduced by this change. Additionally, the changed part is executed 14 times across the unit and acceptance tests.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility