### PR TITLE
Fix LLama RoPE

### DIFF
--- a/transformer_lens/HookedTransformerConfig.py
+++ b/transformer_lens/HookedTransformerConfig.py
@@ -262,6 +262,7 @@ class HookedTransformerConfig:
     NTK_by_parts_low_freq_factor: float = 1.0
     NTK_by_parts_high_freq_factor: float = 4.0
     NTK_by_parts_factor: float = 8.0
+    NTK_original_ctx_len: int = 8192
 
     def __post_init__(self):
         if self.n_heads == -1:

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -504,7 +504,7 @@ class AbstractAttention(ABC, nn.Module):
             factor = self.cfg.NTK_by_parts_factor
             low_freq_factor = self.cfg.NTK_by_parts_low_freq_factor
             high_freq_factor = self.cfg.NTK_by_parts_high_freq_factor
-            old_context_len = n_ctx
+            old_context_len = self.cfg.NTK_original_ctx_len
 
             low_freq_wavelen = old_context_len / low_freq_factor
             high_freq_wavelen = old_context_len / high_freq_factor

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -947,6 +947,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "NTK_by_parts_low_freq_factor": 1.0,
             "NTK_by_parts_high_freq_factor": 4.0,
             "NTK_by_parts_factor": 32.0,
+            "NTK_original_ctx_len": 8192,
         }
     elif "Llama-3.2-3B" in official_model_name:
         cfg_dict = {
@@ -971,6 +972,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "NTK_by_parts_low_freq_factor": 1.0,
             "NTK_by_parts_high_freq_factor": 4.0,
             "NTK_by_parts_factor": 32.0,
+            "NTK_original_ctx_len": 8192,
         }
     elif "Llama-3.3-70B" in official_model_name:
         cfg_dict = {
@@ -995,6 +997,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "NTK_by_parts_low_freq_factor": 1.0,
             "NTK_by_parts_high_freq_factor": 4.0,
             "NTK_by_parts_factor": 8.0,
+            "NTK_original_ctx_len": 8192,
         }
     elif "Llama-3.1-8B" in official_model_name:
         cfg_dict = {
@@ -1019,6 +1022,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "NTK_by_parts_low_freq_factor": 1.0,
             "NTK_by_parts_high_freq_factor": 4.0,
             "NTK_by_parts_factor": 8.0,
+            "NTK_original_ctx_len": 8192,
         }
     elif "Llama-3.1-70B" in official_model_name:
         cfg_dict = {
@@ -1043,6 +1047,7 @@ def convert_hf_model_config(model_name: str, **kwargs):
             "NTK_by_parts_low_freq_factor": 1.0,
             "NTK_by_parts_high_freq_factor": 4.0,
             "NTK_by_parts_factor": 8.0,
+            "NTK_original_ctx_len": 8192,
         }
     elif architecture == "GPTNeoForCausalLM":
         cfg_dict = {


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

The current LLama3.x implementations use incorrect scaling factors for RoPE

https://github.com/huggingface/transformers/blob/3165eb7c2808832d0de86c8f508d9da6b2124044/src/transformers/modeling_rope_utils.py#L407-L410

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

I used this script for testing:
```python
# %%
import os
import torch
from torch.utils.data import DataLoader
from transformer_lens import HookedTransformer
from transformers import AutoModelForCausalLM
from datasets import load_dataset

torch.set_grad_enabled(False)

# %%
# Load models
dtype = torch.float32
model_tl = HookedTransformer.from_pretrained_no_processing("meta-llama/Llama-3.2-1B", dtype=dtype)
model_hf = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.2-1B", torch_dtype=dtype)

# %%
# Load dataset
dataset = load_dataset("EleutherAI/fineweb-edu-dedup-10b", split="train")

# %%
# Create dataloader helper function
def create_dataloader(dataset, model, batch_size=64, max_length=256):
    """Create a dataloader with the dataset."""
    
    def tokenize_collate_fn(batch):
        texts = [item["text"] for item in batch]
        tokenized = model.tokenizer(
            texts,
            padding="max_length",
            truncation=True,
            max_length=max_length,
            return_tensors="pt",
        )
        return tokenized.to(model.cfg.device, non_blocking=True)
    
    return DataLoader(
        dataset,
        batch_size=batch_size,
        shuffle=False,
        collate_fn=tokenize_collate_fn,
    )

# %%
# Create dataloader and get a batch
dataloader = create_dataloader(
    dataset.take(1024), model_tl, batch_size=16
)
batch = next(iter(dataloader))

# %%
# Move models and data to CUDA
model_tl = model_tl.to('cuda').eval()
model_hf = model_hf.to('cuda').eval()
batch = batch.to('cuda')

# %%
# Run both models
with torch.no_grad():
    logits_hf = model_hf(batch.input_ids).logits
    logits_tl = model_tl(batch.input_ids)

# %%
# Compare logits (optional - to verify models produce similar results)
logits_diff = logits_hf - logits_tl
print(f"Logits difference max: {logits_diff.abs().max()}")
print(f"Logits difference mean: {logits_diff.abs().mean()}")

# %%
# Compare top predictions
top_k_hf = logits_hf.argsort(dim=-1, descending=True)[:, :, :5]
top_k_tl = logits_tl.argsort(dim=-1, descending=True)[:, :, :5]

# Check if top predictions match
top_matches = (top_k_hf == top_k_tl).float().mean()
print(f"Top-5 prediction match rate: {top_matches}")
```

Before:
```
Logits difference max: 2.952045440673828
Logits difference mean: 0.05180485174059868
Top-5 prediction match rate: 0.899121105670929
```

After:
```
Logits difference max: 0.00018334388732910156
Logits difference mean: 8.470005013805348e-06
Top-5 prediction match rate: 1.0
```

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->