### PR TITLE
Add support for Qwen_with_Questions

### DIFF
--- a/demos/Colab_Compatibility.ipynb
+++ b/demos/Colab_Compatibility.ipynb
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,6 +415,7 @@
     "    \"meta-llama/Meta-Llama-3-70B-Instruct\",\n",
     "    \"mistralai/Mixtral-8x7B-Instruct-v0.1\",\n",
     "    \"mistralai/Mixtral-8x7B-v0.1\",\n",
+    "    \"Qwen/QwQ-32B-Preview\"\n",
     "]\n",
     "\n",
     "mark_models_as_tested(incompatible_models)"
@@ -509,7 +510,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -523,7 +524,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -212,6 +212,7 @@ OFFICIAL_MODEL_NAMES = [
     "Qwen/Qwen2-1.5B-Instruct",
     "Qwen/Qwen2-7B",
     "Qwen/Qwen2-7B-Instruct",
+    "Qwen/QwQ-32B-Preview",
     "microsoft/phi-1",
     "microsoft/phi-1_5",
     "microsoft/phi-2",


### PR DESCRIPTION
# Description

Adding support for Qwen's newest model QwQ (Qwen with Questions) has been requested multiple times over the past few weeks. This PR intends to address issue #808 by adding support for this model. Since this model uses the Qwen2ForCausalLM architecture, which is already implemented in TransformerLens, adding support for this model was fairly simple.

Fixes #808 

## Comparing TransformerLens to HuggingFace:
Here is a comparison of the TransformerLens logits to the ones from HuggingFace:
```
prompt = "How many r in strawberry."

=== Logits Comparison ===
TransformerLens:
Mean: tensor(-1.2255, device='mps:0', grad_fn=<MeanBackward0>)
Std: tensor(3.0775, device='mps:0', grad_fn=<StdBackward0>)

HuggingFace:
Mean: tensor(-1.2255, device='mps:0', grad_fn=<MeanBackward0>)
Std: tensor(3.0775, device='mps:0', grad_fn=<StdBackward0>)
Max diff: tensor(0.0002, device='mps:0', grad_fn=<MaxBackward1>)
```

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility