### PR TITLE
Manually create repr for partial hooks

### DIFF
--- a/transformer_lens/hook_points.py
+++ b/transformer_lens/hook_points.py
@@ -108,9 +108,13 @@ class HookPoint(nn.Module):
                 module_output = module_output[0]
             return hook(module_output, hook=self)
 
-        full_hook.__name__ = (
-            hook.__repr__()
-        )  # annotate the `full_hook` with the string representation of the `hook` function
+        # annotate the `full_hook` with the string representation of the `hook` function
+        if isinstance(hook, partial):
+            # partial.__repr__() can be extremely slow if arguments contain large objects, which
+            # is common when caching tensors.
+            full_hook.__name__ = f"partial({hook.func.__repr__()},...)"
+        else:
+            full_hook.__name__ = hook.__repr__()
 
         if dir == "fwd":
             pt_handle = self.register_forward_hook(full_hook)


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

`HookPoint.add_hook()` contained the line:
```
full_hook.__name__ = (
    hook.__repr__()
)  # annotate the `full_hook` with the string representation of the `hook` function
```
This PR instead proposes
```
if isinstance(hook, partial):
    full_hook.__name__ = f"partial({hook.func.__repr__()},...)"
else:
    full_hook.__name__ = hook.__repr__()
```

This isn't an issue when the hook is a regular function, but the original code can be extremely expensive when hook is a partial function that contains arguments which may be large, since calling `partial.__repr__` will call `__repr__` on all of its arguments. A very natural and common usage of hooks is to create a partial function which takes a cache object as an argument. Some of the demos in the repo do this, e.g. `Exploratory_Analysis_Demo.ipynb` has:
```
hook_fn = partial(patch_residual_component, pos=position, clean_cache=cache)
        patched_logits = model.run_with_hooks(
            corrupted_tokens,
            fwd_hooks=[(utils.get_act_name("resid_pre", layer), hook_fn)],
            return_type="logits",
        )
```
where `cache` is a gpt2-small `model.run_with_cache()`.

I'll note that I think it's very unlikely that anyone would rely on a specific name of a pytorch-native hook which this affects. This would only break if a user did some kind of string search for one of the specific arguments of their partial function inside the raw `nn.Module._forward_hooks`.

I have not added tests as the use-case for accessing this name attribute when using a partial function is hyper-specific. But can do if I'm missing a reasonable use-case.

This change makes my code 3 times faster (I don't have a public version of it yet, but it does some model training and uses run_with_hooks twice in the forward pass).

Fixes #631 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->