### PR TITLE
Fix new weight conversion for BERT model

### DIFF
--- a/transformer_lens/weight_conversion/bert.py
+++ b/transformer_lens/weight_conversion/bert.py
@@ -7,34 +7,70 @@ from transformer_lens.weight_conversion.conversion_utils.conversion_steps import
 
 class BertWeightConversion(ArchitectureConversion):
     def __init__(self, cfg: HookedTransformerConfig) -> None:
-        super().__init__({
-            "embed.embed.W_E": "bert.embeddings.word_embeddings.weight",
-            "embed.pos_embed.W_pos": "bert.embeddings.position_embeddings.weight",
-            "embed.token_type_embed.W_token_type": "bert.embeddings.token_type_embeddings.weight",
-            "embed.ln.w": "bert.embeddings.LayerNorm.weight",
-            "embed.ln.b": "bert.embeddings.LayerNorm.bias",
-            "mlm_head.W": "bert.cls.predictions.transform.dense.weight",
-            "mlm_head.b": "bert.cls.predictions.transform.dense.bias",
-            "mlm_head.ln.w": "bert.cls.predictions.transform.LayerNorm.weight",
-            "mlm_head.ln.b": "bert.cls.predictions.transform.LayerNorm.bias",
-            "mlm_head.W_U": "bert.embeddings.word_embeddings.weight.T",
-            "mlm_head.b_U": "bert.cls.predictions.bias",
-            "blocks": ("bert.encoder.layer", WeightConversionSet({
-                "attn.W_Q": ("attention.self.query.weight", RearrangeWeightConversion("(i h) m -> i m h", i=cfg.n_heads)),
-                "attn.b_Q": ("attention.self.query.bias", RearrangeWeightConversion("(i h) -> i h", i=cfg.n_heads)),
-                "attn.W_K": ("attention.self.key.weight", RearrangeWeightConversion("(i h) m -> i m h", i=cfg.n_heads)),
-                "attn.b_K": ("attention.self.key.bias", RearrangeWeightConversion("(i h) -> i h", i=cfg.n_heads)),
-                "attn.W_V": ("attention.self.value.weight", RearrangeWeightConversion("(i h) m -> i m h", i=cfg.n_heads)),
-                "attn.b_V": ("attention.self.value.bias", RearrangeWeightConversion("(i h) -> i h", i=cfg.n_heads)),
-                "attn.W_O": ("attention.self.dense.weight", RearrangeWeightConversion("m (i h) -> i h m", i=cfg.n_heads)),
-                "attn.b_O": "attention.output.dense.bias",
-                "ln1.w": "attention.output.LayerNorm.weight",
-                "ln1.b": "attention.output.LayerNorm.bias",
-                "mlp.W_in": ("intermediate.dense.weight", RearrangeWeightConversion("mlp model -> model mlp")),
-                "mlp.b_in": "intermediate.dense.bias",
-                "mlp.W_out": ("output.dense.weight", RearrangeWeightConversion("model mlp -> mlp model")),
-                "mlp.b_out": "output.dense.bias",
-                "ln2.w": "output.LayerNorm.weight",
-                "ln2.b": "output.LayerNorm.bias",
-            }))
-        })
+        super().__init__(
+            {
+                "embed.embed.W_E": "bert.embeddings.word_embeddings.weight",
+                "embed.pos_embed.W_pos": "bert.embeddings.position_embeddings.weight",
+                "embed.token_type_embed.W_token_type": "bert.embeddings.token_type_embeddings.weight",
+                "embed.ln.w": "bert.embeddings.LayerNorm.weight",
+                "embed.ln.b": "bert.embeddings.LayerNorm.bias",
+                "mlm_head.W": "cls.predictions.transform.dense.weight",
+                "mlm_head.b": "cls.predictions.transform.dense.bias",
+                "mlm_head.ln.w": "cls.predictions.transform.LayerNorm.weight",
+                "mlm_head.ln.b": "cls.predictions.transform.LayerNorm.bias",
+                "mlm_head.W_U": "bert.embeddings.word_embeddings.weight.T",
+                "mlm_head.b_U": "cls.predictions.bias",
+                "unembed.W_U": "bert.embeddings.word_embeddings.weight.T",
+                "unembed.b_U": "cls.predictions.bias",
+                "blocks": (
+                    "bert.encoder.layer",
+                    WeightConversionSet(
+                        {
+                            "attn.W_Q": (
+                                "attention.self.query.weight",
+                                RearrangeWeightConversion("(i h) m -> i m h", i=cfg.n_heads),
+                            ),
+                            "attn.b_Q": (
+                                "attention.self.query.bias",
+                                RearrangeWeightConversion("(i h) -> i h", i=cfg.n_heads),
+                            ),
+                            "attn.W_K": (
+                                "attention.self.key.weight",
+                                RearrangeWeightConversion("(i h) m -> i m h", i=cfg.n_heads),
+                            ),
+                            "attn.b_K": (
+                                "attention.self.key.bias",
+                                RearrangeWeightConversion("(i h) -> i h", i=cfg.n_heads),
+                            ),
+                            "attn.W_V": (
+                                "attention.self.value.weight",
+                                RearrangeWeightConversion("(i h) m -> i m h", i=cfg.n_heads),
+                            ),
+                            "attn.b_V": (
+                                "attention.self.value.bias",
+                                RearrangeWeightConversion("(i h) -> i h", i=cfg.n_heads),
+                            ),
+                            "attn.W_O": (
+                                "attention.output.dense.weight",
+                                RearrangeWeightConversion("m (i h) -> i h m", i=cfg.n_heads),
+                            ),
+                            "attn.b_O": "attention.output.dense.bias",
+                            "ln1.w": "attention.output.LayerNorm.weight",
+                            "ln1.b": "attention.output.LayerNorm.bias",
+                            "mlp.W_in": (
+                                "intermediate.dense.weight",
+                                RearrangeWeightConversion("mlp model -> model mlp"),
+                            ),
+                            "mlp.b_in": "intermediate.dense.bias",
+                            "mlp.W_out": (
+                                "output.dense.weight",
+                                RearrangeWeightConversion("model mlp -> mlp model"),
+                            ),
+                            "mlp.b_out": "output.dense.bias",
+                            "ln2.w": "output.LayerNorm.weight",
+                            "ln2.b": "output.LayerNorm.bias",
+                        }
+                    ),
+                ),
+            }
+        )


### PR DESCRIPTION
# Description

The new weight conversion for BERT, forgets to load in the weights and the bias for the unembedding matrix. This leads to inaccurate outputs as can be seen below. This PR fixes that by simply adding the missing conversions to the weight conversion for BERT.

This PR does not address any specific issue.

These are the output differences before the change:
```
Analyzing final_logits similarity:
Equality: False
Maximum difference: 30.604841
Mean difference: 5.686721
```

And this is after the change:
```
Analyzing final_logits similarity:
Equality: True
Maximum difference: 4.2915344e-05
Mean difference: 5.0457793e-06
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility