### PR TITLE
Refactor final issues

### DIFF
--- a/tests/integration/model_bridge/test_bridge_integration.py
+++ b/tests/integration/model_bridge/test_bridge_integration.py
@@ -111,4 +111,4 @@ def test_component_access():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    pytest.main([__file__]) 

--- a/tests/integration/model_bridge/test_bridge_integration.py
+++ b/tests/integration/model_bridge/test_bridge_integration.py
@@ -111,4 +111,4 @@ def test_component_access():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__]) 
+    pytest.main([__file__])

--- a/tests/unit/model_bridge/test_bridge.py
+++ b/tests/unit/model_bridge/test_bridge.py
@@ -4,7 +4,7 @@ This module tests the bridge functionality, including component mapping formatti
 and other bridge operations.
 """
 
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -26,10 +26,10 @@ class TestTransformerBridge:
         self.mock_model = Mock()
         self.mock_adapter = Mock()
         self.mock_tokenizer = Mock()
-        
+
         # Mock the adapter's component_mapping attribute
         self.mock_adapter.component_mapping = {}
-        
+
         # Mock the get_component method to return mock components
         self.mock_components = {
             "embed": Mock(spec=EmbeddingBridge),
@@ -41,23 +41,30 @@ class TestTransformerBridge:
             "ln_final": Mock(spec=LayerNormBridge),
             "unembed": Mock(spec=EmbeddingBridge),
         }
-        
+
         def mock_get_component(model, path):
             if path in self.mock_components:
                 comp = self.mock_components[path]
                 # Add original_component attribute for bridge components
-                if hasattr(comp, 'spec') and comp.spec in [EmbeddingBridge, LayerNormBridge, AttentionBridge, MLPBridge]:
+                if hasattr(comp, "spec") and comp.spec in [
+                    EmbeddingBridge,
+                    LayerNormBridge,
+                    AttentionBridge,
+                    MLPBridge,
+                ]:
                     comp.original_component = Mock()
-                    comp.original_component.__class__.__name__ = f"Mock{comp.spec.__name__.replace('Bridge', '')}"
+                    comp.original_component.__class__.__name__ = (
+                        f"Mock{comp.spec.__name__.replace('Bridge', '')}"
+                    )
                 return comp
             raise AttributeError(f"Component {path} not found")
-        
+
         self.mock_adapter.get_component = mock_get_component
-        
+
         # Mock the cfg to have required attributes
         self.mock_adapter.cfg = Mock()
         self.mock_adapter.cfg.num_hidden_layers = 1
-        
+
         # Create a bridge instance (we'll mock the initialization to avoid complexity)
         self.bridge = TransformerBridge.__new__(TransformerBridge)
         self.bridge.model = self.mock_model
@@ -73,12 +80,12 @@ class TestTransformerBridge:
             "ln_final": ("model.norm", LayerNormBridge),
             "unembed": ("model.embed_tokens", EmbeddingBridge),
         }
-        
+
         result = self.bridge._format_component_mapping(mapping, indent=1)
-        
+
         assert len(result) == 3
         assert "embed:" in result[0]
-        assert "ln_final:" in result[1] 
+        assert "ln_final:" in result[1]
         assert "unembed:" in result[2]
         # Check indentation
         for line in result:
@@ -94,12 +101,12 @@ class TestTransformerBridge:
                     "ln2": ("post_attention_layernorm", LayerNormBridge),
                     "attn": ("self_attn", AttentionBridge),
                     "mlp": ("mlp", MLPBridge),
-                }
+                },
             )
         }
-        
+
         result = self.bridge._format_component_mapping(mapping, indent=1)
-        
+
         # Should have 5 lines: 1 for blocks + 4 for subcomponents
         assert len(result) == 5
         assert "blocks:" in result[0]
@@ -117,13 +124,13 @@ class TestTransformerBridge:
                 {
                     "ln1": ("input_layernorm", LayerNormBridge),
                     "attn": ("self_attn", AttentionBridge),
-                }
+                },
             ),
             "ln_final": ("model.norm", LayerNormBridge),
         }
-        
+
         result = self.bridge._format_component_mapping(mapping, indent=0)
-        
+
         # Should have 5 lines: embed + blocks + 2 subcomponents + ln_final
         assert len(result) == 5
         assert any("embed:" in line for line in result)
@@ -138,9 +145,9 @@ class TestTransformerBridge:
             "ln1": ("input_layernorm", LayerNormBridge),
             "attn": ("self_attn", AttentionBridge),
         }
-        
+
         result = self.bridge._format_component_mapping(mapping, indent=2, prepend="blocks.0")
-        
+
         assert len(result) == 2
         # The _format_single_component should be called with the prepended path
         for line in result:
@@ -149,9 +156,9 @@ class TestTransformerBridge:
     def test_format_empty_mapping(self):
         """Test formatting of an empty mapping."""
         mapping = {}
-        
+
         result = self.bridge._format_component_mapping(mapping, indent=1)
-        
+
         assert result == []
 
     def test_format_non_tuple_values(self):
@@ -159,9 +166,9 @@ class TestTransformerBridge:
         mapping = {
             "some_component": "simple_string_value",
         }
-        
+
         result = self.bridge._format_component_mapping(mapping, indent=1)
-        
+
         assert len(result) == 1
         assert "some_component:" in result[0]
 
@@ -175,14 +182,14 @@ class TestTransformerBridge:
                         "inner_layers",
                         {
                             "ln": ("layernorm", LayerNormBridge),
-                        }
+                        },
                     )
-                }
+                },
             )
         }
-        
+
         result = self.bridge._format_component_mapping(mapping, indent=0)
-        
+
         # Should handle nested structure correctly
         assert len(result) == 3  # outer_blocks + inner_blocks + ln
         assert any("outer_blocks:" in line for line in result)
@@ -194,10 +201,10 @@ class TestTransformerBridge:
         mapping = {
             "nonexistent_component": ("path.to.nowhere", EmbeddingBridge),
         }
-        
+
         # This should not raise an exception, but should handle the error in _format_single_component
         result = self.bridge._format_component_mapping(mapping, indent=1)
-        
+
         assert len(result) == 1
         assert "nonexistent_component:" in result[0]
 
@@ -206,14 +213,14 @@ class TestTransformerBridge:
         mapping = {
             "level0": ("path", EmbeddingBridge),
         }
-        
+
         # Test different indentation levels
         result_0 = self.bridge._format_component_mapping(mapping, indent=0)
         result_1 = self.bridge._format_component_mapping(mapping, indent=1)
         result_2 = self.bridge._format_component_mapping(mapping, indent=2)
-        
+
         assert not result_0[0].startswith(" ")  # No indentation
-        assert result_1[0].startswith("  ")    # 1 level (2 spaces)
+        assert result_1[0].startswith("  ")  # 1 level (2 spaces)
         assert result_2[0].startswith("    ")  # 2 levels (4 spaces)
 
     def test_regression_original_bug(self):
@@ -225,11 +232,11 @@ class TestTransformerBridge:
                 "model.layers",
                 {
                     "attn": ("self_attn", AttentionBridge),
-                }
+                },
             ),
             "unembed": ("model.embed_tokens", EmbeddingBridge),
         }
-        
+
         # This should not raise AttributeError: type object 'EmbeddingBridge' has no attribute 'items'
         try:
             result = self.bridge._format_component_mapping(mapping, indent=1)
@@ -237,10 +244,12 @@ class TestTransformerBridge:
             assert len(result) == 4  # embed + blocks + attn + unembed
         except AttributeError as e:
             if "has no attribute 'items'" in str(e):
-                pytest.fail("Original bug still present: RemoteImport tuples being treated as BlockMapping")
+                pytest.fail(
+                    "Original bug still present: RemoteImport tuples being treated as BlockMapping"
+                )
             else:
                 raise  # Re-raise if it's a different AttributeError
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v"]) 
+    pytest.main([__file__, "-v"])

--- a/tests/unit/model_bridge/test_bridge.py
+++ b/tests/unit/model_bridge/test_bridge.py
@@ -1,0 +1,246 @@
+"""Unit tests for the TransformerBridge class.
+
+This module tests the bridge functionality, including component mapping formatting
+and other bridge operations.
+"""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from transformer_lens.model_bridge.bridge import TransformerBridge
+from transformer_lens.model_bridge.generalized_components import (
+    AttentionBridge,
+    EmbeddingBridge,
+    LayerNormBridge,
+    MLPBridge,
+)
+
+
+class TestTransformerBridge:
+    """Test cases for the TransformerBridge class."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        # Create mock model, adapter, and tokenizer
+        self.mock_model = Mock()
+        self.mock_adapter = Mock()
+        self.mock_tokenizer = Mock()
+        
+        # Mock the adapter's component_mapping attribute
+        self.mock_adapter.component_mapping = {}
+        
+        # Mock the get_component method to return mock components
+        self.mock_components = {
+            "embed": Mock(spec=EmbeddingBridge),
+            "blocks.0": Mock(),
+            "blocks.0.ln1": Mock(spec=LayerNormBridge),
+            "blocks.0.ln2": Mock(spec=LayerNormBridge),
+            "blocks.0.attn": Mock(spec=AttentionBridge),
+            "blocks.0.mlp": Mock(spec=MLPBridge),
+            "ln_final": Mock(spec=LayerNormBridge),
+            "unembed": Mock(spec=EmbeddingBridge),
+        }
+        
+        def mock_get_component(model, path):
+            if path in self.mock_components:
+                comp = self.mock_components[path]
+                # Add original_component attribute for bridge components
+                if hasattr(comp, 'spec') and comp.spec in [EmbeddingBridge, LayerNormBridge, AttentionBridge, MLPBridge]:
+                    comp.original_component = Mock()
+                    comp.original_component.__class__.__name__ = f"Mock{comp.spec.__name__.replace('Bridge', '')}"
+                return comp
+            raise AttributeError(f"Component {path} not found")
+        
+        self.mock_adapter.get_component = mock_get_component
+        
+        # Mock the cfg to have required attributes
+        self.mock_adapter.cfg = Mock()
+        self.mock_adapter.cfg.num_hidden_layers = 1
+        
+        # Create a bridge instance (we'll mock the initialization to avoid complexity)
+        self.bridge = TransformerBridge.__new__(TransformerBridge)
+        self.bridge.model = self.mock_model
+        self.bridge.bridge = self.mock_adapter
+        self.bridge.cfg = self.mock_adapter.cfg
+        self.bridge.tokenizer = self.mock_tokenizer
+
+    def test_format_remote_import_tuple(self):
+        """Test formatting of RemoteImport tuples (like embed, ln_final, unembed)."""
+        # This is the case that was causing the original bug
+        mapping = {
+            "embed": ("model.embed_tokens", EmbeddingBridge),
+            "ln_final": ("model.norm", LayerNormBridge),
+            "unembed": ("model.embed_tokens", EmbeddingBridge),
+        }
+        
+        result = self.bridge._format_component_mapping(mapping, indent=1)
+        
+        assert len(result) == 3
+        assert "embed:" in result[0]
+        assert "ln_final:" in result[1] 
+        assert "unembed:" in result[2]
+        # Check indentation
+        for line in result:
+            assert line.startswith("  ")  # 1 level of indentation
+
+    def test_format_block_mapping_tuple(self):
+        """Test formatting of BlockMapping tuples (like blocks)."""
+        mapping = {
+            "blocks": (
+                "model.layers",
+                {
+                    "ln1": ("input_layernorm", LayerNormBridge),
+                    "ln2": ("post_attention_layernorm", LayerNormBridge),
+                    "attn": ("self_attn", AttentionBridge),
+                    "mlp": ("mlp", MLPBridge),
+                }
+            )
+        }
+        
+        result = self.bridge._format_component_mapping(mapping, indent=1)
+        
+        # Should have 5 lines: 1 for blocks + 4 for subcomponents
+        assert len(result) == 5
+        assert "blocks:" in result[0]
+        assert "  ln1:" in result[1]  # Extra indentation for subcomponents
+        assert "  ln2:" in result[2]
+        assert "  attn:" in result[3]
+        assert "  mlp:" in result[4]
+
+    def test_format_mixed_mapping(self):
+        """Test formatting of a mapping with both RemoteImport and BlockMapping tuples."""
+        mapping = {
+            "embed": ("model.embed_tokens", EmbeddingBridge),
+            "blocks": (
+                "model.layers",
+                {
+                    "ln1": ("input_layernorm", LayerNormBridge),
+                    "attn": ("self_attn", AttentionBridge),
+                }
+            ),
+            "ln_final": ("model.norm", LayerNormBridge),
+        }
+        
+        result = self.bridge._format_component_mapping(mapping, indent=0)
+        
+        # Should have 5 lines: embed + blocks + 2 subcomponents + ln_final
+        assert len(result) == 5
+        assert any("embed:" in line for line in result)
+        assert any("blocks:" in line for line in result)
+        assert any("ln1:" in line for line in result)
+        assert any("attn:" in line for line in result)
+        assert any("ln_final:" in line for line in result)
+
+    def test_format_with_prepend_path(self):
+        """Test formatting with prepend path parameter."""
+        mapping = {
+            "ln1": ("input_layernorm", LayerNormBridge),
+            "attn": ("self_attn", AttentionBridge),
+        }
+        
+        result = self.bridge._format_component_mapping(mapping, indent=2, prepend="blocks.0")
+        
+        assert len(result) == 2
+        # The _format_single_component should be called with the prepended path
+        for line in result:
+            assert line.startswith("    ")  # 2 levels of indentation
+
+    def test_format_empty_mapping(self):
+        """Test formatting of an empty mapping."""
+        mapping = {}
+        
+        result = self.bridge._format_component_mapping(mapping, indent=1)
+        
+        assert result == []
+
+    def test_format_non_tuple_values(self):
+        """Test formatting when mapping contains non-tuple values."""
+        mapping = {
+            "some_component": "simple_string_value",
+        }
+        
+        result = self.bridge._format_component_mapping(mapping, indent=1)
+        
+        assert len(result) == 1
+        assert "some_component:" in result[0]
+
+    def test_format_nested_block_mappings(self):
+        """Test formatting of nested block mappings."""
+        mapping = {
+            "outer_blocks": (
+                "model.outer_layers",
+                {
+                    "inner_blocks": (
+                        "inner_layers",
+                        {
+                            "ln": ("layernorm", LayerNormBridge),
+                        }
+                    )
+                }
+            )
+        }
+        
+        result = self.bridge._format_component_mapping(mapping, indent=0)
+        
+        # Should handle nested structure correctly
+        assert len(result) == 3  # outer_blocks + inner_blocks + ln
+        assert any("outer_blocks:" in line for line in result)
+        assert any("inner_blocks:" in line for line in result)
+        assert any("ln:" in line for line in result)
+
+    def test_format_component_mapping_error_handling(self):
+        """Test that the method handles errors gracefully when components can't be found."""
+        mapping = {
+            "nonexistent_component": ("path.to.nowhere", EmbeddingBridge),
+        }
+        
+        # This should not raise an exception, but should handle the error in _format_single_component
+        result = self.bridge._format_component_mapping(mapping, indent=1)
+        
+        assert len(result) == 1
+        assert "nonexistent_component:" in result[0]
+
+    def test_indentation_levels(self):
+        """Test that indentation is applied correctly at different levels."""
+        mapping = {
+            "level0": ("path", EmbeddingBridge),
+        }
+        
+        # Test different indentation levels
+        result_0 = self.bridge._format_component_mapping(mapping, indent=0)
+        result_1 = self.bridge._format_component_mapping(mapping, indent=1)
+        result_2 = self.bridge._format_component_mapping(mapping, indent=2)
+        
+        assert not result_0[0].startswith(" ")  # No indentation
+        assert result_1[0].startswith("  ")    # 1 level (2 spaces)
+        assert result_2[0].startswith("    ")  # 2 levels (4 spaces)
+
+    def test_regression_original_bug(self):
+        """Regression test for the original bug where EmbeddingBridge was treated as a dict."""
+        # This is the exact scenario that was causing the AttributeError
+        mapping = {
+            "embed": ("model.embed_tokens", EmbeddingBridge),
+            "blocks": (
+                "model.layers",
+                {
+                    "attn": ("self_attn", AttentionBridge),
+                }
+            ),
+            "unembed": ("model.embed_tokens", EmbeddingBridge),
+        }
+        
+        # This should not raise AttributeError: type object 'EmbeddingBridge' has no attribute 'items'
+        try:
+            result = self.bridge._format_component_mapping(mapping, indent=1)
+            # If we get here, the bug is fixed
+            assert len(result) == 4  # embed + blocks + attn + unembed
+        except AttributeError as e:
+            if "has no attribute 'items'" in str(e):
+                pytest.fail("Original bug still present: RemoteImport tuples being treated as BlockMapping")
+            else:
+                raise  # Re-raise if it's a different AttributeError
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"]) 

--- a/tests/unit/pretrained_weight_conversions/test_neo.py
+++ b/tests/unit/pretrained_weight_conversions/test_neo.py
@@ -1,0 +1,52 @@
+from unittest import mock
+
+import torch
+
+from transformer_lens import HookedTransformer
+from transformer_lens.HookedTransformerConfig import HookedTransformerConfig
+from transformer_lens.pretrained.weight_conversions.neo import convert_neo_weights
+
+
+def get_default_config():
+    return HookedTransformerConfig(
+        d_model=128, d_head=8, n_heads=16, n_ctx=128, n_layers=1, d_vocab=50257, attn_only=True
+    )
+
+
+def test_convert_neo_weights_exposed():
+    cfg = get_default_config()
+
+    class MockNeo:
+        def __init__(self):
+            self.transformer = HookedTransformer(cfg)
+            self.transformer.wte = torch.nn.Embedding(cfg.d_vocab, cfg.d_model)
+            self.transformer.wpe = torch.nn.Embedding(cfg.n_ctx, cfg.d_model)
+            self.transformer.final_norm = torch.nn.LayerNorm(cfg.d_model)
+            self.transformer.h = [mock.Mock() for _ in range(cfg.n_layers)]
+            self.lm_head = torch.nn.Linear(cfg.d_model, cfg.d_vocab)
+
+            for layer in self.transformer.h:
+                layer.ln_1 = torch.nn.LayerNorm(cfg.d_model)
+                layer.ln_2 = torch.nn.LayerNorm(cfg.d_model)
+                layer.attn = mock.Mock()
+                layer.attn.attention = mock.Mock()
+                layer.attn.attention.q_proj = torch.nn.Linear(cfg.d_model, cfg.d_model)
+                layer.attn.attention.k_proj = torch.nn.Linear(cfg.d_model, cfg.d_model)
+                layer.attn.attention.v_proj = torch.nn.Linear(cfg.d_model, cfg.d_model)
+                layer.attn.attention.out_proj = torch.nn.Linear(cfg.d_model, cfg.d_model)
+                layer.mlp = mock.Mock()
+                layer.mlp.c_fc = torch.nn.Linear(cfg.d_model, cfg.d_model)
+                layer.mlp.c_proj = torch.nn.Linear(cfg.d_model, cfg.d_model)
+
+            self.transformer.ln_f = torch.nn.LayerNorm(cfg.d_model)
+
+    neo = MockNeo()
+
+    try:
+        convert_neo_weights(neo, cfg)
+        function_works = True
+    except Exception as e:
+        function_works = False
+        print(f"The convert_neo_weights function raised an error: {e}")
+
+    assert function_works

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_weight_conversion_set.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_weight_conversion_set.py
@@ -144,4 +144,4 @@ def test_weight_conversion_set_repr():
     ), f"Expected reference to 'nested conversions', got {rep_str}"
     assert "embed.w_e" in rep_str, "Expected mention of embed.W_E key."
     assert "pos_embed" in rep_str, "Expected mention of pos_embed key."
-    assert "layer_0_attn" in rep_str, "Expected mention of layer_0_attn key." 
+    assert "layer_0_attn" in rep_str, "Expected mention of layer_0_attn key."

--- a/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_weight_conversion_set.py
+++ b/tests/unit/weight_conversion/conversion_utils/conversion_steps/test_weight_conversion_set.py
@@ -144,4 +144,4 @@ def test_weight_conversion_set_repr():
     ), f"Expected reference to 'nested conversions', got {rep_str}"
     assert "embed.w_e" in rep_str, "Expected mention of embed.W_E key."
     assert "pos_embed" in rep_str, "Expected mention of pos_embed key."
-    assert "layer_0_attn" in rep_str, "Expected mention of layer_0_attn key."
+    assert "layer_0_attn" in rep_str, "Expected mention of layer_0_attn key." 

--- a/transformer_lens/HookedEncoderDecoder.py
+++ b/transformer_lens/HookedEncoderDecoder.py
@@ -94,9 +94,8 @@ class HookedEncoderDecoder(HookedRootModule):
 
         self.hook_embed = HookPoint()
 
-        if move_to_device:
-            if self.cfg.device is not None:
-                self.to(self.cfg.device)
+        if move_to_device and self.cfg.device is not None:
+            self.to(self.cfg.device)
 
         self.setup()
 
@@ -578,9 +577,8 @@ class HookedEncoderDecoder(HookedRootModule):
 
         model.load_state_dict(state_dict, strict=False)
 
-        if move_to_device:
-            if cfg.device is not None:
-                model.to(cfg.device)
+        if move_to_device and cfg.device is not None:
+            model.to(cfg.device)
 
         print(f"Loaded pretrained model {model_name} into HookedTransformer")
 

--- a/transformer_lens/model_bridge/conversion_utils/__init__.py
+++ b/transformer_lens/model_bridge/conversion_utils/__init__.py
@@ -2,5 +2,3 @@
 
 This module contains utilities for converting between different model architectures.
 """
-
-__all__: list[str] = []


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->