### PR TITLE
Force unsupported models

### DIFF
--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1134,7 +1134,7 @@ class HookedTransformer(HookedRootModule):
         default_padding_side: Literal["left", "right"] = "right",
         dtype="float32",
         first_n_layers: Optional[int] = None,
-        force_unsupported_model=False,  
+        force_unsupported_model=False,
         **from_pretrained_kwargs,
     ) -> T:
         """Load in a Pretrained Model.
@@ -1323,12 +1323,14 @@ class HookedTransformer(HookedRootModule):
             logging.warning("float16 models may not work on CPU. Consider using a GPU or bfloat16.")
 
         if force_unsupported_model:
-               #Force the loading of an unsupported model
-               logging.warning("You may be loading an unsupported model. Please be sure you know what you are doing and that you can expect unwanted behaviour")
-               official_model_name=model_name
+            # Force the loading of an unsupported model
+            logging.warning(
+                "You may be loading an unsupported model. Please be sure you know what you are doing and that you can expect unwanted behaviour"
+            )
+            official_model_name = model_name
         else:
-               # Get the model name used in HuggingFace, rather than the alias.
-               official_model_name = loading.get_official_model_name(model_name)
+            # Get the model name used in HuggingFace, rather than the alias.
+            official_model_name = loading.get_official_model_name(model_name)
 
         # Load the config into an HookedTransformerConfig object. If loading from a
         # checkpoint, the config object will contain the information about the
@@ -1377,9 +1379,13 @@ class HookedTransformer(HookedRootModule):
         # Get the state dict of the model (ie a mapping of parameter names to tensors), processed to
         # match the HookedTransformer parameter names.
         state_dict = loading.get_pretrained_state_dict(
-            official_model_name, cfg, hf_model, dtype=dtype, force_unsupported_model=force_unsupported_model, **from_pretrained_kwargs
+            official_model_name,
+            cfg,
+            hf_model,
+            dtype=dtype,
+            force_unsupported_model=force_unsupported_model,
+            **from_pretrained_kwargs,
         )
-
 
         # Create the HookedTransformer object
         model = cls(

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -738,7 +738,7 @@ def get_official_model_name(model_name: str):
     return official_model_name
 
 
-def convert_hf_model_config(model_name: str, **kwargs):
+def convert_hf_model_config(model_name: str, force_unsupported_model=False, **kwargs):
     """
     Returns the model config for a HuggingFace model, converted to a dictionary
     in the HookedTransformerConfig format.
@@ -750,7 +750,10 @@ def convert_hf_model_config(model_name: str, **kwargs):
         logging.info("Loading model config from local directory")
         official_model_name = model_name
     else:
-        official_model_name = get_official_model_name(model_name)
+        if force_unsupported_model==False:
+            official_model_name = get_official_model_name(model_name)
+        else:
+            official_model_name = model_name
 
     # Load HuggingFace model config
     if "llama" in official_model_name.lower():
@@ -1562,6 +1565,7 @@ def get_pretrained_model_config(
     default_prepend_bos: Optional[bool] = None,
     dtype: torch.dtype = torch.float32,
     first_n_layers: Optional[int] = None,
+    force_unsupported_model=False,
     **kwargs,
 ):
     """Returns the pretrained model config as an HookedTransformerConfig object.
@@ -1600,16 +1604,22 @@ def get_pretrained_model_config(
             so this empirically seems to give better results. Note that you can also locally override the default behavior
             by passing in prepend_bos=True/False when you call a method that processes the input string.
         dtype (torch.dtype, optional): The dtype to load the TransformerLens model in.
+        force_unsupported_model: If specified, the function will try to load the model specified by the user, even though
+             it may be not official supported by TransformerLens. Use it at your own risk.
         kwargs: Other optional arguments passed to HuggingFace's from_pretrained.
             Also given to other HuggingFace functions when compatible.
 
     """
     if Path(model_name).exists():
         # If the model_name is a path, it's a local model
-        cfg_dict = convert_hf_model_config(model_name, **kwargs)
+        cfg_dict = convert_hf_model_config(model_name, force_unsupported_model=force_unsupported_model, **kwargs)
         official_model_name = model_name
     else:
-        official_model_name = get_official_model_name(model_name)
+        if force_unsupported_model==False:
+             official_model_name = get_official_model_name(model_name)
+        else:
+             #Forcing an unsupported model
+             official_model_name=model_name
     if (
         official_model_name.startswith("NeelNanda")
         or official_model_name.startswith("ArthurConmy")
@@ -1624,7 +1634,7 @@ def get_pretrained_model_config(
                 f"Loading model {official_model_name} requires setting trust_remote_code=True"
             )
             kwargs["trust_remote_code"] = True
-        cfg_dict = convert_hf_model_config(official_model_name, **kwargs)
+        cfg_dict = convert_hf_model_config(official_model_name, force_unsupported_model=force_unsupported_model, **kwargs)
     # Processing common to both model types
     # Remove any prefix, saying the organization who made a model.
     cfg_dict["model_name"] = official_model_name.split("/")[-1]
@@ -1759,6 +1769,7 @@ def get_pretrained_state_dict(
     cfg: HookedTransformerConfig,
     hf_model=None,
     dtype: torch.dtype = torch.float32,
+    force_unsupported_model=False,
     **kwargs,
 ) -> Dict[str, torch.Tensor]:
     """
@@ -1779,7 +1790,10 @@ def get_pretrained_state_dict(
         official_model_name = str(Path(official_model_name).resolve())
         logging.info(f"Loading model from local path {official_model_name}")
     else:
-        official_model_name = get_official_model_name(official_model_name)
+        if force_unsupported_model==False:
+            official_model_name = get_official_model_name(official_model_name)
+        else:
+            official_model_name = official_model_name
     if official_model_name.startswith(NEED_REMOTE_CODE_MODELS) and not kwargs.get(
         "trust_remote_code", False
     ):

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -785,7 +785,7 @@ def convert_hf_model_config(model_name: str, force_unsupported_model=False, **kw
         logging.info("Loading model config from local directory")
         official_model_name = model_name
     else:
-        if force_unsupported_model==False:
+        if force_unsupported_model == False:
             official_model_name = get_official_model_name(model_name)
         else:
             official_model_name = model_name
@@ -1693,14 +1693,16 @@ def get_pretrained_model_config(
     """
     if Path(model_name).exists():
         # If the model_name is a path, it's a local model
-        cfg_dict = convert_hf_model_config(model_name, force_unsupported_model=force_unsupported_model, **kwargs)
+        cfg_dict = convert_hf_model_config(
+            model_name, force_unsupported_model=force_unsupported_model, **kwargs
+        )
         official_model_name = model_name
     else:
-        if force_unsupported_model==False:
-             official_model_name = get_official_model_name(model_name)
+        if force_unsupported_model == False:
+            official_model_name = get_official_model_name(model_name)
         else:
-             #Forcing an unsupported model
-             official_model_name=model_name
+            # Forcing an unsupported model
+            official_model_name = model_name
     if (
         official_model_name.startswith("NeelNanda")
         or official_model_name.startswith("ArthurConmy")
@@ -1715,7 +1717,9 @@ def get_pretrained_model_config(
                 f"Loading model {official_model_name} requires setting trust_remote_code=True"
             )
             kwargs["trust_remote_code"] = True
-        cfg_dict = convert_hf_model_config(official_model_name, force_unsupported_model=force_unsupported_model, **kwargs)
+        cfg_dict = convert_hf_model_config(
+            official_model_name, force_unsupported_model=force_unsupported_model, **kwargs
+        )
     # Processing common to both model types
     # Remove any prefix, saying the organization who made a model.
     cfg_dict["model_name"] = official_model_name.split("/")[-1]
@@ -1873,7 +1877,7 @@ def get_pretrained_state_dict(
         official_model_name = str(Path(official_model_name).resolve())
         logging.info(f"Loading model from local path {official_model_name}")
     else:
-        if force_unsupported_model==False:
+        if force_unsupported_model == False:
             official_model_name = get_official_model_name(official_model_name)
         else:
             official_model_name = official_model_name

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1854,7 +1854,7 @@ def get_pretrained_state_dict(
     dtype: torch.dtype = torch.float32,
     force_unsupported_model=False,
     **kwargs: Any,
-) -> Dict[str, torch.Tensor]:
+) -> dict[str, torch.Tensor]:
     """
     Loads in the model weights for a pretrained model, and processes them to
     have the HookedTransformer parameter names and shapes. Supports checkpointed


### PR DESCRIPTION
Adding the "force_unsupported_models" feature

<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

I added the option "force_unsupported_model" in HookedTransformer.from_pretrained.
The new code simply skips the verification of the "official model names" by setting the parameter force_unsupported_model to True. Default parameter is False.
A warning message is printed on the screen when this option is set.

The reason for this addition is that researchers from non-English based countries may be find useful to adopt TransformerLens library to perform interpretability studies with different models in their languages and these models  are usually not included in the list of supported models.
Because there are many languages in the world and many different monolingual models, I thought it would be hard to  manually add all of these models into the list.
Instead, this option allows the user to force the loading of unsupported models, something that could work perfectly if the model is based on a common architecture.

For example, thanks to this fix I was able to load several Italian models with no issues:

LorenzoDeMattei/GePpeTto (GPT2)
sapienzanlp/Minerva-350M-base-v1.0 (Mistral)
sapienzanlp/Minerva-1B-base-v1.0 (Mistral)
sapienzanlp/Minerva-3B-base-v1.0 (Mistral)
Almawave/Velvet-2B (Mistral)

Sometimes it doesn't work out of the box, for example with sapienzanlp/Minerva-7B-instruct-v1.0 (Mistral), but I still think this option can be valuable to do testing without editing everytime by hand the list of supported models.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Screenshots


<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->