### PR TITLE
Setup tokenizer in boot function

### DIFF
--- a/transformer_lens/boot.py
+++ b/transformer_lens/boot.py
@@ -4,9 +4,15 @@ This module provides functionality to load and convert models from HuggingFace t
 """
 
 
-import torch
 import os
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizerBase
+
+import torch
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    PreTrainedTokenizerBase,
+)
 
 from transformer_lens.model_bridge import ArchitectureAdapterFactory
 from transformer_lens.model_bridge.bridge import TransformerBridge
@@ -68,49 +74,50 @@ def boot(
         tokenizer,
     )
 
+
 def setup_tokenizer(
-        tokenizer,
-        default_padding_side=None,
-    ):
-        """Set's up the tokenizer.
+    tokenizer,
+    default_padding_side=None,
+):
+    """Set's up the tokenizer.
 
-        Args:
-            tokenizer (PreTrainedTokenizer): a pretrained HuggingFace tokenizer.
-            default_padding_side (str): "right" or "left", which side to pad on.
+    Args:
+        tokenizer (PreTrainedTokenizer): a pretrained HuggingFace tokenizer.
+        default_padding_side (str): "right" or "left", which side to pad on.
 
-        """
-        assert isinstance(
-            tokenizer, PreTrainedTokenizerBase
-        ), f"{type(tokenizer)} is not a supported tokenizer, please use PreTrainedTokenizer or PreTrainedTokenizerFast"
+    """
+    assert isinstance(
+        tokenizer, PreTrainedTokenizerBase
+    ), f"{type(tokenizer)} is not a supported tokenizer, please use PreTrainedTokenizer or PreTrainedTokenizerFast"
 
-        assert default_padding_side in [
-            "right",
-            "left",
-            None,
-        ], f"padding_side must be 'right', 'left' or 'None', got {default_padding_side}"
+    assert default_padding_side in [
+        "right",
+        "left",
+        None,
+    ], f"padding_side must be 'right', 'left' or 'None', got {default_padding_side}"
 
-        # Use a tokenizer that is initialized with add_bos_token=True as the default tokenizer.
-        # Such a tokenizer should be set as the default tokenizer because the tokenization of some
-        # tokenizers like LlamaTokenizer are different when bos token is automatically/manually
-        # prepended, and add_bos_token cannot be dynamically controlled after initialization
-        # (https://github.com/huggingface/transformers/issues/25886).
-        tokenizer_with_bos = get_tokenizer_with_bos(tokenizer)
-        tokenizer = tokenizer_with_bos
-        assert tokenizer is not None  # keep mypy happy
+    # Use a tokenizer that is initialized with add_bos_token=True as the default tokenizer.
+    # Such a tokenizer should be set as the default tokenizer because the tokenization of some
+    # tokenizers like LlamaTokenizer are different when bos token is automatically/manually
+    # prepended, and add_bos_token cannot be dynamically controlled after initialization
+    # (https://github.com/huggingface/transformers/issues/25886).
+    tokenizer_with_bos = get_tokenizer_with_bos(tokenizer)
+    tokenizer = tokenizer_with_bos
+    assert tokenizer is not None  # keep mypy happy
 
-        # If user passes default_padding_side explicitly, use that value
-        if default_padding_side is not None:
-            tokenizer.padding_side = default_padding_side
-        # If not, then use the tokenizer's default padding side
-        # If the tokenizer doesn't have a default padding side, use the global default "right"
-        if tokenizer.padding_side is None:
-            tokenizer.padding_side = "right"
+    # If user passes default_padding_side explicitly, use that value
+    if default_padding_side is not None:
+        tokenizer.padding_side = default_padding_side
+    # If not, then use the tokenizer's default padding side
+    # If the tokenizer doesn't have a default padding side, use the global default "right"
+    if tokenizer.padding_side is None:
+        tokenizer.padding_side = "right"
 
-        if tokenizer.eos_token is None:
-            tokenizer.eos_token = "<|endoftext|>"
-        if tokenizer.pad_token is None:
-            tokenizer.pad_token = tokenizer.eos_token
-        if tokenizer.bos_token is None:
-            tokenizer.bos_token = tokenizer.eos_token
+    if tokenizer.eos_token is None:
+        tokenizer.eos_token = "<|endoftext|>"
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    if tokenizer.bos_token is None:
+        tokenizer.bos_token = tokenizer.eos_token
 
-        return tokenizer
+    return tokenizer

--- a/transformer_lens/boot.py
+++ b/transformer_lens/boot.py
@@ -6,6 +6,7 @@ This module provides functionality to load and convert models from HuggingFace t
 
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformer_lens import loading
 
 from transformer_lens.model_bridge import ArchitectureAdapterFactory
 from transformer_lens.model_bridge.bridge import TransformerBridge
@@ -30,21 +31,23 @@ def boot(
     Returns:
         The bridge to the loaded model.
     """
-    hf_config = AutoConfig.from_pretrained(model_name, **kwargs)
+
+    official_model_name = loading.get_official_model_name(model_name)
+    hf_config = AutoConfig.from_pretrained(official_model_name, **kwargs)
     adapter = ArchitectureAdapterFactory.select_architecture_adapter(hf_config)
     default_config = adapter.default_cfg
     merged_config = {**default_config, **(config or {})}
 
     # Load the model from HuggingFace using the original config
     hf_model = AutoModelForCausalLM.from_pretrained(
-        model_name,
+        official_model_name,
         config=hf_config,
         torch_dtype=dtype,
         **merged_config,
     )
 
     # Load the tokenizer
-    tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
+    tokenizer = kwargs.get("tokenizer", None)
 
     return TransformerBridge(
         hf_model,

--- a/transformer_lens/boot.py
+++ b/transformer_lens/boot.py
@@ -5,11 +5,12 @@ This module provides functionality to load and convert models from HuggingFace t
 
 
 import torch
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
-from transformer_lens import loading
+import os
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizerBase
 
 from transformer_lens.model_bridge import ArchitectureAdapterFactory
 from transformer_lens.model_bridge.bridge import TransformerBridge
+from transformer_lens.utils import get_tokenizer_with_bos
 
 
 def boot(
@@ -31,16 +32,14 @@ def boot(
     Returns:
         The bridge to the loaded model.
     """
-
-    official_model_name = loading.get_official_model_name(model_name)
-    hf_config = AutoConfig.from_pretrained(official_model_name, **kwargs)
+    hf_config = AutoConfig.from_pretrained(model_name, **kwargs)
     adapter = ArchitectureAdapterFactory.select_architecture_adapter(hf_config)
     default_config = adapter.default_cfg
     merged_config = {**default_config, **(config or {})}
 
     # Load the model from HuggingFace using the original config
     hf_model = AutoModelForCausalLM.from_pretrained(
-        official_model_name,
+        model_name,
         config=hf_config,
         torch_dtype=dtype,
         **merged_config,
@@ -48,9 +47,70 @@ def boot(
 
     # Load the tokenizer
     tokenizer = kwargs.get("tokenizer", None)
+    default_padding_side = kwargs.get("default_padding_side", None)
+
+    if tokenizer is not None:
+        tokenizer = setup_tokenizer(tokenizer, default_padding_side=default_padding_side)
+    else:
+        huggingface_token = os.environ.get("HF_TOKEN", "")
+        tokenizer = setup_tokenizer(
+            AutoTokenizer.from_pretrained(
+                model_name,
+                add_bos_token=True,
+                token=huggingface_token if len(huggingface_token) > 0 else None,
+            ),
+            default_padding_side=default_padding_side,
+        )
 
     return TransformerBridge(
         hf_model,
         adapter,
         tokenizer,
     )
+
+def setup_tokenizer(
+        tokenizer,
+        default_padding_side=None,
+    ):
+        """Set's up the tokenizer.
+
+        Args:
+            tokenizer (PreTrainedTokenizer): a pretrained HuggingFace tokenizer.
+            default_padding_side (str): "right" or "left", which side to pad on.
+
+        """
+        assert isinstance(
+            tokenizer, PreTrainedTokenizerBase
+        ), f"{type(tokenizer)} is not a supported tokenizer, please use PreTrainedTokenizer or PreTrainedTokenizerFast"
+
+        assert default_padding_side in [
+            "right",
+            "left",
+            None,
+        ], f"padding_side must be 'right', 'left' or 'None', got {default_padding_side}"
+
+        # Use a tokenizer that is initialized with add_bos_token=True as the default tokenizer.
+        # Such a tokenizer should be set as the default tokenizer because the tokenization of some
+        # tokenizers like LlamaTokenizer are different when bos token is automatically/manually
+        # prepended, and add_bos_token cannot be dynamically controlled after initialization
+        # (https://github.com/huggingface/transformers/issues/25886).
+        tokenizer_with_bos = get_tokenizer_with_bos(tokenizer)
+        tokenizer = tokenizer_with_bos
+        assert tokenizer is not None  # keep mypy happy
+
+        # If user passes default_padding_side explicitly, use that value
+        if default_padding_side is not None:
+            tokenizer.padding_side = default_padding_side
+        # If not, then use the tokenizer's default padding side
+        # If the tokenizer doesn't have a default padding side, use the global default "right"
+        if tokenizer.padding_side is None:
+            tokenizer.padding_side = "right"
+
+        if tokenizer.eos_token is None:
+            tokenizer.eos_token = "<|endoftext|>"
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        if tokenizer.bos_token is None:
+            tokenizer.bos_token = tokenizer.eos_token
+
+        return tokenizer

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -20,7 +20,12 @@ from typing import (
 import numpy as np
 import torch
 import torch.nn as nn
+import os
+import logging
 
+from transformer_lens import utils
+
+from transformers import PreTrainedTokenizerBase, AutoTokenizer
 from transformer_lens.ActivationCache import ActivationCache
 from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
 from transformer_lens.model_bridge.component_creation import (
@@ -53,6 +58,46 @@ class TransformerBridge(nn.Module):
         self.cfg = adapter.user_cfg
         self.tokenizer = tokenizer
 
+        tokenizer_name = self.cfg.model_type
+        default_padding_side = None # TODO figure out
+
+        if self.tokenizer is not None:
+            self.set_tokenizer(self.tokenizer, default_padding_side=default_padding_side)
+        elif tokenizer_name is not None:
+            # If we have a tokenizer name, we can load it from HuggingFace
+            if tokenizer_name in "":
+                logging.warning(
+                    "%s tokenizer not loaded. Please load manually.",
+                    tokenizer_name,
+                )
+            else:
+                # Hugging Face defaults to use_fast to True
+                use_fast = True
+                # Phi model's fast tokenizer does not support adding a BOS token, use_fast
+                # should be False
+                if "phi" in tokenizer_name.lower():
+                    use_fast = False
+                huggingface_token = os.environ.get("HF_TOKEN", "")
+                self.set_tokenizer(
+                    AutoTokenizer.from_pretrained(
+                        tokenizer_name,
+                        add_bos_token=True,
+                        trust_remote_code=True,  # TODO figure out,
+                        use_fast=use_fast,
+                        token=huggingface_token if len(huggingface_token) > 0 else None,
+                    ),
+                    default_padding_side=default_padding_side,
+                )
+        else:
+            # If no tokenizer name is provided, we assume we're training on an algorithmic task and
+            # will pass in tokens directly. In this case, we don't need a tokenizer.
+            assert self.cfg.d_vocab != -1, "Must provide a tokenizer if d_vocab is not provided"
+            self.tokenizer = None
+            if default_padding_side != None:
+                logging.warning(
+                    "default_padding_side is explicitly given but ignored because tokenizer is not set."
+                )
+
         if not hasattr(adapter, "component_mapping") or adapter.component_mapping is None:
             raise ValueError("Adapter must have a component_mapping attribute")
 
@@ -60,6 +105,56 @@ class TransformerBridge(nn.Module):
         create_and_replace_components_from_mapping(
             self.bridge.get_component_mapping(), self.original_model, self.bridge, bridge=self
         )
+
+    def set_tokenizer(
+        self,
+        tokenizer,
+        default_padding_side=None,
+    ):
+        """Set the tokenizer to use for this model.
+
+        Args:
+            tokenizer (PreTrainedTokenizer): a pretrained HuggingFace tokenizer.
+            default_padding_side (str): "right" or "left", which side to pad on.
+
+        """
+        assert isinstance(
+            tokenizer, PreTrainedTokenizerBase
+        ), f"{type(tokenizer)} is not a supported tokenizer, please use PreTrainedTokenizer or PreTrainedTokenizerFast"
+
+        assert default_padding_side in [
+            "right",
+            "left",
+            None,
+        ], f"padding_side must be 'right', 'left' or 'None', got {default_padding_side}"
+
+        # Use a tokenizer that is initialized with add_bos_token=True as the default tokenizer.
+        # Such a tokenizer should be set as the default tokenizer because the tokenization of some
+        # tokenizers like LlamaTokenizer are different when bos token is automatically/manually
+        # prepended, and add_bos_token cannot be dynamically controlled after initialization
+        # (https://github.com/huggingface/transformers/issues/25886).
+        tokenizer_with_bos = utils.get_tokenizer_with_bos(tokenizer)
+        self.tokenizer = tokenizer_with_bos
+        assert self.tokenizer is not None  # keep mypy happy
+
+        # If user passes default_padding_side explicitly, use that value
+        if default_padding_side is not None:
+            self.tokenizer.padding_side = default_padding_side
+        # If not, then use the tokenizer's default padding side
+        # If the tokenizer doesn't have a default padding side, use the global default "right"
+        if self.tokenizer.padding_side is None:
+            self.tokenizer.padding_side = "right"
+
+        # Some tokenizers doesn't automatically prepend the BOS token even when they are initialized
+        # with add_bos_token=True. Therefore, we need this information to dynamically control prepend_bos.
+        self.cfg.tokenizer_prepends_bos = len(self.tokenizer.encode("")) > 0
+
+        if self.tokenizer.eos_token is None:
+            self.tokenizer.eos_token = "<|endoftext|>"
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        if self.tokenizer.bos_token is None:
+            self.tokenizer.bos_token = self.tokenizer.eos_token
 
     def __getattr__(self, name: str) -> Any:
         """Provide a clear error message for missing attributes."""
@@ -172,6 +267,10 @@ class TransformerBridge(nn.Module):
         # Handle padding_side logic
         if padding_side is None:
             padding_side = getattr(self.tokenizer, "padding_side", "right")
+
+        if prepend_bos and not self.cfg.tokenizer_prepends_bos:
+                # We want to prepend bos but the tokenizer doesn't automatically do it, so we add it manually
+                input = utils.get_input_with_manually_prepended_bos(self.tokenizer, input)
 
         # Tokenize
         tokens = self.tokenizer(

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -20,16 +20,13 @@ from typing import (
 import numpy as np
 import torch
 import torch.nn as nn
-import os
-import logging
 
+from transformer_lens import utils
 from transformer_lens.ActivationCache import ActivationCache
 from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
 from transformer_lens.model_bridge.component_creation import (
     create_and_replace_components_from_mapping,
 )
-from transformer_lens import utils
-from transformer_lens.loading_from_pretrained import NON_HF_HOSTED_MODEL_NAMES
 
 if TYPE_CHECKING:
     from transformer_lens.ActivationCache import ActivationCache
@@ -182,8 +179,8 @@ class TransformerBridge(nn.Module):
         tokenizer_prepends_bos = len(self.tokenizer.encode("")) > 0
 
         if prepend_bos and not tokenizer_prepends_bos:
-                # We want to prepend bos but the tokenizer doesn't automatically do it, so we add it manually
-                input = utils.get_input_with_manually_prepended_bos(self.tokenizer, input)
+            # We want to prepend bos but the tokenizer doesn't automatically do it, so we add it manually
+            input = utils.get_input_with_manually_prepended_bos(self.tokenizer, input)
 
         # Tokenize
         tokens = self.tokenizer(

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -23,14 +23,13 @@ import torch.nn as nn
 import os
 import logging
 
-from transformer_lens import utils
-
-from transformers import PreTrainedTokenizerBase, AutoTokenizer
 from transformer_lens.ActivationCache import ActivationCache
 from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
 from transformer_lens.model_bridge.component_creation import (
     create_and_replace_components_from_mapping,
 )
+from transformer_lens import utils
+from transformer_lens.loading_from_pretrained import NON_HF_HOSTED_MODEL_NAMES
 
 if TYPE_CHECKING:
     from transformer_lens.ActivationCache import ActivationCache
@@ -58,46 +57,6 @@ class TransformerBridge(nn.Module):
         self.cfg = adapter.user_cfg
         self.tokenizer = tokenizer
 
-        tokenizer_name = self.cfg.model_type
-        default_padding_side = None # TODO figure out
-
-        if self.tokenizer is not None:
-            self.set_tokenizer(self.tokenizer, default_padding_side=default_padding_side)
-        elif tokenizer_name is not None:
-            # If we have a tokenizer name, we can load it from HuggingFace
-            if tokenizer_name in "":
-                logging.warning(
-                    "%s tokenizer not loaded. Please load manually.",
-                    tokenizer_name,
-                )
-            else:
-                # Hugging Face defaults to use_fast to True
-                use_fast = True
-                # Phi model's fast tokenizer does not support adding a BOS token, use_fast
-                # should be False
-                if "phi" in tokenizer_name.lower():
-                    use_fast = False
-                huggingface_token = os.environ.get("HF_TOKEN", "")
-                self.set_tokenizer(
-                    AutoTokenizer.from_pretrained(
-                        tokenizer_name,
-                        add_bos_token=True,
-                        trust_remote_code=True,  # TODO figure out,
-                        use_fast=use_fast,
-                        token=huggingface_token if len(huggingface_token) > 0 else None,
-                    ),
-                    default_padding_side=default_padding_side,
-                )
-        else:
-            # If no tokenizer name is provided, we assume we're training on an algorithmic task and
-            # will pass in tokens directly. In this case, we don't need a tokenizer.
-            assert self.cfg.d_vocab != -1, "Must provide a tokenizer if d_vocab is not provided"
-            self.tokenizer = None
-            if default_padding_side != None:
-                logging.warning(
-                    "default_padding_side is explicitly given but ignored because tokenizer is not set."
-                )
-
         if not hasattr(adapter, "component_mapping") or adapter.component_mapping is None:
             raise ValueError("Adapter must have a component_mapping attribute")
 
@@ -105,56 +64,6 @@ class TransformerBridge(nn.Module):
         create_and_replace_components_from_mapping(
             self.bridge.get_component_mapping(), self.original_model, self.bridge, bridge=self
         )
-
-    def set_tokenizer(
-        self,
-        tokenizer,
-        default_padding_side=None,
-    ):
-        """Set the tokenizer to use for this model.
-
-        Args:
-            tokenizer (PreTrainedTokenizer): a pretrained HuggingFace tokenizer.
-            default_padding_side (str): "right" or "left", which side to pad on.
-
-        """
-        assert isinstance(
-            tokenizer, PreTrainedTokenizerBase
-        ), f"{type(tokenizer)} is not a supported tokenizer, please use PreTrainedTokenizer or PreTrainedTokenizerFast"
-
-        assert default_padding_side in [
-            "right",
-            "left",
-            None,
-        ], f"padding_side must be 'right', 'left' or 'None', got {default_padding_side}"
-
-        # Use a tokenizer that is initialized with add_bos_token=True as the default tokenizer.
-        # Such a tokenizer should be set as the default tokenizer because the tokenization of some
-        # tokenizers like LlamaTokenizer are different when bos token is automatically/manually
-        # prepended, and add_bos_token cannot be dynamically controlled after initialization
-        # (https://github.com/huggingface/transformers/issues/25886).
-        tokenizer_with_bos = utils.get_tokenizer_with_bos(tokenizer)
-        self.tokenizer = tokenizer_with_bos
-        assert self.tokenizer is not None  # keep mypy happy
-
-        # If user passes default_padding_side explicitly, use that value
-        if default_padding_side is not None:
-            self.tokenizer.padding_side = default_padding_side
-        # If not, then use the tokenizer's default padding side
-        # If the tokenizer doesn't have a default padding side, use the global default "right"
-        if self.tokenizer.padding_side is None:
-            self.tokenizer.padding_side = "right"
-
-        # Some tokenizers doesn't automatically prepend the BOS token even when they are initialized
-        # with add_bos_token=True. Therefore, we need this information to dynamically control prepend_bos.
-        self.cfg.tokenizer_prepends_bos = len(self.tokenizer.encode("")) > 0
-
-        if self.tokenizer.eos_token is None:
-            self.tokenizer.eos_token = "<|endoftext|>"
-        if self.tokenizer.pad_token is None:
-            self.tokenizer.pad_token = self.tokenizer.eos_token
-        if self.tokenizer.bos_token is None:
-            self.tokenizer.bos_token = self.tokenizer.eos_token
 
     def __getattr__(self, name: str) -> Any:
         """Provide a clear error message for missing attributes."""
@@ -268,7 +177,11 @@ class TransformerBridge(nn.Module):
         if padding_side is None:
             padding_side = getattr(self.tokenizer, "padding_side", "right")
 
-        if prepend_bos and not self.cfg.tokenizer_prepends_bos:
+        # Some tokenizers don't automatically prepend the BOS token even when they are initialized
+        # with add_bos_token=True. Therefore, we need this information to dynamically control prepend_bos.
+        tokenizer_prepends_bos = len(self.tokenizer.encode("")) > 0
+
+        if prepend_bos and not tokenizer_prepends_bos:
                 # We want to prepend bos but the tokenizer doesn't automatically do it, so we add it manually
                 input = utils.get_input_with_manually_prepended_bos(self.tokenizer, input)
 


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

This PR properly sets up the tokenizer in the boot function such that all the previous functionality, like prepending tokens and specifying which side to use for padding, work as they used to with the old modules.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->