### PR TITLE
Extend support for T5 models

### DIFF
--- a/demos/T5.ipynb
+++ b/demos/T5.ipynb
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## basic sanity check - model generates smth"
+    "## Basic sanity check - Model generates some tokens"
    ]
   },
   {

--- a/demos/T5.ipynb
+++ b/demos/T5.ipynb
@@ -196,6 +196,92 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Model also allows strings or a list of strings as input\n",
+    "The model also allows strings and a list of strings as input, not just tokens.\n",
+    "Here is an example of a string as input to the forward function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([1, 1, 32128])\n"
+     ]
+    }
+   ],
+   "source": [
+    "single_prompt = \"translate English to French: Hello, do you like apples?\"\n",
+    "logits = model(single_prompt)\n",
+    "print(logits.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And here is an example of a list of strings as input to the forward function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([3, 1, 32128])\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompts = [\n",
+    "        \"translate English to German: Hello, do you like bananas?\",\n",
+    "        \"translate English to French: Hello, do you like bananas?\",\n",
+    "        \"translate English to Spanish: Hello, do you like bananas?\",\n",
+    "    ]\n",
+    "\n",
+    "logits = model(prompts)\n",
+    "print(logits.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Text can be generated via the generate function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hallo, magst du Bananen?\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt=\"translate English to German: Hello, do you like bananas?\"\n",
+    "\n",
+    "output = model.generate(prompt, do_sample=False, max_new_tokens=20)\n",
+    "print(output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### visualise encoder patterns"
    ]
   },

--- a/tests/acceptance/test_hooked_encoder_decoder.py
+++ b/tests/acceptance/test_hooked_encoder_decoder.py
@@ -372,6 +372,26 @@ def test_predictions_string_list_input(our_model, huggingface_model, tokenizer):
 
     assert_close(our_model_logits, huggingface_model_logits, rtol=1e-5, atol=1e-5)
 
+
+def test_generate(our_model, huggingface_model, tokenizer):
+    prompt = "translate English to German: Hello, do you like bananas?"
+
+    encodings = tokenizer(prompt, return_tensors="pt")
+
+    our_generation = our_model.generate(prompt, do_sample=False, max_new_tokens=20)
+    huggingface_generated_tokens = huggingface_model.generate(
+        input_ids=encodings.input_ids,
+        attention_mask=encodings.attention_mask,
+        do_sample=False,
+    )[0]
+
+    huggingface_generation = tokenizer.decode(
+        huggingface_generated_tokens, skip_special_tokens=True
+    )
+
+    assert our_generation.lower() == huggingface_generation.lower()
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires a CUDA device")
 def test_cuda(hello_world_tokens, decoder_input_ids):
     model = HookedEncoderDecoder.from_pretrained(MODEL_NAME)

--- a/tests/acceptance/test_hooked_encoder_decoder.py
+++ b/tests/acceptance/test_hooked_encoder_decoder.py
@@ -331,6 +331,47 @@ def test_predictions(our_model, huggingface_model, tokenizer, decoder_input_ids)
     assert our_prediction == huggingface_prediction
 
 
+def test_predictions_string_input(our_model, huggingface_model, tokenizer):
+    prompt = "translate English to German: Hello, do you like bananas?"
+
+    encodings = tokenizer(prompt, return_tensors="pt")
+    tokens = encodings.input_ids
+    batch_size, seq_len = tokens.shape
+    decoder_input_ids = torch.full((batch_size, 1), tokenizer.pad_token_id)
+
+    our_model_logits = our_model(prompt)
+
+    huggingface_model_logits = huggingface_model(
+        input_ids=tokens,
+        attention_mask=encodings.attention_mask,
+        decoder_input_ids=decoder_input_ids,
+    ).logits
+
+    assert_close(our_model_logits, huggingface_model_logits, rtol=1e-5, atol=1e-5)
+
+
+def test_predictions_string_list_input(our_model, huggingface_model, tokenizer):
+    prompt = [
+        "translate English to German: Hello, do you like bananas?",
+        "translate English to French: Hello, do you like bananas?",
+        "translate English to Spanish: Hello, do you like bananas?",
+    ]
+
+    encodings = tokenizer(prompt, return_tensors="pt")
+    tokens = encodings.input_ids
+    batch_size, seq_len = tokens.shape
+    decoder_input_ids = torch.full((batch_size, 1), tokenizer.pad_token_id)
+
+    our_model_logits = our_model(prompt)
+
+    huggingface_model_logits = huggingface_model(
+        input_ids=tokens,
+        attention_mask=encodings.attention_mask,
+        decoder_input_ids=decoder_input_ids,
+    ).logits
+
+    assert_close(our_model_logits, huggingface_model_logits, rtol=1e-5, atol=1e-5)
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires a CUDA device")
 def test_cuda(hello_world_tokens, decoder_input_ids):
     model = HookedEncoderDecoder.from_pretrained(MODEL_NAME)

--- a/transformer_lens/HookedEncoderDecoder.py
+++ b/transformer_lens/HookedEncoderDecoder.py
@@ -135,7 +135,7 @@ class HookedEncoderDecoder(HookedRootModule):
             tokens = tokens.to(self.cfg.device)
             attention_mask = attention_mask.to(self.cfg.device)
         return tokens, attention_mask
-    
+
     @overload
     def forward(
         self,
@@ -224,13 +224,15 @@ class HookedEncoderDecoder(HookedRootModule):
                 logging.warning(
                     "No attention mask provided. Assuming all tokens should be attended to."
                 )
-            
+
             if decoder_input is None:
-                raise ValueError("Must provide decoder_input if input is not a string or list of strings")
+                raise ValueError(
+                    "Must provide decoder_input if input is not a string or list of strings"
+                )
 
         if tokens.device.type != self.cfg.device:
             tokens = tokens.to(self.cfg.device)
-            
+
         if one_zero_attention_mask is not None:
             one_zero_attention_mask = one_zero_attention_mask.to(self.cfg.device)
 
@@ -357,7 +359,7 @@ class HookedEncoderDecoder(HookedRootModule):
                 attention_mask if one_zero_attention_mask is None else one_zero_attention_mask
             )
         else:
-            assert isinstance(input, torch.Tensor) # keep mypy happy
+            assert isinstance(input, torch.Tensor)  # keep mypy happy
             encoder_input = input
 
             # If tokens are provided, user should be aware that attention mask will not be inferred

--- a/transformer_lens/HookedEncoderDecoder.py
+++ b/transformer_lens/HookedEncoderDecoder.py
@@ -135,6 +135,34 @@ class HookedEncoderDecoder(HookedRootModule):
             tokens = tokens.to(self.cfg.device)
             attention_mask = attention_mask.to(self.cfg.device)
         return tokens, attention_mask
+    
+    @overload
+    def forward(
+        self,
+        input: Union[
+            str,
+            List[str],
+            Int[torch.Tensor, "batch pos"],
+        ],
+        decoder_input: Optional[Int[torch.Tensor, "batch decoder_pos"]] = None,
+        return_type: Literal["logits"] = "logits",
+        one_zero_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+    ) -> Float[torch.Tensor, "batch pos d_vocab"]:
+        ...
+
+    @overload
+    def forward(
+        self,
+        input: Union[
+            str,
+            List[str],
+            Int[torch.Tensor, "batch pos"],
+        ],
+        decoder_input: Optional[Int[torch.Tensor, "batch decoder_pos"]] = None,
+        return_type: Literal[None] = None,
+        one_zero_attention_mask: Optional[Int[torch.Tensor, "batch pos"]] = None,
+    ) -> Optional[Float[torch.Tensor, "batch pos d_vocab"]]:
+        ...
 
     def forward(
         self,
@@ -329,6 +357,7 @@ class HookedEncoderDecoder(HookedRootModule):
                 attention_mask if one_zero_attention_mask is None else one_zero_attention_mask
             )
         else:
+            assert isinstance(input, torch.Tensor) # keep mypy happy
             encoder_input = input
 
             # If tokens are provided, user should be aware that attention mask will not be inferred


### PR DESCRIPTION
# Description
The current implementation of HookedEncoderDecoder does not support the input of strings or a list of strings to the models forward function, and also does not support a generate function. This PR addresses these limitations by implementing the following:

Automatic tokenization when input to forward function is either a string or a list of strings.
Generate function which takes either tokens or a string as an input and returns a specified number of newly generated tokens by the model.

I also adapted the T5 notebook to reflect the changes to the HookedEncoderDecoder architecture and give examples of how to use the newly introduced functionalities.

There is no specific issue attached to this PR.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility