### PR TITLE
Adjusting torchvision dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,13 @@
         "rich>=12.6.0",
         "sentencepiece",
         "torch>=2.6",
-        # Pin to the torchvision that pairs with the project's torch 2.7.x so adding
-        # it for multimodal processors doesn't force a repo-wide torch upgrade.
-        "torchvision>=0.22,<0.23",
         "tqdm>=4.64.1",
         "transformers-stream-generator>=0.0.5,<0.1",
         "transformers>=5.4.0",
         "typeguard>=4.2,<5",
         "typing-extensions",
         "wandb>=0.13.5",
-]
+    ]
     description="An implementation of transformers tailored for mechanistic interpretability."
     license={text="MIT"}
     name="transformer-lens"
@@ -38,7 +35,7 @@
     [project.optional-dependencies]
         # chardet<6 works around a `requests<=2.32` compatibility-check warning that fires
         # whenever chardet>=6 is installed. Remove the pin when psf/requests bumps the cap.
-        evals=["lm-eval>=0.4", "chardet<6"]
+        evals=["chardet<6", "lm-eval>=0.4"]
         lit=["lit-nlp>=1.3"]
 
     [project.scripts]
@@ -79,9 +76,11 @@
     jupyter=["ipywidgets>=8.1.1", "jupyterlab>=3.5.0"]
     # Vision/audio deps for multimodal adapters (Gemma 3n's vision tower needs timm; image
     # processors need torchvision). In default-groups so contributor/CI test runs install them,
-    # while downstream users get a light core install. torchvision is pinned to the release
-    # pairing with torch 2.7.x so it doesn't force a repo-wide torch upgrade.
-    multimodal=["timm>=1.0.27", "torchvision>=0.22,<0.23"]
+    # while downstream users get a light core install. No torchvision upper bound: torchvision
+    # exact-pins its matching torch, so the resolver co-selects a compatible
+    # (Python, torch, torchvision) set (e.g. py3.12→0.22/torch2.7, py3.13→0.23+/torch2.8+).
+    # Capping it would just reintroduce the Python-3.13 block on the next torch/torchvision bump.
+    multimodal=["timm>=1.0.27", "torchvision>=0.22"]
     quantization=["bitsandbytes>=0.46.1", "optimum-quanto>=0.2.7"]
 
 [tool.uv]
@@ -102,9 +101,7 @@
             "ignore:distutils Version classes are deprecated:DeprecationWarning",
             "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
         ]
-        markers=[
-            "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-        ]
+        markers=["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
         pythonpath=["."]
         testpaths=["tests", "transformer_lens"] # Only test these directories
 

--- a/uv.lock
+++ b/uv.lock
@@ -6458,7 +6458,6 @@ dependencies = [
     { name = "rich" },
     { name = "sentencepiece" },
     { name = "torch" },
-    { name = "torchvision" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "transformers-stream-generator" },
@@ -6545,7 +6544,6 @@ requires-dist = [
     { name = "rich", specifier = ">=12.6.0" },
     { name = "sentencepiece" },
     { name = "torch", specifier = ">=2.6" },
-    { name = "torchvision", specifier = ">=0.22,<0.23" },
     { name = "tqdm", specifier = ">=4.64.1" },
     { name = "transformers", specifier = ">=5.4.0" },
     { name = "transformers-stream-generator", specifier = ">=0.0.5,<0.1" },
@@ -6595,7 +6593,7 @@ jupyter = [
 ]
 multimodal = [
     { name = "timm", specifier = ">=1.0.27" },
-    { name = "torchvision", specifier = ">=0.22,<0.23" },
+    { name = "torchvision", specifier = ">=0.22" },
 ]
 quantization = [
     { name = "bitsandbytes", specifier = ">=0.46.1" },


### PR DESCRIPTION
# Description

Adjust torchvision version to be uncapped, so future 3.x Python versions can also be supprorted

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility