### PR TITLE
Remove einsum usage in forward function of BertMLMHead

### DIFF
--- a/transformer_lens/components/bert_mlm_head.py
+++ b/transformer_lens/components/bert_mlm_head.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 
 import torch
 import torch.nn as nn
-from fancy_einsum import einsum
+import einops
 from jaxtyping import Float
 
 from transformer_lens.components import LayerNorm
@@ -27,14 +27,15 @@ class BertMLMHead(nn.Module):
         self.ln = LayerNorm(self.cfg)
 
     def forward(self, resid: Float[torch.Tensor, "batch pos d_model"]) -> torch.Tensor:
-        resid = (
-            einsum(
-                "batch pos d_model_in, d_model_out d_model_in -> batch pos d_model_out",
-                resid,
-                self.W,
-            )
-            + self.b
-        )
+        # Add singleton dimension for broadcasting
+        resid = einops.rearrange(resid, "batch pos d_model_in -> batch pos 1 d_model_in")
+
+        # Element-wise multiplication of W and resid
+        resid = resid * self.W
+
+        # Sum over d_model_in dimension and add bias
+        resid = resid.sum(-1) + self.b
+
         resid = self.act_fn(resid)
         resid = self.ln(resid)
         return resid

--- a/transformer_lens/components/bert_mlm_head.py
+++ b/transformer_lens/components/bert_mlm_head.py
@@ -4,9 +4,9 @@ This module contains all the component :class:`BertMLMHead`.
 """
 from typing import Dict, Union
 
+import einops
 import torch
 import torch.nn as nn
-import einops
 from jaxtyping import Float
 
 from transformer_lens.components import LayerNorm


### PR DESCRIPTION
# Description

There are known accuracy issues which are to some extent caused by the usage of einsum across large parts of the codebase. This PR removes one of these usages in the forward function of BertMLMHead. There is no specific issue associated with this PR, although removing a lot of the einsum usages could help in removing implementation inaccuracies addressed in many issues. I have not added specific test cases for this change, but I ran all the models (except those that required authorization and the paid_cpu models) in the Colab_Compatibility notebook and have not run into any compatibility issues introduced by this change. Additionally, the changed part is executed 5 times across the unit and acceptance tests.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility