### PR TITLE
Remove einsum usage in _get_w_in_matrix in SVDInterpreter

### DIFF
--- a/transformer_lens/SVDInterpreter.py
+++ b/transformer_lens/SVDInterpreter.py
@@ -6,7 +6,6 @@ Module for getting the singular vectors of the OV, w_in, and w_out matrices of a
 
 from typing import Optional, Union
 
-import fancy_einsum as einsum
 import torch
 from typeguard import typechecked
 from typing_extensions import Literal

--- a/transformer_lens/SVDInterpreter.py
+++ b/transformer_lens/SVDInterpreter.py
@@ -148,7 +148,7 @@ class SVDInterpreter:
 
         if f"blocks.{layer_index}.ln2.w" in self.params:  # If fold_ln == False
             ln_2 = self.params[f"blocks.{layer_index}.ln2.w"]
-            return einsum.einsum("out in, in -> out in", w_in, ln_2)
+            return w_in * ln_2
 
         return w_in
 


### PR DESCRIPTION
# Description

There are known accuracy issues which are to some extent caused by the usage of einsum across large parts of the codebase. This PR removes one of these usages in the _get_w_in_matrix function in SVDInterpreter.py. There is no specific issue associated with this PR, although removing a lot of the einsum usages could help in removing implementation inaccuracies addressed in many issues. I have not added specific test cases for this change, but I ran all the models (except those that required authorization and the paid_cpu models) in the Colab_Compatibility notebook and have not run into any compatibility issues introduced by this change. Additionally, the changed part is executed once across the unit and acceptance tests.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility