### PR TITLE
Update Patching Hook to avoid causing conflicts

### DIFF
--- a/transformer_lens/patching.py
+++ b/transformer_lens/patching.py
@@ -202,6 +202,10 @@ def generic_activation_patch(
 
     # A generic patching hook - for each index, it applies the patch_setter appropriately to patch the activation
     def patching_hook(corrupted_activation, hook, index, clean_activation):
+        # Clone to break autograd view chain before inplace modification.
+        # Without this, TransformerBridge's HookPoint identity forward creates
+        # a view that conflicts with inplace ops in the patch setters.
+        corrupted_activation = corrupted_activation.clone()
         return patch_setter(corrupted_activation, index, clean_activation)
 
     # Iterate over every list of indices, and make the appropriate patch!


### PR DESCRIPTION

# Description

PyTorch's autograd doesn't allow inplace modification of tensors that are views used in gradient computation. TransformerBridge accesses PyTorch tensors in-place, and when `patch_setter` is called, it attempts to modify those tensors directly. This clones the tensor before modification, which eventually gets returned to be used in the forward pass

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility