### PR TITLE
Fix key and value heads patching for models with different n_heads from n_key_value_heads

### DIFF
--- a/transformer_lens/patching.py
+++ b/transformer_lens/patching.py
@@ -471,7 +471,7 @@ get_act_patch_attn_head_k_by_pos = partial(
     index_axis_names=("layer", "pos", "head"),
 )
 get_act_patch_attn_head_k_by_pos.__doc__ = """
-    Function to get activation patching results for the keys of each Attention Head (by position). Returns a tensor of shape [n_layers, pos, n_heads]
+    Function to get activation patching results for the keys of each Attention Head (by position). Returns a tensor of shape [n_layers, pos, n_heads] or [n_layers, pos, n_key_value_heads] if the model has a different number of key value heads than attention heads.
 
     See generic_activation_patch for a more detailed explanation of activation patching 
 
@@ -482,7 +482,7 @@ get_act_patch_attn_head_k_by_pos.__doc__ = """
         patching_metric: A function from the model's output logits to some metric (eg loss, logit diff, etc)
 
     Returns:
-        patched_output (torch.Tensor): The tensor of the patching metric for each patch. Has shape [n_layers, pos, n_heads]
+        patched_output (torch.Tensor): The tensor of the patching metric for each patch. Has shape [n_layers, pos, n_heads] or [n_layers, pos, n_key_value_heads] if the model has a different number of key value heads than attention heads.
     """
 
 get_act_patch_attn_head_v_by_pos = partial(
@@ -492,7 +492,7 @@ get_act_patch_attn_head_v_by_pos = partial(
     index_axis_names=("layer", "pos", "head"),
 )
 get_act_patch_attn_head_v_by_pos.__doc__ = """
-    Function to get activation patching results for the values of each Attention Head (by position). Returns a tensor of shape [n_layers, pos, n_heads]
+    Function to get activation patching results for the values of each Attention Head (by position). Returns a tensor of shape [n_layers, pos, n_heads] or [n_layers, pos, n_key_value_heads] if the model has a different number of key value heads than attention heads.
 
     See generic_activation_patch for a more detailed explanation of activation patching 
 
@@ -503,7 +503,7 @@ get_act_patch_attn_head_v_by_pos.__doc__ = """
         patching_metric: A function from the model's output logits to some metric (eg loss, logit diff, etc)
 
     Returns:
-        patched_output (torch.Tensor): The tensor of the patching metric for each patch. Has shape [n_layers, pos, n_heads]
+        patched_output (torch.Tensor): The tensor of the patching metric for each patch. Has shape [n_layers, pos, n_heads] or [n_layers, pos, n_key_value_heads] if the model has a different number of key value heads than attention heads.
     """
 # %%
 get_act_patch_attn_head_pattern_by_pos = partial(
@@ -598,7 +598,7 @@ get_act_patch_attn_head_k_all_pos = partial(
     index_axis_names=("layer", "head"),
 )
 get_act_patch_attn_head_k_all_pos.__doc__ = """
-    Function to get activation patching results for the keys of each Attention Head (across all positions). Returns a tensor of shape [n_layers, n_heads]
+    Function to get activation patching results for the keys of each Attention Head (across all positions). Returns a tensor of shape [n_layers, n_heads] or [n_layers, n_key_value_heads] if the model has a different number of key value heads than attention heads.
 
     See generic_activation_patch for a more detailed explanation of activation patching 
 
@@ -609,7 +609,7 @@ get_act_patch_attn_head_k_all_pos.__doc__ = """
         patching_metric: A function from the model's output logits to some metric (eg loss, logit diff, etc)
 
     Returns:
-        patched_output (torch.Tensor): The tensor of the patching metric for each patch. Has shape [n_layers, n_heads]
+        patched_output (torch.Tensor): The tensor of the patching metric for each patch. Has shape [n_layers, n_heads] or [n_layers, n_key_value_heads] if the model has a different number of key value heads than attention heads.
     """
 
 get_act_patch_attn_head_v_all_pos = partial(
@@ -619,7 +619,7 @@ get_act_patch_attn_head_v_all_pos = partial(
     index_axis_names=("layer", "head"),
 )
 get_act_patch_attn_head_v_all_pos.__doc__ = """
-    Function to get activation patching results for the values of each Attention Head (across all positions). Returns a tensor of shape [n_layers, n_heads]
+    Function to get activation patching results for the values of each Attention Head (across all positions). Returns a tensor of shape [n_layers, n_heads] or [n_layers, n_key_value_heads] if the model has a different number of key value heads than attention heads.
 
     See generic_activation_patch for a more detailed explanation of activation patching 
 
@@ -630,7 +630,7 @@ get_act_patch_attn_head_v_all_pos.__doc__ = """
         patching_metric: A function from the model's output logits to some metric (eg loss, logit diff, etc)
 
     Returns:
-        patched_output (torch.Tensor): The tensor of the patching metric for each patch. Has shape [n_layers, n_heads]
+        patched_output (torch.Tensor): The tensor of the patching metric for each patch. Has shape [n_layers, n_heads] or [n_layers, n_key_value_heads] if the model has a different number of key value heads than attention heads.
     """
 
 get_act_patch_attn_head_pattern_all_pos = partial(


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

 * When patch key or value model heads n_key_value_heads is used instead of  n_heads.
 * When stacking the results for them in the attention head patching methods their results are padded due to different dimentions.

The problem is described in the corresponding issue.

Fixes # 980

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->