### PR TITLE
Prevent weight processing split between devices

### DIFF
--- a/tests/unit/test_weight_processing.py
+++ b/tests/unit/test_weight_processing.py
@@ -474,6 +474,35 @@ class TestProcessWeights:
             b_v = processed_dict[f"blocks.{l}.attn._b_V"]
             assert torch.allclose(b_v, torch.zeros_like(b_v), atol=1e-6)
 
+    @pytest.mark.skipif(
+        not (torch.cuda.is_available() or torch.backends.mps.is_available()),
+        reason="Cross-device test requires a non-CPU accelerator (CUDA or MPS)",
+    )
+    def test_fold_value_biases_cross_device_state_dict(self, basic_config, basic_state_dict):
+        """fold_value_biases must align tensors when state_dict has mixed devices.
+
+        Regression for #904: an HF model loaded on GPU could end up with state_dict
+        tensors on different devices (b_V on GPU, b_O on CPU because a downstream
+        converter created it without an explicit device=). The b_V * W_O multiply
+        then failed with a cross-device RuntimeError.
+        """
+        accelerator = "cuda" if torch.cuda.is_available() else "mps"
+        cross_device_dict = deep_copy_state_dict(basic_state_dict)
+        for l in range(basic_config.n_layers):
+            cross_device_dict[f"blocks.{l}.attn.b_V"] = cross_device_dict[
+                f"blocks.{l}.attn.b_V"
+            ].to(accelerator)
+            cross_device_dict[f"blocks.{l}.attn.W_V"] = cross_device_dict[
+                f"blocks.{l}.attn.W_V"
+            ].to(accelerator)
+            # W_O and b_O stay on CPU — mirrors the #904 mismatch pattern.
+
+        processed_dict = ProcessWeights.fold_value_biases(cross_device_dict, basic_config)
+
+        for l in range(basic_config.n_layers):
+            b_v = processed_dict[f"blocks.{l}.attn.b_V"]
+            assert torch.allclose(b_v, torch.zeros_like(b_v), atol=1e-6)
+
     def test_refactor_factored_attn_matrices(self, basic_config, basic_state_dict):
         """Test attention matrix refactoring."""
         original_dict = deep_copy_state_dict(basic_state_dict)

--- a/transformer_lens/weight_processing.py
+++ b/transformer_lens/weight_processing.py
@@ -1426,6 +1426,11 @@ class ProcessWeights:
                         b_O_original_maybe is not None
                     ), f"Attention b_O not found at key {b_O_key}"
                     b_O_original = b_O_original_maybe
+                # Align W_O / b_O to b_V's device.
+                if W_O.device != b_V.device:
+                    W_O = W_O.to(b_V.device)
+                if b_O_original.device != b_V.device:
+                    b_O_original = b_O_original.to(b_V.device)
                 is_split_format = ".attn.v.bias" in b_V_key or ".attn.k.bias" in b_V_key
                 if is_split_format and len(b_V.shape) == 1 and (len(W_O.shape) == 2):
                     n_heads = cfg.n_heads


### PR DESCRIPTION
# Description

Defensive change to prevent #904 from reoccurring in the future. Ensures processing is done on a single device

Fixes #904

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility