### PR TITLE
Fix: preserve tokenizer.padding_side when reloading with add_bos_token

### DIFF
--- a/tests/unit/test_tokenizer_padding_side.py
+++ b/tests/unit/test_tokenizer_padding_side.py
@@ -1,0 +1,45 @@
+"""Tests for tokenizer padding_side preservation.
+
+Regression test for https://github.com/TransformerLensOrg/TransformerLens/issues/801
+
+When a tokenizer is reloaded via AutoTokenizer.from_pretrained() inside
+get_tokenizer_with_bos(), HuggingFace silently resets padding_side to its
+default (usually "right"). This previously caused user-set padding_side="left"
+to be silently discarded.
+"""
+
+import pytest
+from transformers import AutoTokenizer
+
+from transformer_lens.utilities.tokenize_utils import get_tokenizer_with_bos
+
+
+@pytest.fixture(scope="module")
+def gpt2_tokenizer():
+    """A fresh GPT-2 tokenizer (cached by HF). add_bos_token defaults to False."""
+    return AutoTokenizer.from_pretrained("gpt2")
+
+
+def test_padding_side_left_is_preserved(gpt2_tokenizer):
+    """User-set padding_side='left' must be preserved through get_tokenizer_with_bos()."""
+    gpt2_tokenizer.padding_side = "left"
+    result = get_tokenizer_with_bos(gpt2_tokenizer)
+    assert (
+        result.padding_side == "left"
+    ), f"padding_side='left' was reset to '{result.padding_side}' after reload"
+
+
+def test_padding_side_right_is_preserved(gpt2_tokenizer):
+    """User-set padding_side='right' must also round-trip correctly."""
+    gpt2_tokenizer.padding_side = "right"
+    result = get_tokenizer_with_bos(gpt2_tokenizer)
+    assert result.padding_side == "right"
+
+
+def test_padding_side_preserved_when_already_has_bos():
+    """When add_bos_token is already True, function returns original tokenizer unchanged."""
+    tokenizer = AutoTokenizer.from_pretrained("gpt2", add_bos_token=True)
+    tokenizer.padding_side = "left"
+    result = get_tokenizer_with_bos(tokenizer)
+    # Same object (no reload happened), so padding_side is naturally preserved
+    assert result.padding_side == "left"

--- a/transformer_lens/utilities/tokenize_utils.py
+++ b/transformer_lens/utilities/tokenize_utils.py
@@ -58,9 +58,9 @@ def tokenize_and_concatenate(
     _deprecation_warnings_saved = None
     if hasattr(tokenizer, "deprecation_warnings"):
         _deprecation_warnings_saved = tokenizer.deprecation_warnings.copy()
-        tokenizer.deprecation_warnings[
-            "sequence-length-is-longer-than-the-specified-maximum"
-        ] = False
+        tokenizer.deprecation_warnings["sequence-length-is-longer-than-the-specified-maximum"] = (
+            False
+        )
 
     def tokenize_function(examples: Any) -> dict[str, np.ndarray]:
         # datasets.map() may pass a LazyBatch, not a plain dict; accept dict-like batches
@@ -170,6 +170,11 @@ def get_tokenizer_with_bos(tokenizer: PreTrainedTokenizerBase) -> PreTrainedToke
             token=huggingface_token if len(huggingface_token) > 0 else None,
             **init_kwargs,
         )
+        # Preserve padding_side from the original tokenizer, since AutoTokenizer.from_pretrained
+        # resets it to the HuggingFace default (usually "right"). Without this, callers who
+        # explicitly set tokenizer.padding_side = "left" before passing the tokenizer in would
+        # have that setting silently discarded. See issue #801.
+        tokenizer_with_bos.padding_side = tokenizer.padding_side
 
     return tokenizer_with_bos
 

--- a/transformer_lens/utilities/tokenize_utils.py
+++ b/transformer_lens/utilities/tokenize_utils.py
@@ -58,9 +58,9 @@ def tokenize_and_concatenate(
     _deprecation_warnings_saved = None
     if hasattr(tokenizer, "deprecation_warnings"):
         _deprecation_warnings_saved = tokenizer.deprecation_warnings.copy()
-        tokenizer.deprecation_warnings["sequence-length-is-longer-than-the-specified-maximum"] = (
-            False
-        )
+        tokenizer.deprecation_warnings[
+            "sequence-length-is-longer-than-the-specified-maximum"
+        ] = False
 
     def tokenize_function(examples: Any) -> dict[str, np.ndarray]:
         # datasets.map() may pass a LazyBatch, not a plain dict; accept dict-like batches


### PR DESCRIPTION
## Summary

Fixes #801.

When `get_tokenizer_with_bos()` reloads a tokenizer via `AutoTokenizer.from_pretrained(...)` to set `add_bos_token=True`, HuggingFace silently resets `padding_side` to its default (usually `"right"`). User-set `padding_side="left"` was being discarded silently when passing a tokenizer into `HookedTransformer`.

This affects models that need left padding for batched generation — Gemma, Falcon, and other decoder-only models where the user explicitly sets `tokenizer.padding_side = "left"` before passing the tokenizer in.

**Before:**
```python
tok = AutoTokenizer.from_pretrained("gpt2")
tok.padding_side = "left"
model = HookedTransformer.from_pretrained("gpt2", tokenizer=tok)
print(model.tokenizer.padding_side)  # → 'right' (silently reset!)
```

**After:**
```python
tok.padding_side = "left"
model = HookedTransformer.from_pretrained("gpt2", tokenizer=tok)
print(model.tokenizer.padding_side)  # → 'left' (preserved)
```

## Changes

- **`transformer_lens/utilities/tokenize_utils.py`** — In `get_tokenizer_with_bos()`, after `AutoTokenizer.from_pretrained()` reloads the tokenizer, copy `padding_side` from the original tokenizer to the reloaded one
- **`tests/unit/test_tokenizer_padding_side.py`** — New file with 3 regression tests covering left preservation, right preservation, and the no-reload path

## Test plan

- [x] `pytest tests/unit/test_tokenizer_padding_side.py` — 3 passed
- [x] Confirmed bug reproduces on unpatched dev (returns `'right'` when input was `'left'`)
- [x] Confirmed fix resolves the bug
- [x] No effect on tokenizers that already had `add_bos_token=True` (early return path)