### PR TITLE
Add `stop_strings` and `stopping_criteria` support to `TransformerBridge.generate`

### DIFF
--- a/tests/QUARANTINES.md
+++ b/tests/QUARANTINES.md
@@ -66,6 +66,7 @@ Rule ([AGENTS.md §10](../AGENTS.md#10-hard-rules)): **never add `xfail` / `skip
 | Path | Reason | Issue |
 |---|---|---|
 | [`unit/model_bridge/test_bridge_generate_no_tokenizer.py`:30,128](unit/model_bridge/test_bridge_generate_no_tokenizer.py) | `skipif(_MACOS_ARM64)` — KV-cache NaN | Upstream PyTorch/HF on M-series Macs |
+| [`integration/model_bridge/test_bridge_generate_stopping_criteria.py`](integration/model_bridge/test_bridge_generate_stopping_criteria.py) | `skipif(_MACOS_ARM64)`, KV-cache NaN (one `use_past_kv_cache=True` test) | Upstream PyTorch/HF on M-series Macs |
 
 **Un-skip:** when upstream resolves. Don't bypass — produces NaN logits.
 

--- a/tests/integration/model_bridge/test_bridge_generate_stopping_criteria.py
+++ b/tests/integration/model_bridge/test_bridge_generate_stopping_criteria.py
@@ -1,0 +1,456 @@
+"""Tests for stop_strings and stopping_criteria on TransformerBridge.generate().
+
+Coverage:
+- stop_strings (single, list) halts generation early at the match.
+- stopping_criteria (bare StoppingCriteria, list, StoppingCriteriaList) halts.
+- The three signals (EOS, stop_strings, stopping_criteria) are independent: in
+  particular stop_at_eos=False still stops on a stop string (the early-exit and
+  finished-row padding must not be gated on stop_at_eos).
+- Defaults (both None) are a byte-for-byte no-op (back-compat guard).
+- Batched generation stops correctly.
+- Error contracts: stop_strings without a tokenizer raises ValueError, a
+  stopping_criteria callable needs no tokenizer, unsupported input paths raise
+  NotImplementedError, and a bad stopping_criteria type raises TypeError.
+- generate_stream honors the same parameters (shared _generate_tokens loop).
+
+Uses distilgpt2 (CI-cached). Greedy (do_sample=False) for determinism, and
+use_past_kv_cache=False so the tests stay robust on macOS-arm64 CI where the
+cached-eager-attention path can NaN (issue #1322).
+"""
+
+import platform
+
+import pytest
+import torch
+from transformers import StoppingCriteria, StoppingCriteriaList
+
+_MACOS_ARM64 = platform.system() == "Darwin" and platform.machine() == "arm64"
+
+# Common kwargs for the greedy, macOS-safe, token-returning generate calls below.
+_GEN = dict(do_sample=False, use_past_kv_cache=False, return_type="tokens", verbose=False)
+
+
+@pytest.fixture()
+def bridge(distilgpt2_bridge):
+    """Alias the shared session fixture for concise test signatures."""
+    return distilgpt2_bridge
+
+
+@pytest.fixture()
+def tokenizerless_bridge():
+    """A private distilgpt2 bridge with its tokenizer removed.
+
+    Function-scoped (a fresh boot per test) so removing the tokenizer never
+    contaminates the shared session fixture.
+    """
+    from transformer_lens.model_bridge import TransformerBridge
+
+    b = TransformerBridge.boot_transformers("distilgpt2", device="cpu")
+    b.tokenizer = None
+    return b
+
+
+@pytest.fixture(scope="module")
+def bridge_with_pad():
+    """A private distilgpt2 bridge with eos set as the pad token, for batched tests.
+
+    A dedicated boot (not the shared session fixture) so setting the pad token does not
+    leak into other tests.
+    """
+    from transformer_lens.model_bridge import TransformerBridge
+
+    b = TransformerBridge.boot_transformers("distilgpt2", device="cpu")
+    if b.tokenizer.pad_token is None:
+        b.tokenizer.pad_token = b.tokenizer.eos_token
+    return b
+
+
+class _StopAfterTotalLen(StoppingCriteria):
+    """Stop once the running sequence reaches a fixed total length.
+
+    Length-based so the stop step is deterministic and independent of what the
+    model emits, which makes for exact assertions.
+    """
+
+    def __init__(self, total_len: int):
+        self.total_len = total_len
+
+    def __call__(self, input_ids, scores, **kwargs):
+        return input_ids.shape[-1] >= self.total_len
+
+
+def _decode(bridge, out_row):
+    return bridge.tokenizer.decode(out_row, skip_special_tokens=True)
+
+
+def test_stop_string_halts_early(bridge):
+    """A single stop string stops generation before max_new_tokens and appears in the output."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    out = bridge.generate(tokens, max_new_tokens=40, stop_strings=".", **_GEN)
+
+    assert out.shape[1] > prompt_len, "should have generated at least one token"
+    assert out.shape[1] < prompt_len + 40, "should have stopped before the token budget"
+    assert "." in _decode(bridge, out[0]), "the stop string should be present in the output"
+
+
+def test_stop_string_list(bridge):
+    """A list of stop strings stops on whichever appears first, deterministically."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+    stops = [".", ",", " the"]
+
+    out1 = bridge.generate(tokens, max_new_tokens=40, stop_strings=stops, **_GEN)
+    out2 = bridge.generate(tokens, max_new_tokens=40, stop_strings=stops, **_GEN)
+
+    assert out1.shape[1] < prompt_len + 40
+    assert any(s in _decode(bridge, out1[0]) for s in stops)
+    assert torch.equal(out1, out2), "greedy generation with stop strings must be deterministic"
+
+
+def test_custom_stopping_criteria_exact_stop(bridge):
+    """A length-based StoppingCriteria stops at exactly the expected step."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    out = bridge.generate(
+        tokens,
+        max_new_tokens=20,
+        stopping_criteria=_StopAfterTotalLen(prompt_len + 3),
+        **_GEN,
+    )
+
+    assert out.shape[1] == prompt_len + 3
+
+
+@pytest.mark.parametrize("wrap", ["bare", "list", "criteria_list"])
+def test_stopping_criteria_accepted_forms(bridge, wrap):
+    """stopping_criteria accepts a bare StoppingCriteria, a list, or a StoppingCriteriaList."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+    criterion = _StopAfterTotalLen(prompt_len + 3)
+
+    if wrap == "bare":
+        stopping_criteria = criterion
+    elif wrap == "list":
+        stopping_criteria = [criterion]
+    else:
+        stopping_criteria = StoppingCriteriaList([criterion])
+
+    out = bridge.generate(tokens, max_new_tokens=20, stopping_criteria=stopping_criteria, **_GEN)
+
+    assert out.shape[1] == prompt_len + 3
+
+
+def test_stop_at_eos_false_still_stops_on_string(bridge):
+    """With stop_at_eos=False, a stop string still halts generation.
+
+    The early-exit and finished-row padding are shared with the EOS path but must
+    not be gated on stop_at_eos, otherwise a stop string could never end generation
+    when EOS stopping is off.
+    """
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    stopped = bridge.generate(
+        tokens, max_new_tokens=40, stop_at_eos=False, stop_strings=".", **_GEN
+    )
+    baseline = bridge.generate(tokens, max_new_tokens=40, stop_at_eos=False, **_GEN)
+
+    assert baseline.shape[1] == prompt_len + 40, "no stop signal should run to the full budget"
+    assert stopped.shape[1] < prompt_len + 40, "the stop string should stop before the budget"
+    assert "." in _decode(bridge, stopped[0])
+
+
+def test_no_stopping_is_noop(bridge):
+    """Passing both new params as None is byte-identical to not passing them."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    out_explicit_none = bridge.generate(
+        tokens,
+        max_new_tokens=5,
+        stop_at_eos=False,
+        stop_strings=None,
+        stopping_criteria=None,
+        **_GEN,
+    )
+    out_baseline = bridge.generate(tokens, max_new_tokens=5, stop_at_eos=False, **_GEN)
+
+    assert torch.equal(out_explicit_none, out_baseline)
+    assert out_explicit_none.shape[1] == prompt_len + 5, "nothing should stop generation"
+
+
+def test_empty_stop_strings_is_noop(bridge):
+    """An empty stop_strings list is a no-op rather than an error."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    out = bridge.generate(tokens, max_new_tokens=4, stop_at_eos=False, stop_strings=[], **_GEN)
+
+    assert out.shape[1] == prompt_len + 4
+
+
+def test_stopping_criteria_takes_precedence_over_unmet_stop_string(bridge):
+    """When a stop string never appears, a criterion still stops generation."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    out = bridge.generate(
+        tokens,
+        max_new_tokens=20,
+        stop_strings="zzzzzqqqqq",  # not emitted by greedy distilgpt2
+        stopping_criteria=_StopAfterTotalLen(prompt_len + 3),
+        **_GEN,
+    )
+
+    assert out.shape[1] == prompt_len + 3
+
+
+def test_batched_generation_stops(bridge_with_pad):
+    """Batched generation stops on stop strings, deterministically, for every row."""
+    bridge = bridge_with_pad
+    prompts = ["The capital of France is", "Hello, my name is"]
+    tokens = bridge.to_tokens(prompts, prepend_bos=False, padding_side="left")
+    prompt_len = tokens.shape[1]
+
+    out1 = bridge.generate(tokens, max_new_tokens=40, stop_strings=".", **_GEN)
+    out2 = bridge.generate(tokens, max_new_tokens=40, stop_strings=".", **_GEN)
+
+    assert out1.shape[0] == 2, "batch dimension preserved"
+    assert out1.shape[1] < prompt_len + 40, "the batch stopped before the budget"
+    for i in range(2):
+        assert "." in _decode(bridge, out1[i]), f"row {i} should contain its stop string"
+    assert torch.equal(out1, out2), "batched greedy generation must be deterministic"
+
+
+@pytest.mark.skipif(_MACOS_ARM64, reason="Upstream macOS-arm64 KV-cache NaN, see issue #1322.")
+def test_stop_string_with_kv_cache(bridge):
+    """stop_strings also works on the default KV-cache path (not only the no-cache path)."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    out = bridge.generate(
+        tokens,
+        max_new_tokens=40,
+        stop_strings=".",
+        do_sample=False,
+        use_past_kv_cache=True,
+        return_type="tokens",
+        verbose=False,
+    )
+
+    assert out.shape[1] < prompt_len + 40
+    assert "." in _decode(bridge, out[0])
+
+
+def test_stop_strings_requires_tokenizer(tokenizerless_bridge):
+    """stop_strings without a tokenizer raises a clear ValueError, but a criterion does not."""
+    b = tokenizerless_bridge
+    tokens = torch.tensor([[15496, 11, 314, 1101, 257]], dtype=torch.long)
+
+    # stop_at_eos=False isolates the stop_strings tokenizer requirement from the
+    # pre-existing eos-needs-a-tokenizer assertion.
+    with pytest.raises(ValueError, match="tokenizer"):
+        b.generate(tokens, max_new_tokens=3, stop_at_eos=False, stop_strings=".", **_GEN)
+
+    # A token-based stopping_criteria needs no tokenizer and must still work.
+    prompt_len = tokens.shape[1]
+    out = b.generate(
+        tokens,
+        max_new_tokens=20,
+        stop_at_eos=False,
+        stopping_criteria=_StopAfterTotalLen(prompt_len + 3),
+        **_GEN,
+    )
+    assert out.shape[1] == prompt_len + 3
+
+
+def test_invalid_stopping_criteria_type_raises(bridge):
+    """A stopping_criteria of the wrong type raises TypeError."""
+    tokens = bridge.to_tokens("The quick brown")
+    with pytest.raises(TypeError, match="StoppingCriteria"):
+        bridge.generate(tokens, max_new_tokens=3, stopping_criteria=123, **_GEN)
+
+
+def test_unsupported_input_path_raises(bridge):
+    """stop_strings with an inputs_embeds input raises NotImplementedError pointing to hf_generate."""
+    embeds = bridge.original_model.get_input_embeddings()(torch.tensor([[15496, 11, 314]])).float()
+    with pytest.raises(NotImplementedError, match="hf_generate"):
+        bridge.generate(embeds, max_new_tokens=3, stop_strings=".", verbose=False)
+
+
+def test_generate_stream_honors_stop_strings(bridge):
+    """generate_stream stops on a stop string too (shares the _generate_tokens loop)."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    chunks = list(
+        bridge.generate_stream(
+            tokens,
+            max_new_tokens=40,
+            stop_strings=".",
+            do_sample=False,
+            use_past_kv_cache=False,
+            return_type="tokens",
+            verbose=False,
+        )
+    )
+    # First chunk includes the prompt, later chunks are deltas.
+    # Concatenating gives the full prompt + generated sequence.
+    full = torch.cat(chunks, dim=1)
+
+    assert full.shape[1] < prompt_len + 40, "stream should have stopped before the budget"
+    assert "." in _decode(bridge, full[0])
+
+
+def test_stop_string_with_output_logits(bridge):
+    """output_logits=True returns one logits entry per generated token, even on early stop."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    out = bridge.generate(tokens, max_new_tokens=40, stop_strings=".", output_logits=True, **_GEN)
+    n_generated = out.sequences.shape[1] - prompt_len
+
+    assert n_generated < 40, "should have stopped before the budget"
+    assert len(out.logits) == n_generated, "one logits tensor per generated token"
+    assert out.logits[0].shape[0] == 1, "batch dimension on the per-step logits"
+
+
+def test_stop_string_return_type_str(bridge):
+    """return_type='str' decodes the early-stopped sequence, which contains the stop string."""
+    out = bridge.generate(
+        "The quick brown",
+        max_new_tokens=40,
+        stop_strings=".",
+        do_sample=False,
+        use_past_kv_cache=False,
+        return_type="str",
+        verbose=False,
+    )
+    assert isinstance(out, str)
+    assert "." in out
+
+
+def test_malformed_stopping_criteria_shape_raises(bridge):
+    """A criterion returning a non per-row shape gets a clear ValueError, not an opaque error."""
+
+    class _BadShape(StoppingCriteria):
+        def __call__(self, input_ids, scores, **kwargs):
+            return torch.zeros(input_ids.shape[0], 1, dtype=torch.bool)  # [batch, 1], not [batch]
+
+    tokens = bridge.to_tokens("The quick brown")
+    with pytest.raises(ValueError, match="per-row bool"):
+        bridge.generate(tokens, max_new_tokens=3, stopping_criteria=_BadShape(), **_GEN)
+
+
+def test_batched_stopping_criteria_without_pad_token_raises(tokenizerless_bridge):
+    """Batched stopping_criteria with no pad/eos id and stop_at_eos=False raises a clear error.
+
+    Without a padding token, finished rows could not be frozen while the rest of the batch
+    continues, so generate refuses rather than emitting token-0 padding.
+    """
+    b = tokenizerless_bridge
+    batched = torch.tensor([[15496, 11, 314], [15496, 11, 314]], dtype=torch.long)
+    with pytest.raises(ValueError, match="padding token"):
+        b.generate(
+            batched,
+            max_new_tokens=5,
+            stop_at_eos=False,
+            stopping_criteria=_StopAfterTotalLen(5),
+            **_GEN,
+        )
+
+
+# Unsupported-path guards. These exercise the NotImplementedError branches in
+# generate() without booting a heavy enc-dec / multimodal / SSM model, by flipping the
+# exact flag each guard reads on the existing distilgpt2 bridge. The guard fires before
+# any architecture-specific generation code runs, so a stand-in model is sufficient.
+
+
+def test_stop_strings_encoder_decoder_raises(bridge, monkeypatch):
+    """stop_strings on an encoder-decoder model raises NotImplementedError."""
+    monkeypatch.setattr(bridge.original_model.config, "is_encoder_decoder", True)
+    tokens = bridge.to_tokens("The quick brown")
+    with pytest.raises(NotImplementedError, match="encoder-decoder"):
+        bridge.generate(tokens, max_new_tokens=3, stop_strings=".", verbose=False)
+
+
+def test_stop_strings_multimodal_raises(bridge):
+    """stop_strings with a multimodal input (pixel_values) raises NotImplementedError."""
+    tokens = bridge.to_tokens("The quick brown")
+    with pytest.raises(NotImplementedError, match="multimodal"):
+        bridge.generate(
+            tokens,
+            max_new_tokens=3,
+            stop_strings=".",
+            pixel_values=torch.zeros(1, 3, 8, 8),
+            verbose=False,
+        )
+
+
+def test_stop_strings_stateful_fallback_raises(bridge, monkeypatch):
+    """A stateful/SSM model with use_past_kv_cache=False raises, pointing to the cached path.
+
+    With use_past_kv_cache=False the stateful cache is off, so generate() would fall back to
+    hf_generate() and drop the kwargs. The error points to use_past_kv_cache=True, which keeps
+    generation on the hooked loop where stopping is applied.
+    """
+    monkeypatch.setattr(bridge.cfg, "is_stateful", True)
+    tokens = bridge.to_tokens("The quick brown")
+    with pytest.raises(NotImplementedError, match="use_past_kv_cache=True"):
+        bridge.generate(
+            tokens, max_new_tokens=3, stop_strings=".", use_past_kv_cache=False, verbose=False
+        )
+
+
+def test_generate_stream_stop_at_eos_false_stops_on_string(bridge):
+    """generate_stream with stop_at_eos=False still stops on a stop string."""
+    tokens = bridge.to_tokens("The quick brown")
+    prompt_len = tokens.shape[1]
+
+    chunks = list(
+        bridge.generate_stream(
+            tokens,
+            max_new_tokens=40,
+            stop_at_eos=False,
+            stop_strings=".",
+            do_sample=False,
+            use_past_kv_cache=False,
+            return_type="tokens",
+            verbose=False,
+        )
+    )
+    full = torch.cat(chunks, dim=1)
+
+    assert full.shape[1] < prompt_len + 40, "stream should have stopped before the budget"
+    assert "." in _decode(bridge, full[0])
+
+
+def test_generate_stream_batched_without_pad_token_raises(tokenizerless_bridge):
+    """Batched generate_stream stopping_criteria with no pad token and stop_at_eos=False raises."""
+    b = tokenizerless_bridge
+    batched = torch.tensor([[15496, 11, 314], [15496, 11, 314]], dtype=torch.long)
+    stream = b.generate_stream(
+        batched,
+        max_new_tokens=5,
+        stop_at_eos=False,
+        stopping_criteria=_StopAfterTotalLen(5),
+        do_sample=False,
+        use_past_kv_cache=False,
+        return_type="tokens",
+        verbose=False,
+    )
+    with pytest.raises(ValueError, match="padding token"):
+        list(stream)
+
+
+def test_stop_at_eos_false_with_pad_token(bridge_with_pad):
+    """Covers the pad_token_id arm of the no-eos padding fallback (a pad token is present)."""
+    tokens = bridge_with_pad.to_tokens("The quick brown")
+    out = bridge_with_pad.generate(
+        tokens, max_new_tokens=40, stop_at_eos=False, stop_strings=".", **_GEN
+    )
+    assert out.shape[1] < tokens.shape[1] + 40
+    assert "." in _decode(bridge_with_pad, out[0])

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -2347,6 +2347,66 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                 for hook_point, direction in added_hooks:
                     hook_point.remove_hooks(dir=direction)
 
+    def _resolve_stopping_criteria(
+        self,
+        stop_strings: Optional[Union[str, List[str]]],
+        stopping_criteria: Optional[Any],
+    ) -> Optional[Any]:
+        """Combine ``stop_strings`` and ``stopping_criteria`` into one StoppingCriteriaList.
+
+        Returns ``None`` when neither is supplied (or both reduce to no-ops),
+        so callers can cheaply check whether any extra stop signal is active.
+        ``stop_strings`` is turned into a HuggingFace ``StopStringCriteria`` (which reproduces
+        HF's exact partial-token-aware, end-anchored matching: it fires when the stop string
+        ends the generated text, even if the string straddles token boundaries) and therefore
+        requires a tokenizer.
+        A user-supplied ``stopping_criteria`` may be a single ``StoppingCriteria``,
+        a list of them, or a ``StoppingCriteriaList``.
+
+        Raises:
+            ValueError: if ``stop_strings`` is supplied without a tokenizer.
+            TypeError: if ``stopping_criteria`` is not a ``StoppingCriteria``, a
+                list/tuple of them, or a ``StoppingCriteriaList``.
+        """
+        if stop_strings is None and stopping_criteria is None:
+            return None
+
+        from transformers import (  # local import: matches the file's transformers usage
+            StoppingCriteria,
+            StoppingCriteriaList,
+            StopStringCriteria,
+        )
+
+        criteria = StoppingCriteriaList()
+
+        if stop_strings is not None:
+            strings = [stop_strings] if isinstance(stop_strings, str) else list(stop_strings)
+            strings = [s for s in strings if s]  # drop empty strings (HF errors on them)
+            if strings:
+                if self.tokenizer is None:
+                    raise ValueError(
+                        "stop_strings requires a tokenizer (stop strings are detected by "
+                        "matching against the tokenizer vocabulary), but this TransformerBridge "
+                        "has no tokenizer. Pass a stopping_criteria callable that operates on "
+                        "token ids instead, or use hf_generate()."
+                    )
+                criteria.append(StopStringCriteria(tokenizer=self.tokenizer, stop_strings=strings))
+
+        if stopping_criteria is not None:
+            if isinstance(stopping_criteria, StoppingCriteriaList):
+                criteria.extend(stopping_criteria)
+            elif isinstance(stopping_criteria, (list, tuple)):
+                criteria.extend(stopping_criteria)
+            elif isinstance(stopping_criteria, StoppingCriteria):
+                criteria.append(stopping_criteria)
+            else:
+                raise TypeError(
+                    "stopping_criteria must be a transformers.StoppingCriteria, a list of "
+                    f"them, or a StoppingCriteriaList, but got {type(stopping_criteria).__name__}."
+                )
+
+        return criteria if len(criteria) > 0 else None
+
     def _generate_tokens(
         self,
         current_tokens: torch.Tensor,
@@ -2377,14 +2437,21 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
         pixel_values: Optional[torch.Tensor],
         multimodal_kwargs: Dict[str, Any],
         verbose: bool,
+        stopping_criteria_list: Optional[Any] = None,
     ) -> Generator[Tuple[torch.Tensor, torch.Tensor, bool], None, None]:
         """Core generation loop. Yields (sampled_tokens, final_logits, all_finished) per step.
 
-        Owns the forward pass, sampling, EOS handling, token accumulation, and
-        KV cache management. Callers are responsible for try/finally cleanup of
-        ``_capture_hf_cache``.
+        Owns the forward pass, sampling, stop handling (EOS and any
+        ``stopping_criteria_list``), token accumulation, and KV cache management. Callers
+        are responsible for try/finally cleanup of ``_capture_hf_cache``.
+
+        ``stopping_criteria_list`` (from ``_resolve_stopping_criteria``) is evaluated on
+        the running sequence each step and folded into the finished-sequence mask alongside
+        EOS, so when it is ``None`` the loop runs the EOS-only path unchanged.
         """
         _hf_kv_cache = None
+        # A row may finish via EOS and/or any of the configured stopping criteria.
+        any_stop_active = stop_at_eos or stopping_criteria_list is not None
 
         for gen_step_idx in tqdm.tqdm(range(max_new_tokens), disable=not verbose):
             with torch.no_grad():
@@ -2520,9 +2587,13 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                         else (decoder_tokens if is_encoder_decoder else current_tokens),
                     ).to(self.cfg.device)
 
-                # Handle EOS
-                if stop_at_eos:
+                # Freeze rows that finished on an earlier step so they stop emitting
+                # real tokens. Applies to every active stop mechanism, not just EOS.
+                if any_stop_active:
                     sampled_tokens[finished_sequences] = eos_token_for_padding
+
+                # Fold this step's EOS matches into the finished mask.
+                if stop_at_eos:
                     finished_sequences.logical_or_(
                         torch.isin(
                             sampled_tokens.to(self.cfg.device),
@@ -2544,7 +2615,26 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                 else:
                     current_tokens = torch.cat([current_tokens, sampled_tokens.unsqueeze(1)], dim=1)
 
-                all_finished = bool(stop_at_eos and finished_sequences.all().item())
+                # Fold stop_strings / stopping_criteria into the finished mask. They are
+                # evaluated on the full running sequence (prompt + everything generated so
+                # far, including the token just appended) with this step's logits as the
+                # scores argument, matching transformers' StoppingCriteria contract. The
+                # combined list returns a per-row bool [batch] OR-ing every criterion.
+                # generate()/generate_stream() guarantee this is plain decoder-only token
+                # generation, so current_tokens is the running token sequence.
+                if stopping_criteria_list is not None:
+                    criteria_finished = stopping_criteria_list(current_tokens, final_logits).to(
+                        device=self.cfg.device, dtype=torch.bool
+                    )
+                    if criteria_finished.shape != finished_sequences.shape:
+                        raise ValueError(
+                            "A stopping criterion returned shape "
+                            f"{tuple(criteria_finished.shape)}, expected a per-row bool of "
+                            f"shape {tuple(finished_sequences.shape)} (one entry per sequence)."
+                        )
+                    finished_sequences.logical_or_(criteria_finished)
+
+                all_finished = bool(any_stop_active and finished_sequences.all().item())
 
             yield sampled_tokens, final_logits, all_finished
 
@@ -2573,6 +2663,8 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
         names_filter: Optional[Union[str, List[str], Callable[[str], bool]]] = None,
         device: Optional[Union[str, torch.device]] = None,
         pixel_values: Optional[torch.Tensor] = None,
+        stop_strings: Optional[Union[str, List[str]]] = None,
+        stopping_criteria: Optional[Any] = None,
         **multimodal_kwargs,
     ) -> (
         str | list[str] | torch.Tensor | Any | tuple[Any, ActivationCache]
@@ -2621,6 +2713,22 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             pixel_values: Optional image tensor for multimodal models. Only passed on the
                 first generation step (the vision encoder processes the image once, then
                 embeddings are part of the token sequence for subsequent steps).
+            stop_strings: Optional string or list of strings. A sequence stops once its
+                generated text ends with one of these strings, using HuggingFace's
+                StopStringCriteria (partial-token-aware, end-anchored) matching.
+                Requires a tokenizer (raises ValueError otherwise).
+                Independent of stop_at_eos: either can stop a sequence.
+            stopping_criteria: Optional HuggingFace stopping criteria, a single
+                transformers.StoppingCriteria, a list of them, or a StoppingCriteriaList.
+                Each is called as criterion(input_ids, scores) after every step and ORed
+                with the other stop signals, where input_ids is the running sequence and
+                scores is this step's logits ([batch, d_vocab]). Each criterion must return
+                a per-row bool [batch] (or a scalar bool). stop_strings and stopping_criteria
+                are supported only for standard decoder-only text generation. Encoder-decoder,
+                inputs_embeds, and multimodal generation always raise NotImplementedError.
+                Stateful/SSM models raise only when run with use_past_kv_cache=False (the
+                default keeps them on the hooked loop). Each error names the supported
+                alternative.
 
         Returns:
             Generated sequence as string, list of strings, or tensor depending on input type and return_type.
@@ -2775,6 +2883,62 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             and pixel_values is None
             and not multimodal_kwargs
         )
+
+        # stop_strings / stopping_criteria are applied inside the hooked _generate_tokens
+        # loop, so they are supported only on the standard decoder-only text path. Reject
+        # the paths that route around that loop with a clear error rather than silently
+        # dropping the kwargs. This must run before the stateful delegation below.
+        stopping_criteria_list = self._resolve_stopping_criteria(stop_strings, stopping_criteria)
+        if stopping_criteria_list is not None:
+            if is_encoder_decoder:
+                _unsupported = "encoder-decoder models"
+            elif _generate_from_embeds:
+                _unsupported = "inputs_embeds generation"
+            elif pixel_values is not None or multimodal_kwargs:
+                _unsupported = "multimodal (pixel_values) generation"
+            else:
+                _unsupported = None
+            if _unsupported is not None:
+                raise NotImplementedError(
+                    f"stop_strings/stopping_criteria are not supported for {_unsupported} in "
+                    "TransformerBridge.generate(). Call hf_generate(...), which runs "
+                    "HuggingFace's own generation loop and supports HF-native stopping on "
+                    "those inputs."
+                )
+            if is_stateful_model and not use_stateful_cache:
+                # Reached only for a stateful/SSM model with use_past_kv_cache=False: the
+                # hooked loop needs the stateful cache, so generate() would otherwise fall
+                # back to hf_generate() and drop these kwargs. The default cache setting
+                # keeps generation on the hooked loop, where stopping is applied.
+                raise NotImplementedError(
+                    "stop_strings/stopping_criteria on a stateful/SSM model require the "
+                    "stateful cache path, which runs only with use_past_kv_cache=True (the "
+                    "default). With use_past_kv_cache=False generate() falls back to "
+                    "hf_generate(). Set use_past_kv_cache=True to keep stopping on the hooked "
+                    "loop, or call hf_generate(...) directly for HF-native stopping."
+                )
+            # Finished rows are overwritten with this id so they stop emitting real tokens
+            # while the rest of a batch keeps going. stop_at_eos already set a sensible
+            # value, otherwise fall back to the tokenizer pad/eos id. (For a single
+            # sequence this id is never read: the loop exits when the row finishes.)
+            if not stop_at_eos:
+                _pad_id = None
+                if self.tokenizer is not None:
+                    _pad_id = (
+                        self.tokenizer.pad_token_id
+                        if self.tokenizer.pad_token_id is not None
+                        else self.tokenizer.eos_token_id
+                    )
+                if _pad_id is not None:
+                    eos_token_for_padding = _pad_id
+                elif batch_size > 1:
+                    raise ValueError(
+                        "Batched generation with stopping_criteria and stop_at_eos=False "
+                        "needs a padding token to freeze finished rows, but no tokenizer "
+                        "pad/eos id is available. Set stop_at_eos=True, use a tokenizer with "
+                        "a pad or eos token, or generate one sequence at a time."
+                    )
+
         if is_stateful_model and not use_stateful_cache:
             hf_kwargs: dict[str, Any] = {
                 "max_new_tokens": max_new_tokens,
@@ -2857,6 +3021,7 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                 pixel_values=pixel_values,
                 multimodal_kwargs=multimodal_kwargs if multimodal_kwargs else {},
                 verbose=verbose,
+                stopping_criteria_list=stopping_criteria_list,
             ):
                 sampled_tokens_list.append(sampled_tokens.unsqueeze(1))
                 if logits_seq_list is not None:
@@ -2948,6 +3113,8 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
         padding_side: Optional[str] = None,
         return_type: Optional[str] = "input",
         verbose: bool = True,
+        stop_strings: Optional[Union[str, List[str]]] = None,
+        stopping_criteria: Optional[Any] = None,
     ) -> Generator[Union[torch.Tensor, str], None, None]:
         """Stream tokens from the model as they are generated.
 
@@ -2972,6 +3139,12 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                 is forced internally for batched generation.
             return_type: 'input' (match input type), 'str', or 'tokens'.
             verbose: Show progress bar.
+            stop_strings: Optional string or list of strings. A sequence stops once its
+                generated text ends with one of them (HF StopStringCriteria). Requires a
+                tokenizer. See generate() for details.
+            stopping_criteria: Optional transformers StoppingCriteria, list, or
+                StoppingCriteriaList, called as criterion(input_ids, scores) each step
+                (scores is the step's logits). See generate() for the full contract.
 
         Yields:
             Token tensors [batch, seq_len] or strings, accumulated up to
@@ -3036,6 +3209,28 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
 
         finished_sequences = torch.zeros(batch_size, dtype=torch.bool, device=self.cfg.device)
 
+        # stop_strings / stopping_criteria: build the combined criteria list (validates
+        # tokenizer for stop_strings). generate_stream only runs the decoder-only text
+        # path, so no path guards are needed here.
+        stopping_criteria_list = self._resolve_stopping_criteria(stop_strings, stopping_criteria)
+        if stopping_criteria_list is not None and not stop_at_eos:
+            _pad_id = None
+            if self.tokenizer is not None:
+                _pad_id = (
+                    self.tokenizer.pad_token_id
+                    if self.tokenizer.pad_token_id is not None
+                    else self.tokenizer.eos_token_id
+                )
+            if _pad_id is not None:
+                eos_token_for_padding = _pad_id
+            elif batch_size > 1:
+                raise ValueError(
+                    "Batched generate_stream with stopping_criteria and stop_at_eos=False "
+                    "needs a padding token to freeze finished rows, but no tokenizer pad/eos "
+                    "id is available. Set stop_at_eos=True or use a tokenizer with a pad/eos "
+                    "token."
+                )
+
         # --- Cache setup ---
         if use_past_kv_cache:
             self._capture_hf_cache = True
@@ -3087,6 +3282,7 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                     pixel_values=None,
                     multimodal_kwargs={},
                     verbose=verbose,
+                    stopping_criteria_list=stopping_criteria_list,
                 )
             ):
                 new_tokens = sampled_tokens.unsqueeze(-1)


### PR DESCRIPTION
# Description

- Adds `stop_strings` and `stopping_criteria` to `TransformerBridge.generate()` and `generate_stream()`, alongside the existing `stop_at_eos`. HuggingFace-native stopping is already reachable via `hf_generate()`. This brings the same stopping surface to the bridge's own generation loop, which previously supported only EOS stopping.
- `stop_strings` reuses HuggingFace's `StopStringCriteria` rather than a hand-rolled matcher, so its matching behavior is identical to HuggingFace.
- The three stop signals (EOS via `stop_at_eos`, `stop_strings`, and `stopping_criteria`) are independent: any one of them ends a sequence.
- Supported on the standard decoder-only text path (single and batched). Encoder-decoder, inputs_embeds, and multimodal inputs always raise a clear `NotImplementedError`. Stateful/SSM models raise only when run with `use_past_kv_cache=False` (their default keeps them on the supported path).

## Notes for review

- Backward compatibility: with both new parameters left as `None` (the default), generation output is byte-for-byte identical to before, so existing callers are unaffected.
- The `stop_at_eos=False` interaction required a change to shared loop logic, so the diff touches the existing EOS-handling path: the early-exit and finished-row padding were previously gated on `stop_at_eos`, and are now gated on whether any stop signal is active. Without this, a `stop_strings` match with `stop_at_eos=False` would mark a sequence finished but never actually end generation.
- One test exercises the default `use_past_kv_cache=True` path and is skipped on macOS-arm64 (the upstream KV-cache NaN, issue #1322), registered in `tests/QUARANTINES.md` per repo policy. Every other test runs on all platforms.

## Tests added

A new integration suite covering single and list `stop_strings`, custom criteria (bare, list, and `StoppingCriteriaList`), the `stop_at_eos=False` case, no-op defaults, batched generation, `generate_stream` parity, and the error contracts.


Closes #595

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility