### PR TITLE
Unified aliases

### DIFF
--- a/tests/integration/model_bridge/test_bridge_integration.py
+++ b/tests/integration/model_bridge/test_bridge_integration.py
@@ -95,7 +95,7 @@ def test_cache():
     cache_keys = list(cache.keys())
     assert any("embed" in key for key in cache_keys), "Cache should contain word token embeddings"
     assert any("ln_final" in key for key in cache_keys), "Cache should contain final layer norm"
-    assert any("lm_head" in key for key in cache_keys), "Cache should contain language model head"
+    assert any("unembed" in key for key in cache_keys), "Cache should contain unembedding/language model head"
 
     # Verify that cached tensors are actually tensors
     for key, value in cache.items():

--- a/tests/integration/model_bridge/test_bridge_integration.py
+++ b/tests/integration/model_bridge/test_bridge_integration.py
@@ -95,7 +95,9 @@ def test_cache():
     cache_keys = list(cache.keys())
     assert any("embed" in key for key in cache_keys), "Cache should contain word token embeddings"
     assert any("ln_final" in key for key in cache_keys), "Cache should contain final layer norm"
-    assert any("unembed" in key for key in cache_keys), "Cache should contain unembedding/language model head"
+    assert any(
+        "unembed" in key for key in cache_keys
+    ), "Cache should contain unembedding/language model head"
 
     # Verify that cached tensors are actually tensors
     for key, value in cache.items():

--- a/tests/unit/utilities/test_aliases.py
+++ b/tests/unit/utilities/test_aliases.py
@@ -1,0 +1,361 @@
+"""Unit tests for transformer_lens.utilities.aliases module."""
+
+import warnings
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from transformer_lens.utilities.aliases import (
+    _collect_aliases_from_module,
+    collect_aliases_recursive,
+    resolve_hook_alias,
+)
+
+
+class TestResolveHookAlias:
+    """Test cases for resolve_hook_alias function."""
+    
+    def test_resolve_existing_alias(self):
+        """Test resolving an alias that exists in the hook_aliases dictionary."""
+        mock_target = Mock()
+        mock_hook = Mock()
+        mock_target.actual_hook = mock_hook
+        
+        hook_aliases = {"old_hook": "actual_hook"}
+        
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = resolve_hook_alias(mock_target, "old_hook", hook_aliases)
+            
+            # Check that the correct hook was returned
+            assert result == mock_hook
+            
+            # Check that a deprecation warning was issued
+            assert len(w) == 1
+            assert issubclass(w[0].category, FutureWarning)
+            assert "Hook 'old_hook' is deprecated" in str(w[0].message)
+            assert "Use 'actual_hook' instead" in str(w[0].message)
+    
+    def test_resolve_nonexistent_alias(self):
+        """Test resolving an alias that doesn't exist."""
+        mock_target = Mock()
+        hook_aliases = {"old_hook": "actual_hook"}
+        
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = resolve_hook_alias(mock_target, "nonexistent_hook", hook_aliases)
+            
+            # Should return None for non-existent aliases
+            assert result is None
+            
+            # No warning should be issued
+            assert len(w) == 0
+    
+    def test_resolve_alias_empty_dictionary(self):
+        """Test resolving with an empty hook_aliases dictionary."""
+        mock_target = Mock()
+        hook_aliases = {}
+        
+        result = resolve_hook_alias(mock_target, "any_hook", hook_aliases)
+        assert result is None
+
+
+class TestCollectAliasesFromModule:
+    """Test cases for _collect_aliases_from_module helper function."""
+    
+    def test_collect_named_aliases(self):
+        """Test collecting named hook aliases from a module."""
+        mock_module = Mock()
+        mock_module.hook_aliases = {"old_hook": "new_hook", "another_old": "another_new"}
+        mock_module.named_children.return_value = []  # No children
+        
+        aliases = {}
+        visited = set()
+        
+        _collect_aliases_from_module(mock_module, "prefix", aliases, visited)
+        
+        expected = {
+            "prefix.old_hook": "prefix.new_hook",
+            "prefix.another_old": "prefix.another_new"
+        }
+        assert aliases == expected
+    
+    def test_collect_cache_aliases(self):
+        """Test collecting cache aliases (empty string keys) from a module."""
+        mock_module = Mock()
+        mock_module.hook_aliases = {"": "hook_out", "regular_alias": "target"}
+        mock_module.named_children.return_value = []  # No children
+        
+        aliases = {}
+        visited = set()
+        
+        _collect_aliases_from_module(mock_module, "embed", aliases, visited)
+        
+        expected = {
+            "embed": "embed.hook_out",  # Cache alias from empty string
+            "embed.regular_alias": "embed.target"  # Named alias
+        }
+        assert aliases == expected
+    
+    def test_collect_cache_aliases_no_prefix(self):
+        """Test that cache aliases require a prefix."""
+        mock_module = Mock()
+        mock_module.hook_aliases = {"": "hook_out", "regular_alias": "target"}
+        mock_module.named_children.return_value = []  # No children
+        
+        aliases = {}
+        visited = set()
+        
+        _collect_aliases_from_module(mock_module, "", aliases, visited)
+        
+        # Should only include the named alias, not the cache alias
+        expected = {"regular_alias": "target"}
+        assert aliases == expected
+    
+    def test_collect_from_module_no_prefix(self):
+        """Test collecting aliases from a module with no path prefix."""
+        mock_module = Mock()
+        mock_module.hook_aliases = {"old_hook": "new_hook"}
+        mock_module.named_children.return_value = []  # No children
+        
+        aliases = {}
+        visited = set()
+        
+        _collect_aliases_from_module(mock_module, "", aliases, visited)
+        
+        expected = {"old_hook": "new_hook"}
+        assert aliases == expected
+    
+    def test_collect_prevents_infinite_recursion(self):
+        """Test that visited modules are not processed again."""
+        mock_module = Mock()
+        mock_module.hook_aliases = {"old_hook": "new_hook"}
+        
+        aliases = {}
+        visited = {id(mock_module)}  # Already visited
+        
+        _collect_aliases_from_module(mock_module, "prefix", aliases, visited)
+        
+        # Should be empty since module was already visited
+        assert aliases == {}
+    
+    def test_collect_from_module_with_children(self):
+        """Test collecting aliases recursively from child modules."""
+        # Create parent module
+        parent_module = Mock()
+        parent_module.hook_aliases = {"parent_alias": "parent_target"}
+        
+        # Create child module
+        child_module = Mock()
+        child_module.hook_aliases = {"child_alias": "child_target", "": "hook_out"}
+        
+        # Set up named_children
+        parent_module.named_children.return_value = [("child", child_module)]
+        child_module.named_children.return_value = []  # No further children
+        
+        aliases = {}
+        visited = set()
+        
+        _collect_aliases_from_module(parent_module, "", aliases, visited)
+        
+        expected = {
+            "parent_alias": "parent_target",
+            "child.child_alias": "child.child_target",
+            "child": "child.hook_out"  # Cache alias from empty string
+        }
+        assert aliases == expected
+    
+    def test_collect_skips_original_model(self):
+        """Test that original_model children are skipped."""
+        parent_module = Mock()
+        parent_module.hook_aliases = {"parent_alias": "parent_target"}
+        
+        # Create original_model child (should be skipped)
+        original_model = Mock()
+        original_model.hook_aliases = {"skip_this": "skip_target"}
+        
+        # Create regular child (should be included)
+        regular_child = Mock()
+        regular_child.hook_aliases = {"include_this": "include_target"}
+        
+        parent_module.named_children.return_value = [
+            ("original_model", original_model),
+            ("regular_child", regular_child)
+        ]
+        regular_child.named_children.return_value = []
+        
+        aliases = {}
+        visited = set()
+        
+        _collect_aliases_from_module(parent_module, "", aliases, visited)
+        
+        expected = {
+            "parent_alias": "parent_target",
+            "regular_child.include_this": "regular_child.include_target"
+        }
+        assert aliases == expected
+        assert "skip_this" not in str(aliases)  # Ensure original_model was skipped
+
+
+class TestCollectAliasesRecursive:
+    """Test cases for collect_aliases_recursive function."""
+    
+    def test_collect_aliases_integration(self):
+        """Integration test for the unified aliases collection function."""
+        # Create a mock module structure
+        root_module = Mock()
+        root_module.hook_aliases = {"root_alias": "root_target"}
+        
+        embed_module = Mock()
+        embed_module.hook_aliases = {"": "hook_out", "hook_embed": "hook_out"}
+        
+        child_module = Mock()
+        child_module.hook_aliases = {"child_alias": "child_target"}
+        
+        root_module.named_children.return_value = [
+            ("embed", embed_module),
+            ("child", child_module)
+        ]
+        embed_module.named_children.return_value = []
+        child_module.named_children.return_value = []
+        
+        result = collect_aliases_recursive(root_module, "prefix")
+        
+        expected = {
+            "prefix.root_alias": "prefix.root_target",
+            "prefix.embed": "prefix.embed.hook_out",  # Cache alias
+            "prefix.embed.hook_embed": "prefix.embed.hook_out",  # Regular alias
+            "prefix.child.child_alias": "prefix.child.child_target"
+        }
+        assert result == expected
+    
+    def test_collect_aliases_no_prefix(self):
+        """Test collecting aliases without a prefix."""
+        mock_module = Mock()
+        mock_module.hook_aliases = {"alias": "target", "": "hook_out"}
+        mock_module.named_children.return_value = []
+        
+        result = collect_aliases_recursive(mock_module)
+        
+                 # Should only include named alias since no prefix for cache alias
+        expected = {"alias": "target"}
+        assert result == expected
+    
+    def test_collect_mixed_aliases(self):
+        """Test collecting both regular and cache aliases together."""
+        # Create a mock module structure that mimics real bridge components
+        root_module = Mock()
+        root_module.hook_aliases = {}
+        
+        embed_module = Mock()
+        embed_module.hook_aliases = {"": "hook_out", "hook_embed": "hook_out"}
+        
+        pos_embed_module = Mock()
+        pos_embed_module.hook_aliases = {"": "hook_out"}
+        
+        block_module = Mock()
+        block_module.hook_aliases = {"hook_resid_pre": "hook_in", "hook_resid_post": "hook_out"}
+        
+        root_module.named_children.return_value = [
+            ("embed", embed_module),
+            ("pos_embed", pos_embed_module),
+            ("blocks.0", block_module)
+        ]
+        embed_module.named_children.return_value = []
+        pos_embed_module.named_children.return_value = []
+        block_module.named_children.return_value = []
+        
+        result = collect_aliases_recursive(root_module)
+        
+        expected = {
+                         # Cache aliases (from empty string keys)
+             "embed": "embed.hook_out",
+             "pos_embed": "pos_embed.hook_out",
+             # Named hook aliases
+             "embed.hook_embed": "embed.hook_out",
+            "blocks.0.hook_resid_pre": "blocks.0.hook_in",
+            "blocks.0.hook_resid_post": "blocks.0.hook_out"
+        }
+        assert result == expected
+
+
+class TestModuleWithoutHookAliases:
+    """Test cases for modules that don't have hook_aliases attribute."""
+    
+    def test_collect_from_module_without_hook_aliases(self):
+        """Test collecting from a module that doesn't have hook_aliases."""
+        mock_module = Mock()
+        # Remove hook_aliases attribute
+        del mock_module.hook_aliases
+        mock_module.named_children.return_value = []  # No children
+        
+        aliases = {}
+        visited = set()
+        
+        # Should not raise an exception
+        _collect_aliases_from_module(mock_module, "prefix", aliases, visited)
+        
+        # Should result in empty aliases
+        assert aliases == {}
+    
+    def test_collect_from_module_without_named_children(self):
+        """Test collecting from a module that doesn't have named_children."""
+        mock_module = Mock()
+        mock_module.hook_aliases = {"alias": "target"}
+        # Remove named_children attribute
+        del mock_module.named_children
+        
+        aliases = {}
+        visited = set()
+        
+        # Should not raise an exception
+        _collect_aliases_from_module(mock_module, "prefix", aliases, visited)
+        
+        # Should still collect the hook aliases
+        expected = {"prefix.alias": "prefix.target"}
+        assert aliases == expected
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+    
+    def test_resolve_hook_alias_attribute_error(self):
+        """Test resolve_hook_alias when target attribute doesn't exist."""
+        # Create a class that will actually raise AttributeError
+        class MockWithoutAttribute:
+            pass
+        
+        mock_target = MockWithoutAttribute()
+        hook_aliases = {"old_hook": "nonexistent_hook"}
+        
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            with pytest.raises(AttributeError):
+                resolve_hook_alias(mock_target, "old_hook", hook_aliases)
+    
+    def test_collect_aliases_with_circular_references(self):
+        """Test handling of circular references in module hierarchy."""
+        # Create two modules that reference each other
+        module_a = Mock()
+        module_b = Mock()
+        
+        module_a.hook_aliases = {"alias_a": "target_a"}
+        module_b.hook_aliases = {"alias_b": "target_b"}
+        
+        # Create circular reference
+        module_a.named_children.return_value = [("child_b", module_b)]
+        module_b.named_children.return_value = [("child_a", module_a)]
+        
+        aliases = {}
+        visited = set()
+        
+        # Should handle circular references without infinite recursion
+        _collect_aliases_from_module(module_a, "", aliases, visited)
+        
+        # Should collect from both modules without duplication
+        expected = {
+            "alias_a": "target_a",
+            "child_b.alias_b": "child_b.target_b"
+            # module_a should not be processed again when reached via module_b
+        }
+        assert aliases == expected 

--- a/tests/unit/utilities/test_aliases.py
+++ b/tests/unit/utilities/test_aliases.py
@@ -1,7 +1,7 @@
 """Unit tests for transformer_lens.utilities.aliases module."""
 
 import warnings
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -14,184 +14,184 @@ from transformer_lens.utilities.aliases import (
 
 class TestResolveHookAlias:
     """Test cases for resolve_hook_alias function."""
-    
+
     def test_resolve_existing_alias(self):
         """Test resolving an alias that exists in the hook_aliases dictionary."""
         mock_target = Mock()
         mock_hook = Mock()
         mock_target.actual_hook = mock_hook
-        
+
         hook_aliases = {"old_hook": "actual_hook"}
-        
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = resolve_hook_alias(mock_target, "old_hook", hook_aliases)
-            
+
             # Check that the correct hook was returned
             assert result == mock_hook
-            
+
             # Check that a deprecation warning was issued
             assert len(w) == 1
             assert issubclass(w[0].category, FutureWarning)
             assert "Hook 'old_hook' is deprecated" in str(w[0].message)
             assert "Use 'actual_hook' instead" in str(w[0].message)
-    
+
     def test_resolve_nonexistent_alias(self):
         """Test resolving an alias that doesn't exist."""
         mock_target = Mock()
         hook_aliases = {"old_hook": "actual_hook"}
-        
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = resolve_hook_alias(mock_target, "nonexistent_hook", hook_aliases)
-            
+
             # Should return None for non-existent aliases
             assert result is None
-            
+
             # No warning should be issued
             assert len(w) == 0
-    
+
     def test_resolve_alias_empty_dictionary(self):
         """Test resolving with an empty hook_aliases dictionary."""
         mock_target = Mock()
         hook_aliases = {}
-        
+
         result = resolve_hook_alias(mock_target, "any_hook", hook_aliases)
         assert result is None
 
 
 class TestCollectAliasesFromModule:
     """Test cases for _collect_aliases_from_module helper function."""
-    
+
     def test_collect_named_aliases(self):
         """Test collecting named hook aliases from a module."""
         mock_module = Mock()
         mock_module.hook_aliases = {"old_hook": "new_hook", "another_old": "another_new"}
         mock_module.named_children.return_value = []  # No children
-        
+
         aliases = {}
         visited = set()
-        
+
         _collect_aliases_from_module(mock_module, "prefix", aliases, visited)
-        
+
         expected = {
             "prefix.old_hook": "prefix.new_hook",
-            "prefix.another_old": "prefix.another_new"
+            "prefix.another_old": "prefix.another_new",
         }
         assert aliases == expected
-    
+
     def test_collect_cache_aliases(self):
         """Test collecting cache aliases (empty string keys) from a module."""
         mock_module = Mock()
         mock_module.hook_aliases = {"": "hook_out", "regular_alias": "target"}
         mock_module.named_children.return_value = []  # No children
-        
+
         aliases = {}
         visited = set()
-        
+
         _collect_aliases_from_module(mock_module, "embed", aliases, visited)
-        
+
         expected = {
             "embed": "embed.hook_out",  # Cache alias from empty string
-            "embed.regular_alias": "embed.target"  # Named alias
+            "embed.regular_alias": "embed.target",  # Named alias
         }
         assert aliases == expected
-    
+
     def test_collect_cache_aliases_no_prefix(self):
         """Test that cache aliases require a prefix."""
         mock_module = Mock()
         mock_module.hook_aliases = {"": "hook_out", "regular_alias": "target"}
         mock_module.named_children.return_value = []  # No children
-        
+
         aliases = {}
         visited = set()
-        
+
         _collect_aliases_from_module(mock_module, "", aliases, visited)
-        
+
         # Should only include the named alias, not the cache alias
         expected = {"regular_alias": "target"}
         assert aliases == expected
-    
+
     def test_collect_from_module_no_prefix(self):
         """Test collecting aliases from a module with no path prefix."""
         mock_module = Mock()
         mock_module.hook_aliases = {"old_hook": "new_hook"}
         mock_module.named_children.return_value = []  # No children
-        
+
         aliases = {}
         visited = set()
-        
+
         _collect_aliases_from_module(mock_module, "", aliases, visited)
-        
+
         expected = {"old_hook": "new_hook"}
         assert aliases == expected
-    
+
     def test_collect_prevents_infinite_recursion(self):
         """Test that visited modules are not processed again."""
         mock_module = Mock()
         mock_module.hook_aliases = {"old_hook": "new_hook"}
-        
+
         aliases = {}
         visited = {id(mock_module)}  # Already visited
-        
+
         _collect_aliases_from_module(mock_module, "prefix", aliases, visited)
-        
+
         # Should be empty since module was already visited
         assert aliases == {}
-    
+
     def test_collect_from_module_with_children(self):
         """Test collecting aliases recursively from child modules."""
         # Create parent module
         parent_module = Mock()
         parent_module.hook_aliases = {"parent_alias": "parent_target"}
-        
+
         # Create child module
         child_module = Mock()
         child_module.hook_aliases = {"child_alias": "child_target", "": "hook_out"}
-        
+
         # Set up named_children
         parent_module.named_children.return_value = [("child", child_module)]
         child_module.named_children.return_value = []  # No further children
-        
+
         aliases = {}
         visited = set()
-        
+
         _collect_aliases_from_module(parent_module, "", aliases, visited)
-        
+
         expected = {
             "parent_alias": "parent_target",
             "child.child_alias": "child.child_target",
-            "child": "child.hook_out"  # Cache alias from empty string
+            "child": "child.hook_out",  # Cache alias from empty string
         }
         assert aliases == expected
-    
+
     def test_collect_skips_original_model(self):
         """Test that original_model children are skipped."""
         parent_module = Mock()
         parent_module.hook_aliases = {"parent_alias": "parent_target"}
-        
+
         # Create original_model child (should be skipped)
         original_model = Mock()
         original_model.hook_aliases = {"skip_this": "skip_target"}
-        
+
         # Create regular child (should be included)
         regular_child = Mock()
         regular_child.hook_aliases = {"include_this": "include_target"}
-        
+
         parent_module.named_children.return_value = [
             ("original_model", original_model),
-            ("regular_child", regular_child)
+            ("regular_child", regular_child),
         ]
         regular_child.named_children.return_value = []
-        
+
         aliases = {}
         visited = set()
-        
+
         _collect_aliases_from_module(parent_module, "", aliases, visited)
-        
+
         expected = {
             "parent_alias": "parent_target",
-            "regular_child.include_this": "regular_child.include_target"
+            "regular_child.include_this": "regular_child.include_target",
         }
         assert aliases == expected
         assert "skip_this" not in str(aliases)  # Ensure original_model was skipped
@@ -199,118 +199,115 @@ class TestCollectAliasesFromModule:
 
 class TestCollectAliasesRecursive:
     """Test cases for collect_aliases_recursive function."""
-    
+
     def test_collect_aliases_integration(self):
         """Integration test for the unified aliases collection function."""
         # Create a mock module structure
         root_module = Mock()
         root_module.hook_aliases = {"root_alias": "root_target"}
-        
+
         embed_module = Mock()
         embed_module.hook_aliases = {"": "hook_out", "hook_embed": "hook_out"}
-        
+
         child_module = Mock()
         child_module.hook_aliases = {"child_alias": "child_target"}
-        
-        root_module.named_children.return_value = [
-            ("embed", embed_module),
-            ("child", child_module)
-        ]
+
+        root_module.named_children.return_value = [("embed", embed_module), ("child", child_module)]
         embed_module.named_children.return_value = []
         child_module.named_children.return_value = []
-        
+
         result = collect_aliases_recursive(root_module, "prefix")
-        
+
         expected = {
             "prefix.root_alias": "prefix.root_target",
             "prefix.embed": "prefix.embed.hook_out",  # Cache alias
             "prefix.embed.hook_embed": "prefix.embed.hook_out",  # Regular alias
-            "prefix.child.child_alias": "prefix.child.child_target"
+            "prefix.child.child_alias": "prefix.child.child_target",
         }
         assert result == expected
-    
+
     def test_collect_aliases_no_prefix(self):
         """Test collecting aliases without a prefix."""
         mock_module = Mock()
         mock_module.hook_aliases = {"alias": "target", "": "hook_out"}
         mock_module.named_children.return_value = []
-        
+
         result = collect_aliases_recursive(mock_module)
-        
-                 # Should only include named alias since no prefix for cache alias
+
+        # Should only include named alias since no prefix for cache alias
         expected = {"alias": "target"}
         assert result == expected
-    
+
     def test_collect_mixed_aliases(self):
         """Test collecting both regular and cache aliases together."""
         # Create a mock module structure that mimics real bridge components
         root_module = Mock()
         root_module.hook_aliases = {}
-        
+
         embed_module = Mock()
         embed_module.hook_aliases = {"": "hook_out", "hook_embed": "hook_out"}
-        
+
         pos_embed_module = Mock()
         pos_embed_module.hook_aliases = {"": "hook_out"}
-        
+
         block_module = Mock()
         block_module.hook_aliases = {"hook_resid_pre": "hook_in", "hook_resid_post": "hook_out"}
-        
+
         root_module.named_children.return_value = [
             ("embed", embed_module),
             ("pos_embed", pos_embed_module),
-            ("blocks.0", block_module)
+            ("blocks.0", block_module),
         ]
         embed_module.named_children.return_value = []
         pos_embed_module.named_children.return_value = []
         block_module.named_children.return_value = []
-        
+
         result = collect_aliases_recursive(root_module)
-        
+
         expected = {
-                         # Cache aliases (from empty string keys)
-             "embed": "embed.hook_out",
-             "pos_embed": "pos_embed.hook_out",
-             # Named hook aliases
-             "embed.hook_embed": "embed.hook_out",
+            # Cache aliases (from empty string keys)
+            "embed": "embed.hook_out",
+            "pos_embed": "pos_embed.hook_out",
+            # Named hook aliases
+            "embed.hook_embed": "embed.hook_out",
             "blocks.0.hook_resid_pre": "blocks.0.hook_in",
-            "blocks.0.hook_resid_post": "blocks.0.hook_out"
+            "blocks.0.hook_resid_post": "blocks.0.hook_out",
         }
         assert result == expected
 
 
 class TestModuleWithoutHookAliases:
     """Test cases for modules that don't have hook_aliases attribute."""
-    
+
     def test_collect_from_module_without_hook_aliases(self):
         """Test collecting from a module that doesn't have hook_aliases."""
         mock_module = Mock()
         # Remove hook_aliases attribute
         del mock_module.hook_aliases
         mock_module.named_children.return_value = []  # No children
-        
+
         aliases = {}
         visited = set()
-        
+
         # Should not raise an exception
         _collect_aliases_from_module(mock_module, "prefix", aliases, visited)
-        
+
         # Should result in empty aliases
         assert aliases == {}
-    
+
     def test_collect_from_module_without_named_children(self):
         """Test collecting from a module that doesn't have named_children."""
         mock_module = Mock()
         mock_module.hook_aliases = {"alias": "target"}
         # Remove named_children attribute
         del mock_module.named_children
-        
+
         aliases = {}
         visited = set()
-        
+
         # Should not raise an exception
         _collect_aliases_from_module(mock_module, "prefix", aliases, visited)
-        
+
         # Should still collect the hook aliases
         expected = {"prefix.alias": "prefix.target"}
         assert aliases == expected
@@ -318,44 +315,45 @@ class TestModuleWithoutHookAliases:
 
 class TestEdgeCases:
     """Test edge cases and error conditions."""
-    
+
     def test_resolve_hook_alias_attribute_error(self):
         """Test resolve_hook_alias when target attribute doesn't exist."""
+
         # Create a class that will actually raise AttributeError
         class MockWithoutAttribute:
             pass
-        
+
         mock_target = MockWithoutAttribute()
         hook_aliases = {"old_hook": "nonexistent_hook"}
-        
+
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             with pytest.raises(AttributeError):
                 resolve_hook_alias(mock_target, "old_hook", hook_aliases)
-    
+
     def test_collect_aliases_with_circular_references(self):
         """Test handling of circular references in module hierarchy."""
         # Create two modules that reference each other
         module_a = Mock()
         module_b = Mock()
-        
+
         module_a.hook_aliases = {"alias_a": "target_a"}
         module_b.hook_aliases = {"alias_b": "target_b"}
-        
+
         # Create circular reference
         module_a.named_children.return_value = [("child_b", module_b)]
         module_b.named_children.return_value = [("child_a", module_a)]
-        
+
         aliases = {}
         visited = set()
-        
+
         # Should handle circular references without infinite recursion
         _collect_aliases_from_module(module_a, "", aliases, visited)
-        
+
         # Should collect from both modules without duplication
         expected = {
             "alias_a": "target_a",
             "child_b.alias_b": "child_b.target_b"
             # module_a should not be processed again when reached via module_b
         }
-        assert aliases == expected 
+        assert aliases == expected

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -670,7 +670,7 @@ class TransformerBridge(nn.Module):
                 else:
                     # For other types, try to convert to tensor, otherwise skip
                     try:
-                        if hasattr(tensor, 'detach'):
+                        if hasattr(tensor, "detach"):
                             cache[name] = tensor.detach().cpu()
                         # If it's not a tensor-like object, don't cache it
                     except:
@@ -782,18 +782,20 @@ class TransformerBridge(nn.Module):
             # Handle device parameter properly - move model to device if specified
             filtered_kwargs = kwargs.copy()
             target_device = filtered_kwargs.pop("device", None)  # Remove device from kwargs
-            
+
             if target_device is not None:
                 # Ensure model is on the target device
                 self.original_model = self.original_model.to(target_device)
                 # Also move processed_args to the same device if needed
                 if processed_args and isinstance(processed_args[0], torch.Tensor):
-                    processed_args = [processed_args[0].to(target_device)] + list(processed_args[1:])
+                    processed_args = [processed_args[0].to(target_device)] + list(
+                        processed_args[1:]
+                    )
                 # Move any tensor kwargs to the target device
                 for key, value in filtered_kwargs.items():
                     if isinstance(value, torch.Tensor):
                         filtered_kwargs[key] = value.to(target_device)
-            
+
             try:
                 output = self.original_model(*processed_args, **filtered_kwargs)
                 # Extract logits if output is a HuggingFace model output object
@@ -823,7 +825,6 @@ class TransformerBridge(nn.Module):
         # Add the aliased entries to the cache
         cache.update(cache_items_to_add)
 
-        
         # Add cache entries for all aliases (both hook and cache aliases)
         for alias_name, target_name in aliases.items():
             if target_name in cache and alias_name not in cache:

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -31,6 +31,7 @@ from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapt
 from transformer_lens.model_bridge.component_setup import set_original_components
 from transformer_lens.model_bridge.exceptions import StopAtLayerException
 from transformer_lens.model_bridge.types import ComponentMapping
+from transformer_lens.utilities.aliases import collect_aliases_recursive
 
 if TYPE_CHECKING:
     from transformer_lens.ActivationCache import ActivationCache
@@ -618,42 +619,16 @@ class TransformerBridge(nn.Module):
         Returns:
             Tuple of (output, cache)
         """
-        from transformer_lens.hook_points import HookPoint
-
         # Process names_filter to create a callable that handles legacy hook names
-        # Collect hook aliases from all bridge components
-        def get_hook_aliases_from_components():
-            """Collect all hook aliases from bridge components."""
-            aliases = {}
-
-            def collect_aliases_recursive(module, prefix=""):
-                if hasattr(module, "hook_aliases"):
-                    for old_alias, new_name in module.hook_aliases.items():
-                        # Create full hook name with prefix
-                        if prefix:
-                            full_old_name = f"{prefix}.{old_alias}"
-                            full_new_name = f"{prefix}.{new_name}"
-                        else:
-                            full_old_name = old_alias
-                            full_new_name = new_name
-                        aliases[full_old_name] = full_new_name
-
-                # Recursively collect from submodules
-                for child_name, child_module in module.named_children():
-                    child_prefix = f"{prefix}.{child_name}" if prefix else child_name
-                    collect_aliases_recursive(child_module, child_prefix)
-
-            collect_aliases_recursive(self)
-            return aliases
-
-        hook_aliases = get_hook_aliases_from_components()
+        # Collect all aliases from bridge components (both hook and cache aliases)
+        aliases = collect_aliases_recursive(self)
 
         def create_names_filter_fn(filter_input):
             if filter_input is None:
                 return lambda name: True
             elif isinstance(filter_input, str):
                 # Check if this is a legacy hook name that needs mapping
-                mapped_name = hook_aliases.get(filter_input, None)
+                mapped_name = aliases.get(filter_input, None)
                 if mapped_name:
                     return lambda name: name == mapped_name or name == filter_input
                 else:
@@ -663,7 +638,7 @@ class TransformerBridge(nn.Module):
                 mapped_list = []
                 for item in filter_input:
                     mapped_list.append(item)  # Keep original
-                    mapped_name = hook_aliases.get(item, None)
+                    mapped_name = aliases.get(item, None)
                     if mapped_name:
                         mapped_list.append(mapped_name)
                 return lambda name: name in mapped_list
@@ -687,18 +662,20 @@ class TransformerBridge(nn.Module):
                     cache[name] = tensor.detach().cpu()
                 elif isinstance(tensor, tuple):
                     # For tuple outputs, cache the first element (usually hidden states)
-                    # and store the full tuple structure
                     if len(tensor) > 0 and isinstance(tensor[0], torch.Tensor):
                         cache[name] = tensor[0].detach().cpu()
-                        # Also cache the full tuple structure with a special key
-                        cache[f"{name}_full_tuple"] = tuple(
-                            t.detach().cpu() if isinstance(t, torch.Tensor) else t for t in tensor
-                        )
                     else:
-                        cache[name] = tensor
+                        # If tuple doesn't contain tensors, don't cache it
+                        pass
                 else:
-                    # For other types, store as-is
-                    cache[name] = tensor
+                    # For other types, try to convert to tensor, otherwise skip
+                    try:
+                        if hasattr(tensor, 'detach'):
+                            cache[name] = tensor.detach().cpu()
+                        # If it's not a tensor-like object, don't cache it
+                    except:
+                        # If conversion fails, don't cache it
+                        pass
                 return tensor
 
             return cache_hook
@@ -712,6 +689,9 @@ class TransformerBridge(nn.Module):
 
             for attr_name in dir(module):
                 if attr_name.startswith("_"):
+                    continue
+                # Skip the original_model to avoid collecting hooks from HuggingFace model
+                if attr_name == "original_model":
                     continue
                 try:
                     attr = getattr(module, attr_name)
@@ -735,6 +715,9 @@ class TransformerBridge(nn.Module):
             # Also traverse named_children() to catch ModuleList and other containers
             for child_name, child_module in module.named_children():
                 child_path = f"{prefix}.{child_name}" if prefix else child_name
+                # Skip the original_model module
+                if child_name == "original_model":
+                    continue
                 collect_hookpoints(child_module, child_path)
 
         # Collect hooks from bridge components (these have the clean TransformerLens paths)
@@ -796,8 +779,23 @@ class TransformerBridge(nn.Module):
                         hooks.append((hook_dict[block_hook_name], block_hook_name))
 
             # Run the underlying model's forward method
+            # Handle device parameter properly - move model to device if specified
+            filtered_kwargs = kwargs.copy()
+            target_device = filtered_kwargs.pop("device", None)  # Remove device from kwargs
+            
+            if target_device is not None:
+                # Ensure model is on the target device
+                self.original_model = self.original_model.to(target_device)
+                # Also move processed_args to the same device if needed
+                if processed_args and isinstance(processed_args[0], torch.Tensor):
+                    processed_args = [processed_args[0].to(target_device)] + list(processed_args[1:])
+                # Move any tensor kwargs to the target device
+                for key, value in filtered_kwargs.items():
+                    if isinstance(value, torch.Tensor):
+                        filtered_kwargs[key] = value.to(target_device)
+            
             try:
-                output = self.original_model(*processed_args, **kwargs)
+                output = self.original_model(*processed_args, **filtered_kwargs)
                 # Extract logits if output is a HuggingFace model output object
                 if hasattr(output, "logits"):
                     output = output.logits
@@ -810,20 +808,26 @@ class TransformerBridge(nn.Module):
                 hp.remove_hooks()
 
         # Create duplicate cache entries for TransformerLens compatibility
-        # Use the hook aliases collected from components (reverse mapping: new -> old)
-        reverse_hook_aliases = {new_name: old_name for old_name, new_name in hook_aliases.items()}
+        # Use the aliases collected from components (reverse mapping: new -> old)
+        reverse_aliases = {new_name: old_name for old_name, new_name in aliases.items()}
 
         # Create duplicate entries in cache
         cache_items_to_add = {}
         for cache_name, cached_value in cache.items():
             # Check if this cache name should have an alias
-            for new_name, old_name in reverse_hook_aliases.items():
+            for new_name, old_name in reverse_aliases.items():
                 if cache_name == new_name:
                     cache_items_to_add[old_name] = cached_value
                     break
 
         # Add the aliased entries to the cache
         cache.update(cache_items_to_add)
+
+        
+        # Add cache entries for all aliases (both hook and cache aliases)
+        for alias_name, target_name in aliases.items():
+            if target_name in cache and alias_name not in cache:
+                cache[alias_name] = cache[target_name]
 
         if return_cache_object:
             cache_obj = ActivationCache(cache, self, has_batch_dim=not remove_batch_dim)

--- a/transformer_lens/model_bridge/generalized_components/attention.py
+++ b/transformer_lens/model_bridge/generalized_components/attention.py
@@ -22,6 +22,7 @@ class AttentionBridge(GeneralizedComponent):
 
     hook_aliases = {
         "hook_pattern": "hook_attention_weights",
+        "hook_attn_out": "hook_out",
     }
 
     def __init__(

--- a/transformer_lens/model_bridge/generalized_components/attention.py
+++ b/transformer_lens/model_bridge/generalized_components/attention.py
@@ -70,15 +70,21 @@ class AttentionBridge(GeneralizedComponent):
         for i, element in enumerate(output):
             if i == 0:  # First element is typically hidden states
                 if element is not None:
-                    element = self.hook_hidden_states(element)
+                    element = self._apply_hook_preserving_structure(
+                        element, self.hook_hidden_states
+                    )
             elif i == 1:  # Second element is typically attention weights
                 if element is not None:
-                    element = self.hook_attention_weights(element)
+                    element = self._apply_hook_preserving_structure(
+                        element, self.hook_attention_weights
+                    )
             processed_output.append(element)
 
         # Apply the main hook_out to the first element (hidden states) if it exists
         if len(processed_output) > 0 and processed_output[0] is not None:
-            processed_output[0] = self.hook_out(processed_output[0])
+            processed_output[0] = self._apply_hook_preserving_structure(
+                processed_output[0], self.hook_out
+            )
 
         return tuple(processed_output)
 
@@ -95,15 +101,17 @@ class AttentionBridge(GeneralizedComponent):
 
         for key, value in output.items():
             if key in ["last_hidden_state", "hidden_states"] and value is not None:
-                value = self.hook_hidden_states(value)
+                value = self._apply_hook_preserving_structure(value, self.hook_hidden_states)
             elif key in ["attentions", "attention_weights"] and value is not None:
-                value = self.hook_attention_weights(value)
+                value = self._apply_hook_preserving_structure(value, self.hook_attention_weights)
             processed_output[key] = value
 
         # Apply hook_hidden_states and hook_out to the main output (usually hidden_states)
         main_key = next((k for k in output.keys() if "hidden" in k.lower()), None)
         if main_key and main_key in processed_output:
-            processed_output[main_key] = self.hook_out(processed_output[main_key])
+            processed_output[main_key] = self._apply_hook_preserving_structure(
+                processed_output[main_key], self.hook_out
+            )
 
         return processed_output
 
@@ -117,9 +125,30 @@ class AttentionBridge(GeneralizedComponent):
             Processed tensor with hooks applied
         """
         # Apply hooks for single tensor output
-        output = self.hook_hidden_states(output)
-        output = self.hook_out(output)
+        output = self._apply_hook_preserving_structure(output, self.hook_hidden_states)
+        output = self._apply_hook_preserving_structure(output, self.hook_out)
         return output
+
+    def _apply_hook_preserving_structure(self, element: Any, hook_fn) -> Any:
+        """Apply a hook while preserving the original structure.
+
+        Args:
+            element: The element to process (tensor, tuple, etc.)
+            hook_fn: The hook function to apply to tensors
+
+        Returns:
+            The processed element with the same structure as input
+        """
+        if isinstance(element, torch.Tensor):
+            return hook_fn(element)
+        elif isinstance(element, tuple) and len(element) > 0:
+            # For tuple outputs, process the first element if it's a tensor
+            processed_elements = list(element)
+            if isinstance(element[0], torch.Tensor):
+                processed_elements[0] = hook_fn(element[0])
+            return tuple(processed_elements)
+        # For other types, return as-is
+        return element
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         """Forward pass through the attention layer.

--- a/transformer_lens/model_bridge/generalized_components/base.py
+++ b/transformer_lens/model_bridge/generalized_components/base.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 
 from transformer_lens.hook_points import HookPoint
+from transformer_lens.utilities.aliases import resolve_hook_alias
 
 
 class GeneralizedComponent(nn.Module):
@@ -146,16 +147,9 @@ class GeneralizedComponent(nn.Module):
             return self._modules[name]
 
         # Check if this is a deprecated hook alias
-        if name in self.hook_aliases:
-            target_hook = self.hook_aliases[name]
-            warnings.warn(
-                f"Hook '{name}' is deprecated and will be removed in a future version. "
-                f"Use '{target_hook}' instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            # Return the target hook
-            return getattr(self, target_hook)
+        resolved_hook = resolve_hook_alias(self, name, self.hook_aliases)
+        if resolved_hook is not None:
+            return resolved_hook
 
         # Avoid recursion by checking if we're looking for original_component
         if name == "original_component":

--- a/transformer_lens/model_bridge/generalized_components/base.py
+++ b/transformer_lens/model_bridge/generalized_components/base.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable
 from typing import Any, Dict, Optional
 

--- a/transformer_lens/model_bridge/generalized_components/block.py
+++ b/transformer_lens/model_bridge/generalized_components/block.py
@@ -20,6 +20,11 @@ class BlockBridge(GeneralizedComponent):
 
     # Override the class attribute to indicate this is a list item
     is_list_item: bool = True
+    
+    hook_aliases = {
+        "hook_resid_pre": "hook_in",
+        "hook_resid_post": "hook_out",
+    }
 
     def __init__(
         self,

--- a/transformer_lens/model_bridge/generalized_components/block.py
+++ b/transformer_lens/model_bridge/generalized_components/block.py
@@ -20,7 +20,7 @@ class BlockBridge(GeneralizedComponent):
 
     # Override the class attribute to indicate this is a list item
     is_list_item: bool = True
-    
+
     hook_aliases = {
         "hook_resid_pre": "hook_in",
         "hook_resid_post": "hook_out",

--- a/transformer_lens/model_bridge/generalized_components/embedding.py
+++ b/transformer_lens/model_bridge/generalized_components/embedding.py
@@ -18,7 +18,7 @@ class EmbeddingBridge(GeneralizedComponent):
 
     This component provides standardized input/output hooks.
     """
-    
+
     hook_aliases = {
         "hook_embed": "hook_out",
         "": "hook_out",  # Cache key: embed -> embed.hook_out

--- a/transformer_lens/model_bridge/generalized_components/embedding.py
+++ b/transformer_lens/model_bridge/generalized_components/embedding.py
@@ -18,6 +18,11 @@ class EmbeddingBridge(GeneralizedComponent):
 
     This component provides standardized input/output hooks.
     """
+    
+    hook_aliases = {
+        "hook_embed": "hook_out",
+        "": "hook_out",  # Cache key: embed -> embed.hook_out
+    }
 
     def __init__(
         self,

--- a/transformer_lens/model_bridge/generalized_components/mlp.py
+++ b/transformer_lens/model_bridge/generalized_components/mlp.py
@@ -19,7 +19,7 @@ class MLPBridge(GeneralizedComponent):
     This component wraps an MLP layer from a remote model and provides a consistent interface
     for accessing its weights and performing MLP operations.
     """
-    
+
     hook_aliases = {
         "hook_mlp_out": "hook_out",
     }

--- a/transformer_lens/model_bridge/generalized_components/mlp.py
+++ b/transformer_lens/model_bridge/generalized_components/mlp.py
@@ -19,6 +19,10 @@ class MLPBridge(GeneralizedComponent):
     This component wraps an MLP layer from a remote model and provides a consistent interface
     for accessing its weights and performing MLP operations.
     """
+    
+    hook_aliases = {
+        "hook_mlp_out": "hook_out",
+    }
 
     def __init__(
         self,

--- a/transformer_lens/model_bridge/generalized_components/normalization.py
+++ b/transformer_lens/model_bridge/generalized_components/normalization.py
@@ -14,6 +14,11 @@ class NormalizationBridge(GeneralizedComponent):
 
     This component provides standardized input/output hooks.
     """
+    
+    hook_aliases = {
+        "hook_attn_in": "hook_out",
+        "hook_mlp_in": "hook_out",
+    }
 
     def __init__(
         self,

--- a/transformer_lens/model_bridge/generalized_components/normalization.py
+++ b/transformer_lens/model_bridge/generalized_components/normalization.py
@@ -14,7 +14,7 @@ class NormalizationBridge(GeneralizedComponent):
 
     This component provides standardized input/output hooks.
     """
-    
+
     hook_aliases = {
         "hook_attn_in": "hook_out",
         "hook_mlp_in": "hook_out",

--- a/transformer_lens/utilities/aliases.py
+++ b/transformer_lens/utilities/aliases.py
@@ -1,0 +1,97 @@
+"""Utilities for handling hook aliases in the bridge system."""
+
+import warnings
+from typing import Any, Dict, Optional, Set
+
+
+def resolve_hook_alias(
+    target_object: Any, 
+    requested_name: str, 
+    hook_aliases: Dict[str, str]
+) -> Optional[Any]:
+    """Resolve a hook alias to the actual hook object.
+    
+    Args:
+        target_object: The object to get the resolved attribute from
+        requested_name: The name being requested (potentially an alias)
+        hook_aliases: Dictionary mapping alias names to target names
+        
+    Returns:
+        The resolved hook object if alias found, None otherwise
+    """
+    if requested_name in hook_aliases:
+        target_hook = hook_aliases[requested_name]
+        warnings.warn(
+            f"Hook '{requested_name}' is deprecated and will be removed in a future version. "
+            f"Use '{target_hook}' instead.",
+            FutureWarning,
+            stacklevel=3,  # Adjusted for utility function call
+        )
+        # Return the target hook
+        return getattr(target_object, target_hook)
+    return None
+
+
+def _collect_aliases_from_module(
+    module: Any, 
+    path: str, 
+    aliases: Dict[str, str], 
+    visited: Set[int]
+) -> None:
+    """Helper function to collect all aliases from a single module.
+    
+    Args:
+        module: The module to collect aliases from
+        path: Current path prefix for building full names
+        aliases: Dictionary to populate with aliases (modified in-place)
+        visited: Set of already visited module IDs to prevent infinite recursion
+    """
+    mod_id = id(module)
+    if mod_id in visited:
+        return
+    visited.add(mod_id)
+    
+    if hasattr(module, "hook_aliases"):
+        for alias_name, target_name in module.hook_aliases.items():
+            if alias_name == "":
+                # Empty string creates cache alias: embed -> embed.hook_out
+                if path:  # Only add if we have a meaningful path
+                    aliases[path] = f"{path}.{target_name}"
+            else:
+                # Named hook alias: embed.hook_embed -> embed.hook_out
+                if path:
+                    full_alias = f"{path}.{alias_name}"
+                    full_target = f"{path}.{target_name}"
+                else:
+                    full_alias = alias_name
+                    full_target = target_name
+                aliases[full_alias] = full_target
+    
+    # Recursively collect from submodules, excluding original_model
+    if hasattr(module, "named_children"):
+        for child_name, child_module in module.named_children():
+            # Skip the original_model to avoid collecting hooks from HuggingFace model
+            if child_name == "original_model":
+                continue
+            child_path = f"{path}.{child_name}" if path else child_name
+            _collect_aliases_from_module(child_module, child_path, aliases, visited)
+
+
+def collect_aliases_recursive(module: Any, prefix: str = "") -> Dict[str, str]:
+    """Recursively collect all aliases from a module and its children.
+    
+    This unified function collects both:
+    - Named hook aliases: old_hook_name -> new_hook_name  
+    - Cache aliases: component_name -> component_name.hook_out (from empty string keys)
+    
+    Args:
+        module: The module to collect aliases from
+        prefix: Path prefix for building full names
+        
+    Returns:
+        Dictionary mapping all alias names to target names
+    """
+    aliases = {}
+    visited = set()
+    _collect_aliases_from_module(module, prefix, aliases, visited)
+    return aliases 

--- a/transformer_lens/utilities/aliases.py
+++ b/transformer_lens/utilities/aliases.py
@@ -86,7 +86,7 @@ def collect_aliases_recursive(module: Any, prefix: str = "") -> Dict[str, str]:
     Returns:
         Dictionary mapping all alias names to target names
     """
-    aliases = {}
-    visited = set()
+    aliases: Dict[str, str] = {}
+    visited: Set[int] = set()
     _collect_aliases_from_module(module, prefix, aliases, visited)
     return aliases

--- a/transformer_lens/utilities/aliases.py
+++ b/transformer_lens/utilities/aliases.py
@@ -5,17 +5,15 @@ from typing import Any, Dict, Optional, Set
 
 
 def resolve_hook_alias(
-    target_object: Any, 
-    requested_name: str, 
-    hook_aliases: Dict[str, str]
+    target_object: Any, requested_name: str, hook_aliases: Dict[str, str]
 ) -> Optional[Any]:
     """Resolve a hook alias to the actual hook object.
-    
+
     Args:
         target_object: The object to get the resolved attribute from
         requested_name: The name being requested (potentially an alias)
         hook_aliases: Dictionary mapping alias names to target names
-        
+
     Returns:
         The resolved hook object if alias found, None otherwise
     """
@@ -33,13 +31,10 @@ def resolve_hook_alias(
 
 
 def _collect_aliases_from_module(
-    module: Any, 
-    path: str, 
-    aliases: Dict[str, str], 
-    visited: Set[int]
+    module: Any, path: str, aliases: Dict[str, str], visited: Set[int]
 ) -> None:
     """Helper function to collect all aliases from a single module.
-    
+
     Args:
         module: The module to collect aliases from
         path: Current path prefix for building full names
@@ -50,7 +45,7 @@ def _collect_aliases_from_module(
     if mod_id in visited:
         return
     visited.add(mod_id)
-    
+
     if hasattr(module, "hook_aliases"):
         for alias_name, target_name in module.hook_aliases.items():
             if alias_name == "":
@@ -66,7 +61,7 @@ def _collect_aliases_from_module(
                     full_alias = alias_name
                     full_target = target_name
                 aliases[full_alias] = full_target
-    
+
     # Recursively collect from submodules, excluding original_model
     if hasattr(module, "named_children"):
         for child_name, child_module in module.named_children():
@@ -79,19 +74,19 @@ def _collect_aliases_from_module(
 
 def collect_aliases_recursive(module: Any, prefix: str = "") -> Dict[str, str]:
     """Recursively collect all aliases from a module and its children.
-    
+
     This unified function collects both:
-    - Named hook aliases: old_hook_name -> new_hook_name  
+    - Named hook aliases: old_hook_name -> new_hook_name
     - Cache aliases: component_name -> component_name.hook_out (from empty string keys)
-    
+
     Args:
         module: The module to collect aliases from
         prefix: Path prefix for building full names
-        
+
     Returns:
         Dictionary mapping all alias names to target names
     """
     aliases = {}
     visited = set()
     _collect_aliases_from_module(module, prefix, aliases, visited)
-    return aliases 
+    return aliases


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->