### PR TITLE
Added full hook coverage for previous keys

### DIFF
--- a/tests/integration/model_bridge/test_cache_hook_names.py
+++ b/tests/integration/model_bridge/test_cache_hook_names.py
@@ -1,0 +1,54 @@
+from transformer_lens.model_bridge import TransformerBridge
+
+MODEL = "gpt2"
+
+prompt = "Hello World!"
+bridge = TransformerBridge.boot_transformers(MODEL, device="cpu")
+
+act_names_in_cache = [
+    "hook_embed",
+    "hook_pos_embed", 
+    "blocks.0.hook_resid_pre",
+    "blocks.0.ln1.hook_scale",
+    "blocks.0.ln1.hook_normalized",
+    "blocks.0.attn.hook_q",
+    "blocks.0.attn.hook_k",
+    "blocks.0.attn.hook_v",
+    "blocks.0.attn.hook_attn_scores",
+    "blocks.0.attn.hook_pattern",
+    "blocks.0.attn.hook_z",
+    "blocks.0.hook_attn_out",
+    "blocks.0.hook_resid_mid",
+    "blocks.0.ln2.hook_scale",
+    "blocks.0.ln2.hook_normalized",
+    "blocks.0.mlp.hook_pre",
+    "blocks.0.mlp.hook_post",
+    "blocks.0.hook_mlp_out",
+    "blocks.0.hook_resid_post",
+    "ln_final.hook_scale",
+    "ln_final.hook_normalized",
+]
+
+
+def test_cache_hook_names():
+    """Test that TransformerBridge cache contains the expected hook names."""
+    _, cache = bridge.run_with_cache(prompt)
+    
+    # Get the actual cache keys
+    actual_keys = list(cache.keys())
+    
+    print(f"\nExpected hooks: {len(act_names_in_cache)}")
+    print(f"Actual hooks: {len(actual_keys)}")
+    
+    # Find missing and extra hooks
+    expected_set = set(act_names_in_cache)
+    actual_set = set(actual_keys)
+    
+    missing_hooks = expected_set - actual_set
+    extra_hooks = actual_set - expected_set
+    
+    print(f"Missing hooks ({len(missing_hooks)}): {sorted(missing_hooks)}")
+    print(f"Extra hooks ({len(extra_hooks)}): {sorted(list(extra_hooks)[:10])}{'...' if len(extra_hooks) > 10 else ''}")
+    
+    # This assertion will likely fail initially, showing exactly what's missing
+    assert actual_keys == act_names_in_cache, f"Cache keys don't match expected hooks. Missing: {missing_hooks}, Extra: {len(extra_hooks)} hooks" 

--- a/tests/integration/model_bridge/test_hook_compatibility.py
+++ b/tests/integration/model_bridge/test_hook_compatibility.py
@@ -1,0 +1,110 @@
+"""Hook compatibility tests for TransformerBridge.
+
+This module contains tests that verify TransformerBridge provides all the hooks
+that should be available from HookedTransformer for interpretability research.
+"""
+
+from typing import Set
+
+import pytest
+
+from transformer_lens.model_bridge import TransformerBridge
+
+
+class TestHookCompatibility:
+    """Test suite to verify hook compatibility for TransformerBridge."""
+
+    @pytest.fixture
+    def model_name(self):
+        """Model name to use for testing."""
+        return "gpt2"
+
+    @pytest.fixture
+    def transformer_bridge(self, model_name):
+        """Create a TransformerBridge for testing."""
+        return TransformerBridge.boot_transformers(model_name, device="cpu")
+
+
+
+    def get_expected_hooks(self) -> Set[str]:
+        """Get the list of hooks that should be available in a TransformerBridge."""
+        expected_hooks = {
+            # Core embedding hooks
+            'hook_embed',
+            'hook_pos_embed', 
+            
+            # Final layer norm and unembedding
+            'ln_final',
+            'unembed',
+            
+            # Block 0 hooks only
+            # Residual stream hooks
+            'blocks.0.hook_resid_pre',
+            'blocks.0.hook_resid_mid', 
+            'blocks.0.hook_resid_post',
+            
+            # Attention hooks
+            'blocks.0.attn.hook_q',
+            'blocks.0.attn.hook_k',
+            'blocks.0.attn.hook_v',
+            'blocks.0.attn.hook_z',
+            'blocks.0.attn.hook_attn_out',
+            'blocks.0.attn.hook_pattern',
+            'blocks.0.attn.hook_result',
+            'blocks.0.attn.hook_attn_scores',
+            
+            # MLP hooks
+            'blocks.0.mlp.hook_pre',
+            'blocks.0.mlp.hook_post',
+            
+            # Layer norm hooks
+            'blocks.0.ln1.hook_normalized',
+            'blocks.0.ln1.hook_scale',
+            'blocks.0.ln2.hook_normalized', 
+            'blocks.0.ln2.hook_scale',
+            
+            # Hook aliases for commonly used patterns
+            'blocks.0.hook_attn_in',
+            'blocks.0.hook_attn_out',
+            'blocks.0.hook_mlp_in',
+            'blocks.0.hook_mlp_out',
+            'blocks.0.hook_q_input',
+            'blocks.0.hook_k_input', 
+            'blocks.0.hook_v_input',
+        }
+            
+        return expected_hooks
+
+    def test_required_hooks_available(self, transformer_bridge):
+        """Test that TransformerBridge has all required TransformerLens hooks."""
+        def hook_exists_on_model(model, hook_path: str) -> bool:
+            """Check if a hook path exists on the model by traversing attributes."""
+            parts = hook_path.split('.')
+            current = model
+            
+            try:
+                for part in parts:
+                    if '[' in part and ']' in part:
+                        # Handle array indexing like blocks[0]
+                        attr_name = part.split('[')[0]
+                        index = int(part.split('[')[1].split(']')[0])
+                        current = getattr(current, attr_name)[index]
+                    else:
+                        current = getattr(current, part)
+                
+                # Check if the final object is a HookPoint
+                from transformer_lens.hook_points import HookPoint
+                return isinstance(current, HookPoint)
+                
+            except (AttributeError, IndexError, TypeError):
+                return False
+        
+        # Get expected hooks and assert each one exists
+        expected_hooks = self.get_expected_hooks()
+        
+        for hook_name in expected_hooks:
+            assert hook_exists_on_model(transformer_bridge, hook_name), f"Required hook '{hook_name}' is not accessible on TransformerBridge"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"]) 


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->