### PR TITLE
Add weight conversion for Phi model

### DIFF
--- a/transformer_lens/factories/weight_conversion_factory.py
+++ b/transformer_lens/factories/weight_conversion_factory.py
@@ -14,6 +14,7 @@ from transformer_lens.weight_conversion.neo import NEOWeightConversion
 from transformer_lens.weight_conversion.neox import NEOXWeightConversion
 from transformer_lens.weight_conversion.qwen import QwenWeightConversion
 from transformer_lens.weight_conversion.qwen2 import Qwen2WeightConversion
+from transformer_lens.weight_conversion.phi import PhiWeightConversion
 
 
 class WeightConversionFactory:
@@ -44,6 +45,8 @@ class WeightConversionFactory:
                 return Qwen2WeightConversion(cfg)
             case "QWenLMHeadModel":
                 return QwenWeightConversion(cfg)
+            case "PhiForCausalLM":
+                return PhiWeightConversion(cfg)
             case _:
                 raise NotImplementedError(
                     f"{cfg.original_architecture} is not currently supported."

--- a/transformer_lens/weight_conversion/phi.py
+++ b/transformer_lens/weight_conversion/phi.py
@@ -1,64 +1,84 @@
-import einops
-
 from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
+from transformer_lens.weight_conversion.conversion_utils import ArchitectureConversion
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps import (
+    RearrangeWeightConversion,
+    WeightConversionSet,
+)
 
 
-def convert_phi_weights(phi, cfg: HookedTransformerConfig):
-    state_dict = {}
-
-    state_dict["embed.W_E"] = phi.model.embed_tokens.weight
-
-    for l in range(cfg.n_layers):
-        state_dict[f"blocks.{l}.ln1.w"] = phi.model.layers[l].input_layernorm.weight
-        state_dict[f"blocks.{l}.ln1.b"] = phi.model.layers[l].input_layernorm.bias
-
-        W_Q = phi.model.layers[l].self_attn.q_proj.weight
-        W_K = phi.model.layers[l].self_attn.k_proj.weight
-        W_V = phi.model.layers[l].self_attn.v_proj.weight
-        W_Q = einops.rearrange(
-            W_Q, "(n_head d_head) d_model -> n_head d_model d_head", n_head=cfg.n_heads
+class PhiWeightConversion(ArchitectureConversion):
+    def __init__(self, cfg: HookedTransformerConfig) -> None:
+        super().__init__(
+            {
+                "embed.W_E": "model.embed_tokens.weight",
+                "blocks": (
+                    "model.layers",
+                    WeightConversionSet(
+                        {
+                            "ln1.w": "input_layernorm.weight",
+                            "ln1.b": "input_layernorm.bias",
+                            "attn.W_Q": (
+                                "self_attn.q_proj.weight",
+                                RearrangeWeightConversion(
+                                    "(n_head d_head) d_model -> n_head d_model d_head",
+                                    n_head=cfg.n_heads,
+                                ),
+                            ),
+                            "attn.W_K": (
+                                "self_attn.k_proj.weight",
+                                RearrangeWeightConversion(
+                                    "(n_head d_head) d_model -> n_head d_model d_head",
+                                    n_head=cfg.n_heads,
+                                ),
+                            ),
+                            "attn.W_V": (
+                                "self_attn.v_proj.weight",
+                                RearrangeWeightConversion(
+                                    "(n_head d_head) d_model -> n_head d_model d_head",
+                                    n_head=cfg.n_heads,
+                                ),
+                            ),
+                            "attn.b_Q": (
+                                "self_attn.q_proj.bias",
+                                RearrangeWeightConversion(
+                                    "(n_head d_head) -> n_head d_head",
+                                    n_head=cfg.n_heads,
+                                ),
+                            ),
+                            "attn.b_K": (
+                                "self_attn.k_proj.bias",
+                                RearrangeWeightConversion(
+                                    "(n_head d_head) -> n_head d_head",
+                                    n_head=cfg.n_heads,
+                                ),
+                            ),
+                            "attn.b_V": (
+                                "self_attn.v_proj.bias",
+                                RearrangeWeightConversion(
+                                    "(n_head d_head) -> n_head d_head",
+                                    n_head=cfg.n_heads,
+                                ),
+                            ),
+                            "attn.W_O": (
+                                "self_attn.dense.weight",
+                                RearrangeWeightConversion(
+                                    "d_model (n_head d_head) -> n_head d_head d_model",
+                                    n_head=cfg.n_heads,
+                                ),
+                            ),
+                            "attn.b_O": "self_attn.dense.bias",
+                            "ln2.w": "input_layernorm.weight",
+                            "ln2.b": "input_layernorm.bias",
+                            "mlp.W_in": "mlp.fc1.weight.T",
+                            "mlp.b_in": "mlp.fc1.bias",
+                            "mlp.W_out": "mlp.fc2.weight.T",
+                            "mlp.b_out": "mlp.fc2.bias",
+                        }
+                    ),
+                ),
+                "ln_final.w": "model.final_layernorm.weight",
+                "ln_final.b": "model.final_layernorm.bias",
+                "unembed.W_U": "lm_head.weight.T",
+                "unembed.b_U": "lm_head.bias",
+            }
         )
-        W_K = einops.rearrange(
-            W_K, "(n_head d_head) d_model  -> n_head d_model d_head", n_head=cfg.n_heads
-        )
-        W_V = einops.rearrange(
-            W_V, "(n_head d_head) d_model  -> n_head d_model d_head", n_head=cfg.n_heads
-        )
-        state_dict[f"blocks.{l}.attn.W_Q"] = W_Q
-        state_dict[f"blocks.{l}.attn.W_K"] = W_K
-        state_dict[f"blocks.{l}.attn.W_V"] = W_V
-
-        b_Q = phi.model.layers[l].self_attn.q_proj.bias
-        b_K = phi.model.layers[l].self_attn.k_proj.bias
-        b_V = phi.model.layers[l].self_attn.v_proj.bias
-        b_Q = einops.rearrange(b_Q, "(n_head d_head) -> n_head d_head", n_head=cfg.n_heads)
-        b_K = einops.rearrange(b_K, "(n_head d_head) -> n_head d_head", n_head=cfg.n_heads)
-        b_V = einops.rearrange(b_V, "(n_head d_head) -> n_head d_head", n_head=cfg.n_heads)
-        state_dict[f"blocks.{l}.attn.b_Q"] = b_Q
-        state_dict[f"blocks.{l}.attn.b_K"] = b_K
-        state_dict[f"blocks.{l}.attn.b_V"] = b_V
-
-        W_O = phi.model.layers[l].self_attn.dense.weight
-        W_O = einops.rearrange(
-            W_O, "d_model (n_head d_head) -> n_head d_head d_model", n_head=cfg.n_heads
-        )
-
-        state_dict[f"blocks.{l}.attn.W_O"] = W_O
-        state_dict[f"blocks.{l}.attn.b_O"] = phi.model.layers[l].self_attn.dense.bias
-
-        # Layer Norm 1 and 2 are tied.
-        state_dict[f"blocks.{l}.ln2.w"] = state_dict[f"blocks.{l}.ln1.w"]
-        state_dict[f"blocks.{l}.ln2.b"] = state_dict[f"blocks.{l}.ln1.b"]
-
-        state_dict[f"blocks.{l}.mlp.W_in"] = phi.model.layers[l].mlp.fc1.weight.T
-        state_dict[f"blocks.{l}.mlp.b_in"] = phi.model.layers[l].mlp.fc1.bias
-        state_dict[f"blocks.{l}.mlp.W_out"] = phi.model.layers[l].mlp.fc2.weight.T
-        state_dict[f"blocks.{l}.mlp.b_out"] = phi.model.layers[l].mlp.fc2.bias
-
-    state_dict["ln_final.w"] = phi.model.final_layernorm.weight
-    state_dict["ln_final.b"] = phi.model.final_layernorm.bias
-
-    state_dict["unembed.W_U"] = phi.lm_head.weight.T
-    state_dict["unembed.b_U"] = phi.lm_head.bias
-
-    return state_dict


### PR DESCRIPTION
# Description

This PR implements a weight conversion for the Phi model, for the new way weights are loaded in from HuggingFace into TransformerLens

There is no specific issue attached to this PR.

The weight conversion looks like this:

```
Weight conversion details for architecture PhiForCausalLM:
"embed.W_E" -> "model.embed_tokens.weight",
"blocks" -> "model.layers", Is composed of a set of nested conversions with the following details {
        "ln1.w" -> "input_layernorm.weight",
        "ln1.b" -> "input_layernorm.bias",
        "attn.W_Q" -> "self_attn.q_proj.weight", Is a rearrange operation with the pattern "(n_head d_head) d_model -> n_head d_model d_head"
        "attn.W_K" -> "self_attn.k_proj.weight", Is a rearrange operation with the pattern "(n_head d_head) d_model -> n_head d_model d_head"
        "attn.W_V" -> "self_attn.v_proj.weight", Is a rearrange operation with the pattern "(n_head d_head) d_model -> n_head d_model d_head"
        "attn.b_Q" -> "self_attn.q_proj.bias", Is a rearrange operation with the pattern "(n_head d_head) -> n_head d_head"
        "attn.b_K" -> "self_attn.k_proj.bias", Is a rearrange operation with the pattern "(n_head d_head) -> n_head d_head"
        "attn.b_V" -> "self_attn.v_proj.bias", Is a rearrange operation with the pattern "(n_head d_head) -> n_head d_head"
        "attn.W_O" -> "self_attn.dense.weight", Is a rearrange operation with the pattern "d_model (n_head d_head) -> n_head d_head d_model"
        "attn.b_O" -> "self_attn.dense.bias",
        "ln2.w" -> "input_layernorm.weight",
        "ln2.b" -> "input_layernorm.bias",
        "mlp.W_in" -> "mlp.fc1.weight.T",
        "mlp.b_in" -> "mlp.fc1.bias",
        "mlp.W_out" -> "mlp.fc2.weight.T",
        "mlp.b_out" -> "mlp.fc2.bias",
}
"ln_final.w" -> "model.final_layernorm.weight",
"ln_final.b" -> "model.final_layernorm.bias",
"unembed.W_U" -> "lm_head.weight.T",
"unembed.b_U" -> "lm_head.bias",
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility