### PR TITLE
Create bridges for every module in Gemma 1

### DIFF
--- a/transformer_lens/model_bridge/generalized_components/embedding.py
+++ b/transformer_lens/model_bridge/generalized_components/embedding.py
@@ -3,6 +3,7 @@
 This module contains the bridge component for embedding layers.
 """
 
+import inspect
 from typing import Any, Dict, Optional
 
 import torch
@@ -58,10 +59,11 @@ class EmbeddingBridge(GeneralizedComponent):
         # Apply input hook
         input_ids = self.hook_in(input_ids)
 
-        if (
-            not hasattr(self.original_component, "forward")
-            or "position_ids" not in self.original_component.forward.__code__.co_varnames
-        ):
+        # Check if the original component supports position_ids using inspect.signature
+        sig = inspect.signature(self.original_component.forward)
+        supports_position_ids = "position_ids" in sig.parameters
+
+        if not hasattr(self.original_component, "forward") or not supports_position_ids:
             kwargs.pop("position_ids", None)
             output = self.original_component(input_ids, **kwargs)
         else:

--- a/transformer_lens/model_bridge/supported_architectures/gemma1.py
+++ b/transformer_lens/model_bridge/supported_architectures/gemma1.py
@@ -12,6 +12,7 @@ from transformer_lens.model_bridge.generalized_components import (
     BlockBridge,
     EmbeddingBridge,
     LayerNormBridge,
+    LinearBridge,
     MLPBridge,
     UnembeddingBridge,
 )
@@ -62,13 +63,29 @@ class Gemma1ArchitectureAdapter(ArchitectureAdapter):
 
         self.component_mapping = {
             "embed": EmbeddingBridge(name="model.embed_tokens"),
+            "rotary_emb": EmbeddingBridge(name="model.rotary_emb"),
             "blocks": BlockBridge(
                 name="model.layers",
                 submodules={
                     "ln1": LayerNormBridge(name="input_layernorm"),
                     "ln2": LayerNormBridge(name="post_attention_layernorm"),
-                    "attn": AttentionBridge(name="self_attn"),
-                    "mlp": MLPBridge(name="mlp"),
+                    "attn": AttentionBridge(
+                        name="self_attn",
+                        submodules={
+                            "W_Q": LinearBridge(name="q_proj"),
+                            "W_K": LinearBridge(name="k_proj"),
+                            "W_V": LinearBridge(name="v_proj"),
+                            "W_O": LinearBridge(name="o_proj"),
+                        },
+                    ),
+                    "mlp": MLPBridge(
+                        name="mlp",
+                        submodules={
+                            "W_gate": LinearBridge(name="gate_proj"),
+                            "W_in": LinearBridge(name="up_proj"),
+                            "W_out": LinearBridge(name="down_proj"),
+                        },
+                    ),
                 },
             ),
             "ln_final": LayerNormBridge(name="model.norm"),


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

This PR maps a Bridge to every module of Gemma 1 thus creating hooks for every activation that happens during the forward pass in transformers.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->