### PR TITLE
Prep work for Hybrid model integration

### DIFF
--- a/tests/unit/test_optional_submodule.py
+++ b/tests/unit/test_optional_submodule.py
@@ -1,0 +1,887 @@
+"""Unit tests for the optional submodule framework.
+
+Tests the `optional` flag on GeneralizedComponent and the `blocks_with()`
+capability query API on TransformerBridge, which together enable hybrid
+architectures where layers have structurally different submodules.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+from transformer_lens.model_bridge.component_setup import setup_submodules
+from transformer_lens.model_bridge.generalized_components.base import (
+    GeneralizedComponent,
+)
+from transformer_lens.model_bridge.generalized_components.block import BlockBridge
+from transformer_lens.model_bridge.generalized_components.linear import LinearBridge
+
+# ============================================================================
+# Fixtures: synthetic hybrid model
+# ============================================================================
+
+
+class FakeSubmodule(nn.Module):
+    """A simple nn.Linear submodule for testing."""
+
+    def __init__(self, dim: int = 4):
+        super().__init__()
+        self.proj = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x)
+
+
+class HybridLayer(nn.Module):
+    """A layer that conditionally has a 'foo' submodule."""
+
+    def __init__(self, has_foo: bool, dim: int = 4):
+        super().__init__()
+        self.bar = nn.Linear(dim, dim, bias=False)
+        if has_foo:
+            self.foo = FakeSubmodule(dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if hasattr(self, "foo"):
+            x = self.foo(x)
+        return self.bar(x)
+
+
+class HybridModel(nn.Module):
+    """Model with 4 layers: layers 0-2 have 'foo', layer 3 does not."""
+
+    def __init__(self, dim: int = 4):
+        super().__init__()
+        self.layers = nn.ModuleList([HybridLayer(has_foo=(i < 3), dim=dim) for i in range(4)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+class MinimalAdapter(ArchitectureAdapter):
+    """Minimal adapter for testing optional submodule setup."""
+
+    def __init__(self, optional: bool = True):
+        self.cfg = type("Cfg", (), {"n_layers": 4, "d_model": 4})()
+        self.component_mapping = {}
+        self._optional = optional
+
+    def make_block_template(self) -> BlockBridge:
+        return BlockBridge(
+            name="layers",
+            submodules={
+                "bar": LinearBridge(name="bar"),
+                "foo": LinearBridge(name="foo", optional=self._optional),
+            },
+        )
+
+
+# ============================================================================
+# Tests: optional flag on GeneralizedComponent
+# ============================================================================
+
+
+class TestOptionalFlag:
+    """Test that the optional flag is properly stored and defaults to False."""
+
+    def test_default_is_false(self):
+        comp = GeneralizedComponent(name="test")
+        assert comp.optional is False
+
+    def test_optional_true(self):
+        comp = GeneralizedComponent(name="test", optional=True)
+        assert comp.optional is True
+
+    def test_optional_false_explicit(self):
+        comp = GeneralizedComponent(name="test", optional=False)
+        assert comp.optional is False
+
+
+# ============================================================================
+# Tests: setup_submodules with optional
+# ============================================================================
+
+
+class TestOptionalSubmoduleSetup:
+    """Test that optional submodules are skipped cleanly during setup."""
+
+    def test_optional_submodule_skipped_on_missing_layers(self):
+        """Layers 0-2 have 'foo', layer 3 does not. Setup should succeed."""
+        model = HybridModel()
+        adapter = MinimalAdapter(optional=True)
+        template = adapter.make_block_template()
+
+        # Simulate what setup_blocks_bridge does: deepcopy + setup per layer
+        import copy
+
+        blocks = []
+        for i, layer in enumerate(model.layers):
+            block = copy.deepcopy(template)
+            block.name = f"layers.{i}"
+            block.set_original_component(layer)
+            setup_submodules(block, adapter, layer)
+            blocks.append(block)
+
+        # Layers 0-2 should have 'foo' in real_components
+        for i in range(3):
+            assert "foo" in blocks[i].real_components, f"Block {i} should have 'foo'"
+            assert hasattr(blocks[i], "foo"), f"Block {i} should have foo module"
+
+        # Layer 3 should NOT have 'foo' in any lookup path
+        assert (
+            "foo" not in blocks[3].real_components
+        ), "Block 3 should not have 'foo' in real_components"
+        assert "foo" not in blocks[3]._modules, "Block 3 should not have 'foo' in _modules"
+        assert "foo" not in blocks[3].submodules, "Block 3 should not have 'foo' in submodules"
+
+        # All layers should have 'bar'
+        for i in range(4):
+            assert "bar" in blocks[i].real_components, f"Block {i} should have 'bar'"
+
+    def test_non_optional_missing_submodule_raises(self):
+        """When optional=False, missing submodule should raise AttributeError."""
+        model = HybridModel()
+        adapter = MinimalAdapter(optional=False)
+        template = adapter.make_block_template()
+
+        import copy
+
+        # Layer 3 lacks 'foo' and optional=False, so this should raise
+        block = copy.deepcopy(template)
+        block.name = "layers.3"
+        block.set_original_component(model.layers[3])
+        with pytest.raises(AttributeError):
+            setup_submodules(block, adapter, model.layers[3])
+
+
+# ============================================================================
+# Tests: blocks_with() API
+# ============================================================================
+
+
+class TestBlocksWith:
+    """Test the blocks_with() capability query on TransformerBridge."""
+
+    def test_blocks_with_returns_matching_blocks(self):
+        """blocks_with('foo') should return only blocks that have 'foo'."""
+        from transformer_lens.model_bridge.bridge import TransformerBridge
+
+        model = HybridModel()
+        adapter = MinimalAdapter(optional=True)
+        template = adapter.make_block_template()
+
+        import copy
+
+        blocks = nn.ModuleList()
+        for i, layer in enumerate(model.layers):
+            block = copy.deepcopy(template)
+            block.name = f"layers.{i}"
+            block.set_original_component(layer)
+            setup_submodules(block, adapter, layer)
+            blocks.append(block)
+
+        # Create a minimal bridge-like object with blocks attribute
+        # We test blocks_with as a standalone method
+        bridge = TransformerBridge.__new__(TransformerBridge)
+        nn.Module.__init__(bridge)
+        bridge.add_module("blocks", blocks)
+
+        foo_blocks = bridge.blocks_with("foo")
+        assert len(foo_blocks) == 3
+        assert [idx for idx, _ in foo_blocks] == [0, 1, 2]
+
+        bar_blocks = bridge.blocks_with("bar")
+        assert len(bar_blocks) == 4
+
+        missing_blocks = bridge.blocks_with("nonexistent")
+        assert len(missing_blocks) == 0
+
+    def test_blocks_with_no_blocks_attribute(self):
+        """blocks_with() should return empty list if no blocks attribute."""
+        from transformer_lens.model_bridge.bridge import TransformerBridge
+
+        bridge = TransformerBridge.__new__(TransformerBridge)
+        nn.Module.__init__(bridge)
+        assert bridge.blocks_with("attn") == []
+
+
+# ============================================================================
+# Tests: _stack_block_params with hybrid blocks
+# ============================================================================
+
+
+class TestStackBlockParamsHybridSafe:
+    """Test that _stack_block_params raises clear errors for hybrid blocks."""
+
+    def test_logs_warning_and_returns_subset_on_hybrid(self, caplog):
+        """On hybrid blocks, should log warning and return tensor for matching blocks only."""
+        import logging
+
+        from transformer_lens.model_bridge.bridge import TransformerBridge
+
+        # Build blocks where block 3 lacks 'foo' but blocks 0-2 have it
+        model = HybridModel()
+        adapter = MinimalAdapter(optional=True)
+        template = adapter.make_block_template()
+
+        import copy
+
+        blocks = nn.ModuleList()
+        for i, layer in enumerate(model.layers):
+            block = copy.deepcopy(template)
+            block.name = f"layers.{i}"
+            block.set_original_component(layer)
+            setup_submodules(block, adapter, layer)
+            blocks.append(block)
+
+        # Verify precondition: block 3 lacks 'foo'
+        assert "foo" in blocks[0]._modules
+        assert "foo" not in blocks[3]._modules
+
+        bridge = TransformerBridge.__new__(TransformerBridge)
+        nn.Module.__init__(bridge)
+        bridge.add_module("blocks", blocks)
+
+        # Should succeed with a log warning, returning only matching blocks.
+        # logging.warning always emits (no deduplication), so researchers see
+        # the index mapping notice on every access — not just the first.
+        with caplog.at_level(logging.WARNING):
+            result = bridge._stack_block_params("foo.proj.weight")
+        assert any("Hybrid model" in msg for msg in caplog.messages)
+        assert any("stack_params_for" in msg for msg in caplog.messages)
+        # 3 blocks have 'foo', not 4
+        assert result.shape[0] == 3
+
+        # Verify it logs again on a second call (no deduplication)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            result2 = bridge._stack_block_params("foo.proj.weight")
+        assert any(
+            "Hybrid model" in msg for msg in caplog.messages
+        ), "Warning should emit on every call, not just the first"
+
+    def test_raises_when_no_blocks_have_submodule(self):
+        """Should raise AttributeError when zero blocks have the submodule."""
+        from transformer_lens.model_bridge.bridge import TransformerBridge
+
+        bridge = _make_hybrid_bridge()
+        with pytest.raises(AttributeError, match="No blocks have"):
+            bridge._stack_block_params("nonexistent")
+
+    def test_succeeds_on_universal_submodule(self):
+        """Should succeed when all blocks have the requested submodule."""
+        from transformer_lens.model_bridge.bridge import TransformerBridge
+
+        model = HybridModel()
+        adapter = MinimalAdapter(optional=True)
+        template = adapter.make_block_template()
+
+        import copy
+
+        blocks = nn.ModuleList()
+        for i, layer in enumerate(model.layers):
+            block = copy.deepcopy(template)
+            block.name = f"layers.{i}"
+            block.set_original_component(layer)
+            setup_submodules(block, adapter, layer)
+            blocks.append(block)
+
+        bridge = TransformerBridge.__new__(TransformerBridge)
+        nn.Module.__init__(bridge)
+        bridge.add_module("blocks", blocks)
+
+        # 'bar' exists on all blocks → should succeed
+        result = bridge._stack_block_params("bar.weight")
+        assert result.shape[0] == 4  # 4 layers
+
+
+# ============================================================================
+# Tests: refactor_factored_attn_matrices with missing layers
+# ============================================================================
+
+
+class TestRefactorFactoredAttnHybrid:
+    """Test that refactor_factored_attn_matrices skips layers without attn."""
+
+    def test_skips_missing_attn_layers(self):
+        """Should process layers with attn keys and skip those without."""
+        from transformer_lens.config.TransformerLensConfig import TransformerLensConfig
+        from transformer_lens.weight_processing import ProcessWeights
+
+        n_heads = 2
+        d_head = 4
+        d_model = n_heads * d_head
+        cfg = TransformerLensConfig(
+            n_layers=4,
+            n_heads=n_heads,
+            d_head=d_head,
+            d_model=d_model,
+            n_ctx=16,
+            positional_embedding_type="standard",
+        )
+
+        # Create state_dict with attn weights for layers 0-2 only.
+        # W_Q/W_K/W_V: [n_heads, d_model, d_head], W_O: [n_heads, d_head, d_model]
+        # b_Q/b_K/b_V: [n_heads, d_head], b_O: [d_model]
+        state_dict = {}
+        for l in range(3):  # layers 0-2 have attention
+            state_dict[f"blocks.{l}.attn.W_Q"] = torch.randn(n_heads, d_model, d_head)
+            state_dict[f"blocks.{l}.attn.W_K"] = torch.randn(n_heads, d_model, d_head)
+            state_dict[f"blocks.{l}.attn.W_V"] = torch.randn(n_heads, d_model, d_head)
+            state_dict[f"blocks.{l}.attn.W_O"] = torch.randn(n_heads, d_head, d_model)
+            state_dict[f"blocks.{l}.attn.b_Q"] = torch.randn(n_heads, d_head)
+            state_dict[f"blocks.{l}.attn.b_K"] = torch.randn(n_heads, d_head)
+            state_dict[f"blocks.{l}.attn.b_V"] = torch.randn(n_heads, d_head)
+            state_dict[f"blocks.{l}.attn.b_O"] = torch.randn(d_model)
+
+        # Layer 3 has NO attention keys — should be skipped, not crash
+        result = ProcessWeights.refactor_factored_attn_matrices(state_dict, cfg)
+
+        # Layers 0-2 should still have their attn keys (now refactored)
+        for l in range(3):
+            assert f"blocks.{l}.attn.W_Q" in result
+            assert f"blocks.{l}.attn.W_K" in result
+
+        # Layer 3 should have no attn keys
+        assert f"blocks.3.attn.W_Q" not in result
+
+
+# ============================================================================
+# Tests: weight distribution with ragged blocks
+# ============================================================================
+
+
+class TestWeightDistributionRagged:
+    """Test that weight distribution handles heterogeneous real_components."""
+
+    def test_distribute_weights_skips_empty_blocks(self):
+        """Blocks without attn weights should receive no attn keys."""
+        from transformer_lens.weight_processing import ProcessWeights
+
+        # Build a minimal real_components mapping with ragged blocks
+        model = HybridModel()
+        adapter = MinimalAdapter(optional=True)
+        template = adapter.make_block_template()
+
+        import copy
+
+        blocks = []
+        for i, layer in enumerate(model.layers):
+            block = copy.deepcopy(template)
+            block.name = f"layers.{i}"
+            block.set_original_component(layer)
+            setup_submodules(block, adapter, layer)
+            blocks.append(block)
+
+        # Construct state_dict with 'foo' weights for blocks 0-2 only
+        state_dict = {}
+        for i in range(3):
+            state_dict[f"blocks.{i}.foo.weight"] = torch.randn(4, 4)
+        for i in range(4):
+            state_dict[f"blocks.{i}.bar.weight"] = torch.randn(4, 4)
+
+        # Build the component mapping
+        component_mapping = {
+            "blocks": ("layers", blocks),
+        }
+
+        # This should not crash
+        ProcessWeights.distribute_weights_to_components(
+            state_dict=state_dict,
+            component_mapping=component_mapping,
+        )
+
+
+# ============================================================================
+# Helpers for bridge-level tests
+# ============================================================================
+
+
+def _make_hybrid_bridge():
+    """Build a minimal TransformerBridge with hybrid blocks for testing.
+
+    Uses 'foo' and 'bar' as submodule names. Layers 0-2 have 'foo', layer 3 does not.
+    """
+    import copy
+
+    from transformer_lens.model_bridge.bridge import TransformerBridge
+
+    model = HybridModel()
+    adapter = MinimalAdapter(optional=True)
+    template = adapter.make_block_template()
+
+    blocks = nn.ModuleList()
+    for i, layer in enumerate(model.layers):
+        block = copy.deepcopy(template)
+        block.name = f"layers.{i}"
+        block.set_original_component(layer)
+        setup_submodules(block, adapter, layer)
+        blocks.append(block)
+
+    bridge = TransformerBridge.__new__(TransformerBridge)
+    nn.Module.__init__(bridge)
+    bridge.add_module("blocks", blocks)
+
+    # Minimal cfg for accumulated_bias
+    bridge.cfg = type("Cfg", (), {"d_model": 4, "device": "cpu", "n_layers": 4})()
+    return bridge
+
+
+class AttnAdapter(ArchitectureAdapter):
+    """Adapter using 'attn' as the optional submodule name (matches real adapters)."""
+
+    def __init__(self):
+        self.cfg = type("Cfg", (), {"n_layers": 4, "d_model": 4})()
+        self.component_mapping = {}
+
+    def make_block_template(self) -> BlockBridge:
+        return BlockBridge(
+            name="layers",
+            submodules={
+                "bar": LinearBridge(name="bar"),
+                "attn": LinearBridge(name="foo", optional=True),
+            },
+        )
+
+
+def _make_hybrid_bridge_with_attn():
+    """Build a hybrid bridge where 'attn' is the optional submodule.
+
+    Layers 0-2 have 'attn' (mapped from 'foo'), layer 3 does not.
+    Used for testing APIs that specifically look for 'attn' (composition scores, labels).
+    """
+    import copy
+
+    from transformer_lens.model_bridge.bridge import TransformerBridge
+
+    model = HybridModel()
+    adapter = AttnAdapter()
+    template = adapter.make_block_template()
+
+    blocks = nn.ModuleList()
+    for i, layer in enumerate(model.layers):
+        block = copy.deepcopy(template)
+        block.name = f"layers.{i}"
+        block.set_original_component(layer)
+        setup_submodules(block, adapter, layer)
+        blocks.append(block)
+
+    bridge = TransformerBridge.__new__(TransformerBridge)
+    nn.Module.__init__(bridge)
+    bridge.add_module("blocks", blocks)
+    bridge.cfg = type("Cfg", (), {"d_model": 4, "device": "cpu", "n_layers": 4, "n_heads": 2})()
+    return bridge
+
+
+# ============================================================================
+# Tests: blocks_with uses _modules not hasattr
+# ============================================================================
+
+
+class TestBlocksWithModulesCheck:
+    """blocks_with() should only find bridged submodules, not HF attrs."""
+
+    def test_does_not_find_hf_internal_attrs(self):
+        """blocks_with should not match HF attributes that aren't bridged."""
+        bridge = _make_hybrid_bridge()
+        # 'bar' is a bridged submodule (in _modules), should be found
+        assert len(bridge.blocks_with("bar")) == 4
+        # 'training' exists as an attr on nn.Module but is not a bridged submodule
+        assert len(bridge.blocks_with("training")) == 0
+
+    def test_finds_only_bridged_optional_submodules(self):
+        """Optional submodules should be found only on layers where they were bound."""
+        bridge = _make_hybrid_bridge()
+        foo_blocks = bridge.blocks_with("foo")
+        assert [idx for idx, _ in foo_blocks] == [0, 1, 2]
+
+
+# ============================================================================
+# Tests: accumulated_bias on hybrid models
+# ============================================================================
+
+
+class TestAccumulatedBiasHybrid:
+    """accumulated_bias should not crash on hybrid models."""
+
+    def test_accumulated_bias_skips_non_attn_layers(self):
+        """Should not crash when some layers lack attention."""
+        bridge = _make_hybrid_bridge()
+        # Should run without error through all 4 layers (layer 3 has no attn)
+        result = bridge.accumulated_bias(layer=4)
+        assert result.shape == (4,)
+
+    def test_accumulated_bias_mlp_input_on_non_attn_layer(self):
+        """mlp_input=True on a non-attention layer should not crash."""
+        bridge = _make_hybrid_bridge()
+        # Layer 3 has no attn — should still work with mlp_input=True
+        result = bridge.accumulated_bias(layer=3, mlp_input=True)
+        assert result.shape == (4,)
+
+
+# ============================================================================
+# Tests: block_submodules and layer_types introspection
+# ============================================================================
+
+
+class TestBlockIntrospection:
+    """Test layer introspection APIs."""
+
+    def test_block_submodules(self):
+        """block_submodules should list bridged submodules per layer."""
+        bridge = _make_hybrid_bridge()
+        # Layer 0 has both foo and bar
+        subs_0 = bridge.block_submodules(0)
+        assert "foo" in subs_0
+        assert "bar" in subs_0
+        # Layer 3 has only bar
+        subs_3 = bridge.block_submodules(3)
+        assert "foo" not in subs_3
+        assert "bar" in subs_3
+
+    def test_layer_types(self):
+        """layer_types should return a list with one entry per block."""
+        bridge = _make_hybrid_bridge()
+        types = bridge.layer_types()
+        assert len(types) == 4
+        # Layers 0-2 have 'foo', layer 3 does not
+        for i in range(3):
+            assert "foo" in types[i]
+        assert "foo" not in types[3]
+
+
+# ============================================================================
+# Tests: stack_params_for hybrid API
+# ============================================================================
+
+
+class TestStackParamsFor:
+    """Test stack_params_for on hybrid bridges."""
+
+    def test_returns_correct_indices_and_tensors(self):
+        """stack_params_for should return only matching blocks."""
+        bridge = _make_hybrid_bridge()
+        indices, stacked = bridge.stack_params_for("foo", "foo.proj.weight")
+        assert indices == [0, 1, 2]
+        assert stacked.shape[0] == 3
+
+    def test_raises_on_no_matching_blocks(self):
+        """Should raise ValueError when no blocks have the submodule."""
+        bridge = _make_hybrid_bridge()
+        with pytest.raises(ValueError, match="No blocks have submodule"):
+            bridge.stack_params_for("nonexistent", "nonexistent.weight")
+
+
+# ============================================================================
+# Tests: refactor guard validates all attn keys
+# ============================================================================
+
+
+class TestRefactorGuardConsistency:
+    """Test that refactor raises on inconsistent attn keys (W_Q present, W_K missing)."""
+
+    def test_raises_on_partial_attn_keys(self):
+        """If W_Q is present but W_K is missing, should raise ValueError."""
+        from transformer_lens.config.TransformerLensConfig import TransformerLensConfig
+        from transformer_lens.weight_processing import ProcessWeights
+
+        cfg = TransformerLensConfig(
+            n_layers=1,
+            n_heads=2,
+            d_head=4,
+            d_model=8,
+            n_ctx=16,
+            positional_embedding_type="standard",
+        )
+        # Only W_Q present, missing W_K/W_V/W_O
+        state_dict = {
+            "blocks.0.attn.W_Q": torch.randn(2, 8, 4),
+        }
+        with pytest.raises(ValueError, match="Inconsistent attention weights"):
+            ProcessWeights.refactor_factored_attn_matrices(state_dict, cfg)
+
+
+# ============================================================================
+# Tests: __setattr__ whitelist includes optional
+# ============================================================================
+
+
+class TestSetAttrWhitelist:
+    """Test that 'optional' is in the __setattr__ whitelist."""
+
+    def test_optional_set_on_bridge_not_hf_model(self):
+        """Setting optional after set_original_component should stay on bridge."""
+        comp = LinearBridge(name="test")
+        fake_hf = nn.Linear(4, 4, bias=False)
+        comp.set_original_component(fake_hf)
+        comp.optional = True
+        # Should be on the bridge, not on the HF module
+        assert comp.optional is True
+        assert not hasattr(fake_hf, "optional")
+
+
+# ============================================================================
+# Tests: attn_head_labels matches composition scores dimensions
+# ============================================================================
+
+
+class TestAttnHeadLabels:
+    """attn_head_labels should match all_composition_scores dimensions."""
+
+    def test_attn_head_labels_excludes_non_attn_layers(self):
+        """Labels should only cover attention layers, not SSM/linear-attn."""
+        bridge = _make_hybrid_bridge_with_attn()
+        bridge.cfg.n_heads = 2
+        labels = bridge.attn_head_labels
+        # 3 attention layers (0, 1, 2) * 2 heads = 6 labels
+        assert len(labels) == 6
+        assert labels == ["L0H0", "L0H1", "L1H0", "L1H1", "L2H0", "L2H1"]
+        # Should NOT contain L3 (non-attention layer)
+        assert all("L3" not in lbl for lbl in labels)
+
+    def test_all_head_labels_includes_all_layers(self):
+        """all_head_labels should still include every layer."""
+        bridge = _make_hybrid_bridge_with_attn()
+        bridge.cfg.n_heads = 2
+        labels = bridge.all_head_labels
+        # 4 layers * 2 heads = 8 labels
+        assert len(labels) == 8
+
+
+# ============================================================================
+# Tests: hook propagation through optional submodules
+# ============================================================================
+
+
+class TestHookPropagation:
+    """Verify hooks fire on present optional submodules and don't exist on absent ones."""
+
+    def _build_hybrid_model_and_blocks(self):
+        """Build a hybrid model with setup done so hooks are wired."""
+        import copy
+
+        model = HybridModel()
+        adapter = MinimalAdapter(optional=True)
+        template = adapter.make_block_template()
+
+        blocks = []
+        for i, layer in enumerate(model.layers):
+            block = copy.deepcopy(template)
+            block.name = f"layers.{i}"
+            block.set_original_component(layer)
+            setup_submodules(block, adapter, layer)
+            blocks.append(block)
+
+        return model, blocks
+
+    def test_hooks_fire_on_present_optional_submodule(self):
+        """hook_in and hook_out should fire on blocks where the optional submodule exists."""
+        model, blocks = self._build_hybrid_model_and_blocks()
+
+        # Block 0 has 'foo' — its hook_in and hook_out should fire
+        foo_bridge = blocks[0].foo
+        hook_in_fired = []
+        hook_out_fired = []
+
+        foo_bridge.hook_in.add_hook(lambda tensor, hook: hook_in_fired.append(True) or tensor)
+        foo_bridge.hook_out.add_hook(lambda tensor, hook: hook_out_fired.append(True) or tensor)
+
+        # Run a forward pass through the HF model's layer 0
+        # Because replace_remote_component swapped model.layers[0].foo with the bridge,
+        # calling model.layers[0].foo(x) goes through LinearBridge.forward
+        x = torch.randn(1, 4)
+        _ = blocks[0].foo(x)
+
+        assert len(hook_in_fired) == 1, "hook_in should fire on present optional submodule"
+        assert len(hook_out_fired) == 1, "hook_out should fire on present optional submodule"
+
+    def test_absent_optional_submodule_has_no_hooks(self):
+        """Block 3 should not have 'foo' at all — no hooks to fire."""
+        _, blocks = self._build_hybrid_model_and_blocks()
+
+        # Block 3 lacks 'foo' — it shouldn't be in _modules
+        assert "foo" not in blocks[3]._modules
+        # Attempting to access hooks on the absent submodule should fail
+        assert not hasattr(blocks[3], "foo")
+
+    def test_hooks_on_present_dont_affect_absent(self):
+        """Running all blocks should fire hooks only on blocks with the optional submodule."""
+        model, blocks = self._build_hybrid_model_and_blocks()
+
+        # Track which blocks fire foo.hook_out
+        fired_block_indices = []
+        for i, block in enumerate(blocks):
+            if "foo" in block._modules:
+                block.foo.hook_out.add_hook(
+                    lambda tensor, hook, idx=i: fired_block_indices.append(idx) or tensor
+                )
+
+        # Run forward through all HF layers
+        x = torch.randn(1, 4)
+        for i, layer in enumerate(model.layers):
+            x = layer(x)
+
+        # Hooks should fire on layers 0, 1, 2 (have foo) but not 3
+        assert fired_block_indices == [0, 1, 2]
+
+    def test_universal_submodule_hooks_fire_on_all_blocks(self):
+        """'bar' is universal — its hooks should fire on every block."""
+        model, blocks = self._build_hybrid_model_and_blocks()
+
+        fired_block_indices = []
+        for i, block in enumerate(blocks):
+            block.bar.hook_out.add_hook(
+                lambda tensor, hook, idx=i: fired_block_indices.append(idx) or tensor
+            )
+
+        x = torch.randn(1, 4)
+        for layer in model.layers:
+            x = layer(x)
+
+        assert fired_block_indices == [0, 1, 2, 3]
+
+
+# ============================================================================
+# Tests: CompositionScores tensor protocol
+# ============================================================================
+
+
+class TestCompositionScoresProtocol:
+    """CompositionScores should behave like a tensor for existing research code."""
+
+    def _make_scores(self):
+        from transformer_lens.model_bridge.composition_scores import CompositionScores
+
+        t = torch.randn(3, 2, 3, 2)
+        return CompositionScores(t, [0, 2, 5], ["L0H0", "L0H1", "L2H0", "L2H1", "L5H0", "L5H1"])
+
+    def test_shape(self):
+        cs = self._make_scores()
+        assert cs.shape == torch.Size([3, 2, 3, 2])
+
+    def test_device_and_dtype(self):
+        cs = self._make_scores()
+        assert cs.device == torch.device("cpu")
+        assert cs.dtype == torch.float32
+
+    def test_indexing_returns_tensor(self):
+        cs = self._make_scores()
+        sliced = cs[0, :, 1, :]
+        assert isinstance(sliced, torch.Tensor)
+        assert sliced.shape == (2, 2)
+
+    def test_torch_isnan(self):
+        """torch.isnan(scores) must work — used in existing integration tests."""
+        cs = self._make_scores()
+        result = torch.isnan(cs)
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == cs.shape
+        assert not result.any()
+
+    def test_torch_where(self):
+        cs = self._make_scores()
+        result = torch.where(cs > 0, cs.scores, torch.zeros_like(cs.scores))
+        assert isinstance(result, torch.Tensor)
+
+    def test_comparison_gt(self):
+        cs = self._make_scores()
+        mask = cs > 0
+        assert isinstance(mask, torch.Tensor)
+        assert mask.shape == cs.shape
+
+    def test_comparison_ne(self):
+        """scores != 0 must return a tensor, not raise RuntimeError."""
+        cs = self._make_scores()
+        result = cs != 0
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == cs.shape
+
+    def test_comparison_eq(self):
+        cs = self._make_scores()
+        result = cs == 0
+        assert isinstance(result, torch.Tensor)
+
+    def test_tensor_method_abs(self):
+        """scores.abs() must work via __getattr__ delegation."""
+        cs = self._make_scores()
+        result = cs.abs()
+        assert isinstance(result, torch.Tensor)
+
+    def test_tensor_method_sum(self):
+        cs = self._make_scores()
+        result = cs.sum()
+        assert isinstance(result, torch.Tensor)
+
+    def test_tensor_method_any(self):
+        cs = self._make_scores()
+        result = cs.any()
+        assert isinstance(result, torch.Tensor)
+
+    def test_chained_indexing_and_method(self):
+        """scores[l1, :, l2, :].abs().sum() — the exact pattern from integration tests."""
+        cs = self._make_scores()
+        result = cs[0, :, 1, :].abs().sum()
+        assert isinstance(result, torch.Tensor)
+        assert result.ndim == 0  # scalar
+
+    def test_metadata_accessible(self):
+        cs = self._make_scores()
+        assert cs.layer_indices == [0, 2, 5]
+        assert len(cs.head_labels) == 6
+
+    def test_repr(self):
+        cs = self._make_scores()
+        r = repr(cs)
+        assert "CompositionScores" in r
+        assert "layer_indices" in r
+
+
+# ============================================================================
+# Tests: get_bridge_params with hybrid blocks
+# ============================================================================
+
+
+class TestGetBridgeParamsHybrid:
+    """get_bridge_params should skip attn keys for non-attention layers."""
+
+    def test_no_attn_keys_for_non_attn_layers(self):
+        from transformer_lens.model_bridge.get_params_util import get_bridge_params
+
+        bridge = _make_hybrid_bridge_with_attn()
+        bridge.cfg.d_vocab = 10
+        bridge.cfg.n_ctx = 8
+        bridge.cfg.d_mlp = 16
+        bridge.cfg.n_heads = 2
+        bridge.cfg.d_head = 2
+
+        # Add minimal embed/unembed so get_bridge_params doesn't fail
+        bridge.embed = nn.Embedding(10, 4)
+        bridge.pos_embed = type("PE", (), {"weight": torch.randn(8, 4)})()
+        bridge.unembed = type(
+            "UE",
+            (),
+            {
+                "weight": torch.randn(10, 4),
+                "b_U": torch.zeros(10),
+            },
+        )()
+
+        params = get_bridge_params(bridge)
+
+        # Blocks 0-2 have 'attn' — should have attn keys
+        for i in range(3):
+            # attn is mapped but internal structure (q/k/v/o) may not match
+            # our synthetic LinearBridge wrapping FakeSubmodule — so attn keys
+            # may or may not be present depending on structure. The key point
+            # is block 3 must NOT have attn keys.
+            pass
+
+        # Block 3 has NO 'attn' — must not have any attn keys
+        attn_keys_for_block3 = [k for k in params if k.startswith("blocks.3.attn.")]
+        assert len(attn_keys_for_block3) == 0, (
+            f"Block 3 (non-attention layer) should have no attn keys, "
+            f"but found: {attn_keys_for_block3}"
+        )

--- a/tests/unit/test_optional_submodule.py
+++ b/tests/unit/test_optional_submodule.py
@@ -1,9 +1,7 @@
-"""Unit tests for the optional submodule framework.
+"""Tests for optional submodule support in hybrid architectures."""
 
-Tests the `optional` flag on GeneralizedComponent and the `blocks_with()`
-capability query API on TransformerBridge, which together enable hybrid
-architectures where layers have structurally different submodules.
-"""
+import copy
+import logging
 
 import pytest
 import torch
@@ -17,14 +15,10 @@ from transformer_lens.model_bridge.generalized_components.base import (
 from transformer_lens.model_bridge.generalized_components.block import BlockBridge
 from transformer_lens.model_bridge.generalized_components.linear import LinearBridge
 
-# ============================================================================
-# Fixtures: synthetic hybrid model
-# ============================================================================
+# -- Synthetic hybrid model fixtures ------------------------------------------
 
 
 class FakeSubmodule(nn.Module):
-    """A simple nn.Linear submodule for testing."""
-
     def __init__(self, dim: int = 4):
         super().__init__()
         self.proj = nn.Linear(dim, dim, bias=False)
@@ -34,7 +28,7 @@ class FakeSubmodule(nn.Module):
 
 
 class HybridLayer(nn.Module):
-    """A layer that conditionally has a 'foo' submodule."""
+    """Layer that conditionally has a 'foo' submodule."""
 
     def __init__(self, has_foo: bool, dim: int = 4):
         super().__init__()
@@ -49,7 +43,7 @@ class HybridLayer(nn.Module):
 
 
 class HybridModel(nn.Module):
-    """Model with 4 layers: layers 0-2 have 'foo', layer 3 does not."""
+    """4 layers: 0-2 have 'foo', layer 3 does not."""
 
     def __init__(self, dim: int = 4):
         super().__init__()
@@ -62,8 +56,6 @@ class HybridModel(nn.Module):
 
 
 class MinimalAdapter(ArchitectureAdapter):
-    """Minimal adapter for testing optional submodule setup."""
-
     def __init__(self, optional: bool = True):
         self.cfg = type("Cfg", (), {"n_layers": 4, "d_model": 4})()
         self.component_mapping = {}
@@ -79,359 +71,8 @@ class MinimalAdapter(ArchitectureAdapter):
         )
 
 
-# ============================================================================
-# Tests: optional flag on GeneralizedComponent
-# ============================================================================
-
-
-class TestOptionalFlag:
-    """Test that the optional flag is properly stored and defaults to False."""
-
-    def test_default_is_false(self):
-        comp = GeneralizedComponent(name="test")
-        assert comp.optional is False
-
-    def test_optional_true(self):
-        comp = GeneralizedComponent(name="test", optional=True)
-        assert comp.optional is True
-
-    def test_optional_false_explicit(self):
-        comp = GeneralizedComponent(name="test", optional=False)
-        assert comp.optional is False
-
-
-# ============================================================================
-# Tests: setup_submodules with optional
-# ============================================================================
-
-
-class TestOptionalSubmoduleSetup:
-    """Test that optional submodules are skipped cleanly during setup."""
-
-    def test_optional_submodule_skipped_on_missing_layers(self):
-        """Layers 0-2 have 'foo', layer 3 does not. Setup should succeed."""
-        model = HybridModel()
-        adapter = MinimalAdapter(optional=True)
-        template = adapter.make_block_template()
-
-        # Simulate what setup_blocks_bridge does: deepcopy + setup per layer
-        import copy
-
-        blocks = []
-        for i, layer in enumerate(model.layers):
-            block = copy.deepcopy(template)
-            block.name = f"layers.{i}"
-            block.set_original_component(layer)
-            setup_submodules(block, adapter, layer)
-            blocks.append(block)
-
-        # Layers 0-2 should have 'foo' in real_components
-        for i in range(3):
-            assert "foo" in blocks[i].real_components, f"Block {i} should have 'foo'"
-            assert hasattr(blocks[i], "foo"), f"Block {i} should have foo module"
-
-        # Layer 3 should NOT have 'foo' in any lookup path
-        assert (
-            "foo" not in blocks[3].real_components
-        ), "Block 3 should not have 'foo' in real_components"
-        assert "foo" not in blocks[3]._modules, "Block 3 should not have 'foo' in _modules"
-        assert "foo" not in blocks[3].submodules, "Block 3 should not have 'foo' in submodules"
-
-        # All layers should have 'bar'
-        for i in range(4):
-            assert "bar" in blocks[i].real_components, f"Block {i} should have 'bar'"
-
-    def test_non_optional_missing_submodule_raises(self):
-        """When optional=False, missing submodule should raise AttributeError."""
-        model = HybridModel()
-        adapter = MinimalAdapter(optional=False)
-        template = adapter.make_block_template()
-
-        import copy
-
-        # Layer 3 lacks 'foo' and optional=False, so this should raise
-        block = copy.deepcopy(template)
-        block.name = "layers.3"
-        block.set_original_component(model.layers[3])
-        with pytest.raises(AttributeError):
-            setup_submodules(block, adapter, model.layers[3])
-
-
-# ============================================================================
-# Tests: blocks_with() API
-# ============================================================================
-
-
-class TestBlocksWith:
-    """Test the blocks_with() capability query on TransformerBridge."""
-
-    def test_blocks_with_returns_matching_blocks(self):
-        """blocks_with('foo') should return only blocks that have 'foo'."""
-        from transformer_lens.model_bridge.bridge import TransformerBridge
-
-        model = HybridModel()
-        adapter = MinimalAdapter(optional=True)
-        template = adapter.make_block_template()
-
-        import copy
-
-        blocks = nn.ModuleList()
-        for i, layer in enumerate(model.layers):
-            block = copy.deepcopy(template)
-            block.name = f"layers.{i}"
-            block.set_original_component(layer)
-            setup_submodules(block, adapter, layer)
-            blocks.append(block)
-
-        # Create a minimal bridge-like object with blocks attribute
-        # We test blocks_with as a standalone method
-        bridge = TransformerBridge.__new__(TransformerBridge)
-        nn.Module.__init__(bridge)
-        bridge.add_module("blocks", blocks)
-
-        foo_blocks = bridge.blocks_with("foo")
-        assert len(foo_blocks) == 3
-        assert [idx for idx, _ in foo_blocks] == [0, 1, 2]
-
-        bar_blocks = bridge.blocks_with("bar")
-        assert len(bar_blocks) == 4
-
-        missing_blocks = bridge.blocks_with("nonexistent")
-        assert len(missing_blocks) == 0
-
-    def test_blocks_with_no_blocks_attribute(self):
-        """blocks_with() should return empty list if no blocks attribute."""
-        from transformer_lens.model_bridge.bridge import TransformerBridge
-
-        bridge = TransformerBridge.__new__(TransformerBridge)
-        nn.Module.__init__(bridge)
-        assert bridge.blocks_with("attn") == []
-
-
-# ============================================================================
-# Tests: _stack_block_params with hybrid blocks
-# ============================================================================
-
-
-class TestStackBlockParamsHybridSafe:
-    """Test that _stack_block_params raises clear errors for hybrid blocks."""
-
-    def test_logs_warning_and_returns_subset_on_hybrid(self, caplog):
-        """On hybrid blocks, should log warning and return tensor for matching blocks only."""
-        import logging
-
-        from transformer_lens.model_bridge.bridge import TransformerBridge
-
-        # Build blocks where block 3 lacks 'foo' but blocks 0-2 have it
-        model = HybridModel()
-        adapter = MinimalAdapter(optional=True)
-        template = adapter.make_block_template()
-
-        import copy
-
-        blocks = nn.ModuleList()
-        for i, layer in enumerate(model.layers):
-            block = copy.deepcopy(template)
-            block.name = f"layers.{i}"
-            block.set_original_component(layer)
-            setup_submodules(block, adapter, layer)
-            blocks.append(block)
-
-        # Verify precondition: block 3 lacks 'foo'
-        assert "foo" in blocks[0]._modules
-        assert "foo" not in blocks[3]._modules
-
-        bridge = TransformerBridge.__new__(TransformerBridge)
-        nn.Module.__init__(bridge)
-        bridge.add_module("blocks", blocks)
-
-        # Should succeed with a log warning, returning only matching blocks.
-        # logging.warning always emits (no deduplication), so researchers see
-        # the index mapping notice on every access — not just the first.
-        with caplog.at_level(logging.WARNING):
-            result = bridge._stack_block_params("foo.proj.weight")
-        assert any("Hybrid model" in msg for msg in caplog.messages)
-        assert any("stack_params_for" in msg for msg in caplog.messages)
-        # 3 blocks have 'foo', not 4
-        assert result.shape[0] == 3
-
-        # Verify it logs again on a second call (no deduplication)
-        caplog.clear()
-        with caplog.at_level(logging.WARNING):
-            result2 = bridge._stack_block_params("foo.proj.weight")
-        assert any(
-            "Hybrid model" in msg for msg in caplog.messages
-        ), "Warning should emit on every call, not just the first"
-
-    def test_raises_when_no_blocks_have_submodule(self):
-        """Should raise AttributeError when zero blocks have the submodule."""
-        from transformer_lens.model_bridge.bridge import TransformerBridge
-
-        bridge = _make_hybrid_bridge()
-        with pytest.raises(AttributeError, match="No blocks have"):
-            bridge._stack_block_params("nonexistent")
-
-    def test_succeeds_on_universal_submodule(self):
-        """Should succeed when all blocks have the requested submodule."""
-        from transformer_lens.model_bridge.bridge import TransformerBridge
-
-        model = HybridModel()
-        adapter = MinimalAdapter(optional=True)
-        template = adapter.make_block_template()
-
-        import copy
-
-        blocks = nn.ModuleList()
-        for i, layer in enumerate(model.layers):
-            block = copy.deepcopy(template)
-            block.name = f"layers.{i}"
-            block.set_original_component(layer)
-            setup_submodules(block, adapter, layer)
-            blocks.append(block)
-
-        bridge = TransformerBridge.__new__(TransformerBridge)
-        nn.Module.__init__(bridge)
-        bridge.add_module("blocks", blocks)
-
-        # 'bar' exists on all blocks → should succeed
-        result = bridge._stack_block_params("bar.weight")
-        assert result.shape[0] == 4  # 4 layers
-
-
-# ============================================================================
-# Tests: refactor_factored_attn_matrices with missing layers
-# ============================================================================
-
-
-class TestRefactorFactoredAttnHybrid:
-    """Test that refactor_factored_attn_matrices skips layers without attn."""
-
-    def test_skips_missing_attn_layers(self):
-        """Should process layers with attn keys and skip those without."""
-        from transformer_lens.config.TransformerLensConfig import TransformerLensConfig
-        from transformer_lens.weight_processing import ProcessWeights
-
-        n_heads = 2
-        d_head = 4
-        d_model = n_heads * d_head
-        cfg = TransformerLensConfig(
-            n_layers=4,
-            n_heads=n_heads,
-            d_head=d_head,
-            d_model=d_model,
-            n_ctx=16,
-            positional_embedding_type="standard",
-        )
-
-        # Create state_dict with attn weights for layers 0-2 only.
-        # W_Q/W_K/W_V: [n_heads, d_model, d_head], W_O: [n_heads, d_head, d_model]
-        # b_Q/b_K/b_V: [n_heads, d_head], b_O: [d_model]
-        state_dict = {}
-        for l in range(3):  # layers 0-2 have attention
-            state_dict[f"blocks.{l}.attn.W_Q"] = torch.randn(n_heads, d_model, d_head)
-            state_dict[f"blocks.{l}.attn.W_K"] = torch.randn(n_heads, d_model, d_head)
-            state_dict[f"blocks.{l}.attn.W_V"] = torch.randn(n_heads, d_model, d_head)
-            state_dict[f"blocks.{l}.attn.W_O"] = torch.randn(n_heads, d_head, d_model)
-            state_dict[f"blocks.{l}.attn.b_Q"] = torch.randn(n_heads, d_head)
-            state_dict[f"blocks.{l}.attn.b_K"] = torch.randn(n_heads, d_head)
-            state_dict[f"blocks.{l}.attn.b_V"] = torch.randn(n_heads, d_head)
-            state_dict[f"blocks.{l}.attn.b_O"] = torch.randn(d_model)
-
-        # Layer 3 has NO attention keys — should be skipped, not crash
-        result = ProcessWeights.refactor_factored_attn_matrices(state_dict, cfg)
-
-        # Layers 0-2 should still have their attn keys (now refactored)
-        for l in range(3):
-            assert f"blocks.{l}.attn.W_Q" in result
-            assert f"blocks.{l}.attn.W_K" in result
-
-        # Layer 3 should have no attn keys
-        assert f"blocks.3.attn.W_Q" not in result
-
-
-# ============================================================================
-# Tests: weight distribution with ragged blocks
-# ============================================================================
-
-
-class TestWeightDistributionRagged:
-    """Test that weight distribution handles heterogeneous real_components."""
-
-    def test_distribute_weights_skips_empty_blocks(self):
-        """Blocks without attn weights should receive no attn keys."""
-        from transformer_lens.weight_processing import ProcessWeights
-
-        # Build a minimal real_components mapping with ragged blocks
-        model = HybridModel()
-        adapter = MinimalAdapter(optional=True)
-        template = adapter.make_block_template()
-
-        import copy
-
-        blocks = []
-        for i, layer in enumerate(model.layers):
-            block = copy.deepcopy(template)
-            block.name = f"layers.{i}"
-            block.set_original_component(layer)
-            setup_submodules(block, adapter, layer)
-            blocks.append(block)
-
-        # Construct state_dict with 'foo' weights for blocks 0-2 only
-        state_dict = {}
-        for i in range(3):
-            state_dict[f"blocks.{i}.foo.weight"] = torch.randn(4, 4)
-        for i in range(4):
-            state_dict[f"blocks.{i}.bar.weight"] = torch.randn(4, 4)
-
-        # Build the component mapping
-        component_mapping = {
-            "blocks": ("layers", blocks),
-        }
-
-        # This should not crash
-        ProcessWeights.distribute_weights_to_components(
-            state_dict=state_dict,
-            component_mapping=component_mapping,
-        )
-
-
-# ============================================================================
-# Helpers for bridge-level tests
-# ============================================================================
-
-
-def _make_hybrid_bridge():
-    """Build a minimal TransformerBridge with hybrid blocks for testing.
-
-    Uses 'foo' and 'bar' as submodule names. Layers 0-2 have 'foo', layer 3 does not.
-    """
-    import copy
-
-    from transformer_lens.model_bridge.bridge import TransformerBridge
-
-    model = HybridModel()
-    adapter = MinimalAdapter(optional=True)
-    template = adapter.make_block_template()
-
-    blocks = nn.ModuleList()
-    for i, layer in enumerate(model.layers):
-        block = copy.deepcopy(template)
-        block.name = f"layers.{i}"
-        block.set_original_component(layer)
-        setup_submodules(block, adapter, layer)
-        blocks.append(block)
-
-    bridge = TransformerBridge.__new__(TransformerBridge)
-    nn.Module.__init__(bridge)
-    bridge.add_module("blocks", blocks)
-
-    # Minimal cfg for accumulated_bias
-    bridge.cfg = type("Cfg", (), {"d_model": 4, "device": "cpu", "n_layers": 4})()
-    return bridge
-
-
 class AttnAdapter(ArchitectureAdapter):
-    """Adapter using 'attn' as the optional submodule name (matches real adapters)."""
+    """Uses 'attn' as the optional submodule name (matches real adapters)."""
 
     def __init__(self):
         self.cfg = type("Cfg", (), {"n_layers": 4, "d_model": 4})()
@@ -447,144 +88,173 @@ class AttnAdapter(ArchitectureAdapter):
         )
 
 
-def _make_hybrid_bridge_with_attn():
-    """Build a hybrid bridge where 'attn' is the optional submodule.
+# -- Bridge construction helpers ----------------------------------------------
 
-    Layers 0-2 have 'attn' (mapped from 'foo'), layer 3 does not.
-    Used for testing APIs that specifically look for 'attn' (composition scores, labels).
-    """
-    import copy
 
-    from transformer_lens.model_bridge.bridge import TransformerBridge
-
-    model = HybridModel()
-    adapter = AttnAdapter()
+def _setup_blocks(model, adapter):
+    """Deepcopy template per layer and run setup_submodules."""
     template = adapter.make_block_template()
-
-    blocks = nn.ModuleList()
+    blocks = []
     for i, layer in enumerate(model.layers):
         block = copy.deepcopy(template)
         block.name = f"layers.{i}"
         block.set_original_component(layer)
         setup_submodules(block, adapter, layer)
         blocks.append(block)
+    return blocks
+
+
+def _make_bridge(blocks, **cfg_attrs):
+    """Wrap blocks in a minimal TransformerBridge shell."""
+    from transformer_lens.model_bridge.bridge import TransformerBridge
 
     bridge = TransformerBridge.__new__(TransformerBridge)
     nn.Module.__init__(bridge)
-    bridge.add_module("blocks", blocks)
-    bridge.cfg = type("Cfg", (), {"d_model": 4, "device": "cpu", "n_layers": 4, "n_heads": 2})()
+    bridge.add_module("blocks", nn.ModuleList(blocks))
+    defaults = {"d_model": 4, "device": "cpu", "n_layers": 4}
+    defaults.update(cfg_attrs)
+    bridge.cfg = type("Cfg", (), defaults)()
     return bridge
 
 
-# ============================================================================
-# Tests: blocks_with uses _modules not hasattr
-# ============================================================================
+def _make_hybrid_bridge():
+    """Hybrid bridge with 'foo' (optional) and 'bar' (universal)."""
+    return _make_bridge(_setup_blocks(HybridModel(), MinimalAdapter(optional=True)))
 
 
-class TestBlocksWithModulesCheck:
-    """blocks_with() should only find bridged submodules, not HF attrs."""
+def _make_hybrid_bridge_with_attn():
+    """Hybrid bridge where 'attn' is the optional submodule."""
+    return _make_bridge(
+        _setup_blocks(HybridModel(), AttnAdapter()),
+        n_heads=2,
+    )
 
-    def test_does_not_find_hf_internal_attrs(self):
-        """blocks_with should not match HF attributes that aren't bridged."""
+
+# -- Tests: optional flag -----------------------------------------------------
+
+
+class TestOptionalFlag:
+    def test_default_is_false(self):
+        assert GeneralizedComponent(name="test").optional is False
+
+    def test_optional_true(self):
+        assert GeneralizedComponent(name="test", optional=True).optional is True
+
+    def test_optional_false_explicit(self):
+        assert GeneralizedComponent(name="test", optional=False).optional is False
+
+
+# -- Tests: setup_submodules --------------------------------------------------
+
+
+class TestOptionalSubmoduleSetup:
+    def test_skipped_on_missing_layers(self):
+        blocks = _setup_blocks(HybridModel(), MinimalAdapter(optional=True))
+
+        for i in range(3):
+            assert "foo" in blocks[i].real_components
+            assert hasattr(blocks[i], "foo")
+
+        assert "foo" not in blocks[3].real_components
+        assert "foo" not in blocks[3]._modules
+        assert "foo" not in blocks[3].submodules
+
+        for i in range(4):
+            assert "bar" in blocks[i].real_components
+
+    def test_non_optional_raises(self):
+        model = HybridModel()
+        adapter = MinimalAdapter(optional=False)
+        block = copy.deepcopy(adapter.make_block_template())
+        block.name = "layers.3"
+        block.set_original_component(model.layers[3])
+        with pytest.raises(AttributeError):
+            setup_submodules(block, adapter, model.layers[3])
+
+
+# -- Tests: blocks_with() -----------------------------------------------------
+
+
+class TestBlocksWith:
+    def test_returns_matching_blocks(self):
         bridge = _make_hybrid_bridge()
-        # 'bar' is a bridged submodule (in _modules), should be found
+        assert [idx for idx, _ in bridge.blocks_with("foo")] == [0, 1, 2]
         assert len(bridge.blocks_with("bar")) == 4
-        # 'training' exists as an attr on nn.Module but is not a bridged submodule
+        assert bridge.blocks_with("nonexistent") == []
+
+    def test_no_blocks_attribute(self):
+        from transformer_lens.model_bridge.bridge import TransformerBridge
+
+        bridge = TransformerBridge.__new__(TransformerBridge)
+        nn.Module.__init__(bridge)
+        assert bridge.blocks_with("attn") == []
+
+    def test_checks_modules_not_hasattr(self):
+        bridge = _make_hybrid_bridge()
         assert len(bridge.blocks_with("training")) == 0
 
-    def test_finds_only_bridged_optional_submodules(self):
-        """Optional submodules should be found only on layers where they were bound."""
+
+# -- Tests: _stack_block_params -----------------------------------------------
+
+
+class TestStackBlockParams:
+    def test_logs_warning_and_returns_subset(self, caplog):
         bridge = _make_hybrid_bridge()
-        foo_blocks = bridge.blocks_with("foo")
-        assert [idx for idx, _ in foo_blocks] == [0, 1, 2]
+        with caplog.at_level(logging.WARNING):
+            result = bridge._stack_block_params("foo.proj.weight")
+        assert any("Hybrid model" in msg for msg in caplog.messages)
+        assert result.shape[0] == 3
 
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            bridge._stack_block_params("foo.proj.weight")
+        assert any("Hybrid model" in msg for msg in caplog.messages)
 
-# ============================================================================
-# Tests: accumulated_bias on hybrid models
-# ============================================================================
-
-
-class TestAccumulatedBiasHybrid:
-    """accumulated_bias should not crash on hybrid models."""
-
-    def test_accumulated_bias_skips_non_attn_layers(self):
-        """Should not crash when some layers lack attention."""
+    def test_raises_when_no_blocks_match(self):
         bridge = _make_hybrid_bridge()
-        # Should run without error through all 4 layers (layer 3 has no attn)
-        result = bridge.accumulated_bias(layer=4)
-        assert result.shape == (4,)
+        with pytest.raises(AttributeError, match="No blocks have"):
+            bridge._stack_block_params("nonexistent")
 
-    def test_accumulated_bias_mlp_input_on_non_attn_layer(self):
-        """mlp_input=True on a non-attention layer should not crash."""
+    def test_succeeds_on_universal_submodule(self):
         bridge = _make_hybrid_bridge()
-        # Layer 3 has no attn — should still work with mlp_input=True
-        result = bridge.accumulated_bias(layer=3, mlp_input=True)
-        assert result.shape == (4,)
+        result = bridge._stack_block_params("bar.weight")
+        assert result.shape[0] == 4
 
 
-# ============================================================================
-# Tests: block_submodules and layer_types introspection
-# ============================================================================
+# -- Tests: refactor_factored_attn_matrices ------------------------------------
 
 
-class TestBlockIntrospection:
-    """Test layer introspection APIs."""
+class TestRefactorFactoredAttnHybrid:
+    def test_skips_missing_attn_layers(self):
+        from transformer_lens.config.TransformerLensConfig import TransformerLensConfig
+        from transformer_lens.weight_processing import ProcessWeights
 
-    def test_block_submodules(self):
-        """block_submodules should list bridged submodules per layer."""
-        bridge = _make_hybrid_bridge()
-        # Layer 0 has both foo and bar
-        subs_0 = bridge.block_submodules(0)
-        assert "foo" in subs_0
-        assert "bar" in subs_0
-        # Layer 3 has only bar
-        subs_3 = bridge.block_submodules(3)
-        assert "foo" not in subs_3
-        assert "bar" in subs_3
+        cfg = TransformerLensConfig(
+            n_layers=4,
+            n_heads=2,
+            d_head=4,
+            d_model=8,
+            n_ctx=16,
+            positional_embedding_type="standard",
+        )
+        state_dict = {}
+        for l in range(3):
+            state_dict[f"blocks.{l}.attn.W_Q"] = torch.randn(2, 8, 4)
+            state_dict[f"blocks.{l}.attn.W_K"] = torch.randn(2, 8, 4)
+            state_dict[f"blocks.{l}.attn.W_V"] = torch.randn(2, 8, 4)
+            state_dict[f"blocks.{l}.attn.W_O"] = torch.randn(2, 4, 8)
+            state_dict[f"blocks.{l}.attn.b_Q"] = torch.randn(2, 4)
+            state_dict[f"blocks.{l}.attn.b_K"] = torch.randn(2, 4)
+            state_dict[f"blocks.{l}.attn.b_V"] = torch.randn(2, 4)
+            state_dict[f"blocks.{l}.attn.b_O"] = torch.randn(8)
 
-    def test_layer_types(self):
-        """layer_types should return a list with one entry per block."""
-        bridge = _make_hybrid_bridge()
-        types = bridge.layer_types()
-        assert len(types) == 4
-        # Layers 0-2 have 'foo', layer 3 does not
-        for i in range(3):
-            assert "foo" in types[i]
-        assert "foo" not in types[3]
+        result = ProcessWeights.refactor_factored_attn_matrices(state_dict, cfg)
 
-
-# ============================================================================
-# Tests: stack_params_for hybrid API
-# ============================================================================
-
-
-class TestStackParamsFor:
-    """Test stack_params_for on hybrid bridges."""
-
-    def test_returns_correct_indices_and_tensors(self):
-        """stack_params_for should return only matching blocks."""
-        bridge = _make_hybrid_bridge()
-        indices, stacked = bridge.stack_params_for("foo", "foo.proj.weight")
-        assert indices == [0, 1, 2]
-        assert stacked.shape[0] == 3
-
-    def test_raises_on_no_matching_blocks(self):
-        """Should raise ValueError when no blocks have the submodule."""
-        bridge = _make_hybrid_bridge()
-        with pytest.raises(ValueError, match="No blocks have submodule"):
-            bridge.stack_params_for("nonexistent", "nonexistent.weight")
-
-
-# ============================================================================
-# Tests: refactor guard validates all attn keys
-# ============================================================================
-
-
-class TestRefactorGuardConsistency:
-    """Test that refactor raises on inconsistent attn keys (W_Q present, W_K missing)."""
+        for l in range(3):
+            assert f"blocks.{l}.attn.W_Q" in result
+        assert "blocks.3.attn.W_Q" not in result
 
     def test_raises_on_partial_attn_keys(self):
-        """If W_Q is present but W_K is missing, should raise ValueError."""
         from transformer_lens.config.TransformerLensConfig import TransformerLensConfig
         from transformer_lens.weight_processing import ProcessWeights
 
@@ -596,189 +266,177 @@ class TestRefactorGuardConsistency:
             n_ctx=16,
             positional_embedding_type="standard",
         )
-        # Only W_Q present, missing W_K/W_V/W_O
-        state_dict = {
-            "blocks.0.attn.W_Q": torch.randn(2, 8, 4),
-        }
+        state_dict = {"blocks.0.attn.W_Q": torch.randn(2, 8, 4)}
         with pytest.raises(ValueError, match="Inconsistent attention weights"):
             ProcessWeights.refactor_factored_attn_matrices(state_dict, cfg)
 
 
-# ============================================================================
-# Tests: __setattr__ whitelist includes optional
-# ============================================================================
+# -- Tests: weight distribution ------------------------------------------------
+
+
+class TestWeightDistributionRagged:
+    def test_distribute_weights_skips_empty_blocks(self):
+        from transformer_lens.weight_processing import ProcessWeights
+
+        blocks = _setup_blocks(HybridModel(), MinimalAdapter(optional=True))
+        state_dict = {}
+        for i in range(3):
+            state_dict[f"blocks.{i}.foo.weight"] = torch.randn(4, 4)
+        for i in range(4):
+            state_dict[f"blocks.{i}.bar.weight"] = torch.randn(4, 4)
+
+        ProcessWeights.distribute_weights_to_components(
+            state_dict=state_dict,
+            component_mapping={"blocks": ("layers", blocks)},
+        )
+
+
+# -- Tests: __setattr__ whitelist ----------------------------------------------
 
 
 class TestSetAttrWhitelist:
-    """Test that 'optional' is in the __setattr__ whitelist."""
-
-    def test_optional_set_on_bridge_not_hf_model(self):
-        """Setting optional after set_original_component should stay on bridge."""
+    def test_optional_stays_on_bridge(self):
         comp = LinearBridge(name="test")
         fake_hf = nn.Linear(4, 4, bias=False)
         comp.set_original_component(fake_hf)
         comp.optional = True
-        # Should be on the bridge, not on the HF module
         assert comp.optional is True
         assert not hasattr(fake_hf, "optional")
 
 
-# ============================================================================
-# Tests: attn_head_labels matches composition scores dimensions
-# ============================================================================
+# -- Tests: accumulated_bias --------------------------------------------------
+
+
+class TestAccumulatedBiasHybrid:
+    def test_skips_non_attn_layers(self):
+        bridge = _make_hybrid_bridge()
+        result = bridge.accumulated_bias(layer=4)
+        assert result.shape == (4,)
+
+    def test_mlp_input_on_non_attn_layer(self):
+        bridge = _make_hybrid_bridge()
+        result = bridge.accumulated_bias(layer=3, mlp_input=True)
+        assert result.shape == (4,)
+
+
+# -- Tests: block introspection ------------------------------------------------
+
+
+class TestBlockIntrospection:
+    def test_block_submodules(self):
+        bridge = _make_hybrid_bridge()
+        assert "foo" in bridge.block_submodules(0)
+        assert "bar" in bridge.block_submodules(0)
+        assert "foo" not in bridge.block_submodules(3)
+        assert "bar" in bridge.block_submodules(3)
+
+    def test_layer_types(self):
+        bridge = _make_hybrid_bridge()
+        types = bridge.layer_types()
+        assert len(types) == 4
+        for i in range(3):
+            assert "foo" in types[i]
+        assert "foo" not in types[3]
+
+
+# -- Tests: stack_params_for --------------------------------------------------
+
+
+class TestStackParamsFor:
+    def test_returns_correct_indices_and_tensors(self):
+        bridge = _make_hybrid_bridge()
+        indices, stacked = bridge.stack_params_for("foo", "foo.proj.weight")
+        assert indices == [0, 1, 2]
+        assert stacked.shape[0] == 3
+
+    def test_raises_on_no_matching_blocks(self):
+        bridge = _make_hybrid_bridge()
+        with pytest.raises(ValueError, match="No blocks have submodule"):
+            bridge.stack_params_for("nonexistent", "nonexistent.weight")
+
+
+# -- Tests: attn_head_labels --------------------------------------------------
 
 
 class TestAttnHeadLabels:
-    """attn_head_labels should match all_composition_scores dimensions."""
-
-    def test_attn_head_labels_excludes_non_attn_layers(self):
-        """Labels should only cover attention layers, not SSM/linear-attn."""
+    def test_excludes_non_attn_layers(self):
         bridge = _make_hybrid_bridge_with_attn()
-        bridge.cfg.n_heads = 2
         labels = bridge.attn_head_labels
-        # 3 attention layers (0, 1, 2) * 2 heads = 6 labels
         assert len(labels) == 6
         assert labels == ["L0H0", "L0H1", "L1H0", "L1H1", "L2H0", "L2H1"]
-        # Should NOT contain L3 (non-attention layer)
-        assert all("L3" not in lbl for lbl in labels)
 
-    def test_all_head_labels_includes_all_layers(self):
-        """all_head_labels should still include every layer."""
+    def test_all_head_labels_includes_all(self):
         bridge = _make_hybrid_bridge_with_attn()
-        bridge.cfg.n_heads = 2
-        labels = bridge.all_head_labels
-        # 4 layers * 2 heads = 8 labels
-        assert len(labels) == 8
+        assert len(bridge.all_head_labels) == 8
 
 
-# ============================================================================
-# Tests: hook propagation through optional submodules
-# ============================================================================
+# -- Tests: hook propagation --------------------------------------------------
 
 
 class TestHookPropagation:
-    """Verify hooks fire on present optional submodules and don't exist on absent ones."""
+    def test_hooks_fire_on_present_optional(self):
+        blocks = _setup_blocks(HybridModel(), MinimalAdapter(optional=True))
+        fired = []
+        blocks[0].foo.hook_out.add_hook(lambda t, hook: fired.append(True) or t)
 
-    def _build_hybrid_model_and_blocks(self):
-        """Build a hybrid model with setup done so hooks are wired."""
-        import copy
+        blocks[0].foo(torch.randn(1, 4))
+        assert len(fired) == 1
 
-        model = HybridModel()
-        adapter = MinimalAdapter(optional=True)
-        template = adapter.make_block_template()
-
-        blocks = []
-        for i, layer in enumerate(model.layers):
-            block = copy.deepcopy(template)
-            block.name = f"layers.{i}"
-            block.set_original_component(layer)
-            setup_submodules(block, adapter, layer)
-            blocks.append(block)
-
-        return model, blocks
-
-    def test_hooks_fire_on_present_optional_submodule(self):
-        """hook_in and hook_out should fire on blocks where the optional submodule exists."""
-        model, blocks = self._build_hybrid_model_and_blocks()
-
-        # Block 0 has 'foo' — its hook_in and hook_out should fire
-        foo_bridge = blocks[0].foo
-        hook_in_fired = []
-        hook_out_fired = []
-
-        foo_bridge.hook_in.add_hook(lambda tensor, hook: hook_in_fired.append(True) or tensor)
-        foo_bridge.hook_out.add_hook(lambda tensor, hook: hook_out_fired.append(True) or tensor)
-
-        # Run a forward pass through the HF model's layer 0
-        # Because replace_remote_component swapped model.layers[0].foo with the bridge,
-        # calling model.layers[0].foo(x) goes through LinearBridge.forward
-        x = torch.randn(1, 4)
-        _ = blocks[0].foo(x)
-
-        assert len(hook_in_fired) == 1, "hook_in should fire on present optional submodule"
-        assert len(hook_out_fired) == 1, "hook_out should fire on present optional submodule"
-
-    def test_absent_optional_submodule_has_no_hooks(self):
-        """Block 3 should not have 'foo' at all — no hooks to fire."""
-        _, blocks = self._build_hybrid_model_and_blocks()
-
-        # Block 3 lacks 'foo' — it shouldn't be in _modules
+    def test_absent_optional_has_no_module(self):
+        blocks = _setup_blocks(HybridModel(), MinimalAdapter(optional=True))
         assert "foo" not in blocks[3]._modules
-        # Attempting to access hooks on the absent submodule should fail
-        assert not hasattr(blocks[3], "foo")
 
-    def test_hooks_on_present_dont_affect_absent(self):
-        """Running all blocks should fire hooks only on blocks with the optional submodule."""
-        model, blocks = self._build_hybrid_model_and_blocks()
-
-        # Track which blocks fire foo.hook_out
-        fired_block_indices = []
+    def test_hooks_fire_only_on_present(self):
+        model = HybridModel()
+        blocks = _setup_blocks(model, MinimalAdapter(optional=True))
+        fired_indices = []
         for i, block in enumerate(blocks):
             if "foo" in block._modules:
-                block.foo.hook_out.add_hook(
-                    lambda tensor, hook, idx=i: fired_block_indices.append(idx) or tensor
-                )
-
-        # Run forward through all HF layers
-        x = torch.randn(1, 4)
-        for i, layer in enumerate(model.layers):
-            x = layer(x)
-
-        # Hooks should fire on layers 0, 1, 2 (have foo) but not 3
-        assert fired_block_indices == [0, 1, 2]
-
-    def test_universal_submodule_hooks_fire_on_all_blocks(self):
-        """'bar' is universal — its hooks should fire on every block."""
-        model, blocks = self._build_hybrid_model_and_blocks()
-
-        fired_block_indices = []
-        for i, block in enumerate(blocks):
-            block.bar.hook_out.add_hook(
-                lambda tensor, hook, idx=i: fired_block_indices.append(idx) or tensor
-            )
+                block.foo.hook_out.add_hook(lambda t, hook, idx=i: fired_indices.append(idx) or t)
 
         x = torch.randn(1, 4)
         for layer in model.layers:
             x = layer(x)
+        assert fired_indices == [0, 1, 2]
 
-        assert fired_block_indices == [0, 1, 2, 3]
+    def test_universal_hooks_fire_on_all(self):
+        model = HybridModel()
+        blocks = _setup_blocks(model, MinimalAdapter(optional=True))
+        fired_indices = []
+        for i, block in enumerate(blocks):
+            block.bar.hook_out.add_hook(lambda t, hook, idx=i: fired_indices.append(idx) or t)
+
+        x = torch.randn(1, 4)
+        for layer in model.layers:
+            x = layer(x)
+        assert fired_indices == [0, 1, 2, 3]
 
 
-# ============================================================================
-# Tests: CompositionScores tensor protocol
-# ============================================================================
+# -- Tests: CompositionScores tensor protocol ----------------------------------
 
 
 class TestCompositionScoresProtocol:
-    """CompositionScores should behave like a tensor for existing research code."""
-
     def _make_scores(self):
         from transformer_lens.model_bridge.composition_scores import CompositionScores
 
         t = torch.randn(3, 2, 3, 2)
         return CompositionScores(t, [0, 2, 5], ["L0H0", "L0H1", "L2H0", "L2H1", "L5H0", "L5H1"])
 
-    def test_shape(self):
+    def test_shape_device_dtype(self):
         cs = self._make_scores()
         assert cs.shape == torch.Size([3, 2, 3, 2])
-
-    def test_device_and_dtype(self):
-        cs = self._make_scores()
         assert cs.device == torch.device("cpu")
         assert cs.dtype == torch.float32
 
-    def test_indexing_returns_tensor(self):
+    def test_indexing(self):
         cs = self._make_scores()
-        sliced = cs[0, :, 1, :]
-        assert isinstance(sliced, torch.Tensor)
-        assert sliced.shape == (2, 2)
+        assert isinstance(cs[0, :, 1, :], torch.Tensor)
+        assert cs[0, :, 1, :].shape == (2, 2)
 
     def test_torch_isnan(self):
-        """torch.isnan(scores) must work — used in existing integration tests."""
         cs = self._make_scores()
         result = torch.isnan(cs)
         assert isinstance(result, torch.Tensor)
-        assert result.shape == cs.shape
         assert not result.any()
 
     def test_torch_where(self):
@@ -786,67 +444,34 @@ class TestCompositionScoresProtocol:
         result = torch.where(cs > 0, cs.scores, torch.zeros_like(cs.scores))
         assert isinstance(result, torch.Tensor)
 
-    def test_comparison_gt(self):
+    def test_comparisons(self):
         cs = self._make_scores()
-        mask = cs > 0
-        assert isinstance(mask, torch.Tensor)
-        assert mask.shape == cs.shape
+        assert isinstance(cs > 0, torch.Tensor)
+        assert isinstance(cs != 0, torch.Tensor)
+        assert isinstance(cs == 0, torch.Tensor)
 
-    def test_comparison_ne(self):
-        """scores != 0 must return a tensor, not raise RuntimeError."""
+    def test_tensor_methods(self):
         cs = self._make_scores()
-        result = cs != 0
-        assert isinstance(result, torch.Tensor)
-        assert result.shape == cs.shape
-
-    def test_comparison_eq(self):
-        cs = self._make_scores()
-        result = cs == 0
-        assert isinstance(result, torch.Tensor)
-
-    def test_tensor_method_abs(self):
-        """scores.abs() must work via __getattr__ delegation."""
-        cs = self._make_scores()
-        result = cs.abs()
-        assert isinstance(result, torch.Tensor)
-
-    def test_tensor_method_sum(self):
-        cs = self._make_scores()
-        result = cs.sum()
-        assert isinstance(result, torch.Tensor)
-
-    def test_tensor_method_any(self):
-        cs = self._make_scores()
-        result = cs.any()
-        assert isinstance(result, torch.Tensor)
+        assert isinstance(cs.abs(), torch.Tensor)
+        assert isinstance(cs.sum(), torch.Tensor)
+        assert isinstance(cs.any(), torch.Tensor)
 
     def test_chained_indexing_and_method(self):
-        """scores[l1, :, l2, :].abs().sum() — the exact pattern from integration tests."""
         cs = self._make_scores()
         result = cs[0, :, 1, :].abs().sum()
-        assert isinstance(result, torch.Tensor)
-        assert result.ndim == 0  # scalar
+        assert result.ndim == 0
 
-    def test_metadata_accessible(self):
+    def test_metadata(self):
         cs = self._make_scores()
         assert cs.layer_indices == [0, 2, 5]
         assert len(cs.head_labels) == 6
-
-    def test_repr(self):
-        cs = self._make_scores()
-        r = repr(cs)
-        assert "CompositionScores" in r
-        assert "layer_indices" in r
+        assert "CompositionScores" in repr(cs)
 
 
-# ============================================================================
-# Tests: get_bridge_params with hybrid blocks
-# ============================================================================
+# -- Tests: get_bridge_params with hybrid blocks ------------------------------
 
 
 class TestGetBridgeParamsHybrid:
-    """get_bridge_params should skip attn keys for non-attention layers."""
-
     def test_no_attn_keys_for_non_attn_layers(self):
         from transformer_lens.model_bridge.get_params_util import get_bridge_params
 
@@ -854,34 +479,14 @@ class TestGetBridgeParamsHybrid:
         bridge.cfg.d_vocab = 10
         bridge.cfg.n_ctx = 8
         bridge.cfg.d_mlp = 16
-        bridge.cfg.n_heads = 2
         bridge.cfg.d_head = 2
 
-        # Add minimal embed/unembed so get_bridge_params doesn't fail
         bridge.embed = nn.Embedding(10, 4)
         bridge.pos_embed = type("PE", (), {"weight": torch.randn(8, 4)})()
-        bridge.unembed = type(
-            "UE",
-            (),
-            {
-                "weight": torch.randn(10, 4),
-                "b_U": torch.zeros(10),
-            },
-        )()
+        bridge.unembed = type("UE", (), {"weight": torch.randn(10, 4), "b_U": torch.zeros(10)})()
 
         params = get_bridge_params(bridge)
-
-        # Blocks 0-2 have 'attn' — should have attn keys
-        for i in range(3):
-            # attn is mapped but internal structure (q/k/v/o) may not match
-            # our synthetic LinearBridge wrapping FakeSubmodule — so attn keys
-            # may or may not be present depending on structure. The key point
-            # is block 3 must NOT have attn keys.
-            pass
-
-        # Block 3 has NO 'attn' — must not have any attn keys
-        attn_keys_for_block3 = [k for k in params if k.startswith("blocks.3.attn.")]
-        assert len(attn_keys_for_block3) == 0, (
-            f"Block 3 (non-attention layer) should have no attn keys, "
-            f"but found: {attn_keys_for_block3}"
-        )
+        attn_keys_block3 = [k for k in params if k.startswith("blocks.3.attn.")]
+        assert (
+            len(attn_keys_block3) == 0
+        ), f"Non-attn layer should have no attn keys: {attn_keys_block3}"

--- a/transformer_lens/benchmarks/weight_processing.py
+++ b/transformer_lens/benchmarks/weight_processing.py
@@ -149,7 +149,6 @@ def benchmark_weight_sharing(
         if reference_model is not None:
             reference_original = reference_model(test_text, return_type="loss")
 
-            # Find first block with attention (hybrid models may not have attn on block 0)
             bridge_attn_blocks = bridge.blocks_with("attn")
             if not bridge_attn_blocks:
                 return BenchmarkResult(
@@ -558,7 +557,6 @@ def benchmark_attention_output_centering(
                 message="Skipped for tiny/test model (random weights don't center meaningfully)",
             )
 
-        # Find blocks with attention (hybrid architectures may not have attn on all blocks)
         attn_blocks = bridge.blocks_with("attn")
         if not attn_blocks:
             return BenchmarkResult(
@@ -801,7 +799,6 @@ def benchmark_value_bias_folding(
                     },
                 )
 
-        # Find blocks with attention (hybrid architectures may not have attn on all blocks)
         attn_blocks = bridge.blocks_with("attn")
         if not attn_blocks:
             return BenchmarkResult(

--- a/transformer_lens/benchmarks/weight_processing.py
+++ b/transformer_lens/benchmarks/weight_processing.py
@@ -68,8 +68,16 @@ def benchmark_weight_processing(
                 )
 
             # Check weight centering - writing weights should be approximately centered
-            bridge_w_out = bridge.blocks[0].mlp.W_out
-            reference_w_out = reference_model.blocks[0].mlp.W_out  # type: ignore[union-attr]
+            mlp_blocks = bridge.blocks_with("mlp")
+            if not mlp_blocks:
+                return BenchmarkResult(
+                    name="weight_processing",
+                    severity=BenchmarkSeverity.WARNING,
+                    message="No blocks have MLP submodule — cannot check centering",
+                )
+            _mlp_idx, mlp_block = mlp_blocks[0]
+            bridge_w_out = mlp_block.mlp.W_out
+            reference_w_out = reference_model.blocks[_mlp_idx].mlp.W_out  # type: ignore[union-attr]
 
             bridge_mean = torch.mean(torch.abs(torch.mean(bridge_w_out, dim=-1, keepdim=True)))
             reference_mean = torch.mean(
@@ -141,10 +149,20 @@ def benchmark_weight_sharing(
         if reference_model is not None:
             reference_original = reference_model(test_text, return_type="loss")
 
+            # Find first block with attention (hybrid models may not have attn on block 0)
+            bridge_attn_blocks = bridge.blocks_with("attn")
+            if not bridge_attn_blocks:
+                return BenchmarkResult(
+                    name="weight_sharing",
+                    severity=BenchmarkSeverity.INFO,
+                    message="No blocks have attention submodule — skipping weight sharing check",
+                )
+            bridge_attn_idx, bridge_attn_block = bridge_attn_blocks[0]
+
             # Verify weights are identical before modification
-            bridge_W_V = torch.clone(cast(torch.Tensor, bridge.blocks[0].attn.W_V))
+            bridge_W_V = torch.clone(cast(torch.Tensor, bridge_attn_block.attn.W_V))
             reference_W_V = torch.clone(
-                cast(torch.Tensor, reference_model.blocks[0].attn.W_V)  # type: ignore[union-attr]
+                cast(torch.Tensor, reference_model.blocks[bridge_attn_idx].attn.W_V)  # type: ignore[union-attr]
             )
 
             # Check if models have GQA (different head counts for K/V vs Q)
@@ -188,8 +206,8 @@ def benchmark_weight_sharing(
 
             # Modify weights in both models
             with torch.no_grad():
-                bridge.blocks[0].attn.W_V[0, :, :] = 0  # type: ignore[union-attr,operator]
-                reference_model.blocks[0].attn.W_V[0, :, :] = 0  # type: ignore[union-attr,operator]
+                bridge_attn_block.attn.W_V[0, :, :] = 0  # type: ignore[union-attr,operator]
+                reference_model.blocks[bridge_attn_idx].attn.W_V[0, :, :] = 0  # type: ignore[union-attr,operator]
 
             # Test modified losses
             bridge_modified = bridge(test_text, return_type="loss")
@@ -200,8 +218,8 @@ def benchmark_weight_sharing(
 
             # Restore weights
             with torch.no_grad():
-                bridge.blocks[0].attn.W_V.copy_(bridge_W_V)  # type: ignore[union-attr,operator,arg-type]
-                reference_model.blocks[0].attn.W_V.copy_(reference_W_V)  # type: ignore[union-attr,operator,arg-type]
+                bridge_attn_block.attn.W_V.copy_(bridge_W_V)  # type: ignore[union-attr,operator,arg-type]
+                reference_model.blocks[bridge_attn_idx].attn.W_V.copy_(reference_W_V)  # type: ignore[union-attr,operator,arg-type]
 
             diff = abs(bridge_change - reference_change)
             if diff < atol:
@@ -220,16 +238,26 @@ def benchmark_weight_sharing(
                 )
 
         # No reference model - just verify modification has an effect
-        original_W_V = bridge.blocks[0].attn.W_V.clone()
+        # Find first block with attention (hybrid models may not have attn on block 0)
+        bridge_attn_blocks = bridge.blocks_with("attn")
+        if not bridge_attn_blocks:
+            return BenchmarkResult(
+                name="weight_sharing",
+                severity=BenchmarkSeverity.INFO,
+                message="No blocks have attention submodule — skipping weight sharing check",
+            )
+        _ws_idx, ws_attn_block = bridge_attn_blocks[0]
+
+        original_W_V = ws_attn_block.attn.W_V.clone()
         with torch.no_grad():
-            bridge.blocks[0].attn.W_V[0, :, :] = 0
+            ws_attn_block.attn.W_V[0, :, :] = 0
 
         bridge_modified = bridge(test_text, return_type="loss")
         change = abs(bridge_modified - bridge_original)
 
         # Restore weights
         with torch.no_grad():
-            bridge.blocks[0].attn.W_V.copy_(original_W_V)
+            ws_attn_block.attn.W_V.copy_(original_W_V)
 
         if change < 1e-6:
             return BenchmarkResult(
@@ -274,16 +302,26 @@ def benchmark_weight_modification(
         # Get original loss
         original_loss = bridge(test_text, return_type="loss")
 
+        # Find first block with attention (hybrid models may not have attn on block 0)
+        wm_attn_blocks = bridge.blocks_with("attn")
+        if not wm_attn_blocks:
+            return BenchmarkResult(
+                name="weight_modification",
+                severity=BenchmarkSeverity.INFO,
+                message="No blocks have attention submodule — skipping weight modification check",
+            )
+        _wm_idx, wm_attn_block = wm_attn_blocks[0]
+
         # Modify W_V weights
         with torch.no_grad():
-            original_w_v = bridge.blocks[0].attn.W_V.clone()
+            original_w_v = wm_attn_block.attn.W_V.clone()
             # Check dimensionality - GQA models may have 2D tensors instead of 3D
             if original_w_v.ndim == 3:
                 # Standard 3D tensor: [n_heads, d_model, d_head]
-                bridge.blocks[0].attn.W_V[0, :, :] = 0
+                wm_attn_block.attn.W_V[0, :, :] = 0
             elif original_w_v.ndim == 2:
                 # 2D tensor (e.g., GQA models): [n_heads * d_head, d_model] or similar
-                bridge.blocks[0].attn.W_V[0, :] = 0
+                wm_attn_block.attn.W_V[0, :] = 0
             else:
                 return BenchmarkResult(
                     name="weight_modification",
@@ -298,7 +336,7 @@ def benchmark_weight_modification(
         except Exception as forward_error:
             # Restore weights before reporting error
             with torch.no_grad():
-                bridge.blocks[0].attn.W_V.copy_(original_w_v)
+                wm_attn_block.attn.W_V.copy_(original_w_v)
 
             # Some models (e.g., models with complex attention mechanisms) may have
             # forward pass issues after weight modification. Report as skipped.
@@ -311,7 +349,7 @@ def benchmark_weight_modification(
 
         # Restore weights
         with torch.no_grad():
-            bridge.blocks[0].attn.W_V.copy_(original_w_v)
+            wm_attn_block.attn.W_V.copy_(original_w_v)
 
         # Loss should change
         change = abs(modified_loss - original_loss)
@@ -321,13 +359,17 @@ def benchmark_weight_modification(
             # is separate from the combined QKV weight used in forward.
             # Try MLP weight modification as fallback.
             mlp_fallback_error = None
+            mlp_blocks = bridge.blocks_with("mlp")
+            mlp_block = mlp_blocks[0][1] if mlp_blocks else None
             try:
+                if mlp_block is None:
+                    raise AttributeError("No blocks have mlp submodule")
                 with torch.no_grad():
-                    original_mlp_w = bridge.blocks[0].mlp.out.weight.clone()
-                    bridge.blocks[0].mlp.out.weight[0, :] = 0
+                    original_mlp_w = mlp_block.mlp.out.weight.clone()
+                    mlp_block.mlp.out.weight[0, :] = 0
                 mlp_modified_loss = bridge(test_text, return_type="loss")
                 with torch.no_grad():
-                    bridge.blocks[0].mlp.out.weight.copy_(original_mlp_w)
+                    mlp_block.mlp.out.weight.copy_(original_mlp_w)
                 mlp_change = abs(mlp_modified_loss - original_loss)
                 if mlp_change > 1e-6:
                     return BenchmarkResult(
@@ -516,8 +558,19 @@ def benchmark_attention_output_centering(
                 message="Skipped for tiny/test model (random weights don't center meaningfully)",
             )
 
-        # Check if W_O exists and is accessible
-        if not hasattr(bridge.blocks[0].attn, "W_O"):
+        # Find blocks with attention (hybrid architectures may not have attn on all blocks)
+        attn_blocks = bridge.blocks_with("attn")
+        if not attn_blocks:
+            return BenchmarkResult(
+                name="attention_output_centering",
+                severity=BenchmarkSeverity.WARNING,
+                message="No blocks have attention submodule",
+                passed=False,
+            )
+
+        # Check W_O accessibility on first attention block
+        first_idx, first_attn_block = attn_blocks[0]
+        if not hasattr(first_attn_block.attn, "W_O"):
             return BenchmarkResult(
                 name="attention_output_centering",
                 severity=BenchmarkSeverity.WARNING,
@@ -525,26 +578,31 @@ def benchmark_attention_output_centering(
                 passed=False,
             )
 
-        w_o = bridge.blocks[0].attn.W_O
-
-        # Compute mean along output dimension
-        mean_abs = torch.mean(torch.abs(torch.mean(w_o, dim=-1))).item()
-
+        # Compute mean across all attention blocks
         tolerance = 0.01  # 1% tolerance
+        worst_mean = 0.0
+        for idx, block in attn_blocks:
+            w_o = block.attn.W_O
+            mean_abs = torch.mean(torch.abs(torch.mean(w_o, dim=-1))).item()
+            worst_mean = max(worst_mean, mean_abs)
 
-        if mean_abs < tolerance:
+        n_attn = len(attn_blocks)
+        n_total = len(bridge.blocks)
+        block_info = f" ({n_attn}/{n_total} blocks have attention)" if n_attn < n_total else ""
+
+        if worst_mean < tolerance:
             return BenchmarkResult(
                 name="attention_output_centering",
                 severity=BenchmarkSeverity.INFO,
-                message=f"Attention output centering verified (mean={mean_abs:.6f})",
-                details={"mean": mean_abs, "tolerance": tolerance},
+                message=f"Attention output centering verified (worst_mean={worst_mean:.6f}){block_info}",
+                details={"mean": worst_mean, "tolerance": tolerance, "n_attn_blocks": n_attn},
             )
         else:
             return BenchmarkResult(
                 name="attention_output_centering",
                 severity=BenchmarkSeverity.WARNING,
-                message=f"Attention output weights not well-centered (mean={mean_abs:.6f})",
-                details={"mean": mean_abs, "tolerance": tolerance},
+                message=f"Attention output weights not well-centered (worst_mean={worst_mean:.6f}){block_info}",
+                details={"mean": worst_mean, "tolerance": tolerance, "n_attn_blocks": n_attn},
                 passed=False,
             )
 
@@ -743,8 +801,20 @@ def benchmark_value_bias_folding(
                     },
                 )
 
+        # Find blocks with attention (hybrid architectures may not have attn on all blocks)
+        attn_blocks = bridge.blocks_with("attn")
+        if not attn_blocks:
+            return BenchmarkResult(
+                name="value_bias_folding",
+                severity=BenchmarkSeverity.INFO,
+                message="No blocks have attention submodule (expected for hybrid models without mapped attn)",
+                details={"has_bias": False},
+            )
+
+        first_idx, first_attn_block = attn_blocks[0]
+
         # Check if b_V exists
-        if not hasattr(bridge.blocks[0].attn, "b_V"):
+        if not hasattr(first_attn_block.attn, "b_V"):
             return BenchmarkResult(
                 name="value_bias_folding",
                 severity=BenchmarkSeverity.INFO,
@@ -752,7 +822,7 @@ def benchmark_value_bias_folding(
                 details={"has_bias": False},
             )
 
-        b_v = bridge.blocks[0].attn.b_V
+        b_v = first_attn_block.attn.b_V
 
         if b_v is None:
             return BenchmarkResult(

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -1021,21 +1021,10 @@ class TransformerBridge(nn.Module):
         raise AssertionError("Expected a single string token.")
 
     def blocks_with(self, submodule: str) -> List[Tuple[int, "GeneralizedComponent"]]:
-        """Return (index, block) pairs for blocks that have the named submodule.
+        """Return (index, block) pairs for blocks with the named bridged submodule.
 
-        Hybrid architectures have heterogeneous blocks — some layers have
-        attention, others have SSM or linear attention, etc. Use this instead
-        of assuming blocks[0] is representative.
-
-        Only returns blocks where the submodule was explicitly set up as a
-        bridged component (registered in _modules), not submodules that happen
-        to exist on the underlying HF model.
-
-        Args:
-            submodule: Name of the submodule to check for (e.g., "attn", "mamba")
-
-        Returns:
-            List of (layer_index, block) tuples for blocks that have the submodule.
+        Checks _modules (not hasattr) so HF-internal attrs don't match.
+        Use instead of assuming blocks[0] is representative on hybrid models.
         """
         if not hasattr(self, "blocks"):
             return []
@@ -1044,23 +1033,9 @@ class TransformerBridge(nn.Module):
     def stack_params_for(
         self, submodule: str, attr_path: str, reshape_fn: Optional[Callable] = None
     ) -> Tuple[List[int], torch.Tensor]:
-        """Stack a parameter across blocks that have a specific submodule.
+        """Stack a parameter across matching blocks only. Returns (layer_indices, tensor).
 
-        For hybrid architectures where only some blocks have attention (or SSM,
-        etc.), this returns the stacked tensor for only matching blocks along
-        with their layer indices.
-
-        Args:
-            submodule: Submodule to filter on (e.g., "attn", "mamba")
-            attr_path: Dot-separated attr path from block (e.g., "attn.W_K")
-            reshape_fn: Optional function to reshape each weight before stacking
-
-        Returns:
-            Tuple of (layer_indices, stacked_tensor) where layer_indices maps
-            position i in the tensor to the original layer index.
-
-        Raises:
-            ValueError: If no blocks have the requested submodule.
+        Use for hybrid models where not all blocks have the submodule.
         """
         matching = self.blocks_with(submodule)
         if not matching:
@@ -1081,23 +1056,12 @@ class TransformerBridge(nn.Module):
     def _stack_block_params(
         self, attr_path: str, reshape_fn: Optional[Callable] = None
     ) -> torch.Tensor:
-        """Stack a parameter across all blocks, or across matching blocks for hybrids.
+        """Stack a parameter across all blocks; falls back to matching-only on hybrids.
 
-        For homogeneous models, returns a tensor of shape [n_layers, ...].
-        For hybrid models where some blocks lack the requested submodule,
-        returns a tensor of shape [n_matching_blocks, ...] and emits a
-        one-time warning about the index mapping.
-
-        Args:
-            attr_path: Dot-separated attribute path from block (e.g., "attn.W_K")
-            reshape_fn: Optional function to reshape each weight before stacking
-
-        Note:
-            The guard checks only that the first path segment is a bridged
-            submodule (in _modules). Deeper segments resolve via standard
-            getattr, which may fall through to HF model attributes. This is
-            intentional — properties like W_Q are exposed via __getattr__
-            delegation to the underlying weight tensors.
+        On hybrid models, logs a warning about index mapping and returns only
+        blocks that have the submodule. First path segment is checked against
+        _modules; deeper segments resolve via getattr (intentional — W_Q etc.
+        are exposed via __getattr__ delegation).
         """
         first_attr = attr_path.split(".")[0]
         matching_blocks = [
@@ -1231,42 +1195,22 @@ class TransformerBridge(nn.Module):
 
     @property
     def QK(self):
-        """QK circuit as a FactoredMatrix.
-
-        On hybrid models, returns the circuit for attention layers only (with
-        a warning about index mapping). For explicit index control, use
-        QK_for_attn_layers() which returns (layer_indices, FactoredMatrix).
-        """
+        """QK circuit. On hybrids, returns attn layers only (with warning). See QK_for_attn_layers()."""
         return FactoredMatrix(self.W_Q, self.W_K.transpose(-2, -1))
 
     @property
     def OV(self):
-        """OV circuit as a FactoredMatrix.
-
-        On hybrid models, returns the circuit for attention layers only (with
-        a warning about index mapping). For explicit index control, use
-        OV_for_attn_layers() which returns (layer_indices, FactoredMatrix).
-        """
+        """OV circuit. On hybrids, returns attn layers only (with warning). See OV_for_attn_layers()."""
         return FactoredMatrix(self.W_V, self.W_O)
 
     def QK_for_attn_layers(self) -> Tuple[List[int], FactoredMatrix]:
-        """QK circuit for attention layers only (hybrid-safe).
-
-        Returns:
-            Tuple of (layer_indices, FactoredMatrix) where layer_indices maps
-            position i in the matrix to the original layer index.
-        """
+        """QK circuit for attention layers only. Returns (layer_indices, FactoredMatrix)."""
         q_indices, W_Q = self.stack_params_for("attn", "attn.W_Q", self._reshape_qkv)
         _, W_K = self.stack_params_for("attn", "attn.W_K", self._reshape_qkv)
         return q_indices, FactoredMatrix(W_Q, W_K.transpose(-2, -1))
 
     def OV_for_attn_layers(self) -> Tuple[List[int], FactoredMatrix]:
-        """OV circuit for attention layers only (hybrid-safe).
-
-        Returns:
-            Tuple of (layer_indices, FactoredMatrix) where layer_indices maps
-            position i in the matrix to the original layer index.
-        """
+        """OV circuit for attention layers only. Returns (layer_indices, FactoredMatrix)."""
         v_indices, W_V = self.stack_params_for("attn", "attn.W_V", self._reshape_qkv)
         _, W_O = self.stack_params_for("attn", "attn.W_O", self._reshape_o)
         return v_indices, FactoredMatrix(W_V, W_O)
@@ -1314,9 +1258,7 @@ class TransformerBridge(nn.Module):
             residual_direction = self.W_U[:, token]
             return residual_direction
 
-    # Output bias attribute names by variant type. Attention uses "b_O"
-    # (a processed-weight alias). SSM/linear-attn variants use their output
-    # projection's bias. Map variant name → list of attribute paths to check.
+    # Variant → attr paths for the output bias that feeds the residual stream.
     _VARIANT_OUTPUT_BIAS_ATTRS: Dict[str, tuple] = {
         "attn": ("b_O",),
         "linear_attn": ("out_proj.bias",),
@@ -1326,12 +1268,7 @@ class TransformerBridge(nn.Module):
     }
 
     def _get_block_variant_bias(self, block: "GeneralizedComponent") -> Optional[torch.Tensor]:
-        """Get the output bias from whatever variant submodule this block has.
-
-        Each variant type has its own output bias attribute name — attention
-        uses b_O while SSM variants use out_proj.bias. Returns the first
-        found, or None if the variant has no output bias.
-        """
+        """Return the output bias from this block's variant submodule, or None."""
         for name in VARIANT_SUBMODULE_NAMES:
             if name not in block._modules:
                 continue
@@ -1353,22 +1290,10 @@ class TransformerBridge(nn.Module):
         mlp_input: bool = False,
         include_mlp_biases: bool = True,
     ) -> torch.Tensor:
-        """Sum of biases that contribute to the residual stream up to a given layer.
+        """Sum of variant + MLP output biases through the residual stream up to `layer`.
 
-        Includes output biases from whatever variant submodule each block has
-        (attention, Mamba, linear attention, etc.) plus MLP output biases.
-        For hybrid models, non-attention layers still contribute their variant
-        submodule's output bias to the residual stream.
-
-        Args:
-            layer: Layer number in [0, n_layers]. 0 means no layers, n_layers means all.
-            mlp_input: If True, include the variant submodule's output bias of
-                the target layer (i.e. bias up to the MLP input of that layer).
-            include_mlp_biases: Whether to include MLP biases. Useful to set False when
-                expanding attn_out into individual heads but keeping mlp_out as-is.
-
-        Returns:
-            Tensor of shape [d_model] with the accumulated bias.
+        Includes all layer types (attn, SSM, linear-attn). Set mlp_input=True
+        to include the variant bias of the target layer itself.
         """
         accumulated = torch.zeros(self.cfg.d_model, device=self.cfg.device)
         for i in range(layer):
@@ -1389,23 +1314,12 @@ class TransformerBridge(nn.Module):
         return accumulated
 
     def all_composition_scores(self, mode: str) -> CompositionScores:
-        """Composition scores for all pairs of attention heads.
-
-        Returns a ``CompositionScores`` containing the scores tensor, the
-        original layer indices, and human-readable head labels.  The scores
-        tensor has shape (n_attn_layers, n_heads, n_attn_layers, n_heads) and
-        is upper triangular on the layer axes.
-
-        For hybrid models, only attention layers are included.  The returned
-        ``layer_indices`` maps tensor position *i* back to the original layer
-        number so that results cannot be silently misinterpreted.
+        """Composition scores for all attention head pairs. Returns CompositionScores.
 
         See https://transformer-circuits.pub/2021/framework/index.html
-
-        Args:
-            mode: One of "Q", "K", "V" — which composition type to compute.
+        On hybrid models, only attention layers are included; layer_indices
+        maps tensor position i to original layer number.
         """
-        # Single blocks_with call — all weight stacking uses these same blocks
         attn_blocks = self.blocks_with("attn")
         if not attn_blocks:
             raise ValueError("No attention layers found — cannot compute composition scores.")
@@ -1449,59 +1363,23 @@ class TransformerBridge(nn.Module):
         return CompositionScores(scores=scores, layer_indices=indices, head_labels=labels)
 
     def composition_layer_indices(self) -> List[int]:
-        """Return original layer indices for attention layers.
-
-        Maps position i in all_composition_scores() output back to the
-        original layer number. For homogeneous models, returns [0, 1, ..., n-1].
-        For hybrid models, returns only the attention layer indices.
-        """
+        """Original layer indices for attention layers (maps composition score positions)."""
         return [idx for idx, _ in self.blocks_with("attn")]
 
     def block_hooks(self, layer_idx: int) -> List[str]:
-        """Return all hook point names available on a specific block.
-
-        Useful for hybrid architectures where different layers have different
-        hookable submodules — e.g., attention layers expose hook_q/hook_k/etc.
-        while SSM layers expose hook_in_proj/hook_conv/etc.
-
-        Args:
-            layer_idx: Layer index to inspect.
-
-        Returns:
-            Sorted list of hook names (e.g., ["hook_in", "hook_out", "attn.hook_q", ...]).
-        """
+        """Sorted hook names available on block `layer_idx` (block-relative paths)."""
         prefix = f"blocks.{layer_idx}."
         return sorted(name[len(prefix) :] for name in self.hook_dict if name.startswith(prefix))
 
     def block_submodules(self, layer_idx: int) -> List[str]:
-        """Return names of bridged submodules on a specific block.
-
-        Args:
-            layer_idx: Layer index to inspect.
-
-        Returns:
-            List of submodule names (e.g., ["ln1", "ln2", "attn", "mlp"]).
-        """
+        """Return bridged submodule names on block `layer_idx`."""
         block = self.blocks[layer_idx]
         return [name for name in block._modules if name not in _BLOCK_INTERNAL_MODULES]
 
     def layer_types(self) -> List[str]:
-        """Return a human-readable layer type for each block.
-
-        Inspects which bridged submodules are present on each block to infer
-        the layer type. For homogeneous models, all entries will be the same.
-        Variant submodule names are defined in
-        ``generalized_components.block.VARIANT_SUBMODULE_NAMES``.
-
-        Labels are deterministic: variants appear in VARIANT_SUBMODULE_NAMES
-        order, universals are sorted alphabetically.
-
-        Returns:
-            List of strings like ["attn+mlp", "ssm+mlp", "attn+mlp", ...].
-        """
+        """Per-block type labels, e.g. ["attn+mlp", "ssm+mlp", ...]. Deterministic order."""
         types = []
         for block in self.blocks:
-            # Variants in canonical order (tuple iteration = stable)
             variants = [n for n in VARIANT_SUBMODULE_NAMES if n in block._modules]
             universals = sorted(
                 n
@@ -1521,11 +1399,7 @@ class TransformerBridge(nn.Module):
 
     @property
     def attn_head_labels(self) -> list[str]:
-        """Labels for attention heads only, matching all_composition_scores() dimensions.
-
-        For homogeneous models, identical to all_head_labels. For hybrid models,
-        only includes heads from attention layers (skips SSM/linear-attn layers).
-        """
+        """Head labels for attention layers only — matches all_composition_scores() dims."""
         return [
             f"L{l}H{h}" for l in self.composition_layer_indices() for h in range(self.cfg.n_heads)
         ]

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -3,7 +3,9 @@
 This module provides the bridge components that wrap remote model components and provide
 a consistent interface for accessing their weights and performing operations.
 """
+import logging
 import re
+import warnings
 from contextlib import contextmanager
 from functools import lru_cache
 from typing import (
@@ -32,9 +34,16 @@ from transformer_lens.FactoredMatrix import FactoredMatrix
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
 from transformer_lens.model_bridge.component_setup import set_original_components
+from transformer_lens.model_bridge.composition_scores import CompositionScores
 from transformer_lens.model_bridge.exceptions import StopAtLayerException
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
+)
+from transformer_lens.model_bridge.generalized_components.block import (
+    _BLOCK_INTERNAL_MODULES,
+    _NORM_PREFIXES,
+    _VARIANT_SUBMODULE_SET,
+    VARIANT_SUBMODULE_NAMES,
 )
 from transformer_lens.model_bridge.get_params_util import get_bridge_params
 from transformer_lens.utilities.aliases import resolve_alias
@@ -45,6 +54,14 @@ if TYPE_CHECKING:
     from transformer_lens.ActivationCache import ActivationCache
 
 _BLOCK_PATTERN = re.compile("blocks\\.(\\d+)")
+
+
+def _resolve_attr_path(obj: nn.Module, attr_path: str) -> torch.Tensor:
+    """Walk a dot-separated attribute path and return the final tensor."""
+    result = obj
+    for attr in attr_path.split("."):
+        result = getattr(result, attr)
+    return cast(torch.Tensor, result)
 
 
 def build_alias_to_canonical_map(hook_dict, prefix=""):
@@ -247,7 +264,7 @@ class TransformerBridge(nn.Module):
         if not hasattr(self, "blocks"):
             return
         for block in self.blocks:
-            if not hasattr(block, "attn"):
+            if "attn" not in block._modules:
                 continue
             attn = block.attn
             if not (hasattr(attn, "q") and hasattr(attn.q, "weight")):
@@ -1003,20 +1020,114 @@ class TransformerBridge(nn.Module):
             return str(token[0])
         raise AssertionError("Expected a single string token.")
 
+    def blocks_with(self, submodule: str) -> List[Tuple[int, "GeneralizedComponent"]]:
+        """Return (index, block) pairs for blocks that have the named submodule.
+
+        Hybrid architectures have heterogeneous blocks — some layers have
+        attention, others have SSM or linear attention, etc. Use this instead
+        of assuming blocks[0] is representative.
+
+        Only returns blocks where the submodule was explicitly set up as a
+        bridged component (registered in _modules), not submodules that happen
+        to exist on the underlying HF model.
+
+        Args:
+            submodule: Name of the submodule to check for (e.g., "attn", "mamba")
+
+        Returns:
+            List of (layer_index, block) tuples for blocks that have the submodule.
+        """
+        if not hasattr(self, "blocks"):
+            return []
+        return [(i, block) for i, block in enumerate(self.blocks) if submodule in block._modules]
+
+    def stack_params_for(
+        self, submodule: str, attr_path: str, reshape_fn: Optional[Callable] = None
+    ) -> Tuple[List[int], torch.Tensor]:
+        """Stack a parameter across blocks that have a specific submodule.
+
+        For hybrid architectures where only some blocks have attention (or SSM,
+        etc.), this returns the stacked tensor for only matching blocks along
+        with their layer indices.
+
+        Args:
+            submodule: Submodule to filter on (e.g., "attn", "mamba")
+            attr_path: Dot-separated attr path from block (e.g., "attn.W_K")
+            reshape_fn: Optional function to reshape each weight before stacking
+
+        Returns:
+            Tuple of (layer_indices, stacked_tensor) where layer_indices maps
+            position i in the tensor to the original layer index.
+
+        Raises:
+            ValueError: If no blocks have the requested submodule.
+        """
+        matching = self.blocks_with(submodule)
+        if not matching:
+            raise ValueError(
+                f"No blocks have submodule '{submodule}'. "
+                f"Available submodules can be checked with blocks_with()."
+            )
+        indices: List[int] = []
+        weights: List[torch.Tensor] = []
+        for idx, block in matching:
+            w = _resolve_attr_path(block, attr_path)
+            if reshape_fn is not None:
+                w = reshape_fn(w)
+            weights.append(w)
+            indices.append(idx)
+        return indices, torch.stack(weights, dim=0)
+
     def _stack_block_params(
         self, attr_path: str, reshape_fn: Optional[Callable] = None
     ) -> torch.Tensor:
-        """Stack a parameter across all blocks.
+        """Stack a parameter across all blocks, or across matching blocks for hybrids.
+
+        For homogeneous models, returns a tensor of shape [n_layers, ...].
+        For hybrid models where some blocks lack the requested submodule,
+        returns a tensor of shape [n_matching_blocks, ...] and emits a
+        one-time warning about the index mapping.
 
         Args:
             attr_path: Dot-separated attribute path from block (e.g., "attn.W_K")
             reshape_fn: Optional function to reshape each weight before stacking
+
+        Note:
+            The guard checks only that the first path segment is a bridged
+            submodule (in _modules). Deeper segments resolve via standard
+            getattr, which may fall through to HF model attributes. This is
+            intentional — properties like W_Q are exposed via __getattr__
+            delegation to the underlying weight tensors.
         """
-        weights = []
-        for block in self.blocks:
-            w = block
-            for attr in attr_path.split("."):
-                w = getattr(w, attr)
+        first_attr = attr_path.split(".")[0]
+        matching_blocks = [
+            (i, block) for i, block in enumerate(self.blocks) if first_attr in block._modules
+        ]
+
+        if len(matching_blocks) == 0:
+            raise AttributeError(
+                f"No blocks have submodule '{first_attr}'. "
+                f"Use bridge.blocks_with('{first_attr}') to check availability."
+            )
+
+        if len(matching_blocks) < len(self.blocks):
+            indices = [i for i, _ in matching_blocks]
+            logging.warning(
+                "Hybrid model: only %d/%d blocks have '%s'. Returning stacked tensor "
+                "for layers %s only. Tensor index i corresponds to original layer "
+                "indices[i], not layer i. For explicit index mapping, use "
+                "bridge.stack_params_for('%s', '%s').",
+                len(matching_blocks),
+                len(self.blocks),
+                first_attr,
+                indices,
+                first_attr,
+                attr_path,
+            )
+
+        weights: List[torch.Tensor] = []
+        for _, block in matching_blocks:
+            w = _resolve_attr_path(block, attr_path)
             if reshape_fn is not None:
                 w = reshape_fn(w)
             weights.append(w)
@@ -1120,11 +1231,45 @@ class TransformerBridge(nn.Module):
 
     @property
     def QK(self):
+        """QK circuit as a FactoredMatrix.
+
+        On hybrid models, returns the circuit for attention layers only (with
+        a warning about index mapping). For explicit index control, use
+        QK_for_attn_layers() which returns (layer_indices, FactoredMatrix).
+        """
         return FactoredMatrix(self.W_Q, self.W_K.transpose(-2, -1))
 
     @property
     def OV(self):
+        """OV circuit as a FactoredMatrix.
+
+        On hybrid models, returns the circuit for attention layers only (with
+        a warning about index mapping). For explicit index control, use
+        OV_for_attn_layers() which returns (layer_indices, FactoredMatrix).
+        """
         return FactoredMatrix(self.W_V, self.W_O)
+
+    def QK_for_attn_layers(self) -> Tuple[List[int], FactoredMatrix]:
+        """QK circuit for attention layers only (hybrid-safe).
+
+        Returns:
+            Tuple of (layer_indices, FactoredMatrix) where layer_indices maps
+            position i in the matrix to the original layer index.
+        """
+        q_indices, W_Q = self.stack_params_for("attn", "attn.W_Q", self._reshape_qkv)
+        _, W_K = self.stack_params_for("attn", "attn.W_K", self._reshape_qkv)
+        return q_indices, FactoredMatrix(W_Q, W_K.transpose(-2, -1))
+
+    def OV_for_attn_layers(self) -> Tuple[List[int], FactoredMatrix]:
+        """OV circuit for attention layers only (hybrid-safe).
+
+        Returns:
+            Tuple of (layer_indices, FactoredMatrix) where layer_indices maps
+            position i in the matrix to the original layer index.
+        """
+        v_indices, W_V = self.stack_params_for("attn", "attn.W_V", self._reshape_qkv)
+        _, W_O = self.stack_params_for("attn", "attn.W_O", self._reshape_o)
+        return v_indices, FactoredMatrix(W_V, W_O)
 
     # ------------------------------------------------------------------
     # Mechanistic interpretability analysis methods
@@ -1169,18 +1314,56 @@ class TransformerBridge(nn.Module):
             residual_direction = self.W_U[:, token]
             return residual_direction
 
+    # Output bias attribute names by variant type. Attention uses "b_O"
+    # (a processed-weight alias). SSM/linear-attn variants use their output
+    # projection's bias. Map variant name → list of attribute paths to check.
+    _VARIANT_OUTPUT_BIAS_ATTRS: Dict[str, tuple] = {
+        "attn": ("b_O",),
+        "linear_attn": ("out_proj.bias",),
+        "mamba": ("out_proj.bias",),
+        "mixer": ("out_proj.bias",),
+        "ssm": ("out_proj.bias",),
+    }
+
+    def _get_block_variant_bias(self, block: "GeneralizedComponent") -> Optional[torch.Tensor]:
+        """Get the output bias from whatever variant submodule this block has.
+
+        Each variant type has its own output bias attribute name — attention
+        uses b_O while SSM variants use out_proj.bias. Returns the first
+        found, or None if the variant has no output bias.
+        """
+        for name in VARIANT_SUBMODULE_NAMES:
+            if name not in block._modules:
+                continue
+            variant = block._modules[name]
+            for attr_path in self._VARIANT_OUTPUT_BIAS_ATTRS.get(name, ()):
+                obj = variant
+                try:
+                    for attr in attr_path.split("."):
+                        obj = getattr(obj, attr)
+                except AttributeError:
+                    continue
+                if obj is not None and isinstance(obj, torch.Tensor):
+                    return obj
+        return None
+
     def accumulated_bias(
         self,
         layer: int,
         mlp_input: bool = False,
         include_mlp_biases: bool = True,
     ) -> torch.Tensor:
-        """Sum of attention and MLP output biases up to the input of a given layer.
+        """Sum of biases that contribute to the residual stream up to a given layer.
+
+        Includes output biases from whatever variant submodule each block has
+        (attention, Mamba, linear attention, etc.) plus MLP output biases.
+        For hybrid models, non-attention layers still contribute their variant
+        submodule's output bias to the residual stream.
 
         Args:
             layer: Layer number in [0, n_layers]. 0 means no layers, n_layers means all.
-            mlp_input: If True, include the attention output bias of the target layer
-                (i.e. bias up to the MLP input of that layer).
+            mlp_input: If True, include the variant submodule's output bias of
+                the target layer (i.e. bias up to the MLP input of that layer).
             include_mlp_biases: Whether to include MLP biases. Useful to set False when
                 expanding attn_out into individual heads but keeping mlp_out as-is.
 
@@ -1190,54 +1373,162 @@ class TransformerBridge(nn.Module):
         accumulated = torch.zeros(self.cfg.d_model, device=self.cfg.device)
         for i in range(layer):
             block = self.blocks[i]
-            b_O = getattr(block.attn, "b_O", None)
+            b_O = self._get_block_variant_bias(block)
             if b_O is not None:
                 accumulated = accumulated + b_O
-            if include_mlp_biases:
+            if include_mlp_biases and "mlp" in block._modules:
                 b_out = getattr(block.mlp, "b_out", None)
                 if b_out is not None:
                     accumulated = accumulated + b_out
         if mlp_input:
             assert layer < self.cfg.n_layers, "Cannot include attn_bias from beyond the final layer"
             block = self.blocks[layer]
-            b_O = getattr(block.attn, "b_O", None)
+            b_O = self._get_block_variant_bias(block)
             if b_O is not None:
                 accumulated = accumulated + b_O
         return accumulated
 
-    def all_composition_scores(self, mode: str) -> torch.Tensor:
-        """Composition scores for all pairs of heads.
+    def all_composition_scores(self, mode: str) -> CompositionScores:
+        """Composition scores for all pairs of attention heads.
 
-        Returns an (n_layers, n_heads, n_layers, n_heads) tensor that is upper
-        triangular on the layer axes (a head can only compose with later heads).
+        Returns a ``CompositionScores`` containing the scores tensor, the
+        original layer indices, and human-readable head labels.  The scores
+        tensor has shape (n_attn_layers, n_heads, n_attn_layers, n_heads) and
+        is upper triangular on the layer axes.
+
+        For hybrid models, only attention layers are included.  The returned
+        ``layer_indices`` maps tensor position *i* back to the original layer
+        number so that results cannot be silently misinterpreted.
 
         See https://transformer-circuits.pub/2021/framework/index.html
 
         Args:
             mode: One of "Q", "K", "V" — which composition type to compute.
         """
-        left = self.OV
+        # Single blocks_with call — all weight stacking uses these same blocks
+        attn_blocks = self.blocks_with("attn")
+        if not attn_blocks:
+            raise ValueError("No attention layers found — cannot compute composition scores.")
+
+        indices = [idx for idx, _ in attn_blocks]
+        blocks_list = [block for _, block in attn_blocks]
+
+        def _stack(attr_path: str, reshape_fn: Optional[Callable] = None) -> torch.Tensor:
+            weights: List[torch.Tensor] = []
+            for block in blocks_list:
+                w = _resolve_attr_path(block, attr_path)
+                if reshape_fn is not None:
+                    w = reshape_fn(w)
+                weights.append(w)
+            return torch.stack(weights, dim=0)
+
+        W_V = _stack("attn.W_V", self._reshape_qkv)
+        W_O = _stack("attn.W_O", self._reshape_o)
+        left = FactoredMatrix(W_V, W_O)
+
         if mode == "Q":
-            right = self.QK
+            W_Q = _stack("attn.W_Q", self._reshape_qkv)
+            W_K = _stack("attn.W_K", self._reshape_qkv)
+            right = FactoredMatrix(W_Q, W_K.transpose(-2, -1))
         elif mode == "K":
-            right = self.QK.T
+            W_Q = _stack("attn.W_Q", self._reshape_qkv)
+            W_K = _stack("attn.W_K", self._reshape_qkv)
+            right = FactoredMatrix(W_Q, W_K.transpose(-2, -1)).T
         elif mode == "V":
-            right = self.OV
+            right = left
         else:
             raise ValueError(f"mode must be one of ['Q', 'K', 'V'] not {mode}")
 
         scores = utils.composition_scores(left, right, broadcast_dims=True)
-        mask = (
-            torch.arange(self.cfg.n_layers, device=self.cfg.device)[:, None, None, None]
-            < torch.arange(self.cfg.n_layers, device=self.cfg.device)[None, None, :, None]
-        )
+        n_attn = len(indices)
+        idx_tensor = torch.arange(n_attn, device=self.cfg.device)
+        mask = idx_tensor[:, None, None, None] < idx_tensor[None, None, :, None]
         scores = torch.where(mask, scores, torch.zeros_like(scores))
-        return scores
+
+        labels = [f"L{l}H{h}" for l in indices for h in range(self.cfg.n_heads)]
+        return CompositionScores(scores=scores, layer_indices=indices, head_labels=labels)
+
+    def composition_layer_indices(self) -> List[int]:
+        """Return original layer indices for attention layers.
+
+        Maps position i in all_composition_scores() output back to the
+        original layer number. For homogeneous models, returns [0, 1, ..., n-1].
+        For hybrid models, returns only the attention layer indices.
+        """
+        return [idx for idx, _ in self.blocks_with("attn")]
+
+    def block_hooks(self, layer_idx: int) -> List[str]:
+        """Return all hook point names available on a specific block.
+
+        Useful for hybrid architectures where different layers have different
+        hookable submodules — e.g., attention layers expose hook_q/hook_k/etc.
+        while SSM layers expose hook_in_proj/hook_conv/etc.
+
+        Args:
+            layer_idx: Layer index to inspect.
+
+        Returns:
+            Sorted list of hook names (e.g., ["hook_in", "hook_out", "attn.hook_q", ...]).
+        """
+        prefix = f"blocks.{layer_idx}."
+        return sorted(name[len(prefix) :] for name in self.hook_dict if name.startswith(prefix))
+
+    def block_submodules(self, layer_idx: int) -> List[str]:
+        """Return names of bridged submodules on a specific block.
+
+        Args:
+            layer_idx: Layer index to inspect.
+
+        Returns:
+            List of submodule names (e.g., ["ln1", "ln2", "attn", "mlp"]).
+        """
+        block = self.blocks[layer_idx]
+        return [name for name in block._modules if name not in _BLOCK_INTERNAL_MODULES]
+
+    def layer_types(self) -> List[str]:
+        """Return a human-readable layer type for each block.
+
+        Inspects which bridged submodules are present on each block to infer
+        the layer type. For homogeneous models, all entries will be the same.
+        Variant submodule names are defined in
+        ``generalized_components.block.VARIANT_SUBMODULE_NAMES``.
+
+        Labels are deterministic: variants appear in VARIANT_SUBMODULE_NAMES
+        order, universals are sorted alphabetically.
+
+        Returns:
+            List of strings like ["attn+mlp", "ssm+mlp", "attn+mlp", ...].
+        """
+        types = []
+        for block in self.blocks:
+            # Variants in canonical order (tuple iteration = stable)
+            variants = [n for n in VARIANT_SUBMODULE_NAMES if n in block._modules]
+            universals = sorted(
+                n
+                for n in block._modules
+                if n not in _VARIANT_SUBMODULE_SET
+                and n not in _BLOCK_INTERNAL_MODULES
+                and not n.startswith(_NORM_PREFIXES)
+            )
+            parts = variants + universals
+            types.append("+".join(parts) if parts else "unknown")
+        return types
 
     @property
     def all_head_labels(self) -> list[str]:
         """Human-readable labels for all attention heads, e.g. ['L0H0', 'L0H1', ...]."""
         return [f"L{l}H{h}" for l in range(self.cfg.n_layers) for h in range(self.cfg.n_heads)]
+
+    @property
+    def attn_head_labels(self) -> list[str]:
+        """Labels for attention heads only, matching all_composition_scores() dimensions.
+
+        For homogeneous models, identical to all_head_labels. For hybrid models,
+        only includes heads from attention layers (skips SSM/linear-attn layers).
+        """
+        return [
+            f"L{l}H{h}" for l in self.composition_layer_indices() for h in range(self.cfg.n_heads)
+        ]
 
     def parameters(self, recurse: bool = True) -> Iterator[nn.Parameter]:
         """Returns parameters following standard PyTorch semantics.

--- a/transformer_lens/model_bridge/component_setup.py
+++ b/transformer_lens/model_bridge/component_setup.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 "Component setup utilities for creating and configuring bridged components."
 import copy
+import logging
 from typing import TYPE_CHECKING, Any, cast
+
+logger = logging.getLogger(__name__)
 
 import torch.nn as nn
 
@@ -67,6 +70,7 @@ def setup_submodules(
         architecture_adapter: The architecture adapter
         original_model: The original model to get components from
     """
+    skipped_optional: list[str] = []
     for module_name, submodule in component.submodules.items():
         if submodule.is_list_item:
             if submodule.name is None:
@@ -95,9 +99,39 @@ def setup_submodules(
                     original_subcomponent = original_model
                 else:
                     remote_path = submodule.name
-                    original_subcomponent = architecture_adapter.get_remote_component(
-                        original_model, remote_path
-                    )
+                    is_optional = getattr(submodule, "optional", False)
+                    # Fast path: if the first path segment is absent, skip
+                    # immediately. This catches the common hybrid case (e.g.,
+                    # "self_attn" absent on an SSM layer) without entering
+                    # get_remote_component.
+                    first_segment = remote_path.split(".")[0]
+                    if is_optional and not hasattr(original_model, first_segment):
+                        logger.debug(
+                            "Optional submodule '%s' (path '%s') absent on %s — skipping",
+                            module_name,
+                            remote_path,
+                            getattr(component, "name", "unknown"),
+                        )
+                        skipped_optional.append(module_name)
+                        continue  # hybrid layer lacks this submodule; skip binding
+                    # Full resolution — also catches deeper path failures
+                    # (e.g., "self_attn.q_proj" where self_attn exists as a
+                    # stub but q_proj is missing).
+                    try:
+                        original_subcomponent = architecture_adapter.get_remote_component(
+                            original_model, remote_path
+                        )
+                    except AttributeError:
+                        if is_optional:
+                            logger.debug(
+                                "Optional submodule '%s' (path '%s') partially absent on %s — skipping",
+                                module_name,
+                                remote_path,
+                                getattr(component, "name", "unknown"),
+                            )
+                            skipped_optional.append(module_name)
+                            continue
+                        raise
                 submodule.set_original_component(original_subcomponent)
                 setup_submodules(submodule, architecture_adapter, original_subcomponent)
                 if submodule.name is not None:
@@ -110,6 +144,12 @@ def setup_submodules(
             # Add to real_components mapping (for non-list components)
             if not submodule.is_list_item and submodule.name is not None:
                 component.real_components[module_name] = (submodule.name, submodule)
+
+    # Remove skipped optional submodules from the template so that
+    # architecture_adapter traversal code (which reads .submodules) doesn't
+    # find them and try to resolve against the HF model.
+    for name in skipped_optional:
+        component.submodules.pop(name, None)
 
 
 def setup_components(

--- a/transformer_lens/model_bridge/component_setup.py
+++ b/transformer_lens/model_bridge/component_setup.py
@@ -100,23 +100,18 @@ def setup_submodules(
                 else:
                     remote_path = submodule.name
                     is_optional = getattr(submodule, "optional", False)
-                    # Fast path: if the first path segment is absent, skip
-                    # immediately. This catches the common hybrid case (e.g.,
-                    # "self_attn" absent on an SSM layer) without entering
-                    # get_remote_component.
+                    # Fast path: first segment absent → skip without entering get_remote_component
                     first_segment = remote_path.split(".")[0]
                     if is_optional and not hasattr(original_model, first_segment):
                         logger.debug(
-                            "Optional submodule '%s' (path '%s') absent on %s — skipping",
+                            "Optional '%s' (path '%s') absent on %s",
                             module_name,
                             remote_path,
-                            getattr(component, "name", "unknown"),
+                            getattr(component, "name", "?"),
                         )
                         skipped_optional.append(module_name)
-                        continue  # hybrid layer lacks this submodule; skip binding
-                    # Full resolution — also catches deeper path failures
-                    # (e.g., "self_attn.q_proj" where self_attn exists as a
-                    # stub but q_proj is missing).
+                        continue
+                    # Full resolution — catches deeper path failures (e.g. stub self_attn missing q_proj)
                     try:
                         original_subcomponent = architecture_adapter.get_remote_component(
                             original_model, remote_path
@@ -124,10 +119,10 @@ def setup_submodules(
                     except AttributeError:
                         if is_optional:
                             logger.debug(
-                                "Optional submodule '%s' (path '%s') partially absent on %s — skipping",
+                                "Optional '%s' (path '%s') partially absent on %s",
                                 module_name,
                                 remote_path,
-                                getattr(component, "name", "unknown"),
+                                getattr(component, "name", "?"),
                             )
                             skipped_optional.append(module_name)
                             continue
@@ -145,9 +140,7 @@ def setup_submodules(
             if not submodule.is_list_item and submodule.name is not None:
                 component.real_components[module_name] = (submodule.name, submodule)
 
-    # Remove skipped optional submodules from the template so that
-    # architecture_adapter traversal code (which reads .submodules) doesn't
-    # find them and try to resolve against the HF model.
+    # Clean up so architecture_adapter traversal won't find stale entries
     for name in skipped_optional:
         component.submodules.pop(name, None)
 

--- a/transformer_lens/model_bridge/composition_scores.py
+++ b/transformer_lens/model_bridge/composition_scores.py
@@ -1,28 +1,21 @@
-"""CompositionScores — tensor-like container for composition score results."""
+"""Tensor-like container for composition score results with layer-index metadata."""
 from typing import List
 
 import torch
 
 
 class CompositionScores:
-    """Composition scores bundled with layer-index metadata.
+    """Composition scores that behave like a tensor but carry layer-index metadata.
 
-    Behaves like a tensor for backward compatibility — indexing, .shape,
-    arithmetic, and ``torch.*`` namespace functions all delegate to the
-    underlying scores tensor via ``__torch_function__``. The additional
-    ``layer_indices`` and ``head_labels`` attributes provide metadata that
-    prevents silent misinterpretation of indices on hybrid models.
-
-    For hybrid models, the scores tensor has shape
-    (n_attn_layers, n_heads, n_attn_layers, n_heads) where n_attn_layers
-    may be less than n_layers. ``layer_indices`` maps tensor position i
+    Delegates indexing, .shape, arithmetic, and torch.* functions to the
+    underlying ``scores`` tensor via ``__torch_function__``. On hybrid models
+    where n_attn_layers < n_layers, ``layer_indices`` maps tensor position i
     to the original layer number.
 
     Attributes:
         scores: Upper-triangular composition score tensor.
-        layer_indices: Original layer numbers for each position in scores.
-            E.g., [0, 2, 5] means position 0 = layer 0, position 1 = layer 2, etc.
-        head_labels: Labels like ["L0H0", "L0H1", "L2H0", ...] matching scores dims.
+        layer_indices: Original layer numbers, e.g. [0, 2, 5].
+        head_labels: Labels matching scores dims, e.g. ["L0H0", "L0H1", ...].
     """
 
     def __init__(self, scores: torch.Tensor, layer_indices: List[int], head_labels: List[str]):
@@ -30,14 +23,11 @@ class CompositionScores:
         self.layer_indices = layer_indices
         self.head_labels = head_labels
 
-    # --- Tensor protocol ---
-
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
-        """Delegate torch.* calls (torch.isnan, torch.where, etc.) to .scores."""
+        """Unwrap CompositionScores args so torch.isnan, torch.where, etc. work."""
         if kwargs is None:
             kwargs = {}
-        # Unwrap any CompositionScores args to their underlying tensor
         unwrapped_args = tuple(a.scores if isinstance(a, CompositionScores) else a for a in args)
         unwrapped_kwargs = {
             k: v.scores if isinstance(v, CompositionScores) else v for k, v in kwargs.items()
@@ -56,16 +46,11 @@ class CompositionScores:
     def dtype(self) -> torch.dtype:
         return self.scores.dtype
 
-    # Python 3 automatically sets __hash__ = None when __eq__ is defined,
-    # making instances unhashable. No explicit __hash__ needed.
-
     def __getitem__(self, key):
         return self.scores[key]
 
     def __getattr__(self, name):
-        # Delegate tensor methods (.abs(), .sum(), .any(), etc.) to .scores.
-        # Guard against infinite recursion during pickling/unpickling where
-        # self.scores may not exist yet.
+        # Guard against recursion during pickle/deepcopy when self.scores isn't set yet
         try:
             scores = object.__getattribute__(self, "scores")
         except AttributeError:

--- a/transformer_lens/model_bridge/composition_scores.py
+++ b/transformer_lens/model_bridge/composition_scores.py
@@ -1,0 +1,102 @@
+"""CompositionScores — tensor-like container for composition score results."""
+from typing import List
+
+import torch
+
+
+class CompositionScores:
+    """Composition scores bundled with layer-index metadata.
+
+    Behaves like a tensor for backward compatibility — indexing, .shape,
+    arithmetic, and ``torch.*`` namespace functions all delegate to the
+    underlying scores tensor via ``__torch_function__``. The additional
+    ``layer_indices`` and ``head_labels`` attributes provide metadata that
+    prevents silent misinterpretation of indices on hybrid models.
+
+    For hybrid models, the scores tensor has shape
+    (n_attn_layers, n_heads, n_attn_layers, n_heads) where n_attn_layers
+    may be less than n_layers. ``layer_indices`` maps tensor position i
+    to the original layer number.
+
+    Attributes:
+        scores: Upper-triangular composition score tensor.
+        layer_indices: Original layer numbers for each position in scores.
+            E.g., [0, 2, 5] means position 0 = layer 0, position 1 = layer 2, etc.
+        head_labels: Labels like ["L0H0", "L0H1", "L2H0", ...] matching scores dims.
+    """
+
+    def __init__(self, scores: torch.Tensor, layer_indices: List[int], head_labels: List[str]):
+        self.scores = scores
+        self.layer_indices = layer_indices
+        self.head_labels = head_labels
+
+    # --- Tensor protocol ---
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        """Delegate torch.* calls (torch.isnan, torch.where, etc.) to .scores."""
+        if kwargs is None:
+            kwargs = {}
+        # Unwrap any CompositionScores args to their underlying tensor
+        unwrapped_args = tuple(a.scores if isinstance(a, CompositionScores) else a for a in args)
+        unwrapped_kwargs = {
+            k: v.scores if isinstance(v, CompositionScores) else v for k, v in kwargs.items()
+        }
+        return func(*unwrapped_args, **unwrapped_kwargs)
+
+    @property
+    def shape(self) -> torch.Size:
+        return self.scores.shape
+
+    @property
+    def device(self) -> torch.device:
+        return self.scores.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.scores.dtype
+
+    # Python 3 automatically sets __hash__ = None when __eq__ is defined,
+    # making instances unhashable. No explicit __hash__ needed.
+
+    def __getitem__(self, key):
+        return self.scores[key]
+
+    def __getattr__(self, name):
+        # Delegate tensor methods (.abs(), .sum(), .any(), etc.) to .scores.
+        # Guard against infinite recursion during pickling/unpickling where
+        # self.scores may not exist yet.
+        try:
+            scores = object.__getattribute__(self, "scores")
+        except AttributeError:
+            raise AttributeError(name) from None
+        return getattr(scores, name)
+
+    def __gt__(self, other):
+        return self.scores > other
+
+    def __lt__(self, other):
+        return self.scores < other
+
+    def __ge__(self, other):
+        return self.scores >= other
+
+    def __le__(self, other):
+        return self.scores <= other
+
+    def __eq__(self, other):
+        if isinstance(other, CompositionScores):
+            return self.scores == other.scores
+        return self.scores == other
+
+    def __ne__(self, other):
+        if isinstance(other, CompositionScores):
+            return self.scores != other.scores
+        return self.scores != other
+
+    def __repr__(self) -> str:
+        return (
+            f"CompositionScores(shape={self.shape}, "
+            f"layer_indices={self.layer_indices}, "
+            f"n_head_labels={len(self.head_labels)})"
+        )

--- a/transformer_lens/model_bridge/generalized_components/base.py
+++ b/transformer_lens/model_bridge/generalized_components/base.py
@@ -34,6 +34,7 @@ class GeneralizedComponent(nn.Module):
         submodules: Optional[Dict[str, "GeneralizedComponent"]] = None,
         conversion_rule: Optional[BaseTensorConversion] = None,
         hook_alias_overrides: Optional[Dict[str, str]] = None,
+        optional: bool = False,
     ):
         """Initialize the generalized component.
 
@@ -45,12 +46,17 @@ class GeneralizedComponent(nn.Module):
             hook_alias_overrides: Optional dictionary to override default hook aliases.
                 For example, {"hook_attn_out": "ln1_post.hook_out"} will make hook_attn_out
                 point to ln1_post.hook_out instead of the default value in self.hook_aliases.
+            optional: If True, this entire subtree may be absent on some layers.
+                When the remote model lacks this component, setup will skip it
+                cleanly instead of raising AttributeError. Used for hybrid
+                architectures where layers have structurally different submodules.
         """
         super().__init__()
         self.name = name
         self.config = config
         self.submodules = submodules or {}
         self.conversion_rule = conversion_rule
+        self.optional = optional
         self._hook_registry: Dict[str, HookPoint] = {}
         self._hook_alias_registry: Dict[str, Union[str, List[str]]] = {}
         self._property_alias_registry: Dict[str, str] = {}
@@ -337,6 +343,7 @@ class GeneralizedComponent(nn.Module):
             "conversion_rule",
             "compatibility_mode",
             "disable_warnings",
+            "optional",
         ]:
             super().__setattr__(name, value)
             return

--- a/transformer_lens/model_bridge/generalized_components/base.py
+++ b/transformer_lens/model_bridge/generalized_components/base.py
@@ -46,10 +46,7 @@ class GeneralizedComponent(nn.Module):
             hook_alias_overrides: Optional dictionary to override default hook aliases.
                 For example, {"hook_attn_out": "ln1_post.hook_out"} will make hook_attn_out
                 point to ln1_post.hook_out instead of the default value in self.hook_aliases.
-            optional: If True, this entire subtree may be absent on some layers.
-                When the remote model lacks this component, setup will skip it
-                cleanly instead of raising AttributeError. Used for hybrid
-                architectures where layers have structurally different submodules.
+            optional: If True, setup skips this subtree when absent (hybrid architectures).
         """
         super().__init__()
         self.name = name

--- a/transformer_lens/model_bridge/generalized_components/block.py
+++ b/transformer_lens/model_bridge/generalized_components/block.py
@@ -15,19 +15,15 @@ from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
 
-# Submodule names that represent layer-type variants in hybrid architectures.
-# Used by layer_types() for classification and _get_block_variant_bias() for
-# bias accumulation.  Adapters that introduce new variant types should add
-# their submodule name here.  Ordered tuple for deterministic iteration
-# (matters when a block has multiple variants during development/testing).
+# Layer-type variant submodule names. Tuple for deterministic iteration order.
+# Extend here when adding new hybrid variant types.
 VARIANT_SUBMODULE_NAMES: tuple[str, ...] = ("attn", "linear_attn", "mamba", "mixer", "ssm")
 _VARIANT_SUBMODULE_SET: frozenset[str] = frozenset(VARIANT_SUBMODULE_NAMES)
 
-# Internal block modules excluded from submodule introspection (hook points
-# and the wrapped HF component are infrastructure, not user-facing submodules).
+# Infrastructure modules excluded from submodule introspection.
 _BLOCK_INTERNAL_MODULES: frozenset[str] = frozenset({"hook_in", "hook_out", "_original_component"})
 
-# Prefixes for normalization modules excluded from layer_types() labels.
+# Norm-module prefixes excluded from layer_types() labels.
 _NORM_PREFIXES: tuple[str, ...] = ("ln", "layer_norm", "norm", "rms")
 
 

--- a/transformer_lens/model_bridge/generalized_components/block.py
+++ b/transformer_lens/model_bridge/generalized_components/block.py
@@ -15,6 +15,21 @@ from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
 
+# Submodule names that represent layer-type variants in hybrid architectures.
+# Used by layer_types() for classification and _get_block_variant_bias() for
+# bias accumulation.  Adapters that introduce new variant types should add
+# their submodule name here.  Ordered tuple for deterministic iteration
+# (matters when a block has multiple variants during development/testing).
+VARIANT_SUBMODULE_NAMES: tuple[str, ...] = ("attn", "linear_attn", "mamba", "mixer", "ssm")
+_VARIANT_SUBMODULE_SET: frozenset[str] = frozenset(VARIANT_SUBMODULE_NAMES)
+
+# Internal block modules excluded from submodule introspection (hook points
+# and the wrapped HF component are infrastructure, not user-facing submodules).
+_BLOCK_INTERNAL_MODULES: frozenset[str] = frozenset({"hook_in", "hook_out", "_original_component"})
+
+# Prefixes for normalization modules excluded from layer_types() labels.
+_NORM_PREFIXES: tuple[str, ...] = ("ln", "layer_norm", "norm", "rms")
+
 
 class BlockBridge(GeneralizedComponent):
     """Bridge component for transformer blocks.

--- a/transformer_lens/model_bridge/get_params_util.py
+++ b/transformer_lens/model_bridge/get_params_util.py
@@ -37,23 +37,7 @@ def _get_or_create_bias(bias, n_heads: int, d_head: int, device, dtype) -> torch
 
 
 def get_bridge_params(bridge) -> Dict[str, torch.Tensor]:
-    """Access to model parameters in the format expected by SVDInterpreter.
-
-    For hybrid architectures, only layers with attention get attention keys
-    (W_Q, W_K, etc.). Non-attention layers (SSM, linear-attention) are skipped
-    rather than filled with zeros — this prevents downstream consumers like
-    SVDInterpreter from treating synthetic zeros as real weights.
-
-    Args:
-        bridge: TransformerBridge instance
-
-    Returns:
-        dict: Dictionary of parameter tensors with TransformerLens naming convention.
-            For hybrid models, attention keys only exist for layers that have attention.
-
-    Raises:
-        ValueError: If configuration is inconsistent (e.g., cfg.n_layers != len(blocks))
-    """
+    """Model parameters in SVDInterpreter format. Skips attn keys for non-attention layers."""
     params_dict = {}
 
     def _get_device_dtype():
@@ -89,15 +73,11 @@ def get_bridge_params(bridge) -> Dict[str, torch.Tensor]:
             )
         block = bridge.blocks[layer_idx]
 
-        # Only extract attention params from blocks that have attention.
-        # Non-attention layers (SSM, linear-attention) are skipped entirely
-        # rather than filled with zeros — this prevents consumers like
-        # SVDInterpreter from treating synthetic zeros as real weights.
+        # Skip non-attention layers entirely (no zero-fill — prevents SVDInterpreter garbage)
         try:
             has_attn = "attn" in block._modules
         except (TypeError, AttributeError):
-            # Mock objects or non-nn.Module blocks: fall back to hasattr
-            has_attn = hasattr(block, "attn")
+            has_attn = hasattr(block, "attn")  # Mock fallback
         if has_attn:
             try:
                 w_q = block.attn.q.weight

--- a/transformer_lens/model_bridge/get_params_util.py
+++ b/transformer_lens/model_bridge/get_params_util.py
@@ -1,7 +1,10 @@
 """Utility function for getting model parameters in TransformerLens format."""
+import logging
 from typing import Dict
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 
 def _get_n_kv_heads(cfg) -> int:
@@ -36,14 +39,17 @@ def _get_or_create_bias(bias, n_heads: int, d_head: int, device, dtype) -> torch
 def get_bridge_params(bridge) -> Dict[str, torch.Tensor]:
     """Access to model parameters in the format expected by SVDInterpreter.
 
-    For missing weights, returns zero tensors of appropriate shape instead of raising exceptions.
-    This ensures compatibility across different model architectures.
+    For hybrid architectures, only layers with attention get attention keys
+    (W_Q, W_K, etc.). Non-attention layers (SSM, linear-attention) are skipped
+    rather than filled with zeros — this prevents downstream consumers like
+    SVDInterpreter from treating synthetic zeros as real weights.
 
     Args:
         bridge: TransformerBridge instance
 
     Returns:
-        dict: Dictionary of parameter tensors with TransformerLens naming convention
+        dict: Dictionary of parameter tensors with TransformerLens naming convention.
+            For hybrid models, attention keys only exist for layers that have attention.
 
     Raises:
         ValueError: If configuration is inconsistent (e.g., cfg.n_layers != len(blocks))
@@ -51,22 +57,15 @@ def get_bridge_params(bridge) -> Dict[str, torch.Tensor]:
     params_dict = {}
 
     def _get_device_dtype():
-        device = bridge.cfg.device if hasattr(bridge.cfg, "device") else torch.device("cpu")
+        """Infer device/dtype from the first available model parameter."""
+        device = getattr(bridge.cfg, "device", None) or torch.device("cpu")
         dtype = torch.float32
         try:
-            device = bridge.embed.weight.device
-            dtype = bridge.embed.weight.dtype
-        except AttributeError:
-            try:
-                device = bridge.pos_embed.weight.device
-                dtype = bridge.pos_embed.weight.dtype
-            except AttributeError:
-                if len(bridge.blocks) > 0:
-                    try:
-                        device = bridge.blocks[0].attn.q.weight.device
-                        dtype = bridge.blocks[0].attn.q.weight.dtype
-                    except AttributeError:
-                        pass
+            first_param = next(bridge.parameters())
+            device = first_param.device
+            dtype = first_param.dtype
+        except (StopIteration, TypeError, AttributeError):
+            pass
         return (device, dtype)
 
     try:
@@ -89,72 +88,59 @@ def get_bridge_params(bridge) -> Dict[str, torch.Tensor]:
                 f"Configuration mismatch: cfg.n_layers={bridge.cfg.n_layers} but only {len(bridge.blocks)} blocks found. Layer {layer_idx} does not exist."
             )
         block = bridge.blocks[layer_idx]
+
+        # Only extract attention params from blocks that have attention.
+        # Non-attention layers (SSM, linear-attention) are skipped entirely
+        # rather than filled with zeros — this prevents consumers like
+        # SVDInterpreter from treating synthetic zeros as real weights.
         try:
-            w_q = block.attn.q.weight
-            w_k = block.attn.k.weight
-            w_v = block.attn.v.weight
-            w_o = block.attn.o.weight
-            if w_q.shape == (bridge.cfg.d_model, bridge.cfg.d_model):
-                d_head = bridge.cfg.d_model // bridge.cfg.n_heads
-                w_q = w_q.reshape(bridge.cfg.n_heads, bridge.cfg.d_model, d_head)
-                w_o = w_o.reshape(bridge.cfg.n_heads, d_head, bridge.cfg.d_model)
+            has_attn = "attn" in block._modules
+        except (TypeError, AttributeError):
+            # Mock objects or non-nn.Module blocks: fall back to hasattr
+            has_attn = hasattr(block, "attn")
+        if has_attn:
+            try:
+                w_q = block.attn.q.weight
+                w_k = block.attn.k.weight
+                w_v = block.attn.v.weight
+                w_o = block.attn.o.weight
+                if w_q.shape == (bridge.cfg.d_model, bridge.cfg.d_model):
+                    d_head = bridge.cfg.d_model // bridge.cfg.n_heads
+                    w_q = w_q.reshape(bridge.cfg.n_heads, bridge.cfg.d_model, d_head)
+                    w_o = w_o.reshape(bridge.cfg.n_heads, d_head, bridge.cfg.d_model)
+                    device, dtype = _get_device_dtype()
+                    w_k = _reshape_kv_weight(w_k, bridge.cfg, device, dtype)
+                    w_v = _reshape_kv_weight(w_v, bridge.cfg, device, dtype)
+                params_dict[f"blocks.{layer_idx}.attn.W_Q"] = w_q
+                params_dict[f"blocks.{layer_idx}.attn.W_K"] = w_k
+                params_dict[f"blocks.{layer_idx}.attn.W_V"] = w_v
+                params_dict[f"blocks.{layer_idx}.attn.W_O"] = w_o
                 device, dtype = _get_device_dtype()
-                w_k = _reshape_kv_weight(w_k, bridge.cfg, device, dtype)
-                w_v = _reshape_kv_weight(w_v, bridge.cfg, device, dtype)
-            params_dict[f"blocks.{layer_idx}.attn.W_Q"] = w_q
-            params_dict[f"blocks.{layer_idx}.attn.W_K"] = w_k
-            params_dict[f"blocks.{layer_idx}.attn.W_V"] = w_v
-            params_dict[f"blocks.{layer_idx}.attn.W_O"] = w_o
-            device, dtype = _get_device_dtype()
-            n_kv_heads = _get_n_kv_heads(bridge.cfg)
-            params_dict[f"blocks.{layer_idx}.attn.b_Q"] = _get_or_create_bias(
-                block.attn.q.bias, bridge.cfg.n_heads, bridge.cfg.d_head, device, dtype
-            )
-            params_dict[f"blocks.{layer_idx}.attn.b_K"] = _get_or_create_bias(
-                block.attn.k.bias, n_kv_heads, bridge.cfg.d_head, device, dtype
-            )
-            params_dict[f"blocks.{layer_idx}.attn.b_V"] = _get_or_create_bias(
-                block.attn.v.bias, n_kv_heads, bridge.cfg.d_head, device, dtype
-            )
-            if block.attn.o.bias is not None:
-                params_dict[f"blocks.{layer_idx}.attn.b_O"] = block.attn.o.bias
-            else:
-                device, dtype = _get_device_dtype()
-                params_dict[f"blocks.{layer_idx}.attn.b_O"] = torch.zeros(
-                    bridge.cfg.d_model, device=device, dtype=dtype
+                n_kv_heads = _get_n_kv_heads(bridge.cfg)
+                params_dict[f"blocks.{layer_idx}.attn.b_Q"] = _get_or_create_bias(
+                    block.attn.q.bias, bridge.cfg.n_heads, bridge.cfg.d_head, device, dtype
                 )
-        except AttributeError:
-            device, dtype = _get_device_dtype()
-            expected_qkv_shape = (bridge.cfg.n_heads, bridge.cfg.d_model, bridge.cfg.d_head)
-            expected_o_shape = (bridge.cfg.n_heads, bridge.cfg.d_head, bridge.cfg.d_model)
-            expected_q_bias_shape = (bridge.cfg.n_heads, bridge.cfg.d_head)
-            expected_o_bias_shape = (bridge.cfg.d_model,)
-            n_kv_heads = _get_n_kv_heads(bridge.cfg)
-            expected_kv_bias_shape = (n_kv_heads, bridge.cfg.d_head)
-            params_dict[f"blocks.{layer_idx}.attn.W_Q"] = torch.zeros(
-                *expected_qkv_shape, device=device, dtype=dtype
-            )
-            params_dict[f"blocks.{layer_idx}.attn.W_K"] = torch.zeros(
-                *expected_qkv_shape, device=device, dtype=dtype
-            )
-            params_dict[f"blocks.{layer_idx}.attn.W_V"] = torch.zeros(
-                *expected_qkv_shape, device=device, dtype=dtype
-            )
-            params_dict[f"blocks.{layer_idx}.attn.W_O"] = torch.zeros(
-                *expected_o_shape, device=device, dtype=dtype
-            )
-            params_dict[f"blocks.{layer_idx}.attn.b_Q"] = torch.zeros(
-                *expected_q_bias_shape, device=device, dtype=dtype
-            )
-            params_dict[f"blocks.{layer_idx}.attn.b_K"] = torch.zeros(
-                *expected_kv_bias_shape, device=device, dtype=dtype
-            )
-            params_dict[f"blocks.{layer_idx}.attn.b_V"] = torch.zeros(
-                *expected_kv_bias_shape, device=device, dtype=dtype
-            )
-            params_dict[f"blocks.{layer_idx}.attn.b_O"] = torch.zeros(
-                *expected_o_bias_shape, device=device, dtype=dtype
-            )
+                params_dict[f"blocks.{layer_idx}.attn.b_K"] = _get_or_create_bias(
+                    block.attn.k.bias, n_kv_heads, bridge.cfg.d_head, device, dtype
+                )
+                params_dict[f"blocks.{layer_idx}.attn.b_V"] = _get_or_create_bias(
+                    block.attn.v.bias, n_kv_heads, bridge.cfg.d_head, device, dtype
+                )
+                if block.attn.o.bias is not None:
+                    params_dict[f"blocks.{layer_idx}.attn.b_O"] = block.attn.o.bias
+                else:
+                    device, dtype = _get_device_dtype()
+                    params_dict[f"blocks.{layer_idx}.attn.b_O"] = torch.zeros(
+                        bridge.cfg.d_model, device=device, dtype=dtype
+                    )
+            except AttributeError as e:
+                logger.debug(
+                    "Block %d has 'attn' in _modules but attention params could not "
+                    "be extracted (missing q/k/v/o?): %s — skipping attention weights "
+                    "for this layer",
+                    layer_idx,
+                    e,
+                )
         try:
             mlp_in = getattr(block.mlp, "in", None) or getattr(block.mlp, "input", None)
             if mlp_in is None:

--- a/transformer_lens/weight_processing.py
+++ b/transformer_lens/weight_processing.py
@@ -1698,13 +1698,10 @@ class ProcessWeights:
             b_V_key = ProcessWeights._get_param_key(f"blocks.{l}.attn.b_V", adapter)
             b_O_key = ProcessWeights._get_param_key(f"blocks.{l}.attn.b_O", adapter)
 
-            # Skip layers without attention weights (hybrid architectures where
-            # some layers are SSM/linear-attention and lack Q/K/V/O entirely).
-            # Other weight-processing loops (center_writing_weights, fold_value_biases,
-            # fold_layer_norm) already guard with `if key in state_dict:` checks.
+            # Skip hybrid layers without attention (other loops already guard individually)
             if W_Q_key not in state_dict:
                 continue
-            # All four weight matrices must be present if Q is present
+            # If Q is present, K/V/O must be too
             for _required_key in [W_K_key, W_V_key, W_O_key]:
                 if _required_key not in state_dict:
                     raise ValueError(

--- a/transformer_lens/weight_processing.py
+++ b/transformer_lens/weight_processing.py
@@ -1698,6 +1698,21 @@ class ProcessWeights:
             b_V_key = ProcessWeights._get_param_key(f"blocks.{l}.attn.b_V", adapter)
             b_O_key = ProcessWeights._get_param_key(f"blocks.{l}.attn.b_O", adapter)
 
+            # Skip layers without attention weights (hybrid architectures where
+            # some layers are SSM/linear-attention and lack Q/K/V/O entirely).
+            # Other weight-processing loops (center_writing_weights, fold_value_biases,
+            # fold_layer_norm) already guard with `if key in state_dict:` checks.
+            if W_Q_key not in state_dict:
+                continue
+            # All four weight matrices must be present if Q is present
+            for _required_key in [W_K_key, W_V_key, W_O_key]:
+                if _required_key not in state_dict:
+                    raise ValueError(
+                        f"Inconsistent attention weights at layer {l}: "
+                        f"'{W_Q_key}' found but '{_required_key}' missing. "
+                        f"All of W_Q, W_K, W_V, W_O must be present together."
+                    )
+
             # W_QK = W_Q @ W_K.T
             # Concatenate biases to make a d_model+1 input dimension
             W_Q = ProcessWeights.convert_tensor_to_tl_format(


### PR DESCRIPTION
# Description
- Update benchmark system to handle models that do not have MLP and/or Attention on every block
- Significant base Bridge overhaul to add methods for handling hybrid model situations
- Update `component_setup` to allow skipping of components when set to optional
- Created `ComponentScores` – this allows us to expose composition scores with attached meta data, so we can tell which layer they are coming from – the index is no longer implied
- `generalized_components/base` passes through the `optional` parameter and whitelists it
- `_get_or_create_bias` handles hybrid architectures
- `_get_device_dtype` handles hybrid architectures
- weight processing skips layers without attention weights


## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility