### PR TITLE
clarified arguments a bit for hook_points

### DIFF
--- a/transformer_lens/hook_points.py
+++ b/transformer_lens/hook_points.py
@@ -439,7 +439,8 @@ class HookedRootModule(nn.Module):
             clear_contexts (bool): If True, clears hook contexts whenever hooks are reset. Default is
                 False.
             *model_args: Positional arguments for the model.
-            **model_kwargs: Keyword arguments for the model.
+            **model_kwargs: Keyword arguments for the model's forward function. See your related
+                models forward pass for details as to what sort of arguments you can pass through.
 
         Note:
             If you want to use backward hooks, set `reset_hooks_end` to False, so the backward hooks
@@ -540,7 +541,8 @@ class HookedRootModule(nn.Module):
                 Defaults to False.
             pos_slice:
                 The slice to apply to the cache output. Defaults to None, do nothing.
-            **model_kwargs: Keyword arguments for the model.
+            **model_kwargs: Keyword arguments for the model's forward function. See your related
+                models forward pass for details as to what sort of arguments you can pass through.
 
         Returns:
             tuple: A tuple containing the model output and a Cache object.


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Clarifies where arguments come from a bit.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->