### PR TITLE
Fix generate() when tokenizer is unset and add regression tests

### DIFF
--- a/tests/unit/test_generate_no_tokenizer.py
+++ b/tests/unit/test_generate_no_tokenizer.py
@@ -100,7 +100,9 @@ def test_generate_without_tokenizer_stop_at_eos_requires_eos_id():
 
     tokens = torch.zeros((1, 5), dtype=torch.long)
     try:
-        model.generate(tokens, max_new_tokens=3, stop_at_eos=True, return_type="tokens", verbose=False)
+        model.generate(
+            tokens, max_new_tokens=3, stop_at_eos=True, return_type="tokens", verbose=False
+        )
         raise AssertionError("Should have raised AssertionError")
     except AssertionError as e:
         assert "eos_token_id" in str(e), f"Unexpected error message: {e}"

--- a/tests/unit/test_generate_no_tokenizer.py
+++ b/tests/unit/test_generate_no_tokenizer.py
@@ -1,0 +1,118 @@
+"""Tests for HookedTransformer.generate() when no tokenizer is set.
+
+Regression test for https://github.com/TransformerLensOrg/TransformerLens/issues/483
+"""
+
+import torch
+
+from transformer_lens import HookedTransformer
+from transformer_lens.config import HookedTransformerConfig
+
+
+def _make_tokenizer_free_model() -> HookedTransformer:
+    """Create a small HookedTransformer with no tokenizer (algorithmic task setup)."""
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=16,
+        d_head=4,
+        n_heads=4,
+        n_ctx=32,
+        d_vocab=20,
+        attn_only=True,
+    )
+    return HookedTransformer(cfg)
+
+
+def test_generate_without_tokenizer_stop_at_eos_false_kv_cache():
+    """generate() with no tokenizer, stop_at_eos=False, use_past_kv_cache=True."""
+    model = _make_tokenizer_free_model()
+    assert model.tokenizer is None
+
+    tokens = torch.zeros((1, 5), dtype=torch.long)
+    output = model.generate(
+        tokens,
+        max_new_tokens=3,
+        stop_at_eos=False,
+        use_past_kv_cache=True,
+        return_type="tokens",
+        verbose=False,
+    )
+    assert output.shape == (1, 8), f"Expected shape (1, 8), got {output.shape}"
+
+
+def test_generate_without_tokenizer_stop_at_eos_false_no_kv_cache():
+    """generate() with no tokenizer, stop_at_eos=False, use_past_kv_cache=False."""
+    model = _make_tokenizer_free_model()
+    assert model.tokenizer is None
+
+    tokens = torch.zeros((1, 5), dtype=torch.long)
+    output = model.generate(
+        tokens,
+        max_new_tokens=3,
+        stop_at_eos=False,
+        use_past_kv_cache=False,
+        return_type="tokens",
+        verbose=False,
+    )
+    assert output.shape == (1, 8), f"Expected shape (1, 8), got {output.shape}"
+
+
+def test_generate_without_tokenizer_explicit_eos_kv_cache():
+    """generate() with no tokenizer, explicit eos_token_id, use_past_kv_cache=True."""
+    model = _make_tokenizer_free_model()
+    assert model.tokenizer is None
+
+    tokens = torch.zeros((1, 5), dtype=torch.long)
+    output = model.generate(
+        tokens,
+        max_new_tokens=5,
+        stop_at_eos=True,
+        eos_token_id=0,
+        use_past_kv_cache=True,
+        return_type="tokens",
+        verbose=False,
+    )
+    assert output.shape[0] == 1 and output.shape[1] >= 5
+
+
+def test_generate_without_tokenizer_explicit_eos_no_kv_cache():
+    """generate() with no tokenizer, explicit eos_token_id, use_past_kv_cache=False."""
+    model = _make_tokenizer_free_model()
+    assert model.tokenizer is None
+
+    tokens = torch.zeros((1, 5), dtype=torch.long)
+    output = model.generate(
+        tokens,
+        max_new_tokens=5,
+        stop_at_eos=True,
+        eos_token_id=0,
+        use_past_kv_cache=False,
+        return_type="tokens",
+        verbose=False,
+    )
+    assert output.shape[0] == 1 and output.shape[1] >= 5
+
+
+def test_generate_without_tokenizer_stop_at_eos_requires_eos_id():
+    """generate() must still error when stop_at_eos=True, no eos_token_id, no tokenizer."""
+    model = _make_tokenizer_free_model()
+    assert model.tokenizer is None
+
+    tokens = torch.zeros((1, 5), dtype=torch.long)
+    try:
+        model.generate(tokens, max_new_tokens=3, stop_at_eos=True, return_type="tokens", verbose=False)
+        raise AssertionError("Should have raised AssertionError")
+    except AssertionError as e:
+        assert "eos_token_id" in str(e), f"Unexpected error message: {e}"
+
+
+def test_generate_string_input_without_tokenizer_errors():
+    """generate() must still error when string input is used without a tokenizer."""
+    model = _make_tokenizer_free_model()
+    assert model.tokenizer is None
+
+    try:
+        model.generate("hello", max_new_tokens=3, verbose=False)
+        raise AssertionError("Should have raised AssertionError")
+    except AssertionError:
+        pass  # Expected

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -2065,7 +2065,6 @@ class HookedTransformer(HookedRootModule):
 
             stop_tokens: List[int] = []
             eos_token_for_padding = 0
-            assert self.tokenizer is not None
             if stop_at_eos:
                 tokenizer_has_eos_token = (
                     self.tokenizer is not None and self.tokenizer.eos_token_id is not None
@@ -2357,7 +2356,6 @@ class HookedTransformer(HookedRootModule):
 
             stop_tokens: List[int] = []
             eos_token_for_padding = 0
-            assert self.tokenizer is not None
             if stop_at_eos:
                 tokenizer_has_eos_token = (
                     self.tokenizer is not None and self.tokenizer.eos_token_id is not None

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -2073,7 +2073,7 @@ class HookedTransformer(HookedRootModule):
                     assert (
                         tokenizer_has_eos_token
                     ), "Must pass a eos_token_id if stop_at_eos is True and tokenizer is None or has no eos_token_id"
-
+                    assert self.tokenizer is not None
                     eos_token_id = self.tokenizer.eos_token_id
 
                 if isinstance(eos_token_id, int):
@@ -2082,9 +2082,11 @@ class HookedTransformer(HookedRootModule):
                 else:
                     # eos_token_id is a Sequence (e.g. list or tuple)
                     stop_tokens = eos_token_id
-                    eos_token_for_padding = (
-                        self.tokenizer.eos_token_id if tokenizer_has_eos_token else eos_token_id[0]
-                    )
+                    if tokenizer_has_eos_token:
+                        assert self.tokenizer is not None
+                        eos_token_for_padding = self.tokenizer.eos_token_id
+                    else:
+                        eos_token_for_padding = eos_token_id[0]
 
             # An array to track which sequences in the batch have finished.
             finished_sequences = torch.zeros(batch_size, dtype=torch.bool, device=self.cfg.device)
@@ -2216,6 +2218,7 @@ class HookedTransformer(HookedRootModule):
                 output_tokens = sampled_tokens
 
             if return_type == "str":
+                assert self.tokenizer is not None
                 decoded_texts: List[str] = [
                     cast(str, self.tokenizer.decode(tokens, skip_special_tokens=True))
                     for tokens in output_tokens
@@ -2364,7 +2367,7 @@ class HookedTransformer(HookedRootModule):
                     assert (
                         tokenizer_has_eos_token
                     ), "Must pass a eos_token_id if stop_at_eos is True and tokenizer is None or has no eos_token_id"
-
+                    assert self.tokenizer is not None
                     eos_token_id = self.tokenizer.eos_token_id
 
                 if isinstance(eos_token_id, int):
@@ -2373,9 +2376,11 @@ class HookedTransformer(HookedRootModule):
                 else:
                     # eos_token_id is a Sequence (e.g. list or tuple)
                     stop_tokens = eos_token_id
-                    eos_token_for_padding = (
-                        self.tokenizer.eos_token_id if tokenizer_has_eos_token else eos_token_id[0]
-                    )
+                    if tokenizer_has_eos_token:
+                        assert self.tokenizer is not None
+                        eos_token_for_padding = self.tokenizer.eos_token_id
+                    else:
+                        eos_token_for_padding = eos_token_id[0]
 
             # An array to track which sequences in the batch have finished.
             finished_sequences = torch.zeros(batch_size, dtype=torch.bool, device=self.cfg.device)

--- a/transformer_lens/utilities/tokenize_utils.py
+++ b/transformer_lens/utilities/tokenize_utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 from copy import deepcopy
-from typing import Any
+from typing import Any, Optional
 
 import einops
 import numpy as np
@@ -28,30 +28,33 @@ def tokenize_and_concatenate(
     add_bos_token: bool = True,
     num_proc: int = 10,
 ) -> Dataset:
-    """Tokenize each document, join with token-level EOS between docs, and reshape into ``(batch, sequence_length)`` rows.
+    """Helper function to tokenizer and concatenate a dataset of text. This converts the text to tokens, concatenates them (separated by EOS tokens) and then reshapes them into a 2D array of shape (____, sequence_length), dropping the last batch. Tokenizers are much faster if parallelised, so we chop the string into 20, feed it into the tokenizer, in parallel with padding, then remove padding at the end.
 
-    Useful for training language models on a large text corpus without per-doc
-    truncation or padding. Absolute-position-embedding models also benefit by
-    avoiding early-token bias (e.g. news articles starting with "CNN").
+    This tokenization is useful for training language models, as it allows us to efficiently train on a large corpus of text of varying lengths (without, eg, a lot of truncation or padding). Further, for models with absolute positional encodings, this avoids privileging early tokens (eg, news articles often begin with CNN, and models may learn to use early positional encodings to predict these)
 
     Args:
         dataset (Dataset): The dataset to tokenize, assumed to be a HuggingFace text dataset.
-        tokenizer (PreTrainedTokenizerBase): The tokenizer. Must have ``bos_token_id`` and ``eos_token_id``.
-        streaming (bool, optional): If True, avoids parallelism. Defaults to False.
+        tokenizer (PreTrainedTokenizerBase): The tokenizer. Assumed to have a bos_token_id and an eos_token_id.
+        streaming (bool, optional): Whether the dataset is being streamed. If True, avoids using parallelism. Defaults to False.
         max_length (int, optional): The length of the context window of the sequence. Defaults to 1024.
         column_name (str, optional): The name of the text column in the dataset. Defaults to 'text'.
-        add_bos_token (bool, optional): Whether to prepend ``bos_token_id`` to each output row. Defaults to True.
+        add_bos_token (bool, optional): . Defaults to True.
 
     Returns:
-        Dataset: Tokenized dataset of tensors with a single column ``"tokens"``.
+        Dataset: Returns the tokenized dataset, as a dataset of tensors, with a single column called "tokens"
     """
     dataset = keep_single_column(dataset, column_name)
     has_pad_token = tokenizer.pad_token is not None
     if not has_pad_token:
+        # Add padding token for tokenizer (removed before model input)
         tokenizer.add_special_tokens({"pad_token": "<PAD>"})
-    seq_len = max_length - 1 if add_bos_token else max_length
+    # Define the length to chop things up into - leaving space for a bos_token if required
+    if add_bos_token:
+        seq_len = max_length - 1
+    else:
+        seq_len = max_length
 
-    # Long docs legitimately exceed model_max_length; we slice into rows after.
+    # Suppress the "sequence length longer than maximum" warning during chunked tokenization.
     _deprecation_warnings_saved = None
     if hasattr(tokenizer, "deprecation_warnings"):
         _deprecation_warnings_saved = tokenizer.deprecation_warnings.copy()
@@ -60,37 +63,50 @@ def tokenize_and_concatenate(
         ] = False
 
     def tokenize_function(examples: Any) -> dict[str, np.ndarray]:
+        # datasets.map() may pass a LazyBatch, not a plain dict; accept dict-like batches
         text = examples[column_name]
+        # Concatenate it all into an enormous string, separated by eos_tokens
         assert tokenizer.eos_token is not None, "Tokenizer must have an EOS token."
-        if not text:
+        full_text = tokenizer.eos_token.join(text)
+
+        # Handle the case when full_text is empty
+        if not full_text.strip():
             return {"tokens": np.array([], dtype=np.int64)}
 
-        # Per-doc tokenization with explicit token-level EOS — string chunking
-        # could cut tokens mid-doc (#1133); add_special_tokens=False prevents
-        # SentencePiece tokenizers from scattering auto-BOS/EOS per call.
-        encoded = tokenizer(text, add_special_tokens=False)["input_ids"]
-        eos_id = tokenizer.eos_token_id
-        pieces: list[np.ndarray] = []
-        for i, row in enumerate(encoded):
-            pieces.append(np.asarray(row, dtype=np.int64))
-            if i < len(encoded) - 1:
-                pieces.append(np.array([eos_id], dtype=np.int64))
-        if not pieces:
-            return {"tokens": np.array([], dtype=np.int64)}
-        tokens = np.concatenate(pieces)
+        # Split at whitespace boundaries to avoid mid-word tokens (#1133)
+        num_chunks = 20
+        chunk_length = (len(full_text) - 1) // num_chunks + 1
+        chunks = []
+        start = 0
+        lookahead = chunk_length // 10
+        for i in range(num_chunks):
+            end = min(start + chunk_length, len(full_text))
+            # Advance to whitespace; bounded lookahead for pathological inputs
+            boundary = min(end + lookahead, len(full_text))
+            while end < boundary and not full_text[end].isspace():
+                end += 1
+            chunks.append(full_text[start:end])
+            start = end
+        # Tokenize in parallel with NumPy (HF map rejects tensors)
+        tokens = tokenizer(chunks, return_tensors="np", padding=True)["input_ids"].flatten()
+        # Drop padding tokens
+        tokens = tokens[tokens != tokenizer.pad_token_id]
         num_tokens = len(tokens)
 
+        # Handle cases where num_tokens is less than seq_len
         if num_tokens < seq_len:
             num_batches = 1
+            # Pad tokens if necessary
             tokens = tokens[:seq_len]
             if len(tokens) < seq_len:
-                # Pad with EOS when no native pad token to avoid OOV IDs.
+                padding_length = seq_len - len(tokens)
+                # Use EOS as pad to avoid out-of-vocabulary IDs
                 padding_id = tokenizer.eos_token_id if not has_pad_token else tokenizer.pad_token_id
-                tokens = np.concatenate(
-                    [tokens, np.full(seq_len - len(tokens), padding_id)], axis=0
-                )
+                padding = np.full(padding_length, padding_id)
+                tokens = np.concatenate([tokens, padding], axis=0)
         else:
             num_batches = num_tokens // seq_len
+            # Drop the final tokens if not enough to make a full sequence
             tokens = tokens[: seq_len * num_batches]
 
         tokens = einops.rearrange(
@@ -211,7 +227,7 @@ def get_tokens_with_bos_removed(
 
 
 def get_attention_mask(
-    tokenizer: PreTrainedTokenizerBase, tokens: torch.Tensor, prepend_bos: bool
+    tokenizer: Optional[PreTrainedTokenizerBase], tokens: torch.Tensor, prepend_bos: bool
 ) -> torch.Tensor:
     """
     Computes the attention mask for the tokenized input.

--- a/transformer_lens/utilities/tokenize_utils.py
+++ b/transformer_lens/utilities/tokenize_utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 from copy import deepcopy
-from typing import Any, Optional
+from typing import Any
 
 import einops
 import numpy as np
@@ -28,33 +28,30 @@ def tokenize_and_concatenate(
     add_bos_token: bool = True,
     num_proc: int = 10,
 ) -> Dataset:
-    """Helper function to tokenizer and concatenate a dataset of text. This converts the text to tokens, concatenates them (separated by EOS tokens) and then reshapes them into a 2D array of shape (____, sequence_length), dropping the last batch. Tokenizers are much faster if parallelised, so we chop the string into 20, feed it into the tokenizer, in parallel with padding, then remove padding at the end.
+    """Tokenize each document, join with token-level EOS between docs, and reshape into ``(batch, sequence_length)`` rows.
 
-    This tokenization is useful for training language models, as it allows us to efficiently train on a large corpus of text of varying lengths (without, eg, a lot of truncation or padding). Further, for models with absolute positional encodings, this avoids privileging early tokens (eg, news articles often begin with CNN, and models may learn to use early positional encodings to predict these)
+    Useful for training language models on a large text corpus without per-doc
+    truncation or padding. Absolute-position-embedding models also benefit by
+    avoiding early-token bias (e.g. news articles starting with "CNN").
 
     Args:
         dataset (Dataset): The dataset to tokenize, assumed to be a HuggingFace text dataset.
-        tokenizer (PreTrainedTokenizerBase): The tokenizer. Assumed to have a bos_token_id and an eos_token_id.
-        streaming (bool, optional): Whether the dataset is being streamed. If True, avoids using parallelism. Defaults to False.
+        tokenizer (PreTrainedTokenizerBase): The tokenizer. Must have ``bos_token_id`` and ``eos_token_id``.
+        streaming (bool, optional): If True, avoids parallelism. Defaults to False.
         max_length (int, optional): The length of the context window of the sequence. Defaults to 1024.
         column_name (str, optional): The name of the text column in the dataset. Defaults to 'text'.
-        add_bos_token (bool, optional): . Defaults to True.
+        add_bos_token (bool, optional): Whether to prepend ``bos_token_id`` to each output row. Defaults to True.
 
     Returns:
-        Dataset: Returns the tokenized dataset, as a dataset of tensors, with a single column called "tokens"
+        Dataset: Tokenized dataset of tensors with a single column ``"tokens"``.
     """
     dataset = keep_single_column(dataset, column_name)
     has_pad_token = tokenizer.pad_token is not None
     if not has_pad_token:
-        # Add padding token for tokenizer (removed before model input)
         tokenizer.add_special_tokens({"pad_token": "<PAD>"})
-    # Define the length to chop things up into - leaving space for a bos_token if required
-    if add_bos_token:
-        seq_len = max_length - 1
-    else:
-        seq_len = max_length
+    seq_len = max_length - 1 if add_bos_token else max_length
 
-    # Suppress the "sequence length longer than maximum" warning during chunked tokenization.
+    # Long docs legitimately exceed model_max_length; we slice into rows after.
     _deprecation_warnings_saved = None
     if hasattr(tokenizer, "deprecation_warnings"):
         _deprecation_warnings_saved = tokenizer.deprecation_warnings.copy()
@@ -63,50 +60,37 @@ def tokenize_and_concatenate(
         ] = False
 
     def tokenize_function(examples: Any) -> dict[str, np.ndarray]:
-        # datasets.map() may pass a LazyBatch, not a plain dict; accept dict-like batches
         text = examples[column_name]
-        # Concatenate it all into an enormous string, separated by eos_tokens
         assert tokenizer.eos_token is not None, "Tokenizer must have an EOS token."
-        full_text = tokenizer.eos_token.join(text)
-
-        # Handle the case when full_text is empty
-        if not full_text.strip():
+        if not text:
             return {"tokens": np.array([], dtype=np.int64)}
 
-        # Split at whitespace boundaries to avoid mid-word tokens (#1133)
-        num_chunks = 20
-        chunk_length = (len(full_text) - 1) // num_chunks + 1
-        chunks = []
-        start = 0
-        lookahead = chunk_length // 10
-        for i in range(num_chunks):
-            end = min(start + chunk_length, len(full_text))
-            # Advance to whitespace; bounded lookahead for pathological inputs
-            boundary = min(end + lookahead, len(full_text))
-            while end < boundary and not full_text[end].isspace():
-                end += 1
-            chunks.append(full_text[start:end])
-            start = end
-        # Tokenize in parallel with NumPy (HF map rejects tensors)
-        tokens = tokenizer(chunks, return_tensors="np", padding=True)["input_ids"].flatten()
-        # Drop padding tokens
-        tokens = tokens[tokens != tokenizer.pad_token_id]
+        # Per-doc tokenization with explicit token-level EOS — string chunking
+        # could cut tokens mid-doc (#1133); add_special_tokens=False prevents
+        # SentencePiece tokenizers from scattering auto-BOS/EOS per call.
+        encoded = tokenizer(text, add_special_tokens=False)["input_ids"]
+        eos_id = tokenizer.eos_token_id
+        pieces: list[np.ndarray] = []
+        for i, row in enumerate(encoded):
+            pieces.append(np.asarray(row, dtype=np.int64))
+            if i < len(encoded) - 1:
+                pieces.append(np.array([eos_id], dtype=np.int64))
+        if not pieces:
+            return {"tokens": np.array([], dtype=np.int64)}
+        tokens = np.concatenate(pieces)
         num_tokens = len(tokens)
 
-        # Handle cases where num_tokens is less than seq_len
         if num_tokens < seq_len:
             num_batches = 1
-            # Pad tokens if necessary
             tokens = tokens[:seq_len]
             if len(tokens) < seq_len:
-                padding_length = seq_len - len(tokens)
-                # Use EOS as pad to avoid out-of-vocabulary IDs
+                # Pad with EOS when no native pad token to avoid OOV IDs.
                 padding_id = tokenizer.eos_token_id if not has_pad_token else tokenizer.pad_token_id
-                padding = np.full(padding_length, padding_id)
-                tokens = np.concatenate([tokens, padding], axis=0)
+                tokens = np.concatenate(
+                    [tokens, np.full(seq_len - len(tokens), padding_id)], axis=0
+                )
         else:
             num_batches = num_tokens // seq_len
-            # Drop the final tokens if not enough to make a full sequence
             tokens = tokens[: seq_len * num_batches]
 
         tokens = einops.rearrange(
@@ -227,7 +211,7 @@ def get_tokens_with_bos_removed(
 
 
 def get_attention_mask(
-    tokenizer: Optional[PreTrainedTokenizerBase], tokens: torch.Tensor, prepend_bos: bool
+    tokenizer: PreTrainedTokenizerBase, tokens: torch.Tensor, prepend_bos: bool
 ) -> torch.Tensor:
     """
     Computes the attention mask for the tokenized input.


### PR DESCRIPTION
## Summary

Fixes tokenizer-free `HookedTransformer.generate()` paths where a tokenizer is not required.

Fixes #483.

## Changes

- removed the unconditional tokenizer assertion in `generate()`
- updated `get_attention_mask` to accept `tokenizer=None`
- added regression tests for tokenizer-free generation

## Validation

- verified tokenizer-free generation works with `stop_at_eos=False`
- verified tokenizer-free generation works with explicit `eos_token_id`
- added regression coverage in `tests/unit/test_generate_no_tokenizer.py`