### PR TITLE
Add compatibility_mode feature

### DIFF
--- a/transformer_lens/model_bridge/architecture_adapter.py
+++ b/transformer_lens/model_bridge/architecture_adapter.py
@@ -389,3 +389,29 @@ class ArchitectureAdapter:
             items[parent_key] = input
 
         return items
+
+    def enable_compatibility_mode(
+        self, model, component: GeneralizedComponent, disable_warnings: bool = False
+    ) -> None:
+        """Enable compatibility mode for the adapter.
+
+        This sets up the adapter to work with legacy HookedTransformer components.
+        It will also disable warnings about missing components if specified.
+
+        Args:
+            disable_warnings: Whether to disable warnings about missing components
+        """
+
+        component.compatibility_mode = True
+        component.disable_warnings = disable_warnings
+
+        if component.is_list_item:
+            remote_module_list = self.get_remote_component(model, component.name)
+
+            if isinstance(remote_module_list, nn.ModuleList):
+                for block in remote_module_list:
+                    self.enable_compatibility_mode(model, block, disable_warnings=disable_warnings)
+
+        for component_submodule in component.submodules.values():
+            component_submodule.compatibility_mode = True
+            component_submodule.disable_warnings = disable_warnings

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -58,6 +58,7 @@ class TransformerBridge(nn.Module):
         self.adapter = adapter
         self.cfg = adapter.cfg
         self.tokenizer = tokenizer
+        self.compatibility_mode = False
 
         # Add device information to config from the loaded model
         if not hasattr(self.cfg, "device"):
@@ -188,6 +189,23 @@ class TransformerBridge(nn.Module):
         mapping = self.adapter.get_component_mapping()
         lines.extend(self._format_component_mapping(mapping, indent=1))
         return "\n".join(lines)
+
+    def enable_compatibility_mode(self, disable_warnings: bool = False) -> None:
+        """Enable compatibility mode for the bridge.
+
+        This sets up the bridge to work with legacy HookedTransformer components.
+        It will also disable warnings about missing components if specified.
+
+        Args:
+            disable_warnings: Whether to disable warnings about missing components
+        """
+        self.compatibility_mode = True
+        component_mapping = self.adapter.get_component_mapping()
+
+        for component in component_mapping.values():
+            self.adapter.enable_compatibility_mode(
+                self.original_model, component, disable_warnings=disable_warnings
+            )
 
     # ==================== TOKENIZATION METHODS ====================
 
@@ -795,26 +813,28 @@ class TransformerBridge(nn.Module):
             for hp, _ in hooks:
                 hp.remove_hooks()
 
-        # Create duplicate cache entries for TransformerLens compatibility
-        # Use the aliases collected from components (reverse mapping: new -> old)
-        reverse_aliases = {new_name: old_name for old_name, new_name in aliases.items()}
+        if self.compatibility_mode == True:
+            # If compatibility mode is enabled, we need to handle aliases
+            # Create duplicate cache entries for TransformerLens compatibility
+            # Use the aliases collected from components (reverse mapping: new -> old)
+            reverse_aliases = {new_name: old_name for old_name, new_name in aliases.items()}
 
-        # Create duplicate entries in cache
-        cache_items_to_add = {}
-        for cache_name, cached_value in cache.items():
-            # Check if this cache name should have an alias
-            for new_name, old_name in reverse_aliases.items():
-                if cache_name == new_name:
-                    cache_items_to_add[old_name] = cached_value
-                    break
+            # Create duplicate entries in cache
+            cache_items_to_add = {}
+            for cache_name, cached_value in cache.items():
+                # Check if this cache name should have an alias
+                for new_name, old_name in reverse_aliases.items():
+                    if cache_name == new_name:
+                        cache_items_to_add[old_name] = cached_value
+                        break
 
-        # Add the aliased entries to the cache
-        cache.update(cache_items_to_add)
+            # Add the aliased entries to the cache
+            cache.update(cache_items_to_add)
 
-        # Add cache entries for all aliases (both hook and cache aliases)
-        for alias_name, target_name in aliases.items():
-            if target_name in cache and alias_name not in cache:
-                cache[alias_name] = cache[target_name]
+            # Add cache entries for all aliases (both hook and cache aliases)
+            for alias_name, target_name in aliases.items():
+                if target_name in cache and alias_name not in cache:
+                    cache[alias_name] = cache[target_name]
 
         if return_cache_object:
             cache_obj = ActivationCache(cache, self, has_batch_dim=not remove_batch_dim)

--- a/transformer_lens/model_bridge/generalized_components/base.py
+++ b/transformer_lens/model_bridge/generalized_components/base.py
@@ -23,6 +23,8 @@ class GeneralizedComponent(nn.Module):
 
     # Class attribute indicating whether this component represents a list item (like blocks)
     is_list_item: bool = False
+    compatibility_mode: bool = False
+    disable_warnings: bool = False
 
     # Dictionary mapping deprecated hook names to their new equivalents
     # Subclasses can override this to define their own aliases
@@ -164,7 +166,7 @@ class GeneralizedComponent(nn.Module):
 
         # Check if this is a deprecated hook alias
         resolved_hook = resolve_alias(self, name, self.hook_aliases)
-        if resolved_hook is not None:
+        if resolved_hook is not None and self.compatibility_mode == True:
             return resolved_hook
 
         # Avoid recursion by checking if we're looking for original_component
@@ -237,7 +239,7 @@ class GeneralizedComponent(nn.Module):
             # If we reach here, we can resolve the alias normally
             resolved_property = resolve_alias(self, name, self.property_aliases)
 
-            if resolved_property is not None:
+            if resolved_property is not None and self.compatibility_mode == True:
                 return resolved_property
 
         # If an internal call or no alias was found, just regularly get the attribute

--- a/transformer_lens/utilities/aliases.py
+++ b/transformer_lens/utilities/aliases.py
@@ -5,7 +5,9 @@ from typing import Any, Dict, Optional, Set
 
 
 def resolve_alias(
-    target_object: Any, requested_name: str, aliases: Dict[str, str]
+    target_object: Any,
+    requested_name: str,
+    aliases: Dict[str, str],
 ) -> Optional[Any]:
     """Resolve a hook alias to the actual hook object.
 
@@ -19,12 +21,14 @@ def resolve_alias(
     """
     if requested_name in aliases:
         target_name = aliases[requested_name]
-        warnings.warn(
-            f"Hook '{requested_name}' is deprecated and will be removed in a future version. "
-            f"Use '{target_name}' instead.",
-            FutureWarning,
-            stacklevel=3,  # Adjusted for utility function call
-        )
+
+        if target_object.disable_warnings == False:
+            warnings.warn(
+                f"Hook '{requested_name}' is deprecated and will be removed in a future version. "
+                f"Use '{target_name}' instead.",
+                FutureWarning,
+                stacklevel=3,  # Adjusted for utility function call
+            )
 
         target_name_split = target_name.split(".")
 


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->