### PR TITLE
Remove extra checks from Phi adapter setup_component_testing

### DIFF
--- a/transformer_lens/model_bridge/supported_architectures/phi.py
+++ b/transformer_lens/model_bridge/supported_architectures/phi.py
@@ -119,23 +119,7 @@ class PhiArchitectureAdapter(ArchitectureAdapter):
         """
         # Get rotary embedding instance from the model
         # Phi models have rotary_emb at model.model.rotary_emb
-        if hasattr(hf_model, "model") and hasattr(hf_model.model, "rotary_emb"):
-            rotary_emb = hf_model.model.rotary_emb
-        else:
-            # Fallback: try to get from first layer
-            if hasattr(hf_model, "model") and hasattr(hf_model.model, "layers"):
-                if len(hf_model.model.layers) > 0:
-                    first_layer = hf_model.model.layers[0]
-                    if hasattr(first_layer, "self_attn") and hasattr(
-                        first_layer.self_attn, "rotary_emb"
-                    ):
-                        rotary_emb = first_layer.self_attn.rotary_emb
-                    else:
-                        return  # Can't find rotary_emb
-                else:
-                    return
-            else:
-                return
+        rotary_emb = hf_model.model.rotary_emb
 
         # Set rotary_emb on actual bridge instances in bridge_model if available
         if bridge_model is not None and hasattr(bridge_model, "blocks"):


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Remove unnecessary checks for `rotary_emb` location in Phi adapter `setup_component_testing` method.

Fixes #1368 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->