### PR TITLE
Fixed SVD interpreter test

### DIFF
--- a/tests/unit/model_bridge/compatibility/test_svd_interpreter.py
+++ b/tests/unit/model_bridge/compatibility/test_svd_interpreter.py
@@ -5,7 +5,7 @@ from beartype.roar import BeartypeCallHintParamViolation
 from transformer_lens import SVDInterpreter
 from transformer_lens.model_bridge import TransformerBridge
 
-MODEL = "gpt2"  # Use a model that works with TransformerBridge
+MODEL = "Intel/tiny-random-gpt2"  # Use a model that works with TransformerBridge
 VECTOR_TYPES = ["OV", "w_in", "w_out"]
 ATOL = 2e-4  # Absolute tolerance - how far does a float have to be before we consider it no longer equal?
 
@@ -17,14 +17,7 @@ def model():
 
 @pytest.fixture(scope="module")
 def second_model():
-    # Use a different model architecture if available, otherwise same model
-    # Note: If gpt2-medium fails to load, tests that need different models will be skipped
-    try:
-        return TransformerBridge.boot_transformers("gpt2-medium", device="cpu")
-    except Exception:
-        # Fallback to same model if gpt2-medium is not available
-        # The test will skip if both models end up being the same
-        return TransformerBridge.boot_transformers(MODEL, device="cpu")
+    return TransformerBridge.boot_transformers("hyper-accel/tiny-random-gpt2", device="cpu")
 
 
 def test_svd_interpreter_returns_meaningful_values(model):
@@ -56,9 +49,6 @@ def test_svd_interpreter_returns_meaningful_values(model):
 
 
 def test_svd_interpreter_returns_different_answers_for_different_layers(model):
-    # Only test if model has multiple layers
-    if model.cfg.n_layers < 2:
-        pytest.skip("Model only has one layer")
 
     svd_interpreter = SVDInterpreter(model)
 
@@ -91,9 +81,6 @@ def test_svd_interpreter_returns_different_answers_for_different_layers(model):
 
 
 def test_svd_interpreter_returns_different_answers_for_different_models(model, second_model):
-    # Skip if both models are the same (check model name/config, not just object ID)
-    if id(model) == id(second_model) or model.cfg.model_name == second_model.cfg.model_name:
-        pytest.skip("Same model used for both fixtures")
 
     # Get results from first model
     svd_interpreter_1 = SVDInterpreter(model)

--- a/tests/unit/model_bridge/compatibility/test_svd_interpreter.py
+++ b/tests/unit/model_bridge/compatibility/test_svd_interpreter.py
@@ -49,7 +49,6 @@ def test_svd_interpreter_returns_meaningful_values(model):
 
 
 def test_svd_interpreter_returns_different_answers_for_different_layers(model):
-
     svd_interpreter = SVDInterpreter(model)
 
     # Layer 0 results
@@ -81,7 +80,6 @@ def test_svd_interpreter_returns_different_answers_for_different_layers(model):
 
 
 def test_svd_interpreter_returns_different_answers_for_different_models(model, second_model):
-
     # Get results from first model
     svd_interpreter_1 = SVDInterpreter(model)
     ov_1 = svd_interpreter_1.get_singular_vectors(


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->

# Description

This fixes the SVD interpreter tests that skipped due to the fixtures not always satisfying the test requirements.

I replaced the model fixtures with two distinct GPT2 models from `supported_models.json`. The primary model is multi-layer and is compatible for the 4 vector SVD comparisons, and the secondary model is distinct so the cross-model test doesnt fall back to using the same model.

The `pytest.skip(...)` guards are also removed.

Changes:
- Used `Intel/tiny-random-gpt2` as the primary model so the comparison test uses a small multi-layer model.
- Used `hyper-accel/tiny-random-gpt2` as the secondary model so the cross model test uses a distinct model.
- Removed `pytest.skip(...)` guards from the two tests.
- Removed the fallback path that loads the same model for both fixtures.

Result: 7 passed, 2 warnings (dependency deprecation warnings)

Fixes #1327 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility