### PR TITLE
Remove einsum in complex_attn_linear

### DIFF
--- a/transformer_lens/utilities/attention.py
+++ b/transformer_lens/utilities/attention.py
@@ -2,6 +2,7 @@
 
 Utilities for attention components.
 """
+
 import einops
 import torch
 import torch.nn.functional as F
@@ -28,11 +29,14 @@ def complex_attn_linear(
 
     This is almost the same as simple_attn_linear, but the input tensor has an extra head_index dimension, used when calculating the input of each attention head separately.
     """
-    return (
-        einops.einsum(
-            input,
-            w,
-            "batch pos head_index d_model, head_index d_model d_head -> batch pos head_index d_head",
-        )
-        + b
+
+    # Add singleton dimensions for broadcasting
+    input = einops.rearrange(
+        input, "batch pos head_index d_model -> batch pos head_index d_model 1"
     )
+    w = einops.rearrange(w, "head_index d_model d_head -> 1 1 head_index d_model d_head")
+
+    # Element-wise multiplication and sum over the d_model dimension
+    result = input * w
+    result = result.sum(dim=-2)
+    return result + b


### PR DESCRIPTION
# Description

There are known accuracy issues which are to some extent caused by the usage of einsum across large parts of the codebase. This PR removes one of these usages in the complex_attn_linear function in utilities/attention.py. There is no specific issue associated with this PR, although removing a lot of the einsum usages could help in removing implementation inaccuracies addressed in many issues. I ran all the models (except those that required authorization and the paid_cpu models) in the Colab_Compatibility notebook and have not run into any compatibility issues introduced by this change. Additionally, the changed part is executed 7 times across the unit and acceptance tests and I have added a little additional test case myself.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility