### PR TITLE
Updated to remove hardcoded .cpu() processing

### DIFF
--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -1465,21 +1465,26 @@ class TransformerBridge(nn.Module):
         hooks: List[Tuple[HookPoint, str]] = []
         visited: set[int] = set()
 
+        # Extract cache device early so make_cache_hook can capture it.
+        # Default None means .to(None) which is a no-op — tensors stay on
+        # their current device, matching HookedRootModule's default behavior.
+        cache_device = kwargs.pop("device", None)
+
         def make_cache_hook(name: str):
             def cache_hook(tensor: torch.Tensor, *, hook: Any) -> torch.Tensor:
                 if tensor is None:
                     cache[name] = None
                 elif isinstance(tensor, torch.Tensor):
-                    cache[name] = tensor.detach().cpu()
+                    cache[name] = tensor.detach().to(cache_device)
                 elif isinstance(tensor, tuple):
                     if len(tensor) > 0 and isinstance(tensor[0], torch.Tensor):
-                        cache[name] = tensor[0].detach().cpu()
+                        cache[name] = tensor[0].detach().to(cache_device)
                     else:
                         pass
                 else:
                     try:
                         if hasattr(tensor, "detach"):
-                            cache[name] = tensor.detach().cpu()
+                            cache[name] = tensor.detach().to(cache_device)
                     except:
                         pass
                 return tensor
@@ -1535,14 +1540,13 @@ class TransformerBridge(nn.Module):
                     hook_dict[block_hook_name].add_hook(stop_hook)
                     hooks.append((hook_dict[block_hook_name], block_hook_name))
         filtered_kwargs = kwargs.copy()
-        target_device = filtered_kwargs.pop("device", None)
-        if target_device is not None:
-            self.original_model = self.original_model.to(target_device)
+        if cache_device is not None:
+            self.original_model = self.original_model.to(cache_device)
             if processed_args and isinstance(processed_args[0], torch.Tensor):
-                processed_args = [processed_args[0].to(target_device)] + list(processed_args[1:])
+                processed_args = [processed_args[0].to(cache_device)] + list(processed_args[1:])
             for key, value in filtered_kwargs.items():
                 if isinstance(value, torch.Tensor):
-                    filtered_kwargs[key] = value.to(target_device)
+                    filtered_kwargs[key] = value.to(cache_device)
         try:
             if "output_attentions" not in filtered_kwargs:
                 filtered_kwargs["output_attentions"] = True


### PR DESCRIPTION
# Description

TransformerBridge's `run_with_cache` was always storing the cache in CPU. In order to maintain consistency with HookedTransformer behavior, updated `make_cache_hook` to reference the target device.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility