### PR TITLE
fix: set n_ctx=512 for TinyStories models

### DIFF
--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1970,15 +1970,12 @@ def convert_hf_model_config(model_name: str, **kwargs: Any):
     cfg_dict["tokenizer_name"] = official_model_name
     if kwargs.get("trust_remote_code", False):
         cfg_dict["trust_remote_code"] = True
-    # Warn about TinyStories n_ctx mismatch (trained with seq_len=512, but HF config has 2048)
-    # The weights have pos_embed for 2048, so we can't change n_ctx without breaking loading
+    # TinyStories models were trained with seq_len=512, but the HuggingFace config
+    # reports max_position_embeddings=2048. Override n_ctx so the positional embedding
+    # weights are trimmed during weight conversion.
     # See: https://github.com/TransformerLensOrg/TransformerLens/issues/492
     if official_model_name.startswith("roneneldan/TinyStories"):
-        logging.warning(
-            f"TinyStories models were trained with max sequence length 512, but the HuggingFace "
-            f"config reports n_ctx=2048. Performance degrades significantly for sequences longer "
-            f"than 512 tokens. See https://github.com/TransformerLensOrg/TransformerLens/issues/492"
-        )
+        cfg_dict["n_ctx"] = 512
     return cfg_dict
 
 

--- a/transformer_lens/pretrained/weight_conversions/gpt2.py
+++ b/transformer_lens/pretrained/weight_conversions/gpt2.py
@@ -8,7 +8,13 @@ def convert_gpt2_weights(gpt2, cfg: HookedTransformerConfig):
     state_dict = {}
 
     state_dict["embed.W_E"] = gpt2.transformer.wte.weight
-    state_dict["pos_embed.W_pos"] = gpt2.transformer.wpe.weight
+
+    # Trim positional embeddings to n_ctx if the pretrained weights have more
+    # positions than the model expects.
+    pos_embed = gpt2.transformer.wpe.weight
+    if pos_embed.shape[0] > cfg.n_ctx:
+        pos_embed = pos_embed[: cfg.n_ctx, :]
+    state_dict["pos_embed.W_pos"] = pos_embed
 
     for l in range(cfg.n_layers):
         state_dict[f"blocks.{l}.ln1.w"] = gpt2.transformer.h[l].ln_1.weight

--- a/transformer_lens/pretrained/weight_conversions/neo.py
+++ b/transformer_lens/pretrained/weight_conversions/neo.py
@@ -8,7 +8,14 @@ def convert_neo_weights(neo, cfg: HookedTransformerConfig):
     state_dict = {}
 
     state_dict["embed.W_E"] = neo.transformer.wte.weight
-    state_dict["pos_embed.W_pos"] = neo.transformer.wpe.weight
+
+    # Trim positional embeddings to n_ctx if the pretrained weights have more
+    # positions than the model expects (e.g. TinyStories models were trained with
+    # seq_len=512 but the HuggingFace config reports max_position_embeddings=2048).
+    pos_embed = neo.transformer.wpe.weight
+    if pos_embed.shape[0] > cfg.n_ctx:
+        pos_embed = pos_embed[: cfg.n_ctx, :]
+    state_dict["pos_embed.W_pos"] = pos_embed
 
     for l in range(cfg.n_layers):
         state_dict[f"blocks.{l}.ln1.w"] = neo.transformer.h[l].ln_1.weight


### PR DESCRIPTION
## Description

TinyStories models were trained with sequence length 512, but HuggingFace config incorrectly claims `n_ctx=2048`. This causes severe performance degradation for sequences >512 tokens.

This fix adds a post-processing override to correct the `n_ctx` value when loading any TinyStories model.

Fixes #492

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings