### PR TITLE
fix: Bump CI actions and stabilize flaky notebook checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
@@ -114,7 +114,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
           activate-environment: true
@@ -181,7 +181,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
           activate-environment: true
@@ -200,7 +200,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
           activate-environment: true
@@ -219,7 +219,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
           activate-environment: true
@@ -238,7 +238,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
           activate-environment: true
@@ -331,7 +331,7 @@ jobs:
           sudo mkswap /swapfile
           sudo swapon /swapfile
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
           activate-environment: true
@@ -375,7 +375,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
           activate-environment: true

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,15 +54,15 @@ jobs:
           - "3.11"
           - "3.12"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
           enable-cache: true
       - name: Cache Models used with Tests
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/huggingface/hub/models--gpt2
@@ -113,13 +113,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.11"
           activate-environment: true
           enable-cache: true
       - name: MPS Cache Models
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/huggingface/hub/models--roneneldan--TinyStories-1M*
@@ -178,9 +178,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.12"
           activate-environment: true
@@ -197,9 +197,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.12"
           activate-environment: true
@@ -216,9 +216,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.12"
           activate-environment: true
@@ -235,15 +235,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.12"
           activate-environment: true
           enable-cache: true
       - name: Cache Models used with Tests
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/huggingface/hub/models--gpt2
@@ -282,7 +282,7 @@ jobs:
       - name: Build check
         run: uv build
       - name: Upload Coverage Report Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-coverage
           path: htmlcov
@@ -320,7 +320,7 @@ jobs:
           - notebook: "LLaMA2_GPU_Quantized"
             requires_hf_token: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Add swap space
         run: |
           sudo swapoff /swapfile 2>/dev/null || true
@@ -330,13 +330,13 @@ jobs:
           sudo mkswap /swapfile
           sudo swapon /swapfile
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.11"
           activate-environment: true
           enable-cache: true
       - name: Re-use HuggingFace models cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/huggingface/hub
           key: ${{ runner.os }}-huggingface-models
@@ -374,7 +374,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.11"
           activate-environment: true
@@ -389,7 +389,7 @@ jobs:
           uv lock --check
           uv sync
       - name: Download Test Coverage Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: test-coverage
           path: docs/source/_static/coverage
@@ -403,7 +403,7 @@ jobs:
         env:
           HF_TOKEN:  ${{ secrets.HF_TOKEN }}
       - name: Upload Docs Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: documentation
           path: docs/build
@@ -417,7 +417,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download Docs Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: documentation
           path: docs/build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,7 @@
 name: Checks
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
           activate-environment: true
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
           activate-environment: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.12"
           activate-environment: true
@@ -44,9 +44,9 @@ jobs:
       - semver-parser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.12"
           activate-environment: true

--- a/demos/doc_sanitize.cfg
+++ b/demos/doc_sanitize.cfg
@@ -13,3 +13,7 @@ replace: HEX-CODE
 [regex4]
 regex: ,\s*device='[^']*'
 replace:
+
+[regex5]
+regex: (\d+\.\d{3})\d+
+replace: \1

--- a/demos/doc_sanitize.cfg
+++ b/demos/doc_sanitize.cfg
@@ -18,6 +18,18 @@ replace:
 regex: ([1-9]\d*\.\d{3})\d+
 replace: \1
 
-[regex6]
-regex: (0\.\d{4})\d+
+[regex6a]
+regex: (0\.000[1-9]\d{2})\d+
+replace: \1
+
+[regex6b]
+regex: (0\.00[1-9]\d{2})\d+
+replace: \1
+
+[regex6c]
+regex: (0\.0[1-9]\d{2})\d+
+replace: \1
+
+[regex6d]
+regex: (0\.[1-9]\d{2})\d+
 replace: \1

--- a/demos/doc_sanitize.cfg
+++ b/demos/doc_sanitize.cfg
@@ -15,5 +15,9 @@ regex: ,\s*device='[^']*'
 replace:
 
 [regex5]
-regex: (\d+\.\d{3})\d+
+regex: ([1-9]\d*\.\d{3})\d+
+replace: \1
+
+[regex6]
+regex: (0\.\d{4})\d+
 replace: \1


### PR DESCRIPTION
## Description

Two changes:

**1. Node.js deprecation warnings in CI**  
Bumped all GitHub Actions to latest stable versions to clear Node.js 20 deprecation warnings (`checkout@v3-v4`, `cache@v3-v4`, `upload-artifact@v4-v7`, `download-artifact@v4-v8`, `setup-uv@v6-v7`). Also added `workflow_dispatch` to checks.yml for manual runs.

**2. Flaky notebook checks**  
Some notebooks (e.g. Santa_Coder) fail intermittently due to tiny floating-point noise across CI runs (~3.9515 vs ~3.9514). Following the same principle as the GQA `allclose` fix, I added a regex sanitizer to `doc_sanitize.cfg` that truncates floats to 3 decimal places before comparison. This preserves meaningful numerical checks while absorbing last-bit precision noise.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility