### PR TITLE
Raise exception when BERT is loaded with HookedTransformer instead of…

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1232,6 +1232,11 @@ class HookedTransformer(HookedRootModule):
                 "Execution stopped: Please use HookedEncoderDecoder to load T5 models instead of HookedTransformer."
             )
 
+        if model_name.lower().startswith("bert"):
+            raise RuntimeError(
+                "Execution stopped: Please use HookedEncoder to load BERT-style models instead of HookedTransformer."
+            )
+
         assert not (
             from_pretrained_kwargs.get("load_in_8bit", False)
             or from_pretrained_kwargs.get("load_in_4bit", False)


### PR DESCRIPTION
# Description
When the BERT model is loaded the incorrect way via HookedTransformer instead of HookedEncoder, currently no exception is raised although this is being done for the T5 model family with HookedEncoderDecoder. With the code change in this PR, an error is raised in a similar fashion when the BERT model is loaded with the HookedTransformer class. There is no specific issue addressed by this PR


- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility