### PR TITLE
Colab compatibility bug fixes

### DIFF
--- a/demos/Colab_Compatibility.ipynb
+++ b/demos/Colab_Compatibility.ipynb
@@ -60,15 +60,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TransformerLens currently supports 190 models out of the box.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import torch\n",
     "\n",

--- a/demos/Colab_Compatibility.ipynb
+++ b/demos/Colab_Compatibility.ipynb
@@ -466,6 +466,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# This model works on the free version of Colab\n",
     "encoder_only_models = [\"bert-base-cased\"]\n",
     "\n",
     "if IN_COLAB:\n",

--- a/demos/Colab_Compatibility.ipynb
+++ b/demos/Colab_Compatibility.ipynb
@@ -160,7 +160,6 @@
     "                # break if End-Of-Sequence token generated\n",
     "                if token_idx == tokenizer.eos_token_id:\n",
     "                    break\n",
-    "            print(tl_model.generate(\"Hello my name is\"))\n",
     "        del tl_model\n",
     "        gc.collect()\n",
     "        if IN_COLAB:\n",

--- a/demos/Colab_Compatibility.ipynb
+++ b/demos/Colab_Compatibility.ipynb
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,11 +144,11 @@
     "            inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
     "            input_ids = inputs[\"input_ids\"]\n",
     "            attention_mask = inputs[\"attention_mask\"]\n",
-    "            decoder_input_ids = torch.tensor([[model.cfg.decoder_start_token_id]]).to(input_ids.device)\n",
+    "            decoder_input_ids = torch.tensor([[tl_model.cfg.decoder_start_token_id]]).to(input_ids.device)\n",
     "\n",
     "\n",
     "            while True:\n",
-    "                logits = model.forward(input=input_ids, one_zero_attention_mask=attention_mask, decoder_input=decoder_input_ids)\n",
+    "                logits = tl_model.forward(input=input_ids, one_zero_attention_mask=attention_mask, decoder_input=decoder_input_ids)\n",
     "                # logits.shape == (batch_size (1), predicted_pos, vocab_size)\n",
     "\n",
     "                token_idx = torch.argmax(logits[0, -1, :]).item()\n",

--- a/demos/Colab_Compatibility.ipynb
+++ b/demos/Colab_Compatibility.ipynb
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -72,7 +72,7 @@
    "source": [
     "import torch\n",
     "\n",
-    "from transformer_lens import HookedTransformer, HookedEncoderDecoder, loading\n",
+    "from transformer_lens import HookedTransformer, HookedEncoderDecoder, HookedEncoder, loading\n",
     "from transformers import AutoTokenizer, LlamaForCausalLM, LlamaTokenizer\n",
     "from typing import List\n",
     "import gc\n",
@@ -163,12 +163,35 @@
     "        del tl_model\n",
     "        gc.collect()\n",
     "        if IN_COLAB:\n",
+    "            %rm -rf /root/.cache/huggingface/hub/models*\n",
+    "\n",
+    "def run_encoder_only_set(model_set: List[str], device=\"cuda\") -> None:\n",
+    "    for model in model_set:\n",
+    "        print(\"Testing \" + model)\n",
+    "        tokenizer = AutoTokenizer.from_pretrained(\"bert-base-cased\")\n",
+    "        tl_model = HookedEncoder.from_pretrained(model, device=device)\n",
+    "\n",
+    "        if GENERATE:\n",
+    "            # Slightly adapted version of the BERT demo\n",
+    "            prompt = \"The capital of France is [MASK].\"\n",
+    "\n",
+    "            input_ids = tokenizer(prompt, return_tensors=\"pt\")[\"input_ids\"]\n",
+    "\n",
+    "            logprobs = tl_model(input_ids)[input_ids == tokenizer.mask_token_id].log_softmax(dim=-1)\n",
+    "            prediction = tokenizer.decode(logprobs.argmax(dim=-1).item())\n",
+    "\n",
+    "            print(f\"Prompt: {prompt}\")\n",
+    "            print(f'Prediction: \"{prediction}\"')\n",
+    "\n",
+    "        del tl_model\n",
+    "        gc.collect()\n",
+    "        if IN_COLAB:\n",
     "            %rm -rf /root/.cache/huggingface/hub/models*"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +199,6 @@
     "free_compatible = [\n",
     "    \"ai-forever/mGPT\",\n",
     "    \"ArthurConmy/redwood_attn_2l\",\n",
-    "    \"bert-base-cased\",\n",
     "    \"bigcode/santacoder\",\n",
     "    \"bigscience/bloom-1b1\",\n",
     "    \"bigscience/bloom-560m\",\n",
@@ -444,6 +466,20 @@
     "    run_encoder_decoder_set(encoder_decoders)\n",
     "\n",
     "mark_models_as_tested(encoder_decoders)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "encoder_only_models = [\"bert-base-cased\"]\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    run_encoder_only_set(encoder_only_models)\n",
+    "\n",
+    "mark_models_as_tested(encoder_only_models)"
    ]
   },
   {


### PR DESCRIPTION
# Description

While using the Colab_Compatibility notebook to test some of the removals of einsum usages I did, I came across some minor bugs which this PR intends to fix. There is no specific issue this PR addresses.  The bugs in question are:
1. In the run_encoder_decoder_set function, two function calls are not on the model object but on the model name (string object) which throws an error when running this function. I fixed this by adjusting the function calls accordingly.
2. In the run_encoder_decoder_set function, the generate function is called on the HookedEncoderDecoder object, but HookedEncoderDecoder doesn't support the generate function yet. I fixed this by removing the generate function call
3. The Bert model is tested as a HookedTransformer, which is incorrect since this architecture requires the HookedEncoder class. I fixed this by creating a separate function to test models of the type HookedEncoder and call it on the bert-base-cased model (and future encoder only models which can be added to the according list as needed).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility