### PR TITLE
Throw error when using attn_in with grouped query attention

### DIFF
--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -238,6 +238,6 @@ def test_prepending_hooks(zero_attach_pos, prepend):
 
 def test_use_attn_in_with_gqa_raises_error():
     # Create model that uses GroupedQueryAttention
-    model = HookedTransformer.from_pretrained("google/gemma-2b")
+    model = HookedTransformer.from_pretrained("Qwen/Qwen2-0.5B")
     with pytest.raises(AssertionError):
         model.set_use_attn_in(True)

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -234,3 +234,10 @@ def test_prepending_hooks(zero_attach_pos, prepend):
     # exactly when the zero hook is attached last XOR it is prepended
 
     assert torch.allclose(logits, model.unembed.b_U[None, :]) == logits_are_unembed_bias
+
+
+def test_use_attn_in_with_gqa_raises_error():
+    # Create model that uses GroupedQueryAttention
+    model = HookedTransformer.from_pretrained("google/gemma-2b")
+    with pytest.raises(AssertionError):
+        model.set_use_attn_in(True)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1969,6 +1969,9 @@ class HookedTransformer(HookedRootModule):
         """
         Toggles whether to allow editing of inputs to each attention head.
         """
+        assert (
+            self.cfg.n_key_value_heads is None
+        ), "Can't use attn_in with GroupedQueryAttention, please use split_qkv_input instead"
         self.cfg.use_attn_in = use_attn_in
 
     def set_ungroup_grouped_query_attention(self, ungroup_grouped_query_attention: bool):

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1244,7 +1244,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "initializer_range": hf_config.initializer_range,
             "normalization_type": "RMS",
             "positional_embedding_type": "rotary",
-            "rotary_base": hf_config.rope_theta,
+            "rotary_base": int(hf_config.rope_theta),
             "rotary_adjacent_pairs": False,
             "rotary_dim": hf_config.hidden_size // hf_config.num_attention_heads,
             "tokenizer_prepends_bos": True,

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1310,7 +1310,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "act_fn": "gelu_new",
             "initializer_range": 0.02,
             "normalization_type": "RMS",
-            "rotary_base": 10000.0,
+            "rotary_base": 10000,
             "rotary_dim": 256,
             "positional_embedding_type": "rotary",
             "use_attn_scale": True,


### PR DESCRIPTION
# Description
When using attn_in with models that use GroupedQueryAttention, TransformerLens crashes because use_attn_in does not account for the different number of query and key/value heads when using GQA. For models with GQA use_split_qkv_input should be used instead, because it implements hooks for query, key and value heads and therefore can account for the different number of heads for each of them. This PR implements a more meaningful error message that informs the user to use split_qkv_input when working with models with GQA instead of use_attn_in.

This PR is not linked to a specific issue.

After adding a test case, it failed because of a beartype error that stated that rotary_base needs to be an integer instead of a float. I adjusted this accordingly in the configuration of google/gemma-2b

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
