### PR TITLE
Add Olmo3 architecture adapter tests

### DIFF
--- a/tests/unit/model_bridge/supported_architectures/test_olmo3_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_olmo3_adapter.py
@@ -1,0 +1,24 @@
+"""Unit tests for Olmo3ArchitectureAdapter.
+
+The adapter body is `pass` — it inherits its config, component mapping, and
+weight conversions unchanged from Olmo2ArchitectureAdapter (covered by
+test_olmo2_adapter.py). The only contract this subclass owns is the subclass
+relationship itself.
+"""
+
+from transformer_lens.model_bridge.supported_architectures.olmo2 import (
+    Olmo2ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.olmo3 import (
+    Olmo3ArchitectureAdapter,
+)
+
+
+class TestOlmo3Inheritance:
+    """Subclass relationship to Olmo2ArchitectureAdapter. The class body is
+    `pass`, so the inherited surface is the contract worth pinning. A future
+    accidental override would be caught here.
+    """
+
+    def test_subclass_of_olmo2(self) -> None:
+        assert issubclass(Olmo3ArchitectureAdapter, Olmo2ArchitectureAdapter)


### PR DESCRIPTION
# Description

Adds the minimal unit test for `Olmo3ArchitectureAdapter` under `tests/unit/model_bridge/supported_architectures/`.

The adapter body is `pass`. It inherits its config, component mapping, and weight conversions unchanged from `Olmo2ArchitectureAdapter` (covered by `test_olmo2_adapter.py`). Per the [unit-test guide](https://github.com/TransformerLensOrg/TransformerLens/blob/main/docs/source/content/adapter_development/adapter-unit-test-guide.md) ("for a pure-`pass` subclass adapter… the subclass needs exactly one test, that it *is* a subclass"), the only contract this subclass owns is the subclass relationship itself.

The single test asserts `issubclass(Olmo3ArchitectureAdapter, Olmo2ArchitectureAdapter)`. Modeled on the existing `test_llava_next_adapter.py` precedent.

Contributes to #1302 (Olmo3 checkbox).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility