### PR TITLE
Add `return_cache` option to `TransformerBridge.generate`

### DIFF
--- a/tests/integration/model_bridge/test_bridge_generate_return_cache.py
+++ b/tests/integration/model_bridge/test_bridge_generate_return_cache.py
@@ -1,0 +1,155 @@
+"""Tests for TransformerBridge.generate(return_cache=True).
+
+return_cache makes generate() also return an ActivationCache for the full prompt +
+generated sequence, identical to run_with_cache(output) (issue #697). v1 supports
+single-sequence, decoder-only text generation; other paths raise NotImplementedError.
+
+Uses distilgpt2 (CI-cached).
+"""
+
+import warnings
+
+import pytest
+import torch
+
+
+@pytest.fixture()
+def bridge(distilgpt2_bridge):
+    """Alias the session fixture for concise test signatures."""
+    return distilgpt2_bridge
+
+
+# Representative position-indexed hooks present in the non-compat distilgpt2 bridge cache.
+# All have the sequence axis at dim 1, so the cache length is shape[1].
+_PROBE_HOOKS = [
+    "hook_embed",
+    "blocks.0.hook_resid_pre",
+    "blocks.0.hook_resid_post",
+    "blocks.0.hook_mlp_out",
+    "blocks.0.attn.hook_q",
+    "blocks.0.attn.hook_z",
+    "blocks.5.hook_resid_post",
+    "ln_final.hook_normalized",
+]
+_PATTERN_HOOK = "blocks.0.attn.hook_pattern"  # [batch, heads, q, k]
+
+
+class TestGenerateReturnCache:
+    """generate(return_cache=True) returns a run_with_cache-equivalent cache over the output."""
+
+    def test_returns_output_and_cache_tuple(self, bridge):
+        """return_cache=True returns an (output, ActivationCache) tuple over the full sequence."""
+        from transformer_lens.ActivationCache import ActivationCache
+
+        tokens = bridge.to_tokens("The quick brown")
+        with torch.no_grad():
+            out, cache = bridge.generate(
+                tokens, max_new_tokens=5, do_sample=False, return_type="tokens", return_cache=True
+            )
+        assert isinstance(cache, ActivationCache)
+        assert out.shape[1] > tokens.shape[1], "Should generate additional tokens"
+
+    def test_cache_matches_run_with_cache_over_full_sequence(self, bridge):
+        """The returned cache equals run_with_cache(output) and spans prompt + generated tokens."""
+        tokens = bridge.to_tokens("The quick brown")
+        with torch.no_grad():
+            out, gen_cache = bridge.generate(
+                tokens, max_new_tokens=5, do_sample=False, return_type="tokens", return_cache=True
+            )
+            _, ref_cache = bridge.run_with_cache(out)
+
+        for name in _PROBE_HOOKS:
+            assert name in gen_cache, f"{name} missing from generate cache"
+            g, r = gen_cache[name], ref_cache[name]
+            assert g.shape == r.shape, f"{name}: {g.shape} vs {r.shape}"
+            # The cache spans the full output (not just the prompt) - the point of #697.
+            assert g.shape[1] == out.shape[1], f"{name} seq dim {g.shape[1]} != {out.shape[1]}"
+            assert torch.allclose(g, r, atol=1e-5, rtol=1e-4), f"{name} differs from run_with_cache"
+
+    def test_includes_attention_patterns(self, bridge):
+        """The cache includes full [batch, heads, q, k] attention patterns (an Option B benefit)."""
+        tokens = bridge.to_tokens("The quick brown")
+        with torch.no_grad():
+            out, cache = bridge.generate(
+                tokens, max_new_tokens=4, do_sample=False, return_type="tokens", return_cache=True
+            )
+        assert _PATTERN_HOOK in cache
+        pattern = cache[_PATTERN_HOOK]
+        seq_len = out.shape[1]
+        assert pattern.shape[0] == 1 and tuple(pattern.shape[-2:]) == (
+            seq_len,
+            seq_len,
+        ), pattern.shape
+
+    def test_return_cache_false_is_unchanged(self, bridge):
+        """Default return_cache=False returns only the output (no tuple), preserving back-compat."""
+        tokens = bridge.to_tokens("The quick brown")
+        with torch.no_grad():
+            out = bridge.generate(tokens, max_new_tokens=5, do_sample=False, return_type="tokens")
+        assert isinstance(out, torch.Tensor)
+
+    def test_with_output_logits(self, bridge):
+        """output_logits=True + return_cache=True -> (ModelOutput, cache); cache matches the sequences."""
+        tokens = bridge.to_tokens("The quick brown")
+        with torch.no_grad():
+            out, cache = bridge.generate(
+                tokens, max_new_tokens=4, do_sample=False, output_logits=True, return_cache=True
+            )
+            _, ref_cache = bridge.run_with_cache(out.sequences)
+        assert hasattr(out, "sequences") and hasattr(out, "logits")
+        name = "blocks.0.hook_resid_post"
+        assert torch.allclose(cache[name], ref_cache[name], atol=1e-5, rtol=1e-4)
+
+    def test_names_filter_scopes_cache(self, bridge):
+        """names_filter is passed through to run_with_cache: same scoped key set, not the full cache."""
+        tokens = bridge.to_tokens("The quick brown")
+        wanted = "blocks.0.hook_resid_post"
+        with torch.no_grad():
+            out, cache = bridge.generate(
+                tokens,
+                max_new_tokens=4,
+                do_sample=False,
+                return_type="tokens",
+                return_cache=True,
+                names_filter=wanted,
+            )
+            _, ref = bridge.run_with_cache(out, names_filter=wanted)
+        assert wanted in cache
+        # Same scoped key set as run_with_cache (passthrough), and far smaller than the full cache.
+        assert set(cache.cache_dict) == set(ref.cache_dict)
+        assert len(cache.cache_dict) < 20
+
+    def test_device_offload_no_spurious_warning(self, bridge):
+        """device= offloads cache tensors (cpu here) without ActivationCache.to's move_model warning."""
+        tokens = bridge.to_tokens("The quick brown")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with torch.no_grad():
+                _, cache = bridge.generate(
+                    tokens,
+                    max_new_tokens=4,
+                    do_sample=False,
+                    return_type="tokens",
+                    return_cache=True,
+                    device="cpu",
+                )
+        assert str(cache["blocks.0.hook_resid_post"].device) == "cpu"
+        assert not any("move_model" in str(w.message) for w in caught), [
+            str(w.message) for w in caught
+        ]
+
+
+class TestGenerateReturnCacheGuards:
+    """return_cache raises a clear error on unsupported paths (v1 = single-sequence decoder-only text)."""
+
+    def test_batched_raises(self, bridge):
+        """Batched/multi-prompt return_cache raises NotImplementedError."""
+        batched = torch.tensor([[1, 2, 3], [4, 5, 6]])
+        with pytest.raises(NotImplementedError, match="batched"):
+            bridge.generate(batched, max_new_tokens=3, do_sample=False, return_cache=True)
+
+    def test_inputs_embeds_raises(self, bridge):
+        """inputs_embeds (a float tensor) + return_cache raises NotImplementedError."""
+        embeds = torch.randn(1, 4, bridge.cfg.d_model)
+        with pytest.raises(NotImplementedError, match="inputs_embeds"):
+            bridge.generate(embeds, max_new_tokens=3, do_sample=False, return_cache=True)

--- a/tests/integration/model_bridge/test_bridge_generate_return_cache.py
+++ b/tests/integration/model_bridge/test_bridge_generate_return_cache.py
@@ -4,7 +4,10 @@ return_cache makes generate() also return an ActivationCache for the full prompt
 generated sequence, identical to run_with_cache(output) (issue #697). v1 supports
 single-sequence, decoder-only text generation; other paths raise NotImplementedError.
 
-Uses distilgpt2 (CI-cached).
+Uses distilgpt2 (CI-cached). The generating tests pass use_past_kv_cache=False so they stay
+robust on macOS-arm64 CI, where the cached-eager-attention path can NaN (issue #1322).
+return_cache recomputes run_with_cache on the output regardless of the KV-cache mode, so
+this does not change what is being tested.
 """
 
 import warnings
@@ -44,7 +47,12 @@ class TestGenerateReturnCache:
         tokens = bridge.to_tokens("The quick brown")
         with torch.no_grad():
             out, cache = bridge.generate(
-                tokens, max_new_tokens=5, do_sample=False, return_type="tokens", return_cache=True
+                tokens,
+                max_new_tokens=5,
+                do_sample=False,
+                return_type="tokens",
+                return_cache=True,
+                use_past_kv_cache=False,
             )
         assert isinstance(cache, ActivationCache)
         assert out.shape[1] > tokens.shape[1], "Should generate additional tokens"
@@ -54,7 +62,12 @@ class TestGenerateReturnCache:
         tokens = bridge.to_tokens("The quick brown")
         with torch.no_grad():
             out, gen_cache = bridge.generate(
-                tokens, max_new_tokens=5, do_sample=False, return_type="tokens", return_cache=True
+                tokens,
+                max_new_tokens=5,
+                do_sample=False,
+                return_type="tokens",
+                return_cache=True,
+                use_past_kv_cache=False,
             )
             _, ref_cache = bridge.run_with_cache(out)
 
@@ -71,7 +84,12 @@ class TestGenerateReturnCache:
         tokens = bridge.to_tokens("The quick brown")
         with torch.no_grad():
             out, cache = bridge.generate(
-                tokens, max_new_tokens=4, do_sample=False, return_type="tokens", return_cache=True
+                tokens,
+                max_new_tokens=4,
+                do_sample=False,
+                return_type="tokens",
+                return_cache=True,
+                use_past_kv_cache=False,
             )
         assert _PATTERN_HOOK in cache
         pattern = cache[_PATTERN_HOOK]
@@ -85,7 +103,13 @@ class TestGenerateReturnCache:
         """Default return_cache=False returns only the output (no tuple), preserving back-compat."""
         tokens = bridge.to_tokens("The quick brown")
         with torch.no_grad():
-            out = bridge.generate(tokens, max_new_tokens=5, do_sample=False, return_type="tokens")
+            out = bridge.generate(
+                tokens,
+                max_new_tokens=5,
+                do_sample=False,
+                return_type="tokens",
+                use_past_kv_cache=False,
+            )
         assert isinstance(out, torch.Tensor)
 
     def test_with_output_logits(self, bridge):
@@ -93,7 +117,12 @@ class TestGenerateReturnCache:
         tokens = bridge.to_tokens("The quick brown")
         with torch.no_grad():
             out, cache = bridge.generate(
-                tokens, max_new_tokens=4, do_sample=False, output_logits=True, return_cache=True
+                tokens,
+                max_new_tokens=4,
+                do_sample=False,
+                output_logits=True,
+                return_cache=True,
+                use_past_kv_cache=False,
             )
             _, ref_cache = bridge.run_with_cache(out.sequences)
         assert hasattr(out, "sequences") and hasattr(out, "logits")
@@ -112,6 +141,7 @@ class TestGenerateReturnCache:
                 return_type="tokens",
                 return_cache=True,
                 names_filter=wanted,
+                use_past_kv_cache=False,
             )
             _, ref = bridge.run_with_cache(out, names_filter=wanted)
         assert wanted in cache
@@ -132,6 +162,7 @@ class TestGenerateReturnCache:
                     return_type="tokens",
                     return_cache=True,
                     device="cpu",
+                    use_past_kv_cache=False,
                 )
         assert str(cache["blocks.0.hook_resid_post"].device) == "cpu"
         assert not any("move_model" in str(w.message) for w in caught), [

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -2501,9 +2501,14 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
         return_type: Optional[str] = "input",
         verbose: bool = True,
         output_logits: bool = False,
+        return_cache: bool = False,
+        names_filter: Optional[Union[str, List[str], Callable[[str], bool]]] = None,
+        device: Optional[Union[str, torch.device]] = None,
         pixel_values: Optional[torch.Tensor] = None,
         **multimodal_kwargs,
-    ) -> str | list[str] | torch.Tensor | Any:  # Any for transformers.utils.ModelOutput
+    ) -> (
+        str | list[str] | torch.Tensor | Any | tuple[Any, ActivationCache]
+    ):  # Any for transformers.utils.ModelOutput
         # Any: beartype forward ref limitation (beartype#546)
         """Sample tokens from the model.
 
@@ -2533,6 +2538,18 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             return_type: The type of output to return - 'input', 'str', or 'tokens'
             verbose: Not used in Bridge (kept for API compatibility)
             output_logits: If True, return a ModelOutput with sequences and logits tuple
+            return_cache: If True, also return an ActivationCache for the full prompt +
+                generated sequence, identical to ``run_with_cache(output)``, and the call
+                returns an ``(output, cache)`` tuple. Implemented as one extra clean forward
+                over the output, so the cache includes every hook point (attention patterns
+                included). Supported only for single-sequence, decoder-only text generation;
+                encoder-decoder, SSM, multimodal, batched, and inputs_embeds inputs raise
+                NotImplementedError. The cache spans prompt + max_new_tokens and can be large,
+                use ``names_filter`` to scope it and/or ``device`` to offload it.
+            names_filter: Passed to ``run_with_cache`` when ``return_cache=True``; restricts
+                which activations are cached (str, list of str, or callable).
+            device: Passed through when ``return_cache=True`` to offload the cached tensors
+                to this device (e.g. "cpu") to save accelerator memory.
             pixel_values: Optional image tensor for multimodal models. Only passed on the
                 first generation step (the vision encoder processes the image once, then
                 embeddings are part of the token sequence for subsequent steps).
@@ -2540,6 +2557,13 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
         Returns:
             Generated sequence as string, list of strings, or tensor depending on input type and return_type.
             If output_logits=True, returns a ModelOutput-like object with 'sequences' and 'logits' attributes.
+            If return_cache=True, returns an ``(output, ActivationCache)`` tuple where ``output`` is the
+            value that would otherwise be returned and the cache equals ``run_with_cache(output)``.
+
+        Example:
+            ``out, cache = model.generate(prompt, max_new_tokens=20, return_cache=True)`` returns a
+            normal ActivationCache over the full prompt + generated sequence (equivalent to
+            ``run_with_cache(out)``).
         """
         # prepend_bos is intentionally not applied during generation.
         # The HF model expects tokens in its native format. Overriding BOS can silently
@@ -2632,6 +2656,37 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
         is_encoder_decoder = hasattr(self.original_model, "config") and getattr(
             self.original_model.config, "is_encoder_decoder", False
         )
+
+        # return_cache recomputes run_with_cache on the generated output (see issue #697).
+        # That is well-defined only for single-sequence, decoder-only text generation, so
+        # reject the paths whose cache would be wrong/undefined, with a clear pointer to the
+        # run_with_cache workaround. Fail fast here, before any generation work.
+        if return_cache:
+            if is_encoder_decoder:
+                raise NotImplementedError(
+                    "generate(return_cache=True) is not supported for encoder-decoder "
+                    "models yet. Run run_with_cache on the generated output instead."
+                )
+            if is_stateful_model:
+                raise NotImplementedError(
+                    "generate(return_cache=True) is not supported for stateful/SSM models "
+                    "(e.g. Mamba); they do not expose standard transformer hook points."
+                )
+            if pixel_values is not None or multimodal_kwargs:
+                raise NotImplementedError(
+                    "generate(return_cache=True) is not supported for multimodal generation "
+                    "yet. Run run_with_cache on the generated output instead."
+                )
+            if _generate_from_embeds:
+                raise NotImplementedError(
+                    "generate(return_cache=True) requires token input, not inputs_embeds."
+                )
+            if batch_size > 1:
+                raise NotImplementedError(
+                    "generate(return_cache=True) is not supported for batched/multi-prompt "
+                    "generation yet. Pass a single prompt, or run run_with_cache on each "
+                    "output sequence."
+                )
 
         # HF cache flows opaquely through the component chain via
         # _reconstruct_attention() → _update_kv_cache() on each layer.
@@ -2756,7 +2811,8 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
         else:
             output_tokens = torch.cat([input_tokens, sampled_tokens], dim=1)
 
-        # Return ModelOutput if output_logits was requested
+        # Build the formatted output (shape unchanged: ModelOutput / str / list[str] / tokens).
+        result: Any
         if output_logits and logits_seq_list is not None:
             from transformers.utils import ModelOutput  # type: ignore
 
@@ -2768,9 +2824,9 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             try:
                 from transformers.generation.utils import GenerateDecoderOnlyOutput
 
-                # Return a HF-compatible ModelOutput structure
+                # HF-compatible ModelOutput structure.
                 # GenerateDecoderOnlyOutput expects: sequences, scores (optional), logits (optional)
-                return GenerateDecoderOnlyOutput(
+                result = GenerateDecoderOnlyOutput(
                     sequences=cast(torch.LongTensor, output_tokens),
                     # HF's type hint says tuple[FloatTensor] but should be tuple[FloatTensor, ...]
                     # (variable-length tuple with one element per generated token)
@@ -2778,24 +2834,37 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                 )
             except (ImportError, AttributeError):
                 # Fallback if GenerateDecoderOnlyOutput not available in this transformers version
-                return ModelOutput(
+                result = ModelOutput(
                     sequences=output_tokens,
                     logits=_logits_to_tuple(logits_seq_list),
                 )
-
-        # Format output
-        if return_type == "str":
+        elif return_type == "str":
             assert self.tokenizer is not None
             if input_type == "str":
-                return self.tokenizer.decode(output_tokens[0], skip_special_tokens=True)
+                result = self.tokenizer.decode(output_tokens[0], skip_special_tokens=True)
             else:
                 decoded_texts = [
                     self.tokenizer.decode(tokens, skip_special_tokens=True)
                     for tokens in output_tokens
                 ]
-                return decoded_texts[0] if len(decoded_texts) == 1 else decoded_texts
+                result = decoded_texts[0] if len(decoded_texts) == 1 else decoded_texts
         else:  # return_type == "tokens"
-            return output_tokens
+            result = output_tokens
+
+        if not return_cache:
+            return result
+
+        # return_cache: recompute one clean forward over the full generated sequence so the
+        # cache is identical to run_with_cache(output_tokens) - all hook points, including
+        # attention patterns. The guards above restrict this to single-sequence, decoder-only
+        # text generation (see issue #697).
+        _, cache = self.run_with_cache(output_tokens, names_filter=names_filter)
+        if device is not None:
+            # Offload the cached activations to `device`. We move cache_dict directly rather
+            # than calling ActivationCache.to(device), which currently emits a spurious
+            # move_model DeprecationWarning.
+            cache.cache_dict = {key: value.to(device) for key, value in cache.cache_dict.items()}
+        return result, cache
 
     @torch.no_grad()
     def generate_stream(


### PR DESCRIPTION
# Description
Adds an opt-in `return_cache` flag to `TransformerBridge.generate()`. When `return_cache=True`, `generate` returns `(output, cache)` where `cache` is a standard `ActivationCache` over the full prompt+generated sequence, identical to `run_with_cache(output)`. This resolves the gap in #697, where `run_with_cache` only covers the prompt and `generate` returns no activations. A `names_filter` argument lets callers scope the cache, and a `device` argument offloads the returned cache to another device (e.g. CPU); the cache over prompt+max_new_tokens can be large, so the docstring notes the memory cost.

Semantics are "recompute one clean forward over the generated sequence," so the cache is consistent with the rest of TransformerLens, includes attention patterns and all hook points, and avoids the cached-eager-attention path behind #1322. For a causal LM this is numerically identical to capturing during generation (verified), without the ragged per-step shapes. This PR covers single-sequence decoder-only text; encoder-decoder / SSM / multimodal / batched / inputs_embeds raise a clear error pointing to the `run_with_cache`-on-output workaround. Capturing during generation (for active-hook/steering scenarios) remains available via `with model.hooks(...)` around `generate` and can be added later as an explicit opt-in.

Fixes #697

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility