### PR TITLE
Create bridge for every module in Mixtral

### DIFF
--- a/transformer_lens/model_bridge/component_setup.py
+++ b/transformer_lens/model_bridge/component_setup.py
@@ -11,6 +11,7 @@ from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapt
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
+from transformer_lens.model_bridge.generalized_components.block import BlockBridge
 from transformer_lens.model_bridge.types import RemoteModel
 
 
@@ -74,6 +75,12 @@ def setup_submodules(
         original_model: The original model to get components from
     """
     for module_name, submodule in component.submodules.items():
+        if isinstance(submodule, BlockBridge):
+            # Submodule is a BlockBridge - create a ModuleList of bridge components
+            bridged_list = setup_blocks_bridge(submodule, architecture_adapter, original_model)
+            # Set the list on the bridge module as a proper module
+            component.add_module(module_name, bridged_list)
+            replace_remote_component(bridged_list, submodule.name, original_model)
         # Only add if not already registered as a PyTorch module
         if module_name not in component._modules:
             # Get the original component for this submodule
@@ -151,6 +158,7 @@ def setup_blocks_bridge(
     Returns:
         ModuleList of bridged block components
     """
+
     # Get the original blocks container
     original_blocks = architecture_adapter.get_remote_component(
         original_model, blocks_template.name

--- a/transformer_lens/model_bridge/component_setup.py
+++ b/transformer_lens/model_bridge/component_setup.py
@@ -11,7 +11,6 @@ from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapt
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
-from transformer_lens.model_bridge.generalized_components.block import BlockBridge
 from transformer_lens.model_bridge.types import RemoteModel
 
 
@@ -75,7 +74,7 @@ def setup_submodules(
         original_model: The original model to get components from
     """
     for module_name, submodule in component.submodules.items():
-        if isinstance(submodule, BlockBridge):
+        if submodule.is_list_item:
             # Submodule is a BlockBridge - create a ModuleList of bridge components
             bridged_list = setup_blocks_bridge(submodule, architecture_adapter, original_model)
             # Set the list on the bridge module as a proper module


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

This PR maps a Bridge to every module of Mixtral thus creating hooks for every activation that happens during the forward pass in transformers. In order to make this possible, this PR changed the current code such that nested BlockBridges are now supported.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->