### PR TITLE
Use ParallelBlockBridge for StableLM parallel_attn_mlp=True branch

### DIFF
--- a/transformer_lens/model_bridge/supported_architectures/stablelm.py
+++ b/transformer_lens/model_bridge/supported_architectures/stablelm.py
@@ -16,6 +16,7 @@ from transformer_lens.model_bridge.generalized_components import (
     GatedMLPBridge,
     LinearBridge,
     NormalizationBridge,
+    ParallelBlockBridge,
     PositionEmbeddingsAttentionBridge,
     RotaryEmbeddingBridge,
     UnembeddingBridge,
@@ -135,10 +136,13 @@ class StableLmArchitectureAdapter(ArchitectureAdapter):
             },
         )
 
+        # StableLM has both parallel (use_parallel_residual=True) and sequential variants.
+        block_cls = ParallelBlockBridge if use_parallel_residual else BlockBridge
+
         self.component_mapping = {
             "embed": EmbeddingBridge(name="model.embed_tokens"),
             "rotary_emb": RotaryEmbeddingBridge(name="model.rotary_emb"),
-            "blocks": BlockBridge(
+            "blocks": block_cls(
                 name="model.layers",
                 submodules=block_submodules,
             ),


### PR DESCRIPTION
# Description

Fixes the `StableLmArchitectureAdapter` crash on any config with `parallel_attn_mlp=True` (HF `use_parallel_residual=True`). The adapter already conditionally omitted `ln2` from the block submodules in that branch, but wrapped them in a plain `BlockBridge`, which rejects the `attn + mlp, no ln2` shape. Made the container choice conditional too: `ParallelBlockBridge` when `parallel_attn_mlp=True`, `BlockBridge` otherwise. Mirrors the dual-mode pattern in `falcon.py`.

Will add adapter unit tests for StableLM in a separate PR. This one carries only the fix.

Fixes #1386

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
