### PR TITLE
Remove deprecated `move_model` parameter from `ActivationCache.to`

### DIFF
--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -14,7 +14,6 @@ back to these docs depending on what you need to do.
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -220,7 +219,7 @@ class ActivationCache:
         """
         return len(self.cache_dict)
 
-    def to(self, device: Union[str, torch.device], move_model=False) -> ActivationCache:
+    def to(self, device: Union[str, torch.device]) -> ActivationCache:
         """Move the Cache to a Device.
 
         Mostly useful for moving the cache to the CPU after model computation finishes to save GPU
@@ -231,23 +230,10 @@ class ActivationCache:
         Args:
             device:
                 The device to move the cache to (e.g. `torch.device.cpu`).
-            move_model:
-                Whether to also move the model to the same device. @deprecated
 
         """
-        # Move model is deprecated as we plan on de-coupling the classes
-        if move_model is not None:
-            warnings.warn(
-                "The 'move_model' parameter is deprecated.",
-                DeprecationWarning,
-            )
-
         warn_if_mps(device)
         self.cache_dict = {key: value.to(device) for key, value in self.cache_dict.items()}
-
-        if move_model:
-            self.model.to(device)
-
         return self
 
     def toggle_autodiff(self, mode: bool = False):


### PR DESCRIPTION
# Description

Removed the long-deprecated `move_model` parameter from `ActivationCache.to`, along with the spurious `DeprecationWarning` that fired on every call. The guard `if move_model is not None:` always evaluated true because the parameter defaulted to `False`, not `None`, so the normal `cache.to("cpu")` idiom always printed a noisy warning.

Net effect: `cache.to(device)` no longer emits any `DeprecationWarning` and no longer accepts the removed kwarg. This brings the code in line with the [v3.0 release notes](https://transformerlensorg.github.io/TransformerLens/content/news/release-3.0.html#breaking-changes-and-deprecations), which already announced the removal.

No new tests added as this is a pure removal of dead, deprecated code.

Fixes #1342

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility