### PR TITLE
Add Direct Logit Attribution tool for TransformerBridge

### DIFF
--- a/tests/integration/model_bridge/test_direct_logit_attribution.py
+++ b/tests/integration/model_bridge/test_direct_logit_attribution.py
@@ -1,0 +1,102 @@
+"""Integration tests for the Direct Logit Attribution tool on a TransformerBridge.
+
+DLA decomposes the residual-stream part of a logit (or logit difference) via the
+unembedding direction ``W_U[:, token]``. The unembedding bias ``b_U`` is a
+per-token constant that no component produces, so a complete decomposition
+reconstructs ``logit - b_U`` (and, for a difference, ``logit_diff - (b_U[c] -
+b_U[w])``), not the raw logit. We assert that invariant against the bridge's own
+forward-pass logits — the point of issue #1263 is that DLA must be correct on a
+``TransformerBridge`` (compatibility mode), not only ``HookedTransformer``.
+
+Uses distilgpt2 (CI-cached), matching test_analysis_methods.py.
+"""
+
+import pytest
+import torch
+
+from transformer_lens.tools.analysis import dla
+
+PROMPT = "The Eiffel Tower is in the city of"
+CORRECT = " Paris"
+WRONG = " London"
+
+
+def _last_token_logits(bridge, prompt):
+    """Final-position logits from the bridge's own forward pass."""
+    logits, _ = bridge.run_with_cache(prompt)
+    if logits.ndim == 3:  # [batch, pos, vocab]
+        logits = logits[0]
+    return logits[-1]  # [vocab]
+
+
+class TestDirectLogitAttributionCorrectness:
+    """The component contributions must reconstruct the model's real logits."""
+
+    def test_decompose_reconstructs_logit_difference(self, distilgpt2_bridge_compat):
+        bridge = distilgpt2_bridge_compat
+        c, w = bridge.to_single_token(CORRECT), bridge.to_single_token(WRONG)
+        scores, labels = dla(bridge, [PROMPT], torch.tensor([[c, w]]))
+
+        logits = _last_token_logits(bridge, PROMPT)
+        expected = (logits[c] - logits[w]) - (bridge.b_U[c] - bridge.b_U[w])
+        assert scores.sum().item() == pytest.approx(expected.item(), abs=1e-2)
+        assert len(scores) == len(labels)
+
+    def test_decompose_reconstructs_single_token_logit(self, distilgpt2_bridge_compat):
+        bridge = distilgpt2_bridge_compat
+        c = bridge.to_single_token(CORRECT)
+        scores, _ = dla(bridge, [PROMPT], torch.tensor([[c]]))
+
+        logits = _last_token_logits(bridge, PROMPT)
+        expected = logits[c] - bridge.b_U[c]
+        assert scores.sum().item() == pytest.approx(expected.item(), abs=1e-2)
+
+    def test_accumulated_last_entry_reconstructs(self, distilgpt2_bridge_compat):
+        # accumulated_resid is cumulative -> reconstruction is the LAST entry, not the sum
+        bridge = distilgpt2_bridge_compat
+        c, w = bridge.to_single_token(CORRECT), bridge.to_single_token(WRONG)
+        scores, labels = dla(bridge, [PROMPT], torch.tensor([[c, w]]), accumulated=True)
+
+        logits = _last_token_logits(bridge, PROMPT)
+        expected = (logits[c] - logits[w]) - (bridge.b_U[c] - bridge.b_U[w])
+        assert scores[-1].item() == pytest.approx(expected.item(), abs=1e-2)
+        assert len(scores) == len(labels)
+
+
+class TestDirectLogitAttributionShape:
+    def test_decompose_labels_and_shape(self, distilgpt2_bridge_compat):
+        bridge = distilgpt2_bridge_compat
+        c = bridge.to_single_token(CORRECT)
+        scores, labels = dla(bridge, [PROMPT], torch.tensor([[c]]))
+
+        n_layers = bridge.cfg.n_layers
+        assert scores.ndim == 1
+        assert len(scores) == len(labels)
+        assert "embed" in labels
+        assert sum(label.endswith("attn_out") for label in labels) == n_layers
+        assert sum(label.endswith("mlp_out") for label in labels) == n_layers
+
+    def test_batch_of_prompts_is_averaged(self, distilgpt2_bridge_compat):
+        # two identical prompts -> the batch-mean equals the single-prompt result
+        bridge = distilgpt2_bridge_compat
+        c, w = bridge.to_single_token(CORRECT), bridge.to_single_token(WRONG)
+        single, _ = dla(bridge, [PROMPT], torch.tensor([[c, w]]))
+        doubled, _ = dla(bridge, [PROMPT, PROMPT], torch.tensor([[c, w], [c, w]]))
+        assert torch.allclose(single, doubled, atol=1e-4)
+
+
+class TestDirectLogitAttributionGuardsOnRealBridge:
+    """The guards must also fire on a genuine bridge, not just a mock."""
+
+    def test_non_compat_bridge_raises(self, distilgpt2_bridge):
+        bridge = distilgpt2_bridge  # compatibility mode NOT enabled
+        c = bridge.to_single_token(CORRECT)
+        with pytest.raises(ValueError, match="compatibility mode"):
+            dla(bridge, [PROMPT], torch.tensor([[c]]))
+
+    def test_hybrid_layer_types_raises(self, distilgpt2_bridge_compat, monkeypatch):
+        bridge = distilgpt2_bridge_compat
+        monkeypatch.setattr(bridge, "layer_types", lambda: ["attn+mlp", "mamba+mlp"])
+        c = bridge.to_single_token(CORRECT)
+        with pytest.raises(NotImplementedError, match="hybrid"):
+            dla(bridge, [PROMPT], torch.tensor([[c]]))

--- a/tests/unit/tools/test_direct_logit_attribution.py
+++ b/tests/unit/tools/test_direct_logit_attribution.py
@@ -1,0 +1,53 @@
+"""Unit tests for the Direct Logit Attribution guards and argument validation.
+
+These exercise the fast-failing checks (argument validation, the
+compatibility-mode requirement, and the hybrid-architecture refusal) without
+loading a real model, using a ``spec``-ed mock bridge so the checks are reached
+before any forward pass.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from transformer_lens.model_bridge import TransformerBridge
+from transformer_lens.tools.analysis import dla
+
+
+def _mock_bridge(compatibility_mode=True, layer_types=("attn+mlp",)):
+    """A mock TransformerBridge that satisfies isinstance/type checks."""
+    bridge = MagicMock(spec=TransformerBridge)
+    bridge.compatibility_mode = compatibility_mode
+    bridge.layer_types.return_value = list(layer_types)
+    return bridge
+
+
+def test_prompt_answer_length_mismatch_raises():
+    bridge = _mock_bridge()
+    with pytest.raises(ValueError, match="matching row"):
+        dla(bridge, ["a", "b"], torch.tensor([[1]]))
+
+
+def test_invalid_answer_columns_raises():
+    bridge = _mock_bridge()
+    with pytest.raises(ValueError, match="columns"):
+        dla(bridge, ["a"], torch.tensor([[1, 2, 3]]))
+
+
+def test_requires_compatibility_mode():
+    bridge = _mock_bridge(compatibility_mode=False)
+    with pytest.raises(ValueError, match="compatibility mode"):
+        dla(bridge, ["a"], torch.tensor([[1]]))
+
+
+def test_rejects_hybrid_architecture():
+    bridge = _mock_bridge(layer_types=("attn+mlp", "mamba+mlp"))
+    with pytest.raises(NotImplementedError, match="hybrid"):
+        dla(bridge, ["a"], torch.tensor([[1]]))
+
+
+def test_dla_is_exported_from_analysis_package():
+    from transformer_lens.tools import analysis
+
+    assert analysis.dla is dla

--- a/transformer_lens/tools/__init__.py
+++ b/transformer_lens/tools/__init__.py
@@ -4,9 +4,10 @@ This package contains utilities and tools for working with TransformerLens,
 including the model registry for discovering compatible HuggingFace models.
 
 Subpackages:
+    - analysis: Interpretability analyses such as Direct Logit Attribution
     - model_registry: Tools for discovering and documenting supported models
 """
 
-from . import model_registry
+from . import analysis, model_registry
 
-__all__ = ["model_registry"]
+__all__ = ["analysis", "model_registry"]

--- a/transformer_lens/tools/analysis/__init__.py
+++ b/transformer_lens/tools/analysis/__init__.py
@@ -1,5 +1,5 @@
 """Analysis tools for the TransformerBridge system."""
 
-from transformer_lens.tools.analysis.direct_logit_attribution import DLA
+from transformer_lens.tools.analysis.direct_logit_attribution import dla
 
-__all__ = ["DLA"]c
+__all__ = ["dla"]

--- a/transformer_lens/tools/analysis/__init__.py
+++ b/transformer_lens/tools/analysis/__init__.py
@@ -1,0 +1,5 @@
+"""Analysis tools for the TransformerBridge system."""
+
+from transformer_lens.tools.analysis.direct_logit_attribution import DLA
+
+__all__ = ["DLA"]c

--- a/transformer_lens/tools/analysis/direct_logit_attribution.py
+++ b/transformer_lens/tools/analysis/direct_logit_attribution.py
@@ -1,7 +1,7 @@
 """Direct Logit Attribution.
 
 Decomposes a model's logit difference into per-component contributions from
-the residual stream. See :func:`DLA` for usage.
+the residual stream. See :func:`dla` for usage.
 """
 
 from typing import List, Tuple
@@ -12,142 +12,136 @@ from jaxtyping import Float, Int
 
 from transformer_lens.ActivationCache import ActivationCache
 from transformer_lens.model_bridge import TransformerBridge
-from transformer_lens.utils import get_act_name
+from transformer_lens.utilities import get_act_name
 
-# Variant submodule names that indicate a hybrid block. Mamba, SSM, Mixer, and LinearAttention layers don't have the usual attn_out / mlp_out decomposition that ActivationCache.decompose_resid expects.
+# Block variants that lack the attn_out + mlp_out structure decompose_resid expects.
 _HYBRID_VARIANT_NAMES = ("mamba", "ssm", "mixer", "linear_attn")
-dont 
 
-def DLA(
+
+def dla(
     bridge: TransformerBridge,
     prompts: List[str],
     answer_tokens: Int[torch.Tensor, "batch answers"],
     accumulated: bool = False,
 ) -> Tuple[Float[torch.Tensor, "component"], List[str]]:
-    """Compute Direct Logit Attribution For A TransformerBridge Model.
+    """Compute Direct Logit Attribution for a TransformerBridge model.
 
-    Decomposes the logit difference between a correct and wrong answer token
-    into per-component contributions from the residual stream. Two modes:
+    Decomposes the logit (or logit difference between a correct and wrong token)
+    into per-component contributions from the residual stream, averaged across
+    the batch of prompts. Two modes:
 
-    * ``accumulated=False`` (default): returns the contribution of each
-      individual component (embedding, per-layer attention output, per-layer
-      MLP output) — see :meth:`transformer_lens.ActivationCache.decompose_resid`.
-    * ``accumulated=True``: returns the cumulative residual stream contribution
-      at each layer boundary (logit-lens style) — see
-      :meth:`transformer_lens.ActivationCache.accumulated_resid`.
-
-    Warning:
-
-    Returned scores sum to ``actual_logit_diff - (b_U[correct] - b_U[wrong])``,
-    not to ``actual_logit_diff`` directly. The unembedding bias :math:`b_U` is
-    a constant offset added after unembedding, not a contribution from the
-    residual stream, so it is excluded by convention (matching the behavior of
-    :meth:`transformer_lens.ActivationCache.decompose_resid`).
+    * ``accumulated=False`` (default): the contribution of each individual
+      component — embedding, per-layer attention output, per-layer MLP output —
+      via :meth:`transformer_lens.ActivationCache.decompose_resid`. These are
+      additive: their sum reconstructs the (bias-excluded) logit difference.
+    * ``accumulated=True``: the cumulative residual stream at each layer boundary
+      (logit-lens style) via
+      :meth:`transformer_lens.ActivationCache.accumulated_resid`. These are
+      cumulative, so the full reconstruction is the *last* entry, not the sum.
 
     Warning:
 
-    This function requires the bridge to be in compatibility mode so that the
-    final LayerNorm weights are folded into :math:`W_U`. Without folding, the
-    projection direction is incorrect and per-component scores will not reflect
-    actual logit contributions. Call ``bridge.enable_compatibility_mode()``
-    after loading the bridge.
+    Returned scores sum (decompose mode) or end (accumulated mode) at
+    ``actual_logit_diff - (b_U[correct] - b_U[wrong])``, not ``actual_logit_diff``
+    directly. The unembedding bias :math:`b_U` is a constant offset added after
+    unembedding rather than a residual-stream contribution, so it is excluded by
+    convention — matching :meth:`transformer_lens.ActivationCache.logit_attrs`.
+
+    Warning:
+
+    This function requires the bridge to be in compatibility mode so the final
+    LayerNorm weights are folded into :math:`W_U`. Without folding, the
+    projection direction is wrong and the scores do not reflect actual logit
+    contributions. Call ``bridge.enable_compatibility_mode()`` after loading.
 
     Warning:
 
     Hybrid architectures (Mamba, SSM, Mixer, LinearAttention) are not yet
-    supported and will raise :class:`NotImplementedError`. Support requires
-    extending :meth:`transformer_lens.ActivationCache.decompose_resid` to handle
-    non-attention block variants, which is tracked separately.
+    supported and raise :class:`NotImplementedError`; support requires extending
+    :meth:`transformer_lens.ActivationCache.decompose_resid` to handle
+    non-attention blocks.
 
     Args:
         bridge:
             A :class:`transformer_lens.model_bridge.TransformerBridge` with
             compatibility mode enabled.
         prompts:
-            List of prompt strings to evaluate. Length must match
-            ``answer_tokens.shape[0]``.
+            Prompt strings to evaluate. Length must match ``answer_tokens.shape[0]``.
         answer_tokens:
-            Tensor of shape ``(batch, answers)``. When ``answers == 1``, treated
-            as a single target token per prompt. When ``answers == 2``, treated
-            as a ``(correct, wrong)`` pair per prompt and the logit difference
-            ``correct - wrong`` is decomposed.
+            Tensor of shape ``(batch, answers)``. ``answers == 1`` decomposes the
+            single target token's logit; ``answers == 2`` treats each row as a
+            ``(correct, wrong)`` pair and decomposes the logit difference.
         accumulated:
-            If ``True``, return cumulative residual stream contributions at each
-            layer boundary (logit lens). If ``False``, return per-component
-            contributions. Defaults to ``False``.
+            If ``True``, return cumulative per-layer contributions (logit lens).
+            If ``False`` (default), return per-component contributions.
 
     Returns:
-        A tuple ``(scores, labels)`` where ``scores`` is a 1D tensor of per-
-        component or per-layer contributions (averaged across the batch), and
-        ``labels`` is the matching list of human-readable component names.
+        ``(scores, labels)``: ``scores`` is a 1D tensor of per-component (or
+        per-layer) contributions averaged across the batch, and ``labels`` is the
+        matching list of human-readable component names.
 
     Raises:
-        ValueError: If the bridge is not in compatibility mode.
+        ValueError: If ``len(prompts)`` does not match ``answer_tokens.shape[0]``,
+            if ``answer_tokens.shape[1]`` is not ``1`` or ``2``, or if the bridge
+            is not in compatibility mode.
         NotImplementedError: If the bridge contains hybrid (non attention + MLP)
-            block variants.
-        AssertionError: If ``len(prompts)`` does not match
-            ``answer_tokens.shape[0]``, or if ``answer_tokens.shape[1]`` is not
-            ``1`` or ``2``.
+            blocks.
     """
 
-    assert len(prompts) == answer_tokens.shape[0]
-    assert answer_tokens.shape[1] == 1 or answer_tokens.shape[1] == 2
+    # input validation
+    if len(prompts) != answer_tokens.shape[0]:
+        raise ValueError(
+            "Each prompt needs a matching row of answer tokens: got "
+            f"{len(prompts)} prompts but {answer_tokens.shape[0]} answer-token rows."
+        )
+    if answer_tokens.shape[1] not in (1, 2):
+        raise ValueError(
+            "answer_tokens must have 1 (single token) or 2 (correct, wrong) columns, "
+            f"got {answer_tokens.shape[1]}."
+        )
 
-    # DLA requires the LayerNorm gamma to be folded into W_U. Without folding,
-    # projections onto W_U use the wrong direction (some features under-weighted,
-    # others over-weighted) and the per-component scores will not sum to the
-    # actual logit difference. Compatibility mode applies fold_ln by default
+    # safeguard: DLA needs LayerNorm folded into W_U, which compatibility mode does
     if not getattr(bridge, "compatibility_mode", False):
         raise ValueError(
-            "DLA requires bridge to be in compatibility mode so that "
-            "LayerNorm weights are folded into W_U. Call "
-            "`bridge.enable_compatibility_mode()` after loading the bridge, "
-            "then re-run DLA."
+            "DLA requires the bridge to be in compatibility mode so that LayerNorm "
+            "weights are folded into W_U. Call `bridge.enable_compatibility_mode()` "
+            "after loading the bridge, then re-run DLA."
         )
 
-    # Strict mode: hybrid architectures (Mamba, SSM, etc.) aren't supported yet
-    # because ActivationCache.decompose_resid only knows how to decompose into
-    # attn_out + mlp_out per layer. A model with Mamba blocks would silently
-    # under-attribute. Raise here so callers fail loudly instead of getting
-    # wrong numbers.
-    for module_name, _ in bridge.named_modules():
-        lowered = module_name.lower()
-        if any(variant in lowered for variant in _HYBRID_VARIANT_NAMES):
-            raise NotImplementedError(
-                f"DLA does not yet support hybrid architectures "
-                f"(found component {module_name!r}). Currently only standard "
-                f"attention + MLP transformers (e.g. GPT-2, LLaMA, Pythia) are "
-                f"supported. Hybrid support requires extending "
-                f"ActivationCache.decompose_resid — tracked separately."
-            )
-
-    #grab residiual directions from bridge (essentially unembedding matrix transposed)
-    answer_residual_directions: Float[torch.Tensor, "batch answers d_model"] = bridge.tokens_to_residual_directions(answer_tokens)
-
-    #ensure all residual directions are of shape [batch, d_model]
-    if answer_tokens.numel() == 1:
-        logit_diff_directions: Float[torch.Tensor, "batch d_model"] = torch.unsqueeze(answer_residual_directions, dim=0)
-    elif answer_residual_directions.shape[1] == 1:
-        #strip middle dimension
-        logit_diff_directions: Float[torch.Tensor, "batch d_model"] = answer_residual_directions[:, 0, :]
-    else: #case where we have correct tokens and incorrect tokens
-        correct_token_direction, incorrect_token_direction = answer_residual_directions.unbind(dim=1)
-        logit_diff_directions: Float[torch.Tensor, "batch d_model"] = (
-            correct_token_direction - incorrect_token_direction
+    # safeguard: hybrid blocks (Mamba/SSM/...) have no attn_out + mlp_out to decompose
+    hybrid_blocks = [
+        layer_type
+        for layer_type in bridge.layer_types()
+        if any(part in _HYBRID_VARIANT_NAMES for part in layer_type.split("+"))
+    ]
+    if hybrid_blocks:
+        raise NotImplementedError(
+            f"DLA does not yet support hybrid architectures (found block types "
+            f"{hybrid_blocks}). Only standard attention + MLP transformers (e.g. "
+            f"GPT-2, LLaMA, Pythia) are supported; hybrid support requires extending "
+            f"ActivationCache.decompose_resid."
         )
 
-#turns residual stream contributions into logit-difference scores accounting for layerNorm
+    # unembedding direction per prompt; single-token tensors collapse to [d_model]
+    answer_residual_directions = bridge.tokens_to_residual_directions(answer_tokens).reshape(
+        answer_tokens.shape[0], answer_tokens.shape[1], -1
+    )
+    if answer_tokens.shape[1] == 1:
+        logit_diff_directions: Float[torch.Tensor, "batch d_model"] = answer_residual_directions[
+            :, 0, :
+        ]
+    else:  # (correct, wrong) pair -> direction of the logit difference
+        correct_direction, wrong_direction = answer_residual_directions.unbind(dim=1)
+        logit_diff_directions = correct_direction - wrong_direction
+
     def residual_stack_to_logit_diff(
         residual_stack: Float[torch.Tensor, "... batch d_model"],
         cache: ActivationCache,
-        logit_diff_directions: Float[torch.Tensor, "batch d_model"],
     ) -> Float[torch.Tensor, "..."]:
+        # apply the final LayerNorm once, project onto the answer direction, average over prompts
         batch_size = residual_stack.size(-2)
-        scaled_residual_stack = cache.apply_ln_to_stack(
-            residual_stack, layer=-1, pos_slice=-1
-        )
+        scaled_residual_stack = cache.apply_ln_to_stack(residual_stack, layer=-1, pos_slice=-1)
         return (
-            #average logit-difference contribution across prompts
             einops.einsum(
                 scaled_residual_stack,
                 logit_diff_directions,
@@ -156,48 +150,28 @@ def DLA(
             / batch_size
         )
 
-    
     if accumulated:
         n_layers = bridge.cfg.n_layers
-
-        #filtered residual stream cache
-        _, cache = bridge.run_with_cache(prompts,
-            return_type=None,
-            names_filter=lambda x: x == get_act_name("resid_post", n_layers - 1)
-            or x == get_act_name("ln_final.hook_scale")
-            or x.endswith("resid_pre")
-            or x.endswith("resid_mid"),
+        _, cache = bridge.run_with_cache(
+            prompts,
+            names_filter=lambda name: name == get_act_name("resid_post", n_layers - 1)
+            or name == "ln_final.hook_scale"
+            or name.endswith("resid_pre")
+            or name.endswith("resid_mid"),
         )
-        #stack stream into tensor
         accumulated_residual, labels = cache.accumulated_resid(
             layer=-1, pos_slice=-1, incl_mid=True, return_labels=True
         )
-    
-        logit_lens_logit_diffs: Float[
-            torch.Tensor, "component"
-        ] = residual_stack_to_logit_diff(
-            accumulated_residual, cache, logit_diff_directions
-        )
+        return residual_stack_to_logit_diff(accumulated_residual, cache), labels
 
-        return logit_lens_logit_diffs, labels
-
-    else:
-        _, cache = bridge.run_with_cache(
-            prompts,
-            return_type=None,
-            names_filter=lambda x: x == get_act_name("ln_final.hook_scale")
-            or x.endswith("embed")
-            or x.endswith("attn_out")
-            or x.endswith("mlp_out"),
-        )
-
-        per_layer_residual, labels = cache.decompose_resid(
-            layer=-1, pos_slice=-1, return_labels=True
-        )
-        per_layer_logit_diffs: Float[
-            torch.Tensor, "component"
-        ] = residual_stack_to_logit_diff(
-            per_layer_residual, cache, logit_diff_directions
-        )
-
-        return per_layer_logit_diffs, labels
+    _, cache = bridge.run_with_cache(
+        prompts,
+        names_filter=lambda name: name == "ln_final.hook_scale"
+        or name in ("hook_embed", "hook_pos_embed")
+        or name.endswith("attn_out")
+        or name.endswith("mlp_out"),
+    )
+    per_component_residual, labels = cache.decompose_resid(
+        layer=-1, pos_slice=-1, return_labels=True
+    )
+    return residual_stack_to_logit_diff(per_component_residual, cache), labels

--- a/transformer_lens/tools/analysis/direct_logit_attribution.py
+++ b/transformer_lens/tools/analysis/direct_logit_attribution.py
@@ -1,0 +1,203 @@
+"""Direct Logit Attribution.
+
+Decomposes a model's logit difference into per-component contributions from
+the residual stream. See :func:`DLA` for usage.
+"""
+
+from typing import List, Tuple
+
+import einops
+import torch
+from jaxtyping import Float, Int
+
+from transformer_lens.ActivationCache import ActivationCache
+from transformer_lens.model_bridge import TransformerBridge
+from transformer_lens.utils import get_act_name
+
+# Variant submodule names that indicate a hybrid block. Mamba, SSM, Mixer, and LinearAttention layers don't have the usual attn_out / mlp_out decomposition that ActivationCache.decompose_resid expects.
+_HYBRID_VARIANT_NAMES = ("mamba", "ssm", "mixer", "linear_attn")
+dont 
+
+def DLA(
+    bridge: TransformerBridge,
+    prompts: List[str],
+    answer_tokens: Int[torch.Tensor, "batch answers"],
+    accumulated: bool = False,
+) -> Tuple[Float[torch.Tensor, "component"], List[str]]:
+    """Compute Direct Logit Attribution For A TransformerBridge Model.
+
+    Decomposes the logit difference between a correct and wrong answer token
+    into per-component contributions from the residual stream. Two modes:
+
+    * ``accumulated=False`` (default): returns the contribution of each
+      individual component (embedding, per-layer attention output, per-layer
+      MLP output) — see :meth:`transformer_lens.ActivationCache.decompose_resid`.
+    * ``accumulated=True``: returns the cumulative residual stream contribution
+      at each layer boundary (logit-lens style) — see
+      :meth:`transformer_lens.ActivationCache.accumulated_resid`.
+
+    Warning:
+
+    Returned scores sum to ``actual_logit_diff - (b_U[correct] - b_U[wrong])``,
+    not to ``actual_logit_diff`` directly. The unembedding bias :math:`b_U` is
+    a constant offset added after unembedding, not a contribution from the
+    residual stream, so it is excluded by convention (matching the behavior of
+    :meth:`transformer_lens.ActivationCache.decompose_resid`).
+
+    Warning:
+
+    This function requires the bridge to be in compatibility mode so that the
+    final LayerNorm weights are folded into :math:`W_U`. Without folding, the
+    projection direction is incorrect and per-component scores will not reflect
+    actual logit contributions. Call ``bridge.enable_compatibility_mode()``
+    after loading the bridge.
+
+    Warning:
+
+    Hybrid architectures (Mamba, SSM, Mixer, LinearAttention) are not yet
+    supported and will raise :class:`NotImplementedError`. Support requires
+    extending :meth:`transformer_lens.ActivationCache.decompose_resid` to handle
+    non-attention block variants, which is tracked separately.
+
+    Args:
+        bridge:
+            A :class:`transformer_lens.model_bridge.TransformerBridge` with
+            compatibility mode enabled.
+        prompts:
+            List of prompt strings to evaluate. Length must match
+            ``answer_tokens.shape[0]``.
+        answer_tokens:
+            Tensor of shape ``(batch, answers)``. When ``answers == 1``, treated
+            as a single target token per prompt. When ``answers == 2``, treated
+            as a ``(correct, wrong)`` pair per prompt and the logit difference
+            ``correct - wrong`` is decomposed.
+        accumulated:
+            If ``True``, return cumulative residual stream contributions at each
+            layer boundary (logit lens). If ``False``, return per-component
+            contributions. Defaults to ``False``.
+
+    Returns:
+        A tuple ``(scores, labels)`` where ``scores`` is a 1D tensor of per-
+        component or per-layer contributions (averaged across the batch), and
+        ``labels`` is the matching list of human-readable component names.
+
+    Raises:
+        ValueError: If the bridge is not in compatibility mode.
+        NotImplementedError: If the bridge contains hybrid (non attention + MLP)
+            block variants.
+        AssertionError: If ``len(prompts)`` does not match
+            ``answer_tokens.shape[0]``, or if ``answer_tokens.shape[1]`` is not
+            ``1`` or ``2``.
+    """
+
+    assert len(prompts) == answer_tokens.shape[0]
+    assert answer_tokens.shape[1] == 1 or answer_tokens.shape[1] == 2
+
+    # DLA requires the LayerNorm gamma to be folded into W_U. Without folding,
+    # projections onto W_U use the wrong direction (some features under-weighted,
+    # others over-weighted) and the per-component scores will not sum to the
+    # actual logit difference. Compatibility mode applies fold_ln by default
+    if not getattr(bridge, "compatibility_mode", False):
+        raise ValueError(
+            "DLA requires bridge to be in compatibility mode so that "
+            "LayerNorm weights are folded into W_U. Call "
+            "`bridge.enable_compatibility_mode()` after loading the bridge, "
+            "then re-run DLA."
+        )
+
+    # Strict mode: hybrid architectures (Mamba, SSM, etc.) aren't supported yet
+    # because ActivationCache.decompose_resid only knows how to decompose into
+    # attn_out + mlp_out per layer. A model with Mamba blocks would silently
+    # under-attribute. Raise here so callers fail loudly instead of getting
+    # wrong numbers.
+    for module_name, _ in bridge.named_modules():
+        lowered = module_name.lower()
+        if any(variant in lowered for variant in _HYBRID_VARIANT_NAMES):
+            raise NotImplementedError(
+                f"DLA does not yet support hybrid architectures "
+                f"(found component {module_name!r}). Currently only standard "
+                f"attention + MLP transformers (e.g. GPT-2, LLaMA, Pythia) are "
+                f"supported. Hybrid support requires extending "
+                f"ActivationCache.decompose_resid — tracked separately."
+            )
+
+    #grab residiual directions from bridge (essentially unembedding matrix transposed)
+    answer_residual_directions: Float[torch.Tensor, "batch answers d_model"] = bridge.tokens_to_residual_directions(answer_tokens)
+
+    #ensure all residual directions are of shape [batch, d_model]
+    if answer_tokens.numel() == 1:
+        logit_diff_directions: Float[torch.Tensor, "batch d_model"] = torch.unsqueeze(answer_residual_directions, dim=0)
+    elif answer_residual_directions.shape[1] == 1:
+        #strip middle dimension
+        logit_diff_directions: Float[torch.Tensor, "batch d_model"] = answer_residual_directions[:, 0, :]
+    else: #case where we have correct tokens and incorrect tokens
+        correct_token_direction, incorrect_token_direction = answer_residual_directions.unbind(dim=1)
+        logit_diff_directions: Float[torch.Tensor, "batch d_model"] = (
+            correct_token_direction - incorrect_token_direction
+        )
+
+#turns residual stream contributions into logit-difference scores accounting for layerNorm
+    def residual_stack_to_logit_diff(
+        residual_stack: Float[torch.Tensor, "... batch d_model"],
+        cache: ActivationCache,
+        logit_diff_directions: Float[torch.Tensor, "batch d_model"],
+    ) -> Float[torch.Tensor, "..."]:
+        batch_size = residual_stack.size(-2)
+        scaled_residual_stack = cache.apply_ln_to_stack(
+            residual_stack, layer=-1, pos_slice=-1
+        )
+        return (
+            #average logit-difference contribution across prompts
+            einops.einsum(
+                scaled_residual_stack,
+                logit_diff_directions,
+                "... batch d_model, batch d_model -> ...",
+            )
+            / batch_size
+        )
+
+    
+    if accumulated:
+        n_layers = bridge.cfg.n_layers
+
+        #filtered residual stream cache
+        _, cache = bridge.run_with_cache(prompts,
+            return_type=None,
+            names_filter=lambda x: x == get_act_name("resid_post", n_layers - 1)
+            or x == get_act_name("ln_final.hook_scale")
+            or x.endswith("resid_pre")
+            or x.endswith("resid_mid"),
+        )
+        #stack stream into tensor
+        accumulated_residual, labels = cache.accumulated_resid(
+            layer=-1, pos_slice=-1, incl_mid=True, return_labels=True
+        )
+    
+        logit_lens_logit_diffs: Float[
+            torch.Tensor, "component"
+        ] = residual_stack_to_logit_diff(
+            accumulated_residual, cache, logit_diff_directions
+        )
+
+        return logit_lens_logit_diffs, labels
+
+    else:
+        _, cache = bridge.run_with_cache(
+            prompts,
+            return_type=None,
+            names_filter=lambda x: x == get_act_name("ln_final.hook_scale")
+            or x.endswith("embed")
+            or x.endswith("attn_out")
+            or x.endswith("mlp_out"),
+        )
+
+        per_layer_residual, labels = cache.decompose_resid(
+            layer=-1, pos_slice=-1, return_labels=True
+        )
+        per_layer_logit_diffs: Float[
+            torch.Tensor, "component"
+        ] = residual_stack_to_logit_diff(
+            per_layer_residual, cache, logit_diff_directions
+        )
+
+        return per_layer_logit_diffs, labels


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

- Implemented a Direct Logit Attribution (DLA) tool for the new `TransformerBridge` system, closes #1263. Based on the stale PR #466 but adapted to utilize 3.0 TransformerBridge.
- returns per-component (or per-layer) contributions to logit difference ebtween correct and wrong token, decomposing residual stream based off accumulated bool.
 - generated docstring (according to contributing.md) highlighting important warnings of limitations of DLA tool (currently does not support hybrid layers like mamba, requires bridge compatibility mode)

## Acknowledged limitations

  - **Strict mode only.** hybrid architectures (Mamba, SSM, Mixer, LinearAttention) raise
  `NotImplementedError`. `ActivationCache.decompose_resid` only knows how to decompose `attn_out +
  mlp_out` per layer; supporting hybrid blocks requires extending that method and is out of scope
  for this PR. (will be working on this in next steps)
  - **Requires compatibility mode.** Raises `ValueError` if `bridge.enable_compatibility_mode()`
  hasn't been called. Without folded LayerNorm weights, the projection direction is wrong and
  per-component scores don't reflect actual logit contributions.
  - **Excludes unembedding bias.** Per-component scores sum to `actual_logit_diff − (b_U[correct] −
  b_U[wrong])`. This matches the convention in `cache.decompose_resid` and PR #466 — the bias is a constant offset

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Screenshots
<img width="564" height="534" alt="image" src="https://github.com/user-attachments/assets/8370c690-c465-4fa1-b66c-e0e601350957" />

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility