### PR TITLE
Support callable filters in TransformerBridge.add_hook()

### DIFF
--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -2171,8 +2171,36 @@ class TransformerBridge(nn.Module):
         """
         return self.to(torch.device("mps"))
 
-    def add_hook(self, name: str, hook_fn, dir="fwd", is_permanent=False):
-        """Add a hook to a specific component."""
+    def add_hook(
+        self,
+        name: Union[str, Callable[[str], bool]],
+        hook_fn,
+        dir="fwd",
+        is_permanent=False,
+    ):
+        """Add a hook to a specific component or to all components matching a filter.
+
+        Args:
+            name: Either a string hook point name (e.g. "blocks.0.attn.hook_q")
+                or a callable filter ``(str) -> bool`` that is applied to every
+                hook point name; the hook is added to each point where the filter
+                returns True.
+            hook_fn: The hook function ``(activation, hook) -> activation | None``.
+            dir: Hook direction, ``"fwd"`` or ``"bwd"``.
+            is_permanent: If True the hook survives ``reset_hooks()`` calls.
+        """
+        if callable(name) and not isinstance(name, str):
+            hook_dict = self.hook_dict
+            seen_hooks: set[int] = set()
+            for hook_name, hook_point in hook_dict.items():
+                if name(hook_name):
+                    hook_id = id(hook_point)
+                    if hook_id in seen_hooks:
+                        continue
+                    seen_hooks.add(hook_id)
+                    hook_point.add_hook(hook_fn, dir=dir, is_permanent=is_permanent)
+            return
+
         component = self
         parts = name.split(".")
         for part in parts[:-1]:


### PR DESCRIPTION
# Description

`add_hooks` functionality had the necessary wiring to exist in TransformerBridge, but was not properly configured to be usable.

`- `TransformerBridge.add_hook()` now accepts a callable filter `(str) -> bool` as the `name` parameter, matching the `HookedTransformer` API
- When a callable is passed, the hook is added to every hook point whose name satisfies the filter
- This was already supported in `run_with_hooks()` but missing from `add_hook()`, causing `AttributeError` when migrating notebooks that use filter-based hook registration (e.g. Attribution Patching Demo)
- Adds 4 regression tests covering forward/backward callable filters, string names, and empty matches

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
