### PR TITLE
Parametrize the Cohere logit_scale fold test with a scale other than 1.0

### DIFF
--- a/tests/integration/model_bridge/test_cohere_adapter.py
+++ b/tests/integration/model_bridge/test_cohere_adapter.py
@@ -207,20 +207,36 @@ class TestCohereTiedEmbedding:
             max_diff < 1e-6
         ), f"embed.W_E was corrupted (possibly by logit_scale fold): max_diff={max_diff:.6f}"
 
-    def test_embed_and_unembed_weights_differ(
-        self, cohere_bridge_processed: TransformerBridge
-    ) -> None:
-        # After the logit_scale fold, embed.W_E and unembed.weight must NOT be identical.
-        # If they are, the untie or fold did not take effect.
-        logit_scale = getattr(cohere_bridge_processed.cfg, "logit_scale")
-        if logit_scale == 1.0:
-            pytest.skip("logit_scale=1.0 — fold is a no-op, skip this check")
-        tl_embed = cohere_bridge_processed.embed.W_E
-        tl_unembed = cohere_bridge_processed.unembed.original_component.weight
-        assert not torch.allclose(tl_embed, tl_unembed), (
-            "embed.W_E and unembed.weight are identical — "
-            "logit_scale fold may not have been applied or untied correctly"
+    @pytest.mark.parametrize("logit_scale", [0.0625, 1.0])
+    def test_embed_and_unembed_weights_differ(self, logit_scale: float) -> None:
+        # After the logit_scale fold, embed.W_E and unembed.weight must NOT be
+        # identical for a non-trivial scale. logit_scale=1.0 is kept as a regression
+        # guard for the no-op case, where the two weights stay tied.
+        #
+        # cfg.logit_scale is set before process_weights so the fold (which reads it
+        # inside preprocess_weights) runs with the parametrized value.
+        bridge = TransformerBridge.boot_transformers(MODEL, device="cpu")
+        bridge.cfg.logit_scale = logit_scale  # type: ignore[attr-defined]
+        bridge.process_weights(
+            fold_ln=False,
+            center_writing_weights=False,
+            center_unembed=False,
+            fold_value_biases=False,
+            refactor_factored_attn_matrices=False,
         )
+        tl_embed = bridge.embed.W_E
+        tl_unembed = bridge.unembed.original_component.weight
+        weights_identical = torch.allclose(tl_embed, tl_unembed)
+        if logit_scale == 1.0:
+            assert weights_identical, (
+                "embed.W_E and unembed.weight should remain tied when logit_scale=1.0 "
+                "(the fold is a no-op)"
+            )
+        else:
+            assert not weights_identical, (
+                "embed.W_E and unembed.weight are identical — "
+                "logit_scale fold may not have been applied or untied correctly"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This fixes issue #1325.

The test test_embed_and_unembed_weights_differ in tests/integration/model_bridge/test_cohere_adapter.py guarded its fold assertion behind an inline if logit_scale == 1.0 then pytest.skip branch. The fixture model trl-internal-testing/tiny-CohereForCausalLM ships logit_scale=0.0625, so that guard was dead code for the current model and the no-op case it was meant to skip was never actually reached. The result was that the test claimed to cover the fold while the skip branch only added noise.

This change parametrizes logit_scale over a non-trivial value of 0.0625 and over 1.0. For each value the test boots a fresh bridge, sets cfg.logit_scale before calling process_weights, and lets the fold run with the parametrized value. The fold reads cfg.logit_scale inside preprocess_weights, so setting it before process_weights is what makes the parametrization actually flow into the fold path.

The non-trivial 0.0625 case exercises the fold and asserts that embed.W_E and unembed.weight are no longer identical, which is the behavior the test was always meant to verify. The 1.0 case stays as a regression guard and asserts the two weights remain tied, since the fold is a no-op at unit scale. The inline pytest.skip is removed.

This satisfies the acceptance criteria in the issue. The test now parametrizes logit_scale with a non-1.0 value plus 1.0 as the optional no-op regression guard, the non-1.0 case fires the assertion with no skip, and the inline skip is gone.

Verification. In an isolated Python 3.12 venv with the package installed editable alongside pytest, torch, and transformers, the targeted run pytest tests/integration/model_bridge/test_cohere_adapter.py -k test_embed_and_unembed_weights_differ -x -q passed both parametrized cases (2 passed, 21 deselected). The tiny model downloaded and the fold path ran. black and isort were run against the changed file and report no changes needed.
