### PR TITLE
Updated `boot_transformers` to use local hf_config, if provided

### DIFF
--- a/tests/integration/model_bridge/test_bridge_creation_modes.py
+++ b/tests/integration/model_bridge/test_bridge_creation_modes.py
@@ -130,3 +130,78 @@ class TestBridgeCreationModes:
 
         # Should not raise any memory-related errors
         assert True, "Memory cleanup should work correctly"
+
+
+class TestBridgeOfflineWithHfModel:
+    """Bridge must reuse hf_model.config when supplied, not refetch from the Hub (#846)."""
+
+    OFFLINE_MODEL = "trl-internal-testing/tiny-MistralForCausalLM-0.2"
+
+    @pytest.fixture
+    def hf_model(self):
+        from transformers import AutoModelForCausalLM
+
+        return AutoModelForCausalLM.from_pretrained(self.OFFLINE_MODEL).eval()
+
+    @pytest.fixture
+    def tokenizer(self):
+        from transformers import AutoTokenizer
+
+        return AutoTokenizer.from_pretrained(self.OFFLINE_MODEL)
+
+    def test_offline_boot_with_hf_model(self, hf_model, tokenizer):
+        """Bridge boot succeeds when AutoConfig.from_pretrained would fail."""
+        from unittest.mock import patch
+
+        import transformer_lens.model_bridge.sources.transformers as bridge_source
+
+        with patch.object(bridge_source, "AutoConfig") as mock_autoconfig:
+            mock_autoconfig.from_pretrained.side_effect = OSError("Simulated Hub failure")
+
+            bridge = TransformerBridge.boot_transformers(
+                self.OFFLINE_MODEL, hf_model=hf_model, tokenizer=tokenizer
+            )
+
+            test_input = tokenizer("Hello", return_tensors="pt")["input_ids"]
+            with torch.no_grad():
+                logits = bridge(test_input)
+            assert torch.isfinite(logits).all()
+
+    def test_hf_model_config_not_mutated_by_bridge(self, hf_model, tokenizer):
+        """hf_config_overrides / n_ctx / pad_token_id mutations must not leak into hf_model.config.
+
+        Bridge works on a deepcopy so the user's loaded model stays clean. Catches a
+        regression where the deepcopy is dropped in favor of a direct reference.
+        """
+        snapshot = {
+            "max_position_embeddings": getattr(hf_model.config, "max_position_embeddings", None),
+            "pad_token_id": getattr(hf_model.config, "pad_token_id", None),
+            "output_attentions": getattr(hf_model.config, "output_attentions", None),
+        }
+
+        TransformerBridge.boot_transformers(
+            self.OFFLINE_MODEL,
+            hf_model=hf_model,
+            tokenizer=tokenizer,
+            hf_config_overrides={"max_position_embeddings": 999},
+            n_ctx=128,
+        )
+
+        for attr, original_value in snapshot.items():
+            assert (
+                getattr(hf_model.config, attr, None) == original_value
+            ), f"Bridge mutated hf_model.config.{attr}"
+
+    def test_autoconfig_not_called_when_hf_model_provided(self, hf_model, tokenizer):
+        """Patches AutoConfig in the bridge module only — transitive calls from AutoTokenizer
+        (which uses ``transformers.AutoConfig`` directly) aren't intercepted.
+        """
+        from unittest.mock import patch
+
+        import transformer_lens.model_bridge.sources.transformers as bridge_source
+
+        with patch.object(bridge_source, "AutoConfig") as mock_autoconfig:
+            TransformerBridge.boot_transformers(
+                self.OFFLINE_MODEL, hf_model=hf_model, tokenizer=tokenizer
+            )
+            assert not mock_autoconfig.from_pretrained.called

--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -335,12 +335,17 @@ def boot(
     from transformer_lens.utilities.hf_utils import get_hf_token
 
     _hf_token = get_hf_token()
-    hf_config = AutoConfig.from_pretrained(
-        model_name,
-        output_attentions=True,
-        trust_remote_code=trust_remote_code,
-        token=_hf_token,
-    )
+    if hf_model is not None:
+        # Reuse the pre-loaded model's config to avoid a Hub call when model_name
+        # is a Hub repo ID, but the model is already loaded locally.
+        hf_config = copy.deepcopy(hf_model.config)
+    else:
+        hf_config = AutoConfig.from_pretrained(
+            model_name,
+            output_attentions=True,
+            trust_remote_code=trust_remote_code,
+            token=_hf_token,
+        )
     _n_ctx_field: str | None = None
     if n_ctx is not None:
         # Validation (#2): reject non-positive values before doing anything else.


### PR DESCRIPTION
# Description

When a local `hf_model` is provided, default to using that models `hf_config` object rather than requesting from HuggingFace again. This saves a network call to HF and will working better for users with limited access.

Added tests to confirm this new load path works as expected.

Fixes #846 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility