### PR TITLE
Fixed deprecated torch_dtype argument from HuggingFace transformers: replaced with dtype to avoid warning

### DIFF
--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1903,7 +1903,7 @@ def get_pretrained_state_dict(
                 hf_model = AutoModelForCausalLM.from_pretrained(
                     official_model_name,
                     revision=f"checkpoint-{cfg.checkpoint_value}",
-                    torch_dtype=dtype,
+                    dtype=dtype,
                     token=huggingface_token if len(huggingface_token) > 0 else None,
                     **kwargs,
                 )
@@ -1911,7 +1911,7 @@ def get_pretrained_state_dict(
                 hf_model = AutoModelForCausalLM.from_pretrained(
                     official_model_name,
                     revision=f"step{cfg.checkpoint_value}",
-                    torch_dtype=dtype,
+                    dtype=dtype,
                     token=huggingface_token,
                     **kwargs,
                 )
@@ -1924,21 +1924,21 @@ def get_pretrained_state_dict(
             elif "bert" in official_model_name:
                 hf_model = BertForPreTraining.from_pretrained(
                     official_model_name,
-                    torch_dtype=dtype,
+                    dtype=dtype,
                     token=huggingface_token if len(huggingface_token) > 0 else None,
                     **kwargs,
                 )
             elif "t5" in official_model_name:
                 hf_model = T5ForConditionalGeneration.from_pretrained(
                     official_model_name,
-                    torch_dtype=dtype,
+                    dtype=dtype,
                     token=huggingface_token if len(huggingface_token) > 0 else None,
                     **kwargs,
                 )
             else:
                 hf_model = AutoModelForCausalLM.from_pretrained(
                     official_model_name,
-                    torch_dtype=dtype,
+                    dtype=dtype,
                     token=huggingface_token if len(huggingface_token) > 0 else None,
                     **kwargs,
                 )


### PR DESCRIPTION
This PR resolves the warning from huggingface deprecation of the `torch_dtype` argument when loading a model from HuggingFace transformers. Replaced it with `dtype` whenever loading a model from `transformers`. Kept `torch_dtype` in kwargs since it automatically gets assigned to `dtype` when loading from TransformerLens.

Fixes #1093 

Before:

```
hf_model = AutoModelForCausalLM.from_pretrained(
    official_model_name,
    torch_dtype=dtype,
    token=huggingface_token if len(huggingface_token) > 0 else None,
    **kwargs,
)
```

After:

```
hf_model = AutoModelForCausalLM.from_pretrained(
    official_model_name,
    dtype=dtype,
    token=huggingface_token if len(huggingface_token) > 0 else None,
    **kwargs,
)
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility