### PR TITLE
Add Mixtral architecture adapter tests

### DIFF
--- a/tests/unit/model_bridge/supported_architectures/test_mixtral_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_mixtral_adapter.py
@@ -1,0 +1,589 @@
+"""Unit tests for the MixtralArchitectureAdapter (download-free: tiny programmatic configs
+plus small synthetic tensors and a fake attention module, no real checkpoints).
+
+Covered:
+- Adapter config defaults (RMSNorm, rotary, gated MoE MLP).
+- Weight conversions: QKVO weights plus Q/K/V biases, with GQA-aware head counts.
+- Numerical round-trips: the rearranges actually reshape and revert losslessly.
+- Component-mapping structure, bridge types, and HF module paths.
+- Factory registration and dispatch.
+- GQA forward hook shapes (Q uses n_heads, K/V use n_key_value_heads).
+- setup_component_testing rotary-embedding wiring, eager forcing, and robustness.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch.nn as nn
+from torch import equal, ones, randn, zeros
+
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.conversion_utils.conversion_steps.rearrange_tensor_conversion import (
+    RearrangeTensorConversion,
+)
+from transformer_lens.conversion_utils.param_processing_conversion import (
+    ParamProcessingConversion,
+)
+from transformer_lens.factories.architecture_adapter_factory import (
+    SUPPORTED_ARCHITECTURES,
+    ArchitectureAdapterFactory,
+)
+from transformer_lens.model_bridge.generalized_components import (
+    BlockBridge,
+    EmbeddingBridge,
+    GatedMLPBridge,
+    LinearBridge,
+    MoEBridge,
+    PositionEmbeddingsAttentionBridge,
+    RMSNormalizationBridge,
+    RotaryEmbeddingBridge,
+    UnembeddingBridge,
+)
+from transformer_lens.model_bridge.supported_architectures.mixtral import (
+    MixtralArchitectureAdapter,
+)
+
+
+@pytest.fixture(scope="class")
+def cfg() -> TransformerBridgeConfig:
+    return TransformerBridgeConfig(
+        d_model=64,
+        d_head=16,
+        n_layers=2,
+        n_ctx=128,
+        n_heads=4,
+        n_key_value_heads=2,
+        d_vocab=256,
+        architecture="MixtralForCausalLM",
+    )
+
+
+@pytest.fixture(scope="class")
+def adapter(cfg: TransformerBridgeConfig) -> MixtralArchitectureAdapter:
+    return MixtralArchitectureAdapter(cfg)
+
+
+def _cfg(*, n_key_value_heads: int | None = 2) -> TransformerBridgeConfig:
+    # Keep dimensions tiny so adapter tests do not need HF downloads or real checkpoints.
+    # n_key_value_heads=None exercises the GQA fallback to n_heads in the adapter.
+    return TransformerBridgeConfig(
+        d_model=64,
+        d_head=16,
+        n_layers=2,
+        n_ctx=128,
+        n_heads=4,
+        n_key_value_heads=n_key_value_heads,
+        d_vocab=256,
+        architecture="MixtralForCausalLM",
+    )
+
+
+def _mapping(adapter: MixtralArchitectureAdapter) -> dict:
+    """Narrow component_mapping (Optional on the base class) to a non-None dict.
+
+    Factored into a helper so each test stays a one-liner instead of repeating the
+    `assert ... is not None` prelude in every method. The qwen3_moe adapter test
+    inlines that prelude per method instead; this is the deduplicated equivalent.
+    """
+    mapping = adapter.component_mapping
+    assert mapping is not None
+    return mapping
+
+
+def _conversions(adapter: MixtralArchitectureAdapter) -> dict:
+    """weight_processing_conversions is Optional on the base class; assert it is populated."""
+    conversions = adapter.weight_processing_conversions
+    assert conversions is not None
+    return conversions
+
+
+def _param_conversion(adapter: MixtralArchitectureAdapter, key: str) -> ParamProcessingConversion:
+    conv = _conversions(adapter)[key]
+    assert isinstance(conv, ParamProcessingConversion)
+    return conv
+
+
+def _rearrange(adapter: MixtralArchitectureAdapter, key: str) -> RearrangeTensorConversion:
+    tensor_conversion = _param_conversion(adapter, key).tensor_conversion
+    assert isinstance(tensor_conversion, RearrangeTensorConversion)
+    return tensor_conversion
+
+
+def _fake_hf_model(rotary_emb: object) -> SimpleNamespace:
+    """Minimal HF model exposing only model.rotary_emb (no config/layers)."""
+    return SimpleNamespace(model=SimpleNamespace(rotary_emb=rotary_emb))
+
+
+def _fake_hf_model_with_eager_targets(rotary_emb: object) -> SimpleNamespace:
+    """HF model whose top-level and per-layer attention impl start non-eager."""
+    layers = [
+        SimpleNamespace(
+            self_attn=SimpleNamespace(config=SimpleNamespace(_attn_implementation="sdpa"))
+        )
+        for _ in range(2)
+    ]
+    return SimpleNamespace(
+        config=SimpleNamespace(_attn_implementation="sdpa"),
+        model=SimpleNamespace(rotary_emb=rotary_emb, layers=layers),
+    )
+
+
+class DummyAttention:
+    def __init__(self) -> None:
+        self.rotary_emb = None
+
+    def set_rotary_emb(self, rotary_emb: object) -> None:
+        self.rotary_emb = rotary_emb
+
+
+class DummyBlock:
+    def __init__(self, has_attention: bool = True) -> None:
+        if has_attention:
+            self.attn = DummyAttention()
+
+
+class DummyBridgeModel:
+    def __init__(self, blocks: list[DummyBlock]) -> None:
+        self.blocks = blocks
+
+
+class FakeMixtralAttention(nn.Module):
+    """Minimal Mixtral-style attention module for adapter hook-shape tests.
+
+    Stock Mixtral has no attention bias, so the projections are bias-free here;
+    the adapter still declares Q/K/V bias conversions for variants that enable
+    them, which the round-trip tests exercise separately.
+    """
+
+    def __init__(self, cfg: TransformerBridgeConfig) -> None:
+        super().__init__()
+        # PositionEmbeddingsAttentionBridge reads these HF-style attributes during forward.
+        self.head_dim = cfg.d_head
+        self.num_key_value_groups = cfg.n_heads // (cfg.n_key_value_heads or cfg.n_heads)
+        self.scaling = cfg.d_head**-0.5
+        self.attention_dropout = 0.0
+
+        # GQA: Q has n_heads, while K/V have n_key_value_heads.
+        kv_width = (cfg.n_key_value_heads or cfg.n_heads) * cfg.d_head
+        self.q_proj = nn.Linear(cfg.d_model, cfg.n_heads * cfg.d_head, bias=False)
+        self.k_proj = nn.Linear(cfg.d_model, kv_width, bias=False)
+        self.v_proj = nn.Linear(cfg.d_model, kv_width, bias=False)
+        self.o_proj = nn.Linear(cfg.n_heads * cfg.d_head, cfg.d_model, bias=False)
+
+
+class TestMixtralAdapterConfig:
+    """Adapter-owned config defaults that downstream bridge code relies on."""
+
+    def test_normalization_type_is_rms(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert adapter.cfg.normalization_type == "RMS"
+
+    def test_positional_embedding_type_is_rotary(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert adapter.cfg.positional_embedding_type == "rotary"
+
+    def test_final_rms_is_false(self, adapter: MixtralArchitectureAdapter) -> None:
+        """Mixtral does not apply the final-RMS fold that Qwen-style adapters use."""
+        assert adapter.cfg.final_rms is False
+
+    def test_gated_mlp_is_true(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert adapter.cfg.gated_mlp is True
+
+    def test_attn_only_is_false(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert adapter.cfg.attn_only is False
+
+    def test_uses_rms_norm_is_true(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert adapter.cfg.uses_rms_norm is True
+
+    def test_n_kv_heads_propagated(self) -> None:
+        adapter = MixtralArchitectureAdapter(_cfg(n_key_value_heads=2))
+        assert adapter.cfg.n_key_value_heads == 2
+
+
+class TestMixtralWeightConversions:
+    """Mixtral uses QKVO weight conversions plus Q/K/V biases, with GQA head counts."""
+
+    def test_conversion_keys_are_exactly_qkvo_and_biases(
+        self, adapter: MixtralArchitectureAdapter
+    ) -> None:
+        assert set(_conversions(adapter).keys()) == {
+            "blocks.{i}.attn.q.weight",
+            "blocks.{i}.attn.k.weight",
+            "blocks.{i}.attn.v.weight",
+            "blocks.{i}.attn.q.bias",
+            "blocks.{i}.attn.k.bias",
+            "blocks.{i}.attn.v.bias",
+            "blocks.{i}.attn.o.weight",
+        }
+
+    def test_q_weight_rearrange_uses_n_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        rearrange = _rearrange(adapter, "blocks.{i}.attn.q.weight")
+        assert rearrange.pattern == "(n h) m -> n m h"
+        assert rearrange.axes_lengths.get("n") == 4
+
+    def test_kv_weight_rearrange_uses_n_kv_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        """GQA: K/V weights follow n_key_value_heads (2), not n_heads."""
+        for slot in ("k", "v"):
+            rearrange = _rearrange(adapter, f"blocks.{{i}}.attn.{slot}.weight")
+            assert rearrange.pattern == "(n h) m -> n m h"
+            assert rearrange.axes_lengths.get("n") == 2
+
+    def test_o_weight_rearrange_uses_n_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        rearrange = _rearrange(adapter, "blocks.{i}.attn.o.weight")
+        assert rearrange.pattern == "m (n h) -> n h m"
+        assert rearrange.axes_lengths.get("n") == 4
+
+    def test_q_bias_rearrange_uses_n_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        rearrange = _rearrange(adapter, "blocks.{i}.attn.q.bias")
+        assert rearrange.pattern == "(h d_head) -> h d_head"
+        assert rearrange.axes_lengths.get("h") == 4
+
+    def test_kv_bias_rearrange_uses_n_kv_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        for slot in ("k", "v"):
+            rearrange = _rearrange(adapter, f"blocks.{{i}}.attn.{slot}.bias")
+            assert rearrange.pattern == "(h d_head) -> h d_head"
+            assert rearrange.axes_lengths.get("h") == 2
+
+    def test_gqa_fallback_to_n_heads_without_kv_heads(self) -> None:
+        """Without n_key_value_heads, K/V fall back to n_heads for both weight and bias."""
+        adapter = MixtralArchitectureAdapter(_cfg(n_key_value_heads=None))
+        for slot in ("k", "v"):
+            assert _rearrange(adapter, f"blocks.{{i}}.attn.{slot}.weight").axes_lengths["n"] == 4
+            assert _rearrange(adapter, f"blocks.{{i}}.attn.{slot}.bias").axes_lengths["h"] == 4
+
+    def test_gqa_does_not_affect_q_or_o(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert _rearrange(adapter, "blocks.{i}.attn.q.weight").axes_lengths["n"] == 4
+        assert _rearrange(adapter, "blocks.{i}.attn.o.weight").axes_lengths["n"] == 4
+
+
+class TestMixtralWeightConversionRoundTrips:
+    """Run the rearranges on synthetic HF-shaped tensors.
+
+    The pattern/axis assertions above only check metadata. These confirm the
+    conversions actually reshape realistic weight and bias tensors into the
+    split-head layout and revert losslessly (a rearrange is a pure permutation,
+    so the round-trip must be exactly equal).
+    """
+
+    N_HEADS = 4
+    N_KV_HEADS = 2
+    D_HEAD = 16
+    D_MODEL = 64
+
+    @pytest.fixture
+    def adapter(self) -> MixtralArchitectureAdapter:
+        return MixtralArchitectureAdapter(_cfg(n_key_value_heads=self.N_KV_HEADS))
+
+    def _roundtrip(self, adapter: MixtralArchitectureAdapter, key: str, tensor: Any) -> tuple:
+        conv = _param_conversion(adapter, key)
+        converted = conv.convert({key: tensor}, key)
+        reverted = conv.revert(converted)
+        return converted, reverted
+
+    def test_q_weight_splits_into_n_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        w = randn(self.N_HEADS * self.D_HEAD, self.D_MODEL)
+        converted, reverted = self._roundtrip(adapter, "blocks.{i}.attn.q.weight", w)
+        assert converted.shape == (self.N_HEADS, self.D_MODEL, self.D_HEAD)
+        assert equal(reverted, w)
+
+    def test_kv_weight_splits_into_n_kv_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        for slot in ("k", "v"):
+            w = randn(self.N_KV_HEADS * self.D_HEAD, self.D_MODEL)
+            converted, reverted = self._roundtrip(adapter, f"blocks.{{i}}.attn.{slot}.weight", w)
+            assert converted.shape == (self.N_KV_HEADS, self.D_MODEL, self.D_HEAD)
+            assert equal(reverted, w)
+
+    def test_o_weight_merges_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        w = randn(self.D_MODEL, self.N_HEADS * self.D_HEAD)
+        converted, reverted = self._roundtrip(adapter, "blocks.{i}.attn.o.weight", w)
+        assert converted.shape == (self.N_HEADS, self.D_HEAD, self.D_MODEL)
+        assert equal(reverted, w)
+
+    def test_q_bias_splits_into_n_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        b = randn(self.N_HEADS * self.D_HEAD)
+        converted, reverted = self._roundtrip(adapter, "blocks.{i}.attn.q.bias", b)
+        assert converted.shape == (self.N_HEADS, self.D_HEAD)
+        assert equal(reverted, b)
+
+    def test_kv_bias_splits_into_n_kv_heads(self, adapter: MixtralArchitectureAdapter) -> None:
+        for slot in ("k", "v"):
+            b = randn(self.N_KV_HEADS * self.D_HEAD)
+            converted, reverted = self._roundtrip(adapter, f"blocks.{{i}}.attn.{slot}.bias", b)
+            assert converted.shape == (self.N_KV_HEADS, self.D_HEAD)
+            assert equal(reverted, b)
+
+
+class TestMixtralComponentMapping:
+    """Structure of the component mapping: required keys and submodules."""
+
+    def test_has_required_top_level_keys(self, adapter: MixtralArchitectureAdapter) -> None:
+        mapping = _mapping(adapter)
+        for key in ("embed", "rotary_emb", "blocks", "ln_final", "unembed"):
+            assert key in mapping, f"Missing top-level key: {key!r}"
+
+    def test_blocks_has_required_submodules(self, adapter: MixtralArchitectureAdapter) -> None:
+        blocks = _mapping(adapter)["blocks"]
+        for key in ("ln1", "ln2", "attn", "mlp"):
+            assert key in blocks.submodules, f"Missing blocks submodule: {key!r}"
+
+    def test_attn_has_qkvo_submodules(self, adapter: MixtralArchitectureAdapter) -> None:
+        attn = _mapping(adapter)["blocks"].submodules["attn"]
+        assert set(attn.submodules.keys()) == {"q", "k", "v", "o"}
+
+    def test_attn_has_no_qk_norm(self, adapter: MixtralArchitectureAdapter) -> None:
+        """Mixtral, unlike Qwen3, has no per-head Q/K normalization."""
+        attn = _mapping(adapter)["blocks"].submodules["attn"]
+        assert "q_norm" not in attn.submodules
+        assert "k_norm" not in attn.submodules
+
+    def test_ln1_ln2_are_rms_norm_bridges(self, adapter: MixtralArchitectureAdapter) -> None:
+        subs = _mapping(adapter)["blocks"].submodules
+        assert isinstance(subs["ln1"], RMSNormalizationBridge)
+        assert isinstance(subs["ln2"], RMSNormalizationBridge)
+
+    def test_mlp_has_only_gate_submodule(self, adapter: MixtralArchitectureAdapter) -> None:
+        """Experts are batched tensors inside block_sparse_moe; only the router is mapped."""
+        mlp = _mapping(adapter)["blocks"].submodules["mlp"]
+        assert set(mlp.submodules.keys()) == {"gate"}
+
+    def test_hf_module_paths(self, adapter: MixtralArchitectureAdapter) -> None:
+        mapping = _mapping(adapter)
+        assert mapping["embed"].name == "model.embed_tokens"
+        assert mapping["rotary_emb"].name == "model.rotary_emb"
+        assert mapping["ln_final"].name == "model.norm"
+        assert mapping["unembed"].name == "lm_head"
+        assert mapping["blocks"].name == "model.layers"
+        subs = mapping["blocks"].submodules
+        assert subs["ln1"].name == "input_layernorm"
+        assert subs["ln2"].name == "post_attention_layernorm"
+        assert subs["attn"].name == "self_attn"
+        assert subs["mlp"].name == "block_sparse_moe"
+        assert subs["mlp"].submodules["gate"].name == "gate"
+
+
+class TestMixtralComponentTypes:
+    """Top-level bridge classes, guarding against silent type substitution."""
+
+    def test_embed_is_embedding_bridge(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["embed"], EmbeddingBridge)
+
+    def test_rotary_emb_is_rotary_bridge(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["rotary_emb"], RotaryEmbeddingBridge)
+
+    def test_blocks_is_block_bridge(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["blocks"], BlockBridge)
+
+    def test_ln_final_is_rms_norm_bridge(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["ln_final"], RMSNormalizationBridge)
+
+    def test_unembed_is_unembedding_bridge(self, adapter: MixtralArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["unembed"], UnembeddingBridge)
+
+
+class TestMixtralBlockSubmodules:
+    """BlockBridge submodule types and HF paths."""
+
+    def test_attn_is_position_embeddings_attention(
+        self, adapter: MixtralArchitectureAdapter
+    ) -> None:
+        attn = _mapping(adapter)["blocks"].submodules["attn"]
+        assert isinstance(attn, PositionEmbeddingsAttentionBridge)
+
+    def test_attn_requires_attention_mask_and_position_embeddings(
+        self, adapter: MixtralArchitectureAdapter
+    ) -> None:
+        """MixtralAttention.forward() needs both an attention mask and position embeddings."""
+        attn = _mapping(adapter)["blocks"].submodules["attn"]
+        assert attn.requires_attention_mask is True
+        assert attn.requires_position_embeddings is True
+
+    def test_attn_qkvo_submodule_types_and_paths(self, adapter: MixtralArchitectureAdapter) -> None:
+        attn = _mapping(adapter)["blocks"].submodules["attn"]
+        for sub_name, expected_path in (
+            ("q", "q_proj"),
+            ("k", "k_proj"),
+            ("v", "v_proj"),
+            ("o", "o_proj"),
+        ):
+            sub = attn.submodules[sub_name]
+            assert isinstance(sub, LinearBridge)
+            assert sub.name == expected_path
+
+    def test_mlp_gate_submodule_type(self, adapter: MixtralArchitectureAdapter) -> None:
+        """Router is a LinearBridge so the routing logits can be hooked."""
+        mlp = _mapping(adapter)["blocks"].submodules["mlp"]
+        assert isinstance(mlp.submodules["gate"], LinearBridge)
+
+
+class TestMixtralMoEStructure:
+    """MoE structural invariants distinguishing Mixtral from a dense decoder."""
+
+    def test_mlp_is_moe_not_gated_mlp(self, adapter: MixtralArchitectureAdapter) -> None:
+        mlp = _mapping(adapter)["blocks"].submodules["mlp"]
+        assert isinstance(mlp, MoEBridge)
+        assert not isinstance(mlp, GatedMLPBridge)
+
+
+class TestMixtralGQAHookShapes:
+    """Wire a fake attention module into the bridge and verify GQA hook shapes.
+
+    Spec assertions cannot prove the bridge reshapes activations correctly. Here
+    Q must surface n_heads while K/V surface n_key_value_heads, which is the whole
+    point of grouped-query attention.
+    """
+
+    N_HEADS = 4
+    N_KV_HEADS = 2
+    D_MODEL = 64
+    D_HEAD = D_MODEL // N_HEADS
+    BATCH = 2
+    SEQ = 8
+
+    @pytest.fixture
+    def wired_attn_bridge(self) -> PositionEmbeddingsAttentionBridge:
+        adapter = MixtralArchitectureAdapter(_cfg(n_key_value_heads=self.N_KV_HEADS))
+        fake_attn = FakeMixtralAttention(adapter.cfg)
+        attn_bridge = _mapping(adapter)["blocks"].submodules["attn"]
+        assert isinstance(attn_bridge, PositionEmbeddingsAttentionBridge)
+        attn_bridge.set_original_component(fake_attn)
+        # A full TransformerBridge build materializes these child bridge modules for us.
+        # This unit test wires them by hand so it can stay download-free.
+        for name, original in {
+            "q": fake_attn.q_proj,
+            "k": fake_attn.k_proj,
+            "v": fake_attn.v_proj,
+            "o": fake_attn.o_proj,
+        }.items():
+            submodule = attn_bridge.submodules[name]
+            submodule.set_original_component(original)
+            attn_bridge.add_module(name, submodule)
+        attn_bridge.setup_hook_compatibility()
+        return attn_bridge
+
+    def _run_and_capture(self, attn_bridge: PositionEmbeddingsAttentionBridge) -> tuple:
+        captured: dict = {}
+
+        def _capture(name: str) -> Any:
+            def _hook(x: Any, hook: Any) -> Any:
+                captured[name] = x.detach()
+                return x
+
+            return _hook
+
+        attn_bridge.q.hook_out.add_hook(_capture("q"))
+        attn_bridge.k.hook_out.add_hook(_capture("k"))
+        attn_bridge.v.hook_out.add_hook(_capture("v"))
+
+        hidden = randn(self.BATCH, self.SEQ, self.D_MODEL)
+        # Identity RoPE inputs keep this test focused on hook reshaping, not rotation math.
+        cos = ones(1, self.SEQ, self.D_HEAD)
+        sin = zeros(1, self.SEQ, self.D_HEAD)
+        out = attn_bridge(hidden, position_embeddings=(cos, sin))
+        # The attention bridge may return either a bare tensor or an (output, ...) tuple.
+        out_tensor = out[0] if isinstance(out, tuple) else out
+
+        return captured["q"], captured["k"], captured["v"], out_tensor
+
+    def test_hook_q_uses_n_heads(
+        self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
+    ) -> None:
+        q, _, _, _ = self._run_and_capture(wired_attn_bridge)
+        assert q.shape == (self.BATCH, self.SEQ, self.N_HEADS, self.D_HEAD)
+
+    def test_hook_kv_use_n_kv_heads(
+        self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
+    ) -> None:
+        _, k, v, _ = self._run_and_capture(wired_attn_bridge)
+        assert k.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
+        assert v.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
+
+    def test_attn_output_shape(self, wired_attn_bridge: PositionEmbeddingsAttentionBridge) -> None:
+        _, _, _, out = self._run_and_capture(wired_attn_bridge)
+        assert out.shape == (self.BATCH, self.SEQ, self.D_MODEL)
+
+
+class TestMixtralFactoryRegistration:
+    """Mixtral is registered in the factory and dispatched from a matching config."""
+
+    def test_factory_lookup_returns_adapter_class(self) -> None:
+        assert SUPPORTED_ARCHITECTURES["MixtralForCausalLM"] is MixtralArchitectureAdapter
+
+    def test_factory_selects_correct_adapter(self) -> None:
+        adapter = ArchitectureAdapterFactory.select_architecture_adapter(_cfg())
+        assert isinstance(adapter, MixtralArchitectureAdapter)
+
+
+class TestMixtralSetupComponentTesting:
+    """setup_component_testing wires the shared rotary embedding and forces eager attention."""
+
+    def test_sets_rotary_emb_on_template_attention(
+        self, adapter: MixtralArchitectureAdapter
+    ) -> None:
+        rotary_emb = object()
+        attn_template = adapter.get_generalized_component("blocks.0.attn")
+        assert isinstance(attn_template, PositionEmbeddingsAttentionBridge)
+        assert attn_template._rotary_emb is None
+
+        adapter.setup_component_testing(_fake_hf_model(rotary_emb))
+
+        assert attn_template._rotary_emb is rotary_emb
+
+    def test_sets_rotary_emb_on_each_bridge_model_attention(
+        self, adapter: MixtralArchitectureAdapter
+    ) -> None:
+        rotary_emb = object()
+        bridge_model = DummyBridgeModel([DummyBlock(), DummyBlock(), DummyBlock()])
+
+        adapter.setup_component_testing(_fake_hf_model(rotary_emb), bridge_model=bridge_model)
+
+        for block in bridge_model.blocks:
+            assert block.attn.rotary_emb is rotary_emb
+
+    def test_skips_bridge_blocks_without_attention(
+        self, adapter: MixtralArchitectureAdapter
+    ) -> None:
+        rotary_emb = object()
+        bridge_model = DummyBridgeModel([DummyBlock(), DummyBlock(has_attention=False)])
+
+        adapter.setup_component_testing(_fake_hf_model(rotary_emb), bridge_model=bridge_model)
+
+        assert bridge_model.blocks[0].attn.rotary_emb is rotary_emb
+
+    def test_forces_eager_attention_implementation(
+        self, adapter: MixtralArchitectureAdapter
+    ) -> None:
+        """Bridge attention only matches HF under eager attention, so it is forced on."""
+        hf_model = _fake_hf_model_with_eager_targets(object())
+
+        adapter.setup_component_testing(hf_model)
+
+        assert hf_model.config._attn_implementation == "eager"
+        for layer in hf_model.model.layers:
+            assert layer.self_attn.config._attn_implementation == "eager"
+
+    def test_tolerates_minimal_hf_model_without_config_or_layers(
+        self, adapter: MixtralArchitectureAdapter
+    ) -> None:
+        """The defensive hasattr branches must not raise when config/layers are absent."""
+        rotary_emb = object()
+        # _fake_hf_model exposes only model.rotary_emb (no config, no layers).
+        adapter.setup_component_testing(_fake_hf_model(rotary_emb))
+
+        attn_template = adapter.get_generalized_component("blocks.0.attn")
+        assert isinstance(attn_template, PositionEmbeddingsAttentionBridge)
+        assert attn_template._rotary_emb is rotary_emb
+
+
+class TestMixtralArchitectureGuards:
+    """Guards against drift from Mixtral conventions."""
+
+    def test_no_norm_offset_conversions(self, adapter: MixtralArchitectureAdapter) -> None:
+        """LLaMA-style RMSNorm, with no normalization weights in the conversion map."""
+        for key in _conversions(adapter):
+            assert "ln1" not in key
+            assert "ln2" not in key
+            assert "ln_final" not in key
+
+    def test_attn_is_not_optional(self, adapter: MixtralArchitectureAdapter) -> None:
+        """Every layer has self_attn (no hybrid/optional attention)."""
+        attn = _mapping(adapter)["blocks"].submodules["attn"]
+        assert getattr(attn, "optional", False) is False

--- a/tests/unit/model_bridge/supported_architectures/test_mixtral_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_mixtral_adapter.py
@@ -4,7 +4,7 @@ plus small synthetic tensors and a fake attention module, no real checkpoints).
 Covered:
 - Adapter config defaults (RMSNorm, rotary, gated MoE MLP).
 - Weight conversions: QKVO weights plus Q/K/V biases, with GQA-aware head counts.
-- Numerical round-trips: the rearranges actually reshape and revert losslessly.
+- Numerical round-trips: the rearrange conversions actually reshape and revert losslessly.
 - Component-mapping structure, bridge types, and HF module paths.
 - Factory registration and dispatch.
 - GQA forward hook shapes (Q uses n_heads, K/V use n_key_value_heads).
@@ -256,11 +256,11 @@ class TestMixtralWeightConversions:
 
 
 class TestMixtralWeightConversionRoundTrips:
-    """Run the rearranges on synthetic HF-shaped tensors.
+    """Run the rearrange conversions on synthetic HF-shaped tensors.
 
     The pattern/axis assertions above only check metadata. These confirm the
     conversions actually reshape realistic weight and bias tensors into the
-    split-head layout and revert losslessly (a rearrange is a pure permutation,
+    split-head layout and revert losslessly (a rearrange operation is a pure permutation,
     so the round-trip must be exactly equal).
     """
 


### PR DESCRIPTION
# Description

Adds a unit test suite for `MixtralArchitectureAdapter` under `tests/unit/model_bridge/supported_architectures/`, following the existing adapter-test pattern (modelled on the qwen3_moe and qwen2 suites). It needs no model downloads or real checkpoints, it uses tiny programmatic `TransformerBridgeConfig` objects, plus small synthetic tensors and a fake attention module for the behavioural tests, so it runs on CPU in seconds.

The suite (49 tests) covers:
- Adapter config defaults (RMSNorm, rotary, gated MoE MLP, `final_rms=False`).
- Weight conversions: QKVO weights plus Q/K/V biases, with GQA-aware head counts and the no-`n_key_value_heads` fallback.
- Numerical round-trips: the rearrange conversions are actually run on synthetic HF-shaped weight and bias tensors, asserting the split-head output shapes and lossless reversion.
- Component-mapping structure, bridge types, and HF module paths, including the `block_sparse_moe` MoE bridge with its `gate` router and the absence of Q/K-norm.
- Factory registration and dispatch via `select_architecture_adapter`.
- GQA forward hook shapes: a fake attention module wired into the bridge confirms Q surfaces `n_heads` while K/V surface `n_key_value_heads`.
- `setup_component_testing` rotary-embedding wiring, eager-attention forcing, and robustness on a minimal HF model.
- Architecture guards against drift.

Contributes to #1302 (Mixtral checkbox).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility