### PR TITLE
Bug new loading

### DIFF
--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/rearrange_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/rearrange_weight_conversion.py
@@ -19,7 +19,7 @@ class RearrangeWeightConversion(BaseWeightConversion):
         self.pattern = pattern
         self.axes_lengths = axes_lengths
 
-    def handle_conversion(self, input_value: torch.Tensor) -> torch.Tensor:
+    def handle_conversion(self, input_value: torch.Tensor, *full_context) -> torch.Tensor:
         return einops.rearrange(input_value, self.pattern, **self.axes_lengths)
 
     def __repr__(self):

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/repeat_weight_conversion.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/repeat_weight_conversion.py
@@ -19,7 +19,7 @@ class RepeatWeightConversion(BaseWeightConversion):
         self.pattern = pattern
         self.axes_lengths = axes_lengths
 
-    def handle_conversion(self, input_value: torch.Tensor) -> torch.Tensor:
+    def handle_conversion(self, input_value: torch.Tensor, *full_context) -> torch.Tensor:
         return einops.repeat(input_value, self.pattern, **self.axes_lengths)
 
     def __repr__(self):

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
@@ -45,7 +45,7 @@ class WeightConversionSet(BaseWeightConversion):
         self, input_value, remote_field: str, conversion: BaseWeightConversion, *full_context
     ):
         field = find_property(remote_field, input_value)
-        if isinstance(field, WeightConversionSet):
+        if isinstance(conversion, WeightConversionSet):
             result = []
             for layer in field:
                 result.append(conversion.convert(layer, input_value, *full_context))

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
@@ -39,8 +39,6 @@ class WeightConversionSet(BaseWeightConversion):
             return find_property(conversion_details, input_value)
         else:
             (remote_field, conversion) = conversion_details
-            # print("remote_field", remote_field)
-            # print("input_value", input_value)
             return self.process_conversion(input_value, remote_field, conversion, *full_context)
 
     def process_conversion(

--- a/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
+++ b/transformer_lens/weight_conversion/conversion_utils/conversion_steps/weight_conversion_set.py
@@ -39,6 +39,8 @@ class WeightConversionSet(BaseWeightConversion):
             return find_property(conversion_details, input_value)
         else:
             (remote_field, conversion) = conversion_details
+            # print("remote_field", remote_field)
+            # print("input_value", input_value)
             return self.process_conversion(input_value, remote_field, conversion, *full_context)
 
     def process_conversion(

--- a/transformer_lens/weight_conversion/gemma.py
+++ b/transformer_lens/weight_conversion/gemma.py
@@ -13,7 +13,7 @@ from transformer_lens.weight_conversion.conversion_utils.conversion_steps import
 
 
 class GemmaWeightNormalizationConversion(BaseWeightConversion):
-    def convert(self, input_value):
+    def convert(self, input_value, *full_context):
         return input_value.float() + torch.ones_like(input_value, dtype=torch.float32)
 
     def __repr__(self):
@@ -24,7 +24,7 @@ class GemmaWeightConversion(ArchitectureConversion):
     def __init__(self, cfg: HookedTransformerConfig) -> None:
         super().__init__(
             {
-                "unembed.W_U": "model.lm_head.weight.T",
+                "unembed.W_U": "lm_head.weight.T",
                 "unembed.b_U": torch.zeros(cfg.d_vocab),
                 "ln_final.w": (
                     "model.norm.weight",
@@ -100,4 +100,4 @@ class GemmaWeightConversion(ArchitectureConversion):
         }
 
     def standard_normalization_conversions(self) -> FIELD_SET:
-        return {"ln2.w": ("pre_feedforward_layernorm.weight", GemmaWeightNormalizationConversion())}
+        return {"ln2.w": ("post_attention_layernorm.weight", GemmaWeightNormalizationConversion())}


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Allows loading of Gemma and gpt in new structure

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->