### PR TITLE
Fix loading on specific device

### DIFF
--- a/tests/acceptance/test_multi_gpu.py
+++ b/tests/acceptance/test_multi_gpu.py
@@ -87,13 +87,16 @@ def test_device_separation_and_cache(gpt2_medium_on_1_device, n_devices):
         f"Time taken (1 device): {elapsed_time_1_device:.4f} seconds, Time taken ({n_devices} devices): {elapsed_time_n_devices:.4f} seconds"
     )
 
+
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 CUDA devices")
 def test_load_model_on_target_device():
     model = HookedTransformer.from_pretrained("gpt2-small", device="cuda:1")
     assert model.cfg.device == "cuda:1"
 
     for name, param in model.named_parameters():
-        assert param.device == torch.device("cuda:1"), f"Parameter {name} is on {param.device} instead of cuda:1"
+        assert param.device == torch.device(
+            "cuda:1"
+        ), f"Parameter {name} is on {param.device} instead of cuda:1"
 
     output = model("Hello world")
     assert output.device == torch.device("cuda:1")

--- a/tests/acceptance/test_multi_gpu.py
+++ b/tests/acceptance/test_multi_gpu.py
@@ -43,7 +43,10 @@ def test_device_separation_and_cache(gpt2_medium_on_1_device, n_devices):
     loss_n_devices = model_n_devices(model_description_text, return_type="loss")
     elapsed_time_n_devices = time.time() - start_time_n_devices
 
-    gpt2_text = "Natural language processing tasks, such as question answering, machine translation, reading comprehension, and summarization, are typically approached with supervised learning on taskspecific datasets."
+    gpt2_text = (
+        "Natural language processing tasks, such as question answering, machine translation, reading comprehension, "
+        "and summarization, are typically approached with supervised learning on taskspecific datasets."
+    )
     gpt2_tokens = model_1_device.to_tokens(gpt2_text)
 
     gpt2_logits_1_device, gpt2_cache_1_device = model_1_device.run_with_cache(
@@ -55,7 +58,7 @@ def test_device_separation_and_cache(gpt2_medium_on_1_device, n_devices):
 
     # Make sure the tensors in cache remain on their respective devices
     for i in range(model_n_devices.cfg.n_layers):
-        expected_device = get_best_available_device(model_n_devices.cfg.device)
+        expected_device = get_best_available_device(model_n_devices.cfg)
         cache_device = gpt2_cache_n_devices[f"blocks.{i}.mlp.hook_post"].device
         assert cache_device == expected_device
 
@@ -80,8 +83,20 @@ def test_device_separation_and_cache(gpt2_medium_on_1_device, n_devices):
         assert prop_device == pytest.approx(expected_prop_device, rel=0.20)
 
     print(
-        f"Number of devices: {n_devices}, Model loss (1 device): {loss_1_device}, Model loss ({n_devices} devices): {loss_n_devices}, Time taken (1 device): {elapsed_time_1_device:.4f} seconds, Time taken ({n_devices} devices): {elapsed_time_n_devices:.4f} seconds"
+        f"Number of devices: {n_devices}, Model loss (1 device): {loss_1_device}, Model loss ({n_devices} devices): {loss_n_devices}, "
+        f"Time taken (1 device): {elapsed_time_1_device:.4f} seconds, Time taken ({n_devices} devices): {elapsed_time_n_devices:.4f} seconds"
     )
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 CUDA devices")
+def test_load_model_on_target_device():
+    model = HookedTransformer.from_pretrained("gpt2-small", device="cuda:1")
+    assert model.cfg.device == "cuda:1"
+
+    for name, param in model.named_parameters():
+        assert param.device == torch.device("cuda:1"), f"Parameter {name} is on {param.device} instead of cuda:1"
+
+    output = model("Hello world")
+    assert output.device == torch.device("cuda:1")
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 CUDA devices")

--- a/transformer_lens/utilities/devices.py
+++ b/transformer_lens/utilities/devices.py
@@ -95,7 +95,7 @@ def get_best_available_device(cfg: "transformer_lens.HookedTransformerConfig") -
     assert cfg.device is not None
     device = torch.device(cfg.device)
 
-    if device.type == "cuda":
+    if device.type == "cuda" and cfg.n_devices > 1:
         return get_best_available_cuda_device(cfg.n_devices)
     else:
         return device


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Current implementation will always load models on `cuda:0` due to the implementation of `get_best_available_cuda_device` which always enumerates devices from 0. This PR fixes the case of loading one model to specific device.

<!-- Fixes # (issue) -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->