### PR TITLE
Component test coverage

### DIFF
--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_base_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_base_weight_conversion.py
@@ -11,12 +11,12 @@ class MockWeightConversion(BaseWeightConversion):
         return weight + 5
 
 
-
 def test_base_weight_conversion_convert_throws_error():
     weight_conversion = BaseWeightConversion()
     with pytest.raises(NotImplementedError):
         weight_conversion.convert(torch.zeros(1, 4))
-        
+
+
 def test_mock_weight_conversion_adds_five():
     """
     Verify that the mock subclass adds 5 to every element of the tensor.
@@ -25,12 +25,13 @@ def test_mock_weight_conversion_adds_five():
     input_tensor = torch.zeros((1, 4), dtype=torch.float32)
     output_tensor = weight_conversion.convert(input_tensor)
     expected_tensor = torch.full((1, 4), 5.0, dtype=torch.float32)
-    
+
     # Option 1: simple equality check
     assert torch.equal(output_tensor, expected_tensor)
 
     # Option 2: more robust approximate check
     # torch.testing.assert_close(output_tensor, expected_tensor)
+
 
 @pytest.mark.parametrize("shape", [(1, 4), (2, 2), (3,)])
 def test_mock_weight_conversion_various_shapes(shape):
@@ -42,6 +43,7 @@ def test_mock_weight_conversion_various_shapes(shape):
     output_tensor = weight_conversion.convert(input_tensor)
     expected_tensor = torch.full(shape, 5.0)
     assert torch.equal(output_tensor, expected_tensor)
+
 
 def test_mock_weight_conversion_empty_tensor():
     """

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_callable_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_callable_weight_conversion.py
@@ -4,11 +4,13 @@ from transformer_lens.weight_conversion.conversion_utils.conversion_steps.callab
     CallableWeightConversion,
 )
 
+
 def test_callable_weight_conversion_basic():
     """
     Verifies that the given callable is invoked on a dict of tensors
     and the result is returned as expected.
     """
+
     def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         # Example transformation: add 1 to each tensor value
         new_dict = {}
@@ -42,6 +44,7 @@ def test_callable_weight_conversion_input_filter():
     Ensures BaseWeightConversion's input_filter is applied
     to the dict of tensors before the main callable runs.
     """
+
     def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         new_dict = {}
         for k, v in tensor_dict.items():
@@ -75,10 +78,11 @@ def test_callable_weight_conversion_output_filter():
     Ensures BaseWeightConversion's output_filter is applied
     to the dict of tensors after the main callable runs.
     """
+
     def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         new_dict = {}
         for k, v in tensor_dict.items():
-            new_dict[k] = v ** 2
+            new_dict[k] = v**2
         return new_dict
 
     def my_output_filter(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
@@ -107,6 +111,7 @@ def test_callable_weight_conversion_input_and_output_filters():
     Tests that input_filter and output_filter both run in the correct order
     around the callable, for a dict of tensors.
     """
+
     def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         new_dict = {}
         for k, v in tensor_dict.items():
@@ -149,11 +154,12 @@ def test_callable_weight_conversion_repr():
     Simple test confirming __repr__ returns the expected info
     about the callable operation.
     """
+
     def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         return tensor_dict
 
     conversion = CallableWeightConversion(my_callable)
     rep = repr(conversion).lower()
-    assert "callable operation" in rep, (
-        f"Expected '__repr__' to mention 'callable operation', got '{rep}'"
-    )
+    assert (
+        "callable operation" in rep
+    ), f"Expected '__repr__' to mention 'callable operation', got '{rep}'"

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_callable_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_callable_weight_conversion.py
@@ -1,0 +1,160 @@
+import pytest
+import torch
+
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps.callable_weight_conversion import (
+    CallableWeightConversion,
+)
+
+def test_callable_weight_conversion_basic():
+    """
+    Verifies that the given callable is invoked on a dict of tensors
+    and the result is returned as expected.
+    """
+    def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        # Example transformation: add 1 to each tensor value
+        new_dict = {}
+        for k, v in tensor_dict.items():
+            new_dict[k] = v + 1
+        return new_dict
+
+    conversion = CallableWeightConversion(my_callable)
+
+    input_data = {
+        "a": torch.tensor([1.0, 2.0]),
+        "b": torch.tensor([[3.0, 4.0], [5.0, 6.0]]),
+    }
+    # Original copies to verify no in-place modification
+    original_a = input_data["a"].clone()
+    original_b = input_data["b"].clone()
+
+    output_data = conversion.convert(input_data)
+
+    # Check the callable was applied
+    assert torch.allclose(output_data["a"], input_data["a"] + 1)
+    assert torch.allclose(output_data["b"], input_data["b"] + 1)
+
+    # Confirm the original dict is not modified (unless that's desired)
+    assert torch.allclose(input_data["a"], original_a), "Input data 'a' was modified in place!"
+    assert torch.allclose(input_data["b"], original_b), "Input data 'b' was modified in place!"
+
+
+def test_callable_weight_conversion_input_filter():
+    """
+    Ensures BaseWeightConversion's input_filter is applied
+    to the dict of tensors before the main callable runs.
+    """
+    def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        new_dict = {}
+        for k, v in tensor_dict.items():
+            new_dict[k] = v + 10
+        return new_dict
+
+    def my_input_filter(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        # Multiply each tensor by 2
+        filtered_dict = {}
+        for k, v in tensor_dict.items():
+            filtered_dict[k] = v * 2
+        return filtered_dict
+
+    conversion = CallableWeightConversion(my_callable)
+    conversion.input_filter = my_input_filter
+
+    input_data = {
+        "x": torch.tensor([1.0, 2.0, 3.0]),
+        "y": torch.tensor([4.0]),
+    }
+    output_data = conversion.convert(input_data)
+
+    # The input_filter doubles each value => x=[2,4,6], y=[8],
+    # then my_callable adds 10 => x=[12,14,16], y=[18].
+    assert torch.allclose(output_data["x"], torch.tensor([12.0, 14.0, 16.0]))
+    assert torch.allclose(output_data["y"], torch.tensor([18.0]))
+
+
+def test_callable_weight_conversion_output_filter():
+    """
+    Ensures BaseWeightConversion's output_filter is applied
+    to the dict of tensors after the main callable runs.
+    """
+    def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        new_dict = {}
+        for k, v in tensor_dict.items():
+            new_dict[k] = v ** 2
+        return new_dict
+
+    def my_output_filter(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        # Subtract 5 from each element
+        filtered_dict = {}
+        for k, v in tensor_dict.items():
+            filtered_dict[k] = v - 5
+        return filtered_dict
+
+    conversion = CallableWeightConversion(my_callable)
+    conversion.output_filter = my_output_filter
+
+    input_data = {
+        "first": torch.tensor([2.0, 3.0]),
+        "second": torch.tensor([4.0]),
+    }
+    output_data = conversion.convert(input_data)
+    # After callable: first=[4.0,9.0], second=[16.0]
+    # After output_filter: first=[-1,4], second=[11]
+    assert torch.allclose(output_data["first"], torch.tensor([-1.0, 4.0]))
+    assert torch.allclose(output_data["second"], torch.tensor([11.0]))
+
+
+def test_callable_weight_conversion_input_and_output_filters():
+    """
+    Tests that input_filter and output_filter both run in the correct order
+    around the callable, for a dict of tensors.
+    """
+    def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        new_dict = {}
+        for k, v in tensor_dict.items():
+            new_dict[k] = v + 10
+        return new_dict
+
+    def my_input_filter(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        new_dict = {}
+        for k, v in tensor_dict.items():
+            new_dict[k] = v * 2
+        return new_dict
+
+    def my_output_filter(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        new_dict = {}
+        for k, v in tensor_dict.items():
+            new_dict[k] = v - 3
+        return new_dict
+
+    conversion = CallableWeightConversion(my_callable)
+    conversion.input_filter = my_input_filter
+    conversion.output_filter = my_output_filter
+
+    input_data = {
+        "stuff": torch.tensor([1.0, 2.0]),
+        "things": torch.tensor([3.0]),
+    }
+    output_data = conversion.convert(input_data)
+    # Steps:
+    #   1) input_filter => stuff=[2,4], things=[6]
+    #   2) callable => +10 => stuff=[12,14], things=[16]
+    #   3) output_filter => -3 => stuff=[9,11], things=[13]
+    expected_stuff = torch.tensor([9.0, 11.0])
+    expected_things = torch.tensor([13.0])
+    assert torch.allclose(output_data["stuff"], expected_stuff)
+    assert torch.allclose(output_data["things"], expected_things)
+
+
+def test_callable_weight_conversion_repr():
+    """
+    Simple test confirming __repr__ returns the expected info
+    about the callable operation.
+    """
+    def my_callable(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        return tensor_dict
+
+    conversion = CallableWeightConversion(my_callable)
+    rep = repr(conversion).lower()
+    assert "callable operation" in rep, (
+        f"Expected '__repr__' to mention 'callable operation', got '{rep}'"
+    )

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_callable_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_callable_weight_conversion.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 
 from transformer_lens.weight_conversion.conversion_utils.conversion_steps.callable_weight_conversion import (

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_rearrange_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_rearrange_weight_conversion.py
@@ -39,15 +39,12 @@ def test_rearrange_weight_conversion_input_filter():
     """
     Tests that the input_filter is applied correctly before rearrange.
     """
+
     def input_filter(tensor):
         # E.g., multiply by 2
         return tensor * 2
 
-    conversion = RearrangeWeightConversion(
-        "(n h) m->n m h",
-        input_filter=input_filter,
-        n=8
-    )
+    conversion = RearrangeWeightConversion("(n h) m->n m h", input_filter=input_filter, n=8)
     starting = torch.arange(80 * 5, dtype=torch.float32).reshape(80, 5)
     result = conversion.convert(starting)
 
@@ -68,15 +65,12 @@ def test_rearrange_weight_conversion_output_filter():
     """
     Tests that the output_filter is applied to the rearranged output.
     """
+
     def output_filter(tensor):
         # E.g., add 10
         return tensor + 10
 
-    conversion = RearrangeWeightConversion(
-        "(n h) m->n m h",
-        output_filter=output_filter,
-        n=8
-    )
+    conversion = RearrangeWeightConversion("(n h) m->n m h", output_filter=output_filter, n=8)
     starting = torch.arange(80 * 5, dtype=torch.float32).reshape(80, 5)
     result = conversion.convert(starting)
 
@@ -100,6 +94,7 @@ def test_rearrange_weight_conversion_input_output_filters():
     """
     Tests that both input_filter and output_filter are applied in sequence.
     """
+
     def input_filter(tensor):
         return tensor * 2  # Double
 
@@ -107,10 +102,7 @@ def test_rearrange_weight_conversion_input_output_filters():
         return tensor + 3  # Then add 3
 
     conversion = RearrangeWeightConversion(
-        "(n h) m->n m h",
-        input_filter=input_filter,
-        output_filter=output_filter,
-        n=8
+        "(n h) m->n m h", input_filter=input_filter, output_filter=output_filter, n=8
     )
     starting = torch.arange(80 * 5, dtype=torch.float32).reshape(80, 5)
     result = conversion.convert(starting)
@@ -122,6 +114,6 @@ def test_rearrange_weight_conversion_input_output_filters():
             base_val = float(i * 5 + j)
             expected_value = (base_val * 2) + 3
             new_val = result[i // 10, j, i % 10].item()
-            assert new_val == pytest.approx(expected_value), (
-                f"Incorrect arrangement or filter chain: expected {expected_value}, got {new_val}"
-            )
+            assert new_val == pytest.approx(
+                expected_value
+            ), f"Incorrect arrangement or filter chain: expected {expected_value}, got {new_val}"

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_rearrange_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_rearrange_weight_conversion.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from transformer_lens.weight_conversion.conversion_utils.conversion_steps.rearrange_weight_conversion import (
@@ -5,11 +6,122 @@ from transformer_lens.weight_conversion.conversion_utils.conversion_steps.rearra
 )
 
 
-def test_rearrange_weight_conversion():
+def test_rearrange_weight_conversion_basic():
+    """
+    Basic test: rearranging (n h) m->n m h with n=8.
+    Verifies shape, element count, and correctness of mapping.
+    """
     conversion = RearrangeWeightConversion("(n h) m->n m h", n=8)
-
-    starting = torch.rand(80, 5)
+    starting = torch.arange(80 * 5, dtype=torch.float32).reshape(80, 5)
 
     result = conversion.convert(starting)
 
+    # Check shape
     assert result.shape == (8, 5, 10)
+
+    # Check total number of elements is the same
+    assert result.numel() == starting.numel()
+
+    # Verify each element's new position
+    # pattern = "(n h) m->n m h", with n=8 => h=80/8=10
+    for i in range(80):
+        for j in range(5):
+            # new index: (i//10, j, i%10)
+            expected_value = float(i * 5 + j)  # Because starting is arange(80*5)
+            new_val = result[i // 10, j, i % 10].item()
+            assert new_val == pytest.approx(expected_value), (
+                f"Incorrect rearrangement: expected {expected_value}, "
+                f"got {new_val} at new index ({i//10}, {j}, {i%10})."
+            )
+
+
+def test_rearrange_weight_conversion_input_filter():
+    """
+    Tests that the input_filter is applied correctly before rearrange.
+    """
+    def input_filter(tensor):
+        # E.g., multiply by 2
+        return tensor * 2
+
+    conversion = RearrangeWeightConversion(
+        "(n h) m->n m h",
+        input_filter=input_filter,
+        n=8
+    )
+    starting = torch.arange(80 * 5, dtype=torch.float32).reshape(80, 5)
+    result = conversion.convert(starting)
+
+    # After filter, the input to einops is starting*2, so each element is doubled.
+    # So the expected value in new index is (original_index_value * 2).
+    assert result.shape == (8, 5, 10)
+    for i in range(80):
+        for j in range(5):
+            expected_value = float(i * 5 + j) * 2
+            new_val = result[i // 10, j, i % 10].item()
+            assert new_val == pytest.approx(expected_value), (
+                f"Incorrect rearrangement or input_filter application: "
+                f"expected {expected_value}, got {new_val}"
+            )
+
+
+def test_rearrange_weight_conversion_output_filter():
+    """
+    Tests that the output_filter is applied to the rearranged output.
+    """
+    def output_filter(tensor):
+        # E.g., add 10
+        return tensor + 10
+
+    conversion = RearrangeWeightConversion(
+        "(n h) m->n m h",
+        output_filter=output_filter,
+        n=8
+    )
+    starting = torch.arange(80 * 5, dtype=torch.float32).reshape(80, 5)
+    result = conversion.convert(starting)
+
+    # The rearrangement hasn't changed, but the entire result is +10
+    # from the original rearranged values.
+    assert result.shape == (8, 5, 10)
+    for i in range(80):
+        for j in range(5):
+            # rearranged index
+            rearranged_val = float(i * 5 + j)
+            # after output_filter
+            expected_value = rearranged_val + 10
+            new_val = result[i // 10, j, i % 10].item()
+            assert new_val == pytest.approx(expected_value), (
+                f"Incorrect rearrangement or output_filter application: "
+                f"expected {expected_value}, got {new_val}"
+            )
+
+
+def test_rearrange_weight_conversion_input_output_filters():
+    """
+    Tests that both input_filter and output_filter are applied in sequence.
+    """
+    def input_filter(tensor):
+        return tensor * 2  # Double
+
+    def output_filter(tensor):
+        return tensor + 3  # Then add 3
+
+    conversion = RearrangeWeightConversion(
+        "(n h) m->n m h",
+        input_filter=input_filter,
+        output_filter=output_filter,
+        n=8
+    )
+    starting = torch.arange(80 * 5, dtype=torch.float32).reshape(80, 5)
+    result = conversion.convert(starting)
+
+    # Expect rearranged_val = (original_index_value * 2) + 3
+    assert result.shape == (8, 5, 10)
+    for i in range(80):
+        for j in range(5):
+            base_val = float(i * 5 + j)
+            expected_value = (base_val * 2) + 3
+            new_val = result[i // 10, j, i % 10].item()
+            assert new_val == pytest.approx(expected_value), (
+                f"Incorrect arrangement or filter chain: expected {expected_value}, got {new_val}"
+            )

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_repeat_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_repeat_weight_conversion.py
@@ -4,25 +4,26 @@ from transformer_lens.weight_conversion.conversion_utils.conversion_steps.repeat
     RepeatWeightConversion,
 )
 
+
 def test_repeat_weight_conversion_basic():
     """
     Tests a basic repeat operation on a single tensor, verifying shape
     and data repetition.
-    
+
     Example pattern (h w -> h 2 w):
     We repeat along the second dimension.
     """
-    # Pattern says: "h w -> h repeat1 w" 
+    # Pattern says: "h w -> h repeat1 w"
     # let's do: pattern="h w -> h 2 w", so we define repeat2=2 for the new axis
     conversion = RepeatWeightConversion("h w -> h 2 w", h=3, w=4)
-    
+
     # Start with a known shape: [3,4], fill with arange to track values
     input_tensor = torch.arange(12.0).reshape(3, 4)  # shape [3,4]
     result = conversion.convert(input_tensor)
-    
+
     # The new shape should be [3, 2, 4]
     assert result.shape == (3, 2, 4)
-    
+
     # Because we're repeating along the second dimension with factor=2,
     # each row is duplicated in that dimension:
     # For row 0, we expect the same data repeated in the second dimension.
@@ -40,19 +41,19 @@ def test_repeat_weight_conversion_axes_lengths():
     e.g., "h w -> (2 h) (3 w)", verifying shape and data duplication.
     """
     conversion = RepeatWeightConversion("h w -> (repeat_h h) (repeat_w w)", repeat_h=2, repeat_w=3)
-    
-    input_tensor = torch.tensor([[1,2],[3,4]], dtype=torch.float32)  # shape [2,2], h=2, w=2
+
+    input_tensor = torch.tensor([[1, 2], [3, 4]], dtype=torch.float32)  # shape [2,2], h=2, w=2
     result = conversion.convert(input_tensor)
-    
+
     # The new shape should be [2*2, 3*2] => [4, 6]
     assert result.shape == (4, 6)
-    
-    # Each original element is repeated 2 times in the 'h' dimension 
+
+    # Each original element is repeated 2 times in the 'h' dimension
     # and 3 times in the 'w' dimension. We'll do a thorough check:
     for h_idx in range(2):
         for w_idx in range(2):
             original_val = input_tensor[h_idx, w_idx].item()
-            
+
             for rep_h in range(2):
                 for rep_w in range(3):
                     h_key = h_idx + rep_h * 2
@@ -68,6 +69,7 @@ def test_repeat_weight_conversion_input_filter():
     """
     Verifies input_filter is applied before the repeat operation.
     """
+
     def multiply_by_5(tensor: torch.Tensor) -> torch.Tensor:
         return tensor * 5
 
@@ -76,22 +78,25 @@ def test_repeat_weight_conversion_input_filter():
     conversion = RepeatWeightConversion("b -> (b rep)", input_filter=multiply_by_5, rep=2)
 
     # input shape [4]
-    input_tensor = torch.tensor([1,2,3,4], dtype=torch.float32)
+    input_tensor = torch.tensor([1, 2, 3, 4], dtype=torch.float32)
     # input_filter => [5,10,15,20]
     # repeated => shape [8], each original index repeated once
     # final => [5,5,10,10,15,15,20,20]
     result = conversion.convert(input_tensor)
-    
+
     print("result", result)
     assert result.shape == (8,)
-    expected = torch.tensor([5,5,10,10,15,15,20,20], dtype=torch.float32)
-    assert torch.allclose(result, expected), "Input filter or repeat pattern didn't apply correctly."
+    expected = torch.tensor([5, 5, 10, 10, 15, 15, 20, 20], dtype=torch.float32)
+    assert torch.allclose(
+        result, expected
+    ), "Input filter or repeat pattern didn't apply correctly."
 
 
 def test_repeat_weight_conversion_output_filter():
     """
     Verifies output_filter is applied after the repeat operation.
     """
+
     def add_ten(tensor: torch.Tensor) -> torch.Tensor:
         return tensor + 10
 
@@ -102,17 +107,20 @@ def test_repeat_weight_conversion_output_filter():
     # repeated => shape [2,3], each row is the same as input_tensor
     # then +10
     result = conversion.convert(input_tensor)
-    
+
     assert result.shape == (2, 3)
     # repeated: [[0,1,2],[0,1,2]] => after +10 => [[10,11,12],[10,11,12]]
-    expected = torch.tensor([[10,11,12],[10,11,12]], dtype=torch.float32)
-    assert torch.allclose(result, expected), "Output filter or repeat pattern didn't apply correctly."
+    expected = torch.tensor([[10, 11, 12], [10, 11, 12]], dtype=torch.float32)
+    assert torch.allclose(
+        result, expected
+    ), "Output filter or repeat pattern didn't apply correctly."
 
 
 def test_repeat_weight_conversion_both_filters():
     """
     Tests the pipeline: input_filter -> repeat -> output_filter.
     """
+
     def input_filter(tensor: torch.Tensor) -> torch.Tensor:
         return tensor * 2  # double
 
@@ -121,23 +129,19 @@ def test_repeat_weight_conversion_both_filters():
 
     # pattern: "c -> 3 c", triple the dimension
     conversion = RepeatWeightConversion(
-        "c -> rep c", 
-        c=2, 
-        rep=3,
-        input_filter=input_filter,
-        output_filter=output_filter
+        "c -> rep c", c=2, rep=3, input_filter=input_filter, output_filter=output_filter
     )
 
-    input_tensor = torch.tensor([2.0,3.0])
+    input_tensor = torch.tensor([2.0, 3.0])
     # Steps:
     #   1) input_filter => [4.0, 6.0]
     #   2) repeat => shape [3,2]: [[4,6],[4,6],[4,6]]
     #   3) output_filter => subtract 3 => [[1,3],[1,3],[1,3]]
     result = conversion.convert(input_tensor)
-    expected = torch.tensor([[1.0,3.0],[1.0,3.0],[1.0,3.0]])
-    assert torch.allclose(result, expected), (
-        "Both filters or repeat pattern not applied correctly in sequence!"
-    )
+    expected = torch.tensor([[1.0, 3.0], [1.0, 3.0], [1.0, 3.0]])
+    assert torch.allclose(
+        result, expected
+    ), "Both filters or repeat pattern not applied correctly in sequence!"
 
 
 def test_repeat_weight_conversion_repr():

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_repeat_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_repeat_weight_conversion.py
@@ -1,0 +1,150 @@
+import torch
+
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps.repeat_weight_conversion import (
+    RepeatWeightConversion,
+)
+
+def test_repeat_weight_conversion_basic():
+    """
+    Tests a basic repeat operation on a single tensor, verifying shape
+    and data repetition.
+    
+    Example pattern (h w -> h 2 w):
+    We repeat along the second dimension.
+    """
+    # Pattern says: "h w -> h repeat1 w" 
+    # let's do: pattern="h w -> h 2 w", so we define repeat2=2 for the new axis
+    conversion = RepeatWeightConversion("h w -> h 2 w", h=3, w=4)
+    
+    # Start with a known shape: [3,4], fill with arange to track values
+    input_tensor = torch.arange(12.0).reshape(3, 4)  # shape [3,4]
+    result = conversion.convert(input_tensor)
+    
+    # The new shape should be [3, 2, 4]
+    assert result.shape == (3, 2, 4)
+    
+    # Because we're repeating along the second dimension with factor=2,
+    # each row is duplicated in that dimension:
+    # For row 0, we expect the same data repeated in the second dimension.
+    # We'll just check a few positions to ensure it repeated:
+    for h_idx in range(3):
+        for w_idx in range(4):
+            val_1 = result[h_idx, 0, w_idx].item()
+            val_2 = result[h_idx, 1, w_idx].item()
+            assert val_1 == val_2, f"Expected repeated values, got {val_1} and {val_2}."
+
+
+def test_repeat_weight_conversion_axes_lengths():
+    """
+    Tests the repeat pattern with multiple expansions,
+    e.g., "h w -> (2 h) (3 w)", verifying shape and data duplication.
+    """
+    conversion = RepeatWeightConversion("h w -> (repeat_h h) (repeat_w w)", repeat_h=2, repeat_w=3)
+    
+    input_tensor = torch.tensor([[1,2],[3,4]], dtype=torch.float32)  # shape [2,2], h=2, w=2
+    result = conversion.convert(input_tensor)
+    
+    # The new shape should be [2*2, 3*2] => [4, 6]
+    assert result.shape == (4, 6)
+    
+    # Each original element is repeated 2 times in the 'h' dimension 
+    # and 3 times in the 'w' dimension. We'll do a thorough check:
+    for h_idx in range(2):
+        for w_idx in range(2):
+            original_val = input_tensor[h_idx, w_idx].item()
+            
+            for rep_h in range(2):
+                for rep_w in range(3):
+                    h_key = h_idx + rep_h * 2
+                    w_key = w_idx + rep_w * 2
+                    new_val = result[h_key, w_key].item()
+                    assert new_val == original_val, (
+                        f"Mismatch at repeated block for input ({h_idx},{w_idx}). "
+                        f"Expected {original_val}, got {new_val}."
+                    )
+
+
+def test_repeat_weight_conversion_input_filter():
+    """
+    Verifies input_filter is applied before the repeat operation.
+    """
+    def multiply_by_5(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor * 5
+
+    # We'll keep a simple pattern for clarity: "b -> (2 b)"
+    # Repeats the existing dimension 2 times.
+    conversion = RepeatWeightConversion("b -> (b rep)", input_filter=multiply_by_5, rep=2)
+
+    # input shape [4]
+    input_tensor = torch.tensor([1,2,3,4], dtype=torch.float32)
+    # input_filter => [5,10,15,20]
+    # repeated => shape [8], each original index repeated once
+    # final => [5,5,10,10,15,15,20,20]
+    result = conversion.convert(input_tensor)
+    
+    print("result", result)
+    assert result.shape == (8,)
+    expected = torch.tensor([5,5,10,10,15,15,20,20], dtype=torch.float32)
+    assert torch.allclose(result, expected), "Input filter or repeat pattern didn't apply correctly."
+
+
+def test_repeat_weight_conversion_output_filter():
+    """
+    Verifies output_filter is applied after the repeat operation.
+    """
+    def add_ten(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor + 10
+
+    # pattern: "h -> 2 h", doubling the first dimension
+    conversion = RepeatWeightConversion("h -> 2 h", h=3, output_filter=add_ten)
+
+    input_tensor = torch.arange(3.0)
+    # repeated => shape [2,3], each row is the same as input_tensor
+    # then +10
+    result = conversion.convert(input_tensor)
+    
+    assert result.shape == (2, 3)
+    # repeated: [[0,1,2],[0,1,2]] => after +10 => [[10,11,12],[10,11,12]]
+    expected = torch.tensor([[10,11,12],[10,11,12]], dtype=torch.float32)
+    assert torch.allclose(result, expected), "Output filter or repeat pattern didn't apply correctly."
+
+
+def test_repeat_weight_conversion_both_filters():
+    """
+    Tests the pipeline: input_filter -> repeat -> output_filter.
+    """
+    def input_filter(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor * 2  # double
+
+    def output_filter(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor - 3  # subtract 3
+
+    # pattern: "c -> 3 c", triple the dimension
+    conversion = RepeatWeightConversion(
+        "c -> rep c", 
+        c=2, 
+        rep=3,
+        input_filter=input_filter,
+        output_filter=output_filter
+    )
+
+    input_tensor = torch.tensor([2.0,3.0])
+    # Steps:
+    #   1) input_filter => [4.0, 6.0]
+    #   2) repeat => shape [3,2]: [[4,6],[4,6],[4,6]]
+    #   3) output_filter => subtract 3 => [[1,3],[1,3],[1,3]]
+    result = conversion.convert(input_tensor)
+    expected = torch.tensor([[1.0,3.0],[1.0,3.0],[1.0,3.0]])
+    assert torch.allclose(result, expected), (
+        "Both filters or repeat pattern not applied correctly in sequence!"
+    )
+
+
+def test_repeat_weight_conversion_repr():
+    """
+    Simple test confirming __repr__ returns info about the repeat operation.
+    """
+    conversion = RepeatWeightConversion("h -> 2 h")
+    rep_str = repr(conversion).lower()
+    assert "repeat operation" in rep_str, f"Expected 'repeat operation', got {rep_str}"
+    assert "pattern" in rep_str, f"Expected mention of 'pattern', got {rep_str}"

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_terenary_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_terenary_weight_conversion.py
@@ -1,0 +1,272 @@
+import pytest
+import torch
+
+from unittest.mock import MagicMock
+
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps.ternary_weight_conversion import (
+    TernaryWeightConversion,
+)
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps.base_weight_conversion import (
+    BaseWeightConversion,
+)
+
+###################################
+# Mock Conversions for Testing
+###################################
+
+class MockPrimaryConversion(BaseWeightConversion):
+    """
+    A primary conversion class that modifies the input tensor
+    (e.g., adds 42) to show it's been called.
+    """
+    def handle_conversion(self, input_value: torch.Tensor, **unused) -> torch.Tensor:
+        return input_value + 42
+
+class MockFallbackConversion(BaseWeightConversion):
+    """
+    A fallback conversion that returns a known tensor if input_value is None,
+    or modifies the existing tensor if not None.
+    """
+    def __init__(self):
+        super().__init__()
+        self.was_called = False
+
+    def handle_conversion(self, input_value: torch.Tensor | None, **unused) -> torch.Tensor:
+        self.was_called = True
+        if input_value is None:
+            return torch.tensor([999.0])
+        else:
+            return input_value + 999
+
+###################################
+# Ternary Tests
+###################################
+
+def test_ternary_weight_conversion_primary_none():
+    """
+    If primary_conversion is None, it should just return the input_value unmodified.
+    """
+    fallback = torch.tensor([10.0])  # Not used if input_value is not None
+    ternary = TernaryWeightConversion(
+        fallback_conversion=fallback,
+        primary_conversion=None
+    )
+    input_tensor = torch.tensor([1.0, 2.0])
+    output_tensor = ternary.convert(input_tensor)
+    assert torch.allclose(output_tensor, input_tensor), (
+        "Expected primary=None to return input_value as is."
+    )
+
+
+def test_ternary_weight_conversion_primary_tensor():
+    """
+    If primary_conversion is a torch.Tensor, ignore input_value and return that tensor.
+    """
+    fallback = torch.tensor([10.0])  # Not used if input_value is not None
+    primary_tensor = torch.tensor([100.0, 200.0])
+    ternary = TernaryWeightConversion(
+        fallback_conversion=fallback,
+        primary_conversion=primary_tensor
+    )
+    input_tensor = torch.tensor([1.0, 2.0])
+    output_tensor = ternary.convert(input_tensor)
+    assert torch.allclose(output_tensor, primary_tensor), (
+        "Expected to return primary tensor, ignoring input_value."
+    )
+
+
+def test_ternary_weight_conversion_primary_conversion_class():
+    """
+    If primary_conversion is a BaseWeightConversion, .convert() should be called.
+    """
+    fallback = torch.tensor([10.0])
+    mock_primary = MockPrimaryConversion()
+    ternary = TernaryWeightConversion(
+        fallback_conversion=fallback,
+        primary_conversion=mock_primary
+    )
+    input_tensor = torch.tensor([1.0, 2.0])
+    output_tensor = ternary.convert(input_tensor)
+
+    # MockPrimaryConversion adds 42
+    expected = input_tensor + 42
+    assert torch.allclose(output_tensor, expected)
+
+
+def test_ternary_weight_conversion_fallback_tensor():
+    """
+    If input_value is None and fallback is a Tensor, return that tensor directly.
+    """
+    fallback_tensor = torch.tensor([999.0])
+    ternary = TernaryWeightConversion(
+        fallback_conversion=fallback_tensor,
+        primary_conversion=None
+    )
+    # Trigger fallback by passing input_value=None
+    output = ternary.convert(None)
+    assert torch.allclose(output, fallback_tensor), "Expected fallback tensor to be returned."
+
+
+def test_ternary_weight_conversion_fallback_str():
+    """
+    If input_value is None and fallback is a str, we do a context lookup
+    with find_context_field().
+    """
+    # Suppose the context dict has "my_remote_field" -> [123.0, 456.0]
+    ternary = TernaryWeightConversion(
+        fallback_conversion="my_remote_field",  # str fallback
+    )
+
+    # We'll pass a dictionary as context
+    context = {"my_remote_field": torch.tensor([123.0, 456.0])}
+    # Convert(None, context=...) => fallback => find_context_field("my_remote_field") => returns [123.0, 456.0]
+    output = ternary.convert(None, context)
+
+    assert torch.allclose(output, torch.tensor([123.0, 456.0])), (
+        "Expected fallback str to be found in context dictionary."
+    )
+
+
+def test_ternary_weight_conversion_fallback_tuple():
+    """
+    If fallback is a tuple (REMOTE_FIELD, BaseWeightConversion), 
+    we do a context lookup for the REMOTE_FIELD,
+    then pass that to the second item, which is a conversion class.
+    """
+    class MockTupleConversion(BaseWeightConversion):
+        def __init__(self):
+            super().__init__()
+            self.was_called = False
+
+        def handle_conversion(self, input_value: torch.Tensor, *unused) -> torch.Tensor:
+            self.was_called = True
+            return input_value + 1000
+
+    mock_fallback_conv = MockTupleConversion()
+    fallback_tuple = ("my_backup_field", mock_fallback_conv)  # type: ignore
+
+    ternary = TernaryWeightConversion(
+        fallback_conversion=fallback_tuple,
+        primary_conversion=None
+    )
+
+    # Suppose the context dictionary has "my_backup_field" => [5,6,7]
+    context = {"my_backup_field": torch.tensor([5.0, 6.0, 7.0])}
+
+    output = ternary.convert(None, context)
+
+    assert mock_fallback_conv.was_called, (
+        "Expected fallback conversion in the tuple to be called."
+    )
+    # The fallback conv adds 1000
+    assert torch.allclose(output, torch.tensor([1005.0, 1006.0, 1007.0]))
+
+
+def test_ternary_weight_conversion_find_context_field_failure():
+    """
+    If fallback is a str, but the context doesn't contain that key,
+    find_context_field returns None, and so fallback is effectively None => 
+    This might cause an error or we accept returning None.
+    We'll see how your code handles that scenario.
+    """
+    ternary = TernaryWeightConversion(
+        fallback_conversion="missing_key",
+        primary_conversion=None
+    )
+    # No context => won't find 'missing_key'
+    output = ternary.convert(None, *{})
+    # According to your code, if nothing is found, we return None from find_context_field.
+    # handle_fallback_conversion will return that None from the function. 
+    # => This might break if the calling code expects a tensor.
+    # We'll just check it's None.
+    assert output is None, (
+        "Expected None if the fallback str wasn't found in the provided context."
+    )
+
+
+########################################
+# Tests for Input/Output Filters
+########################################
+
+def test_ternary_input_filter():
+    """
+    If there's an input_filter, it should run before handle_primary_conversion.
+    """
+    def input_filter(x: torch.Tensor) -> torch.Tensor:
+        return x * 10
+
+    mock_primary = MockPrimaryConversion()  # adds 42
+    ternary = TernaryWeightConversion(
+        fallback_conversion=torch.tensor([999.0]),
+        primary_conversion=mock_primary,
+        input_filter=input_filter
+    )
+    # Steps: input_filter => *10 => [10,20], primary => +42 => [52,62]
+    inp = torch.tensor([1.0,2.0])
+    out = ternary.convert(inp)
+    expected = torch.tensor([52.0,62.0])
+    assert torch.allclose(out, expected)
+
+
+def test_ternary_output_filter():
+    """
+    Output filter is applied after the main logic, 
+    i.e. after handle_primary_conversion or fallback.
+    """
+    def output_filter(x: torch.Tensor) -> torch.Tensor:
+        return x - 100
+
+    mock_primary = MockPrimaryConversion()  # adds 42
+    ternary = TernaryWeightConversion(
+        fallback_conversion=torch.tensor([999.0]),
+        primary_conversion=mock_primary,
+        output_filter=output_filter
+    )
+    # primary => +42 => [43,44], then output_filter => -100 => [-57, -56]
+    inp = torch.tensor([1.0,2.0])
+    out = ternary.convert(inp)
+    expected = torch.tensor([-57.0, -56.0])
+    assert torch.allclose(out, expected), "Output filter didn't apply after primary conversion."
+
+
+def test_ternary_both_filters():
+    """
+    Combination: input_filter -> primary -> output_filter
+    """
+    def input_filter(x: torch.Tensor) -> torch.Tensor:
+        return x * 3
+
+    def output_filter(x: torch.Tensor) -> torch.Tensor:
+        return x + 5
+
+    mock_primary = MockPrimaryConversion()  # +42
+    ternary = TernaryWeightConversion(
+        fallback_conversion=("backup_field", MockFallbackConversion()),
+        primary_conversion=mock_primary,
+        input_filter=input_filter,
+        output_filter=output_filter
+    )
+    # Steps:
+    #   1) input_filter => *3 => [3,6]
+    #   2) primary => +42 => [45,48]
+    #   3) output_filter => +5 => [50,53]
+    inp = torch.tensor([1.0,2.0])
+    out = ternary.convert(inp)
+    expected = torch.tensor([50.0, 53.0])
+    assert torch.allclose(out, expected), "Filter pipeline or primary logic is off."
+
+
+def test_ternary_repr():
+    """
+    Check that __repr__ includes mention of primary and fallback.
+    """
+    mock_primary = MockPrimaryConversion()
+    fallback_tuple = ("my_field", MockFallbackConversion())  # type: ignore
+    ternary = TernaryWeightConversion(
+        fallback_conversion=fallback_tuple,
+        primary_conversion=mock_primary
+    )
+    rep = repr(ternary).lower()
+    assert "ternary operation" in rep, f"Expected mention of 'ternary operation', got {rep}"
+    assert "primary conversion" in rep, f"Expected mention of 'primary conversion', got {rep}"
+    assert "fallback conversion" in rep, f"Expected mention of 'fallback conversion', got {rep}"

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_terenary_weight_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_terenary_weight_conversion.py
@@ -1,32 +1,33 @@
-import pytest
 import torch
 
-from unittest.mock import MagicMock
-
-from transformer_lens.weight_conversion.conversion_utils.conversion_steps.ternary_weight_conversion import (
-    TernaryWeightConversion,
-)
 from transformer_lens.weight_conversion.conversion_utils.conversion_steps.base_weight_conversion import (
     BaseWeightConversion,
+)
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps.ternary_weight_conversion import (
+    TernaryWeightConversion,
 )
 
 ###################################
 # Mock Conversions for Testing
 ###################################
 
+
 class MockPrimaryConversion(BaseWeightConversion):
     """
     A primary conversion class that modifies the input tensor
     (e.g., adds 42) to show it's been called.
     """
+
     def handle_conversion(self, input_value: torch.Tensor, **unused) -> torch.Tensor:
         return input_value + 42
+
 
 class MockFallbackConversion(BaseWeightConversion):
     """
     A fallback conversion that returns a known tensor if input_value is None,
     or modifies the existing tensor if not None.
     """
+
     def __init__(self):
         super().__init__()
         self.was_called = False
@@ -38,24 +39,23 @@ class MockFallbackConversion(BaseWeightConversion):
         else:
             return input_value + 999
 
+
 ###################################
 # Ternary Tests
 ###################################
+
 
 def test_ternary_weight_conversion_primary_none():
     """
     If primary_conversion is None, it should just return the input_value unmodified.
     """
     fallback = torch.tensor([10.0])  # Not used if input_value is not None
-    ternary = TernaryWeightConversion(
-        fallback_conversion=fallback,
-        primary_conversion=None
-    )
+    ternary = TernaryWeightConversion(fallback_conversion=fallback, primary_conversion=None)
     input_tensor = torch.tensor([1.0, 2.0])
     output_tensor = ternary.convert(input_tensor)
-    assert torch.allclose(output_tensor, input_tensor), (
-        "Expected primary=None to return input_value as is."
-    )
+    assert torch.allclose(
+        output_tensor, input_tensor
+    ), "Expected primary=None to return input_value as is."
 
 
 def test_ternary_weight_conversion_primary_tensor():
@@ -65,14 +65,13 @@ def test_ternary_weight_conversion_primary_tensor():
     fallback = torch.tensor([10.0])  # Not used if input_value is not None
     primary_tensor = torch.tensor([100.0, 200.0])
     ternary = TernaryWeightConversion(
-        fallback_conversion=fallback,
-        primary_conversion=primary_tensor
+        fallback_conversion=fallback, primary_conversion=primary_tensor
     )
     input_tensor = torch.tensor([1.0, 2.0])
     output_tensor = ternary.convert(input_tensor)
-    assert torch.allclose(output_tensor, primary_tensor), (
-        "Expected to return primary tensor, ignoring input_value."
-    )
+    assert torch.allclose(
+        output_tensor, primary_tensor
+    ), "Expected to return primary tensor, ignoring input_value."
 
 
 def test_ternary_weight_conversion_primary_conversion_class():
@@ -81,10 +80,7 @@ def test_ternary_weight_conversion_primary_conversion_class():
     """
     fallback = torch.tensor([10.0])
     mock_primary = MockPrimaryConversion()
-    ternary = TernaryWeightConversion(
-        fallback_conversion=fallback,
-        primary_conversion=mock_primary
-    )
+    ternary = TernaryWeightConversion(fallback_conversion=fallback, primary_conversion=mock_primary)
     input_tensor = torch.tensor([1.0, 2.0])
     output_tensor = ternary.convert(input_tensor)
 
@@ -98,10 +94,7 @@ def test_ternary_weight_conversion_fallback_tensor():
     If input_value is None and fallback is a Tensor, return that tensor directly.
     """
     fallback_tensor = torch.tensor([999.0])
-    ternary = TernaryWeightConversion(
-        fallback_conversion=fallback_tensor,
-        primary_conversion=None
-    )
+    ternary = TernaryWeightConversion(fallback_conversion=fallback_tensor, primary_conversion=None)
     # Trigger fallback by passing input_value=None
     output = ternary.convert(None)
     assert torch.allclose(output, fallback_tensor), "Expected fallback tensor to be returned."
@@ -122,17 +115,18 @@ def test_ternary_weight_conversion_fallback_str():
     # Convert(None, context=...) => fallback => find_context_field("my_remote_field") => returns [123.0, 456.0]
     output = ternary.convert(None, context)
 
-    assert torch.allclose(output, torch.tensor([123.0, 456.0])), (
-        "Expected fallback str to be found in context dictionary."
-    )
+    assert torch.allclose(
+        output, torch.tensor([123.0, 456.0])
+    ), "Expected fallback str to be found in context dictionary."
 
 
 def test_ternary_weight_conversion_fallback_tuple():
     """
-    If fallback is a tuple (REMOTE_FIELD, BaseWeightConversion), 
+    If fallback is a tuple (REMOTE_FIELD, BaseWeightConversion),
     we do a context lookup for the REMOTE_FIELD,
     then pass that to the second item, which is a conversion class.
     """
+
     class MockTupleConversion(BaseWeightConversion):
         def __init__(self):
             super().__init__()
@@ -145,19 +139,14 @@ def test_ternary_weight_conversion_fallback_tuple():
     mock_fallback_conv = MockTupleConversion()
     fallback_tuple = ("my_backup_field", mock_fallback_conv)  # type: ignore
 
-    ternary = TernaryWeightConversion(
-        fallback_conversion=fallback_tuple,
-        primary_conversion=None
-    )
+    ternary = TernaryWeightConversion(fallback_conversion=fallback_tuple, primary_conversion=None)
 
     # Suppose the context dictionary has "my_backup_field" => [5,6,7]
     context = {"my_backup_field": torch.tensor([5.0, 6.0, 7.0])}
 
     output = ternary.convert(None, context)
 
-    assert mock_fallback_conv.was_called, (
-        "Expected fallback conversion in the tuple to be called."
-    )
+    assert mock_fallback_conv.was_called, "Expected fallback conversion in the tuple to be called."
     # The fallback conv adds 1000
     assert torch.allclose(output, torch.tensor([1005.0, 1006.0, 1007.0]))
 
@@ -165,33 +154,30 @@ def test_ternary_weight_conversion_fallback_tuple():
 def test_ternary_weight_conversion_find_context_field_failure():
     """
     If fallback is a str, but the context doesn't contain that key,
-    find_context_field returns None, and so fallback is effectively None => 
+    find_context_field returns None, and so fallback is effectively None =>
     This might cause an error or we accept returning None.
     We'll see how your code handles that scenario.
     """
-    ternary = TernaryWeightConversion(
-        fallback_conversion="missing_key",
-        primary_conversion=None
-    )
+    ternary = TernaryWeightConversion(fallback_conversion="missing_key", primary_conversion=None)
     # No context => won't find 'missing_key'
     output = ternary.convert(None, *{})
     # According to your code, if nothing is found, we return None from find_context_field.
-    # handle_fallback_conversion will return that None from the function. 
+    # handle_fallback_conversion will return that None from the function.
     # => This might break if the calling code expects a tensor.
     # We'll just check it's None.
-    assert output is None, (
-        "Expected None if the fallback str wasn't found in the provided context."
-    )
+    assert output is None, "Expected None if the fallback str wasn't found in the provided context."
 
 
 ########################################
 # Tests for Input/Output Filters
 ########################################
 
+
 def test_ternary_input_filter():
     """
     If there's an input_filter, it should run before handle_primary_conversion.
     """
+
     def input_filter(x: torch.Tensor) -> torch.Tensor:
         return x * 10
 
@@ -199,20 +185,21 @@ def test_ternary_input_filter():
     ternary = TernaryWeightConversion(
         fallback_conversion=torch.tensor([999.0]),
         primary_conversion=mock_primary,
-        input_filter=input_filter
+        input_filter=input_filter,
     )
     # Steps: input_filter => *10 => [10,20], primary => +42 => [52,62]
-    inp = torch.tensor([1.0,2.0])
+    inp = torch.tensor([1.0, 2.0])
     out = ternary.convert(inp)
-    expected = torch.tensor([52.0,62.0])
+    expected = torch.tensor([52.0, 62.0])
     assert torch.allclose(out, expected)
 
 
 def test_ternary_output_filter():
     """
-    Output filter is applied after the main logic, 
+    Output filter is applied after the main logic,
     i.e. after handle_primary_conversion or fallback.
     """
+
     def output_filter(x: torch.Tensor) -> torch.Tensor:
         return x - 100
 
@@ -220,10 +207,10 @@ def test_ternary_output_filter():
     ternary = TernaryWeightConversion(
         fallback_conversion=torch.tensor([999.0]),
         primary_conversion=mock_primary,
-        output_filter=output_filter
+        output_filter=output_filter,
     )
     # primary => +42 => [43,44], then output_filter => -100 => [-57, -56]
-    inp = torch.tensor([1.0,2.0])
+    inp = torch.tensor([1.0, 2.0])
     out = ternary.convert(inp)
     expected = torch.tensor([-57.0, -56.0])
     assert torch.allclose(out, expected), "Output filter didn't apply after primary conversion."
@@ -233,6 +220,7 @@ def test_ternary_both_filters():
     """
     Combination: input_filter -> primary -> output_filter
     """
+
     def input_filter(x: torch.Tensor) -> torch.Tensor:
         return x * 3
 
@@ -244,13 +232,13 @@ def test_ternary_both_filters():
         fallback_conversion=("backup_field", MockFallbackConversion()),
         primary_conversion=mock_primary,
         input_filter=input_filter,
-        output_filter=output_filter
+        output_filter=output_filter,
     )
     # Steps:
     #   1) input_filter => *3 => [3,6]
     #   2) primary => +42 => [45,48]
     #   3) output_filter => +5 => [50,53]
-    inp = torch.tensor([1.0,2.0])
+    inp = torch.tensor([1.0, 2.0])
     out = ternary.convert(inp)
     expected = torch.tensor([50.0, 53.0])
     assert torch.allclose(out, expected), "Filter pipeline or primary logic is off."
@@ -263,8 +251,7 @@ def test_ternary_repr():
     mock_primary = MockPrimaryConversion()
     fallback_tuple = ("my_field", MockFallbackConversion())  # type: ignore
     ternary = TernaryWeightConversion(
-        fallback_conversion=fallback_tuple,
-        primary_conversion=mock_primary
+        fallback_conversion=fallback_tuple, primary_conversion=mock_primary
     )
     rep = repr(ternary).lower()
     assert "ternary operation" in rep, f"Expected mention of 'ternary operation', got {rep}"

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_weight_conversoin_set.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_weight_conversoin_set.py
@@ -1,0 +1,162 @@
+import pytest
+import torch
+from unittest.mock import MagicMock
+
+# These imports reflect your code structure
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps.weight_conversion_set import (
+    WeightConversionSet,
+)
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps.base_weight_conversion import (
+    BaseWeightConversion,
+)
+
+class MockSubConversion(BaseWeightConversion):
+    """
+    A mock sub-conversion that emulates deeper logic.
+    For demonstration, it just adds 10 to each element if given a tensor,
+    or returns a known tensor if input is None.
+    """
+    def __init__(self):
+        super().__init__()
+        self.was_called = False
+
+    def handle_conversion(self, input_value, *full_context):
+        self.was_called = True
+        if isinstance(input_value, torch.Tensor):
+            return input_value + 10
+        else:
+            return torch.tensor([999.0])
+
+
+def test_weight_conversion_set_basic_tensor_and_str():
+    """
+    Tests a field set that includes a direct Tensor and a str (property).
+    Ensures handle_conversion returns a dict with the correct resolved values.
+    """
+    # We'll pass 'pos_embed.weight' as a string property to find in an input structure
+    field_set = {
+        "embed.W_E": torch.ones(2, 2),            # direct tensor
+        "pos_embed": "pos_embed.weight",          # property to look up in input_value
+    }
+
+    conversion_set = WeightConversionSet(weights=field_set)
+    
+    # Suppose the input_value is a dictionary or object that find_property can parse
+    input_value = {
+        "pos_embed": {
+            "weight": torch.tensor([3.0, 4.0])  # the property we want to find
+        }
+    }
+
+    output = conversion_set.convert(input_value)
+
+    # 1) Check embed.W_E is the same tensor
+    assert "embed.W_E" in output
+    assert torch.allclose(output["embed.W_E"], torch.ones(2, 2))
+
+    # 2) Check pos_embed is the retrieved property
+    assert "pos_embed" in output
+    assert torch.allclose(output["pos_embed"], torch.tensor([3.0, 4.0]))
+
+
+def test_weight_conversion_set_tuple_subconversion():
+    """
+    Tests a field set containing a tuple (remote_field, conversion).
+    The sub-conversion is a mock that we ensure gets called with the correct input.
+    """
+    mock_sub = MockSubConversion()
+    field_set = {
+        "layer_0_attn": ("attn_proj.weight", mock_sub)
+    }
+    conversion_set = WeightConversionSet(weights=field_set)
+
+    # We'll store "attn_proj.weight" in our input_value so find_property can retrieve it
+    input_value = {
+        "attn_proj": {
+            "weight": torch.tensor([1.0, 2.0])
+        }
+    }
+
+    output = conversion_set.convert(input_value)
+    assert "layer_0_attn" in output, "Expected output key for the field set."
+    
+    # The sub-conversion 'MockSubConversion' adds 10
+    expected_tensor = torch.tensor([1.0, 2.0]) + 10
+    result_tensor = output["layer_0_attn"]
+
+    assert mock_sub.was_called, "Expected mock_sub to be invoked."
+    assert torch.allclose(result_tensor, expected_tensor), (
+        f"Expected [11, 12], got {result_tensor}"
+    )
+
+
+def test_weight_conversion_set_process_conversion_action_tensor():
+    """
+    Tests process_conversion_action for a direct tensor.
+    """
+    field_set = {"some_weight": torch.tensor([5.0])}
+    conversion_set = WeightConversionSet(field_set)
+
+    input_value = {}  # not used for direct tensor
+    output = conversion_set.convert(input_value)
+    assert "some_weight" in output
+    assert torch.allclose(output["some_weight"], torch.tensor([5.0]))
+
+
+def test_weight_conversion_set_process_conversion_action_str_property():
+    """
+    Tests process_conversion_action for a str property lookup
+    with a nested dict.
+    """
+    field_set = {"some_str_key": "my_field.data"}
+    conversion_set = WeightConversionSet(field_set)
+
+    input_value = {
+        "my_field": {
+            "data": torch.tensor([42.0])
+        }
+    }
+    output = conversion_set.convert(input_value)
+    assert torch.allclose(output["some_str_key"], torch.tensor([42.0]))
+
+
+def test_weight_conversion_set_process_conversion_action_tuple():
+    """
+    Tests process_conversion_action for a tuple (remote_field, sub_conversion).
+    We'll reuse MockSubConversion for demonstration.
+    """
+    mock_sub = MockSubConversion()
+    field_set = {"my_tuple_key": ("fieldA", mock_sub)}
+    conversion_set = WeightConversionSet(field_set)
+
+    input_value = {
+        "fieldA": torch.tensor([0.0])
+    }
+    output = conversion_set.convert(input_value)
+
+    assert mock_sub.was_called, "Expected the sub-conversion to be used."
+    assert torch.allclose(output["my_tuple_key"], torch.tensor([10.0]))
+
+
+def test_weight_conversion_set_repr():
+    """
+    Checks that __repr__ includes a string of the nested conversions,
+    based on WeightConversionUtils.create_conversion_string output.
+    """
+    # We'll just define some fields to see that it formats them
+    mock_sub = MockSubConversion()
+    field_set = {
+        "embed.W_E": torch.zeros(2, 2),
+        "pos_embed": "pos_embed.weight",
+        "layer_0_attn": ("attn_proj.weight", mock_sub)
+    }
+
+    conversion_set = WeightConversionSet(field_set)
+    rep_str = repr(conversion_set).lower()
+
+    assert "is composed of a set of nested conversions" in rep_str, (
+        f"Expected reference to 'nested conversions', got {rep_str}"
+    )
+    assert "embed.w_e" in rep_str, "Expected mention of embed.W_E key."
+    assert "pos_embed" in rep_str, "Expected mention of pos_embed key."
+    assert "layer_0_attn" in rep_str, "Expected mention of layer_0_attn key."

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_zeros_like_conversion.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_zeros_like_conversion.py
@@ -1,0 +1,27 @@
+import torch
+
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps.zeros_like_conversion import (
+    ZerosLikeConversion,
+)
+
+
+def test_zeros_like_basic():
+    """
+    Ensures that handle_conversion returns a zero tensor
+    with the same shape and dtype as the input.
+    """
+    conversion = ZerosLikeConversion()
+    input_tensor = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+    output_tensor = conversion.convert(input_tensor)
+
+    # 1) Check shape matches
+    assert (
+        output_tensor.shape == input_tensor.shape
+    ), f"Expected shape {input_tensor.shape}, got {output_tensor.shape}"
+    # 2) Check dtype matches
+    assert (
+        output_tensor.dtype == input_tensor.dtype
+    ), f"Expected dtype {input_tensor.dtype}, got {output_tensor.dtype}"
+    # 3) Check values are zeros
+    assert torch.count_nonzero(output_tensor) == 0, "Expected all zeros, found nonzero elements!"

--- a/transformer_lens/factories/mlp_factory.py
+++ b/transformer_lens/factories/mlp_factory.py
@@ -13,7 +13,6 @@ from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
 class MLPFactory:
     @staticmethod
     def create_mlp(cfg: HookedTransformerConfig) -> CanBeUsedAsMLP:
-
         if cfg.num_experts:
             return MoE(cfg)
         elif cfg.gated_mlp:

--- a/transformer_lens/factories/weight_conversion_factory.py
+++ b/transformer_lens/factories/weight_conversion_factory.py
@@ -14,10 +14,11 @@ from transformer_lens.weight_conversion.mistral import MistralWeightConversion
 from transformer_lens.weight_conversion.mixtral import MixtralWeightConversion
 from transformer_lens.weight_conversion.neo import NEOWeightConversion
 from transformer_lens.weight_conversion.neox import NEOXWeightConversion
+from transformer_lens.weight_conversion.phi import PhiWeightConversion
 from transformer_lens.weight_conversion.qwen import QwenWeightConversion
 from transformer_lens.weight_conversion.qwen2 import Qwen2WeightConversion
 from transformer_lens.weight_conversion.t5 import T5WeightConversion
-from transformer_lens.weight_conversion.phi import PhiWeightConversion
+
 
 class WeightConversionFactory:
     @staticmethod

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_helpers.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_helpers.py
@@ -1,10 +1,10 @@
 
 
-def find_property(needle: str, haystack):
+def find_property(needle: str, haystack: object|dict):
     needle_levels = needle.split(".")
     first_key = needle_levels.pop(0)
 
-    current_level = getattr(haystack, first_key)
+    current_level = haystack[first_key] if isinstance(haystack, dict) else getattr(haystack, first_key)
 
     if len(needle_levels) > 0:
         return find_property(".".join(needle_levels), current_level)

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_helpers.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_helpers.py
@@ -1,13 +1,12 @@
-
-
-def find_property(needle: str, haystack: object|dict):
+def find_property(needle: str, haystack: object | dict):
     needle_levels = needle.split(".")
     first_key = needle_levels.pop(0)
 
-    current_level = haystack[first_key] if isinstance(haystack, dict) else getattr(haystack, first_key)
+    current_level = (
+        haystack[first_key] if isinstance(haystack, dict) else getattr(haystack, first_key)
+    )
 
     if len(needle_levels) > 0:
         return find_property(".".join(needle_levels), current_level)
 
     return current_level
-

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/arithmetic_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/arithmetic_weight_conversion.py
@@ -4,7 +4,9 @@ from typing import Optional
 
 import torch
 
-from transformer_lens.weight_conversion.conversion_utils.conversion_steps.base_weight_conversion import BaseWeightConversion
+from transformer_lens.weight_conversion.conversion_utils.conversion_steps.base_weight_conversion import (
+    BaseWeightConversion,
+)
 
 
 class OperationTypes(Enum):

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/arithmetic_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/arithmetic_weight_conversion.py
@@ -26,7 +26,7 @@ class ArithmeticWeightConversion(BaseWeightConversion):
         self.operation = operation
         self.value = value
 
-    def handle_conversion(self, input_value):
+    def handle_conversion(self, input_value, *full_context):
         match self.operation:
             case OperationTypes.ADDITION:
                 return input_value + self.value

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
@@ -1,8 +1,7 @@
 from collections.abc import Callable
-import torch
 from typing import Optional
 from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
-from .types import WeightConversionInterface, CONVERSION_ACTION, CONVERSION
+from .types import WeightConversionInterface, CONVERSION
 
 
 class BaseWeightConversion(WeightConversionInterface):
@@ -12,36 +11,26 @@ class BaseWeightConversion(WeightConversionInterface):
         self.input_filter = input_filter
         self.output_filter = output_filter
 
-    def convert(self, input_value):
+    def convert(self, input_value, *full_context):
         input_value = (
             self.input_filter(input_value) if self.input_filter is not None else input_value
         )
-        output = self.handle_conversion(input_value)
+        output = self.handle_conversion(input_value, *full_context)
         return self.output_filter(output) if self.output_filter is not None else output
 
 
-    def handle_conversion(self, input_value):
+    def handle_conversion(self, input_value, *full_context):
         raise NotImplementedError(
             f"The conversion function for {type(self).__name__} needs to be implemented."
         )
-        
-
-    def process_conversion_action(self, input_value, conversion_details: CONVERSION_ACTION):
-        if isinstance(conversion_details, torch.Tensor):
-            return conversion_details
-        elif isinstance(conversion_details, str):
-            return find_property(conversion_details, input_value)
-        else:
-            (remote_field, conversion) = conversion_details
-            return self.process_conversion(input_value, remote_field, conversion)
             
-    def process_conversion(self, input_value, remote_field: str, conversion: CONVERSION):
+    def process_conversion(self, input_value, remote_field: str, conversion: CONVERSION, *full_context):
         field = find_property(remote_field, input_value)
         if isinstance(field, WeightConversionSet):
             result = []
             for layer in field:
-                result.append(conversion.convert(layer))
+                result.append(conversion.convert(layer, input_value, *full_context))
             return result
 
         else:
-            return conversion.convert(field)
+            return conversion.convert(field, input_value, *full_context)

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
@@ -26,16 +26,3 @@ class BaseWeightConversion(WeightConversionInterface):
         raise NotImplementedError(
             f"The conversion function for {type(self).__name__} needs to be implemented."
         )
-
-    def process_conversion(
-        self, input_value, remote_field: str, conversion: CONVERSION, *full_context
-    ):
-        field = find_property(remote_field, input_value)
-        if isinstance(field, WeightConversionSet):
-            result = []
-            for layer in field:
-                result.append(conversion.convert(layer, input_value, *full_context))
-            return result
-
-        else:
-            return conversion.convert(field, input_value, *full_context)

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
@@ -1,11 +1,7 @@
 from collections.abc import Callable
 from typing import Optional
 
-from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import (
-    find_property,
-)
-
-from .types import CONVERSION, WeightConversionInterface
+from .types import WeightConversionInterface
 
 
 class BaseWeightConversion(WeightConversionInterface):

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
@@ -1,7 +1,11 @@
 from collections.abc import Callable
 from typing import Optional
-from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
-from .types import WeightConversionInterface, CONVERSION
+
+from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import (
+    find_property,
+)
+
+from .types import CONVERSION, WeightConversionInterface
 
 
 class BaseWeightConversion(WeightConversionInterface):
@@ -18,13 +22,14 @@ class BaseWeightConversion(WeightConversionInterface):
         output = self.handle_conversion(input_value, *full_context)
         return self.output_filter(output) if self.output_filter is not None else output
 
-
     def handle_conversion(self, input_value, *full_context):
         raise NotImplementedError(
             f"The conversion function for {type(self).__name__} needs to be implemented."
         )
-            
-    def process_conversion(self, input_value, remote_field: str, conversion: CONVERSION, *full_context):
+
+    def process_conversion(
+        self, input_value, remote_field: str, conversion: CONVERSION, *full_context
+    ):
         field = find_property(remote_field, input_value)
         if isinstance(field, WeightConversionSet):
             result = []

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/base_weight_conversion.py
@@ -1,8 +1,11 @@
 from collections.abc import Callable
+import torch
 from typing import Optional
+from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
+from .types import WeightConversionInterface, CONVERSION_ACTION, CONVERSION
 
 
-class BaseWeightConversion:
+class BaseWeightConversion(WeightConversionInterface):
     def __init__(
         self, input_filter: Optional[Callable] = None, output_filter: Optional[Callable] = None
     ):
@@ -21,3 +24,24 @@ class BaseWeightConversion:
         raise NotImplementedError(
             f"The conversion function for {type(self).__name__} needs to be implemented."
         )
+        
+
+    def process_conversion_action(self, input_value, conversion_details: CONVERSION_ACTION):
+        if isinstance(conversion_details, torch.Tensor):
+            return conversion_details
+        elif isinstance(conversion_details, str):
+            return find_property(conversion_details, input_value)
+        else:
+            (remote_field, conversion) = conversion_details
+            return self.process_conversion(input_value, remote_field, conversion)
+            
+    def process_conversion(self, input_value, remote_field: str, conversion: CONVERSION):
+        field = find_property(remote_field, input_value)
+        if isinstance(field, WeightConversionSet):
+            result = []
+            for layer in field:
+                result.append(conversion.convert(layer))
+            return result
+
+        else:
+            return conversion.convert(field)

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/callable_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/callable_weight_conversion.py
@@ -8,8 +8,8 @@ class CallableWeightConversion(BaseWeightConversion):
         super().__init__()
         self.convert_callable = convert_callable
 
-    def handle_conversion(self, input_value: dict):
-        return self.convert_callable(input_value)
+    def handle_conversion(self, input_value: dict, *full_context):
+        return self.convert_callable(input_value, *full_context)
 
     def __repr__(self):
         return f"Is the following callable operation: {self.convert_callable}"

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/ternary_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/ternary_weight_conversion.py
@@ -1,7 +1,9 @@
 from collections.abc import Callable
-from typing import Optional
+from typing import Optional, Union
 
 import torch
+
+from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
 
 from .types import CONVERSION_ACTION
 from .base_weight_conversion import BaseWeightConversion
@@ -21,22 +23,37 @@ class TernaryWeightConversion(BaseWeightConversion):
         self.primary_conversion = primary_conversion
         self.fallback_conversion = fallback_conversion
 
-    def handle_primary_conversion(self, input_value: torch.Tensor) -> torch.Tensor:
+    def handle_conversion(self, input_value: Union[torch.Tensor|None], *full_context) -> torch.Tensor|None:
+        if input_value is not None:
+            return self.handle_primary_conversion(input_value, *full_context)
+        else:
+            return self.handle_fallback_conversion(*full_context)
+
+    def handle_primary_conversion(self, input_value: torch.Tensor, *full_context) -> torch.Tensor:
         if self.primary_conversion is None:
             return input_value
         elif isinstance(self.primary_conversion, torch.Tensor):
             return self.primary_conversion
         else:
-            return self.primary_conversion.convert(input_value=input_value)
-
-    def handle_conversion(self, input_value: torch.Tensor or None) -> torch.Tensor:
-        if input_value is not None:
-            return self.handle_primary_conversion(input_value=input_value)
+            return self.primary_conversion.convert(input_value=input_value, *full_context)
+        
+    def handle_fallback_conversion(self, *full_context) -> torch.Tensor|None:
+        if isinstance(self.fallback_conversion, torch.Tensor):
+            return self.fallback_conversion
+        elif isinstance(self.fallback_conversion, str):
+            return self.find_context_field(self.fallback_conversion, *full_context)
         else:
-            self.fallback_conversion.convert()
-            return super().process_conversion_action(
-                input_value=input_value, conversion_details=self.fallback_conversion
-            )
+            (backup_field, conversion) = self.fallback_conversion
+            backup_input = self.find_context_field(backup_field, *full_context)
+            return conversion.convert(backup_input, *full_context)
+        
+    def find_context_field(self, field_key: str, *full_context):
+        for context in full_context:
+            maybe_field = find_property(field_key, context)
+            if maybe_field is not None:
+                return maybe_field
+            
+        return None
 
     def __repr__(self):
         return f"Is a ternary operation with the following primary conversion: {self.primary_conversion} and fallback conversion: {self.fallback_conversion}"

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/ternary_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/ternary_weight_conversion.py
@@ -10,7 +10,6 @@ PRIMARY_CONVERSION = torch.Tensor | BaseWeightConversion | None
 
 
 class TernaryWeightConversion(BaseWeightConversion):
-    # TODO add none as fallback
     def __init__(
         self,
         fallback_conversion: CONVERSION_ACTION,
@@ -25,7 +24,7 @@ class TernaryWeightConversion(BaseWeightConversion):
     def handle_primary_conversion(self, input_value: torch.Tensor) -> torch.Tensor:
         if self.primary_conversion is None:
             return input_value
-        if isinstance(self.primary_conversion, torch.Tensor):
+        elif isinstance(self.primary_conversion, torch.Tensor):
             return self.primary_conversion
         else:
             return self.primary_conversion.convert(input_value=input_value)
@@ -34,7 +33,8 @@ class TernaryWeightConversion(BaseWeightConversion):
         if input_value is not None:
             return self.handle_primary_conversion(input_value=input_value)
         else:
-            return super().process_weight_conversion(
+            self.fallback_conversion.convert()
+            return super().process_conversion_action(
                 input_value=input_value, conversion_details=self.fallback_conversion
             )
 

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/ternary_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/ternary_weight_conversion.py
@@ -3,10 +3,12 @@ from typing import Optional, Union
 
 import torch
 
-from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
+from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import (
+    find_property,
+)
 
-from .types import CONVERSION_ACTION
 from .base_weight_conversion import BaseWeightConversion
+from .types import CONVERSION_ACTION
 
 PRIMARY_CONVERSION = torch.Tensor | BaseWeightConversion | None
 
@@ -23,7 +25,9 @@ class TernaryWeightConversion(BaseWeightConversion):
         self.primary_conversion = primary_conversion
         self.fallback_conversion = fallback_conversion
 
-    def handle_conversion(self, input_value: Union[torch.Tensor|None], *full_context) -> torch.Tensor|None:
+    def handle_conversion(
+        self, input_value: Union[torch.Tensor | None], *full_context
+    ) -> torch.Tensor | None:
         if input_value is not None:
             return self.handle_primary_conversion(input_value, *full_context)
         else:
@@ -36,8 +40,8 @@ class TernaryWeightConversion(BaseWeightConversion):
             return self.primary_conversion
         else:
             return self.primary_conversion.convert(input_value=input_value, *full_context)
-        
-    def handle_fallback_conversion(self, *full_context) -> torch.Tensor|None:
+
+    def handle_fallback_conversion(self, *full_context) -> torch.Tensor | None:
         if isinstance(self.fallback_conversion, torch.Tensor):
             return self.fallback_conversion
         elif isinstance(self.fallback_conversion, str):
@@ -46,13 +50,13 @@ class TernaryWeightConversion(BaseWeightConversion):
             (backup_field, conversion) = self.fallback_conversion
             backup_input = self.find_context_field(backup_field, *full_context)
             return conversion.convert(backup_input, *full_context)
-        
+
     def find_context_field(self, field_key: str, *full_context):
         for context in full_context:
             maybe_field = find_property(field_key, context)
             if maybe_field is not None:
                 return maybe_field
-            
+
         return None
 
     def __repr__(self):

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/types.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/types.py
@@ -1,15 +1,14 @@
 import torch
 
+
 class WeightConversionInterface:
     def convert(self, input_value, *full_context):
-        raise NotImplementedError(
-            f"WeightConversionInterface called directly!"
-        )
-        
+        raise NotImplementedError(f"WeightConversionInterface called directly!")
+
 
 # This type is used to indicate the position of a field in the remote model
 REMOTE_FIELD = str
-# This is the typing for a weight conversion when operations are needed on the REMOTE_FIELD. 
+# This is the typing for a weight conversion when operations are needed on the REMOTE_FIELD.
 # The WeightConversionInterface will be the instructions on the operations needed to bring the
 # field into TransformerLens
 CONVERSION = tuple[REMOTE_FIELD, WeightConversionInterface]

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/types.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/types.py
@@ -1,8 +1,7 @@
 import torch
-from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
 
 class WeightConversionInterface:
-    def convert(self, input_value):
+    def convert(self, input_value, *full_context):
         raise NotImplementedError(
             f"WeightConversionInterface called directly!"
         )

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/types.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/types.py
@@ -1,13 +1,19 @@
 import torch
+from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
 
-from .base_weight_conversion import BaseWeightConversion 
+class WeightConversionInterface:
+    def convert(self, input_value):
+        raise NotImplementedError(
+            f"WeightConversionInterface called directly!"
+        )
+        
 
 # This type is used to indicate the position of a field in the remote model
 REMOTE_FIELD = str
 # This is the typing for a weight conversion when operations are needed on the REMOTE_FIELD. 
-# The BaseWeightConversion will be the instructions on the operations needed to bring the field
-# into TransformerLens
-CONVERSION = tuple[REMOTE_FIELD, BaseWeightConversion]
+# The WeightConversionInterface will be the instructions on the operations needed to bring the
+# field into TransformerLens
+CONVERSION = tuple[REMOTE_FIELD, WeightConversionInterface]
 # This is the full range of actions that can be taken to bring a field into TransformerLens
 # These can be configured as a predefined tensor, or a direction copy of the REMOTE_FIELD into
 # TransformerLens, or a more in depth CONVERSION

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
@@ -1,5 +1,8 @@
-from .types import FIELD_SET
+import torch
+
+from .types import FIELD_SET, CONVERSION_ACTION
 from .base_weight_conversion import BaseWeightConversion
+from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
 from transformer_lens.weight_conversion.conversion_utils.weight_conversion_utils import WeightConversionUtils
 
 
@@ -11,15 +14,25 @@ class WeightConversionSet(BaseWeightConversion):
         super().__init__()
         self.weights = weights
 
-    def handle_conversion(self, input_value):
+    def handle_conversion(self, input_value, *full_context):
         result = {}
         for weight_name in self.weights:
+            conversion_action = self.weights[weight_name]
             result[weight_name] = self.process_conversion_action(
                 input_value,
-                conversion_details=self.weights[weight_name],
+                conversion_details=conversion_action,
             )
 
         return result
+
+    def process_conversion_action(self, input_value, conversion_details: CONVERSION_ACTION, *full_context):
+        if isinstance(conversion_details, torch.Tensor):
+            return conversion_details
+        elif isinstance(conversion_details, str):
+            return find_property(conversion_details, input_value)
+        else:
+            (remote_field, conversion) = conversion_details
+            return self.process_conversion(input_value, remote_field, conversion, *full_context)
 
     def __repr__(self):
         conversion_string = (

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
@@ -1,7 +1,4 @@
-import torch
-
-from .types import FIELD_SET, CONVERSION_ACTION, CONVERSION
-from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
+from .types import FIELD_SET
 from .base_weight_conversion import BaseWeightConversion
 from transformer_lens.weight_conversion.conversion_utils.weight_conversion_utils import WeightConversionUtils
 
@@ -23,26 +20,6 @@ class WeightConversionSet(BaseWeightConversion):
             )
 
         return result
-
-    def process_conversion_action(self, input_value, conversion_details: CONVERSION_ACTION):
-        if isinstance(conversion_details, torch.Tensor):
-            return conversion_details
-        elif isinstance(conversion_details, str):
-            return find_property(conversion_details, input_value)
-        else:
-            (remote_field, conversion) = conversion_details
-            return self.process_conversion(input_value, remote_field, conversion)
-            
-    def process_conversion(self, input_value, remote_field: str, conversion: CONVERSION):
-        field = find_property(remote_field, input_value)
-        if isinstance(field, WeightConversionSet):
-            result = []
-            for layer in field:
-                result.append(conversion.convert(layer))
-            return result
-
-        else:
-            return conversion.convert(field)
 
     def __repr__(self):
         conversion_string = (

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
@@ -41,6 +41,19 @@ class WeightConversionSet(BaseWeightConversion):
             (remote_field, conversion) = conversion_details
             return self.process_conversion(input_value, remote_field, conversion, *full_context)
 
+    def process_conversion(
+        self, input_value, remote_field: str, conversion: BaseWeightConversion, *full_context
+    ):
+        field = find_property(remote_field, input_value)
+        if isinstance(field, WeightConversionSet):
+            result = []
+            for layer in field:
+                result.append(conversion.convert(layer, input_value, *full_context))
+            return result
+
+        else:
+            return conversion.convert(field, *[input_value, *full_context])
+
     def __repr__(self):
         conversion_string = (
             "Is composed of a set of nested conversions with the following details {\n\t"

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
@@ -1,9 +1,14 @@
 import torch
 
-from .types import FIELD_SET, CONVERSION_ACTION
+from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import (
+    find_property,
+)
+from transformer_lens.weight_conversion.conversion_utils.weight_conversion_utils import (
+    WeightConversionUtils,
+)
+
 from .base_weight_conversion import BaseWeightConversion
-from transformer_lens.weight_conversion.conversion_utils.conversion_helpers import find_property
-from transformer_lens.weight_conversion.conversion_utils.weight_conversion_utils import WeightConversionUtils
+from .types import CONVERSION_ACTION, FIELD_SET
 
 
 class WeightConversionSet(BaseWeightConversion):
@@ -25,7 +30,9 @@ class WeightConversionSet(BaseWeightConversion):
 
         return result
 
-    def process_conversion_action(self, input_value, conversion_details: CONVERSION_ACTION, *full_context):
+    def process_conversion_action(
+        self, input_value, conversion_details: CONVERSION_ACTION, *full_context
+    ):
         if isinstance(conversion_details, torch.Tensor):
             return conversion_details
         elif isinstance(conversion_details, str):

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/zeros_like_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/zeros_like_conversion.py
@@ -4,7 +4,7 @@ from .base_weight_conversion import BaseWeightConversion
 
 
 class ZerosLikeConversion(BaseWeightConversion):
-    def handle_conversion(self, input_value: torch.Tensor) -> torch.Tensor:
+    def handle_conversion(self, input_value: torch.Tensor, *full_context) -> torch.Tensor:
         return torch.zeros_like(input_value)
 
     def __repr__(self):

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/zeros_like_conversoin.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/zeros_like_conversoin.py
@@ -1,0 +1,11 @@
+import torch
+
+from .base_weight_conversion import BaseWeightConversion
+
+
+class ZerosLikeConversion(BaseWeightConversion):
+    def handle_conversion(self, input_value: torch.Tensor) -> torch.Tensor:
+        return torch.zeros_like(input_value)
+
+    def __repr__(self):
+        return f"Is a zeros_like operation"

--- a/transformer_lens/weight_conversion/gemma.py
+++ b/transformer_lens/weight_conversion/gemma.py
@@ -42,7 +42,6 @@ class GemmaWeightConversion(ArchitectureConversion):
         )
 
     def blocks_conversions(self, cfg: HookedTransformerConfig) -> WeightConversionSet:
-        
         number_key_value_heads = cfg.n_key_value_heads if cfg.n_key_value_heads is not None else 0
         base_conversion_dict = {
             "mlp.W_in": "mlp.up_proj.weight.T",
@@ -75,14 +74,14 @@ class GemmaWeightConversion(ArchitectureConversion):
                 RearrangeWeightConversion("m (n h)->n h m", n=cfg.n_heads),
             ),
         }
-        
+
         laynorm_conversion = {}
         if cfg.use_normalization_before_and_after:
             laynorm_conversion = self.normalization_before_and_after_conversions()
         else:
             laynorm_conversion = self.standard_normalization_conversions()
 
-        return WeightConversionSet({**base_conversion_dict, ** laynorm_conversion})
+        return WeightConversionSet({**base_conversion_dict, **laynorm_conversion})
 
     def normalization_before_and_after_conversions(self) -> FIELD_SET:
         return {

--- a/transformer_lens/weight_conversion/t5.py
+++ b/transformer_lens/weight_conversion/t5.py
@@ -101,4 +101,3 @@ class T5WeightConversion(ArchitectureConversion):
                 "decoder_final_ln.w": "decoder.final_layer_norm.weight",
             }
         )
-        


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Adds additional tests for weight conversion components 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->