### PR TITLE
This is the plot which have made

### DIFF
--- a/lot_activation_sizes.py
+++ b/lot_activation_sizes.py
@@ -1,0 +1,46 @@
+from transformer_lens import HookedTransformer
+import torch
+import matplotlib.pyplot as plt
+import numpy as np
+
+model = HookedTransformer.from_pretrained("gpt2-small")
+_, cache = model.run_with_cache("Hello world")
+
+names = []
+dim0 = []
+dim1 = []
+dim2 = []
+
+for name, value in cache.items():
+    if isinstance(value, torch.Tensor):
+        shp = tuple(value.shape)
+        names.append(name)
+        # record up to three dims, use 1 if missing to avoid plotting gaps
+        dim0.append(shp[0] if len(shp) > 0 else 1)
+        dim1.append(shp[1] if len(shp) > 1 else 1)
+        dim2.append(shp[2] if len(shp) > 2 else 1)
+    else:
+        # non-tensor entries get 0 dims
+        names.append(name)
+        dim0.append(0)
+        dim1.append(0)
+        dim2.append(0)
+
+# Keep order stable; you may want to trim long lists for readability
+MAX = 60
+indices = list(range(min(len(names), MAX)))
+
+x = np.arange(len(indices))
+
+plt.figure(figsize=(12, 6))
+plt.plot(x, [dim0[i] for i in indices], marker='o', label='dim0 (batch)')
+plt.plot(x, [dim1[i] for i in indices], marker='o', label='dim1 (seq)')
+plt.plot(x, [dim2[i] for i in indices], marker='o', label='dim2 (channels/heads/...)')
+
+plt.xticks(x, [names[i] for i in indices], rotation=90, fontsize=8)
+plt.xlabel("Activation name (truncated to first {})".format(len(indices)))
+plt.ylabel("Dimension size")
+plt.title("Activation tensor dimensions (first {})".format(len(indices)))
+plt.legend()
+plt.tight_layout()
+plt.show()

--- a/print_all_shapes.py
+++ b/print_all_shapes.py
@@ -1,0 +1,19 @@
+from transformer_lens import HookedTransformer
+import torch
+
+model = HookedTransformer.from_pretrained("gpt2-small")
+logits, cache = model.run_with_cache("Hello world")
+
+print("type(logits) =", type(logits))
+if isinstance(logits, torch.Tensor):
+    print("logits:", logits.shape)
+else:
+    print("logits is not a tensor!")
+
+for name, value in cache.items():
+    if isinstance(value, torch.Tensor):
+        print(f"{name:40s} -> {tuple(value.shape)}")
+    else:
+        print(f"{name:40s} -> NON-TENSOR type: {type(value)}")
+
+print(logits.shape)  # type: ignore[attr-defined]

--- a/test_tl.py
+++ b/test_tl.py
@@ -1,0 +1,21 @@
+from transformer_lens import HookedTransformer
+import torch
+from typing import cast
+
+print("Loading model...")
+model = HookedTransformer.from_pretrained("gpt2-small")
+
+print("Running model...")
+logits, activations = model.run_with_cache("Hello World")
+
+# runtime type + repr
+print("type(logits) =", type(logits))
+print("repr(logits)[:200] =", repr(logits)[:200])
+
+# safe checks and printing shape
+if isinstance(logits, torch.Tensor):
+    print("logits.shape (runtime):", logits.shape)
+else:
+    # cast for type-checkers (see next section)
+    logits = cast(torch.Tensor, logits)
+    print("After cast, logits.shape:", getattr(logits, "shape", None))


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->