### PR TITLE
Drop round-trip and output-shape tests per the unit-test guide

### DIFF
--- a/tests/unit/model_bridge/supported_architectures/test_gpt_oss_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_gpt_oss_adapter.py
@@ -361,28 +361,22 @@ class TestGPTOSSGQAHookShapes:
         # Identity RoPE inputs keep this test focused on hook reshaping, not rotation math.
         cos = ones(1, self.SEQ, self.D_HEAD)
         sin = zeros(1, self.SEQ, self.D_HEAD)
-        out = attn_bridge(hidden, position_embeddings=(cos, sin))
-        # The attention bridge may return either a bare tensor or an (output, ...) tuple.
-        out_tensor = out[0] if isinstance(out, tuple) else out
+        attn_bridge(hidden, position_embeddings=(cos, sin))
 
-        return captured["q"], captured["k"], captured["v"], out_tensor
+        return captured["q"], captured["k"], captured["v"]
 
     def test_hook_q_uses_n_heads(
         self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
     ) -> None:
-        q, _, _, _ = self._run_and_capture(wired_attn_bridge)
+        q, _, _ = self._run_and_capture(wired_attn_bridge)
         assert q.shape == (self.BATCH, self.SEQ, self.N_HEADS, self.D_HEAD)
 
     def test_hook_kv_use_n_kv_heads(
         self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
     ) -> None:
-        _, k, v, _ = self._run_and_capture(wired_attn_bridge)
+        _, k, v = self._run_and_capture(wired_attn_bridge)
         assert k.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
         assert v.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
-
-    def test_attn_output_shape(self, wired_attn_bridge: PositionEmbeddingsAttentionBridge) -> None:
-        _, _, _, out = self._run_and_capture(wired_attn_bridge)
-        assert out.shape == (self.BATCH, self.SEQ, self.D_MODEL)
 
 
 class TestGPTOSSSetupHookCompatibility:

--- a/tests/unit/model_bridge/supported_architectures/test_mixtral_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_mixtral_adapter.py
@@ -392,28 +392,22 @@ class TestMixtralGQAHookShapes:
         # Identity RoPE inputs keep this test focused on hook reshaping, not rotation math.
         cos = ones(1, self.SEQ, self.D_HEAD)
         sin = zeros(1, self.SEQ, self.D_HEAD)
-        out = attn_bridge(hidden, position_embeddings=(cos, sin))
-        # The attention bridge may return either a bare tensor or an (output, ...) tuple.
-        out_tensor = out[0] if isinstance(out, tuple) else out
+        attn_bridge(hidden, position_embeddings=(cos, sin))
 
-        return captured["q"], captured["k"], captured["v"], out_tensor
+        return captured["q"], captured["k"], captured["v"]
 
     def test_hook_q_uses_n_heads(
         self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
     ) -> None:
-        q, _, _, _ = self._run_and_capture(wired_attn_bridge)
+        q, _, _ = self._run_and_capture(wired_attn_bridge)
         assert q.shape == (self.BATCH, self.SEQ, self.N_HEADS, self.D_HEAD)
 
     def test_hook_kv_use_n_kv_heads(
         self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
     ) -> None:
-        _, k, v, _ = self._run_and_capture(wired_attn_bridge)
+        _, k, v = self._run_and_capture(wired_attn_bridge)
         assert k.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
         assert v.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
-
-    def test_attn_output_shape(self, wired_attn_bridge: PositionEmbeddingsAttentionBridge) -> None:
-        _, _, _, out = self._run_and_capture(wired_attn_bridge)
-        assert out.shape == (self.BATCH, self.SEQ, self.D_MODEL)
 
 
 class TestMixtralSetupComponentTesting:

--- a/tests/unit/model_bridge/supported_architectures/test_olmoe_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_olmoe_adapter.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import pytest
 import torch.nn as nn
-from torch import equal, ones, randn, zeros
+from torch import ones, randn, zeros
 
 from transformer_lens.config import TransformerBridgeConfig
 from transformer_lens.conversion_utils.conversion_steps.rearrange_tensor_conversion import (
@@ -225,50 +225,6 @@ class TestOlmoeWeightConversions:
         assert _rearrange(adapter, "blocks.{i}.attn.o.weight").axes_lengths["n"] == 4
 
 
-class TestOlmoeWeightConversionRoundTrips:
-    """Run the rearrange conversions on synthetic HF-shaped tensors.
-
-    The pattern/axis assertions above only check metadata. These confirm the
-    conversions actually reshape realistic weight tensors into the split-head
-    layout and revert losslessly (a rearrange operation is a pure permutation,
-    so the round-trip must be exactly equal).
-    """
-
-    N_HEADS = 4
-    N_KV_HEADS = 2
-    D_HEAD = 16
-    D_MODEL = 64
-
-    @pytest.fixture
-    def adapter(self) -> OlmoeArchitectureAdapter:
-        return OlmoeArchitectureAdapter(_cfg(n_key_value_heads=self.N_KV_HEADS))
-
-    def _roundtrip(self, adapter: OlmoeArchitectureAdapter, key: str, tensor: Any) -> tuple:
-        conv = _param_conversion(adapter, key)
-        converted = conv.convert({key: tensor}, key)
-        reverted = conv.revert(converted)
-        return converted, reverted
-
-    def test_q_weight_splits_into_n_heads(self, adapter: OlmoeArchitectureAdapter) -> None:
-        w = randn(self.N_HEADS * self.D_HEAD, self.D_MODEL)
-        converted, reverted = self._roundtrip(adapter, "blocks.{i}.attn.q.weight", w)
-        assert converted.shape == (self.N_HEADS, self.D_MODEL, self.D_HEAD)
-        assert equal(reverted, w)
-
-    def test_kv_weight_splits_into_n_kv_heads(self, adapter: OlmoeArchitectureAdapter) -> None:
-        for slot in ("k", "v"):
-            w = randn(self.N_KV_HEADS * self.D_HEAD, self.D_MODEL)
-            converted, reverted = self._roundtrip(adapter, f"blocks.{{i}}.attn.{slot}.weight", w)
-            assert converted.shape == (self.N_KV_HEADS, self.D_MODEL, self.D_HEAD)
-            assert equal(reverted, w)
-
-    def test_o_weight_merges_heads(self, adapter: OlmoeArchitectureAdapter) -> None:
-        w = randn(self.D_MODEL, self.N_HEADS * self.D_HEAD)
-        converted, reverted = self._roundtrip(adapter, "blocks.{i}.attn.o.weight", w)
-        assert converted.shape == (self.N_HEADS, self.D_HEAD, self.D_MODEL)
-        assert equal(reverted, w)
-
-
 class TestOlmoeComponentMapping:
     """Structure of the component mapping: required keys and submodules."""
 
@@ -438,28 +394,22 @@ class TestOlmoeGQAHookShapes:
         # Identity RoPE inputs keep this test focused on hook reshaping, not rotation math.
         cos = ones(1, self.SEQ, self.D_HEAD)
         sin = zeros(1, self.SEQ, self.D_HEAD)
-        out = attn_bridge(hidden, position_embeddings=(cos, sin))
-        # The attention bridge may return either a bare tensor or an (output, ...) tuple.
-        out_tensor = out[0] if isinstance(out, tuple) else out
+        attn_bridge(hidden, position_embeddings=(cos, sin))
 
-        return captured["q"], captured["k"], captured["v"], out_tensor
+        return captured["q"], captured["k"], captured["v"]
 
     def test_hook_q_uses_n_heads(
         self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
     ) -> None:
-        q, _, _, _ = self._run_and_capture(wired_attn_bridge)
+        q, _, _ = self._run_and_capture(wired_attn_bridge)
         assert q.shape == (self.BATCH, self.SEQ, self.N_HEADS, self.D_HEAD)
 
     def test_hook_kv_use_n_kv_heads(
         self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
     ) -> None:
-        _, k, v, _ = self._run_and_capture(wired_attn_bridge)
+        _, k, v = self._run_and_capture(wired_attn_bridge)
         assert k.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
         assert v.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
-
-    def test_attn_output_shape(self, wired_attn_bridge: PositionEmbeddingsAttentionBridge) -> None:
-        _, _, _, out = self._run_and_capture(wired_attn_bridge)
-        assert out.shape == (self.BATCH, self.SEQ, self.D_MODEL)
 
 
 class TestOlmoeSetupComponentTesting:

--- a/tests/unit/model_bridge/supported_architectures/test_smollm3_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_smollm3_adapter.py
@@ -383,27 +383,22 @@ class TestSmolLM3GQAHookShapes:
         # Identity RoPE inputs keep this test focused on hook reshaping, not rotation math.
         cos = ones(1, self.SEQ, self.D_HEAD)
         sin = zeros(1, self.SEQ, self.D_HEAD)
-        out = attn_bridge(hidden, position_embeddings=(cos, sin))
-        out_tensor = out[0] if isinstance(out, tuple) else out
+        attn_bridge(hidden, position_embeddings=(cos, sin))
 
-        return captured["q"], captured["k"], captured["v"], out_tensor
+        return captured["q"], captured["k"], captured["v"]
 
     def test_hook_q_uses_n_heads(
         self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
     ) -> None:
-        q, _, _, _ = self._run_and_capture(wired_attn_bridge)
+        q, _, _ = self._run_and_capture(wired_attn_bridge)
         assert q.shape == (self.BATCH, self.SEQ, self.N_HEADS, self.D_HEAD)
 
     def test_hook_kv_use_n_kv_heads(
         self, wired_attn_bridge: PositionEmbeddingsAttentionBridge
     ) -> None:
-        _, k, v, _ = self._run_and_capture(wired_attn_bridge)
+        _, k, v = self._run_and_capture(wired_attn_bridge)
         assert k.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
         assert v.shape == (self.BATCH, self.SEQ, self.N_KV_HEADS, self.D_HEAD)
-
-    def test_attn_output_shape(self, wired_attn_bridge: PositionEmbeddingsAttentionBridge) -> None:
-        _, _, _, out = self._run_and_capture(wired_attn_bridge)
-        assert out.shape == (self.BATCH, self.SEQ, self.D_MODEL)
 
 
 class TestSmolLM3NoPE:


### PR DESCRIPTION
# Description

Cleanup pass on adapter test files per the [unit-test guide](https://github.com/TransformerLensOrg/TransformerLens/blob/main/docs/source/content/adapter_development/adapter-unit-test-guide.md).

Removes `test_attn_output_shape` from `TestMixtralGQAHookShapes`, `TestOlmoeGQAHookShapes`, `TestGPTOSSGQAHookShapes`, and `TestSmolLM3GQAHookShapes`. The guide's What-to-test table lists generic `(batch, seq, d_model)` output-shape assertions under Skip for Behavioral hook shapes.

Drops `TestOlmoeWeightConversionRoundTrips` entirely. The class survived #1365 and matches the guide's AP3 example (convert/revert round-trips over `RearrangeTensorConversion` test einops, not the adapter). Flagged in https://github.com/TransformerLensOrg/TransformerLens/pull/1365#issuecomment-4700516007

Per-file:
- `test_mixtral_adapter.py`: 34 -> 33 tests
- `test_olmoe_adapter.py`: 41 -> 37 tests
- `test_gpt_oss_adapter.py`: 32 -> 31 tests
- `test_smollm3_adapter.py`: 41 -> 40 tests

Each file's `_run_and_capture` helper was simplified to drop the now-orphan output-tensor return. The forward call is preserved (it still triggers the q/k/v hooks).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility