### PR TITLE
feat: Bridge.boot should allow using alias model names, but show a deprecation warning

### DIFF
--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -3,8 +3,8 @@
 This module provides functionality to load and convert models from HuggingFace to TransformerLens format.
 """
 
-
 import copy
+import logging
 import os
 
 import torch
@@ -16,6 +16,7 @@ from transformers import (
 )
 
 from transformer_lens.model_bridge.bridge import TransformerBridge
+from transformer_lens.supported_models import MODEL_ALIASES
 from transformer_lens.utils import get_tokenizer_with_bos
 
 
@@ -110,6 +111,16 @@ def boot(
     from transformer_lens.factories.architecture_adapter_factory import (
         ArchitectureAdapterFactory,
     )
+
+    # MODEL_ALIASES is a dict of {official_name: [alias1, alias2, ...]}
+    # Check if model_name that the user passed is an alias, and if so, use the official name
+    for official_name, aliases in MODEL_ALIASES.items():
+        if model_name in aliases:
+            logging.warning(
+                f"DEPRECATED: You are using a deprecated, model_name alias '{model_name}'. TransformerLens will now load the official transformers model name, '{official_name}' instead.\n Please update your code to use the official name by changing model_name from '{model_name}' to '{official_name}'.\nSince TransformerLens v3, all model names should be the official transformers model names.\nThe aliases will be removed in the next version of TransformerLens, so please do the update now."
+            )
+            model_name = official_name
+            break
 
     hf_config = AutoConfig.from_pretrained(model_name, output_attentions=True)
 


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Bridge.boot should allow using alias model names, but show a deprecation warning
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
