### PR TITLE
fix(benchmarks): remove hooks via HookPoint instead of bogus add_hook handle

### DIFF
--- a/transformer_lens/benchmarks/backward_gradients.py
+++ b/transformer_lens/benchmarks/backward_gradients.py
@@ -11,6 +11,7 @@ from transformer_lens.benchmarks.utils import (
     make_grad_capture_hook,
     safe_allclose,
 )
+from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge import TransformerBridge
 
 
@@ -44,12 +45,15 @@ def benchmark_backward_hooks(
             hook_names = list(bridge._hook_registry.keys())
 
         # Register backward hooks on bridge
-        bridge_handles = []
+        bridge_hook_points: list[HookPoint] = []
         for hook_name in hook_names:
             if hook_name in bridge.hook_dict:
                 hook_point = bridge.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_grad_capture_hook(bridge_gradients, hook_name, return_none=True), dir="bwd")  # type: ignore[func-returns-value]
-                bridge_handles.append(handle)
+                hook_point.add_hook(
+                    make_grad_capture_hook(bridge_gradients, hook_name, return_none=True),
+                    dir="bwd",
+                )
+                bridge_hook_points.append(hook_point)
 
         # Run bridge forward and backward
         bridge_output = bridge(test_text)
@@ -57,9 +61,8 @@ def benchmark_backward_hooks(
         bridge_loss.backward()
 
         # Clean up hooks
-        for handle in bridge_handles:
-            if handle is not None:
-                handle.remove()
+        for hook_point in bridge_hook_points:
+            hook_point.remove_hooks(dir="bwd")
 
         if reference_model is None:
             # No reference - just verify gradients were captured
@@ -77,12 +80,15 @@ def benchmark_backward_hooks(
             return result
 
         # Register backward hooks on reference model
-        reference_handles = []
+        reference_hook_points: list[HookPoint] = []
         for hook_name in hook_names:
             if hook_name in reference_model.hook_dict:
                 hook_point = reference_model.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_grad_capture_hook(reference_gradients, hook_name, return_none=True), dir="bwd")  # type: ignore[func-returns-value]
-                reference_handles.append(handle)
+                hook_point.add_hook(
+                    make_grad_capture_hook(reference_gradients, hook_name, return_none=True),
+                    dir="bwd",
+                )
+                reference_hook_points.append(hook_point)
 
         # Run reference forward and backward
         reference_output = reference_model(test_text)
@@ -90,9 +96,8 @@ def benchmark_backward_hooks(
         reference_loss.backward()
 
         # Clean up hooks
-        for handle in reference_handles:
-            if handle is not None:
-                handle.remove()
+        for hook_point in reference_hook_points:
+            hook_point.remove_hooks(dir="bwd")
 
         # Compare gradients
         common_hooks = set(bridge_gradients.keys()) & set(reference_gradients.keys())
@@ -295,12 +300,15 @@ def benchmark_critical_backward_hooks(
         bridge_gradients: Dict[str, torch.Tensor] = {}
 
         # Register backward hooks on bridge
-        bridge_handles = []
+        bridge_hook_points: list[HookPoint] = []
         for hook_name in critical_hooks:
             if hook_name in bridge.hook_dict:
                 hook_point = bridge.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_grad_capture_hook(bridge_gradients, hook_name, return_none=True), dir="bwd")  # type: ignore[func-returns-value]
-                bridge_handles.append(handle)
+                hook_point.add_hook(
+                    make_grad_capture_hook(bridge_gradients, hook_name, return_none=True),
+                    dir="bwd",
+                )
+                bridge_hook_points.append(hook_point)
 
         # Run bridge forward and backward
         bridge_output = bridge(test_text)
@@ -308,9 +316,8 @@ def benchmark_critical_backward_hooks(
         bridge_loss.backward()
 
         # Clean up hooks
-        for handle in bridge_handles:
-            if handle is not None:
-                handle.remove()
+        for hook_point in bridge_hook_points:
+            hook_point.remove_hooks(dir="bwd")
 
         if reference_model is None:
             # No reference - just verify gradients were captured
@@ -331,12 +338,15 @@ def benchmark_critical_backward_hooks(
         # Register backward hooks on reference model
         reference_gradients: Dict[str, torch.Tensor] = {}
 
-        reference_handles = []
+        reference_hook_points: list[HookPoint] = []
         for hook_name in critical_hooks:
             if hook_name in reference_model.hook_dict:
                 hook_point = reference_model.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_grad_capture_hook(reference_gradients, hook_name, return_none=True), dir="bwd")  # type: ignore[func-returns-value]
-                reference_handles.append(handle)
+                hook_point.add_hook(
+                    make_grad_capture_hook(reference_gradients, hook_name, return_none=True),
+                    dir="bwd",
+                )
+                reference_hook_points.append(hook_point)
 
         # Run reference forward and backward
         reference_output = reference_model(test_text)
@@ -344,9 +354,8 @@ def benchmark_critical_backward_hooks(
         reference_loss.backward()
 
         # Clean up hooks
-        for handle in reference_handles:
-            if handle is not None:
-                handle.remove()
+        for hook_point in reference_hook_points:
+            hook_point.remove_hooks(dir="bwd")
 
         # Compare gradients
         mismatches = []

--- a/transformer_lens/benchmarks/hook_registration.py
+++ b/transformer_lens/benchmarks/hook_registration.py
@@ -13,6 +13,7 @@ from transformer_lens.benchmarks.utils import (
     filter_expected_missing_hooks,
     make_capture_hook,
 )
+from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge import TransformerBridge
 
 
@@ -134,13 +135,13 @@ def benchmark_forward_hooks(
             hook_names = list(bridge.hook_dict.keys())
 
         # Register hooks on bridge and track missing hooks
-        bridge_handles = []
+        bridge_hook_points: list[tuple[str, HookPoint]] = []
         missing_from_bridge = []
         for hook_name in hook_names:
             if hook_name in bridge.hook_dict:
                 hook_point = bridge.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_capture_hook(bridge_activations, hook_name))  # type: ignore[func-returns-value]
-                bridge_handles.append((hook_name, handle))
+                hook_point.add_hook(make_capture_hook(bridge_activations, hook_name))
+                bridge_hook_points.append((hook_name, hook_point))
             else:
                 missing_from_bridge.append(hook_name)
 
@@ -152,12 +153,11 @@ def benchmark_forward_hooks(
                 _ = bridge(test_text)
 
         # Clean up bridge hooks
-        for hook_name, handle in bridge_handles:
-            if handle is not None:
-                handle.remove()
+        for _, hook_point in bridge_hook_points:
+            hook_point.remove_hooks()
 
         # Check for hooks that didn't fire (registered but no activation captured)
-        registered_hooks = {name for name, _ in bridge_handles}
+        registered_hooks = {name for name, _ in bridge_hook_points}
         hooks_that_didnt_fire = registered_hooks - set(bridge_activations.keys())
 
         if reference_model is None:
@@ -182,12 +182,12 @@ def benchmark_forward_hooks(
             )
 
         # Register hooks on reference model
-        reference_handles = []
+        reference_hook_points: list[HookPoint] = []
         for hook_name in hook_names:
             if hook_name in reference_model.hook_dict:
                 hook_point = reference_model.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_capture_hook(reference_activations, hook_name))  # type: ignore[func-returns-value]
-                reference_handles.append(handle)
+                hook_point.add_hook(make_capture_hook(reference_activations, hook_name))
+                reference_hook_points.append(hook_point)
 
         # Run reference forward pass
         with torch.no_grad():
@@ -197,9 +197,8 @@ def benchmark_forward_hooks(
                 _ = reference_model(test_text)
 
         # Clean up reference hooks
-        for handle in reference_handles:
-            if handle is not None:
-                handle.remove()
+        for hook_point in reference_hook_points:
+            hook_point.remove_hooks()
 
         # CRITICAL CHECK: Bridge must have all hooks that reference has.
         # Filter out hooks that bridge models inherently don't have.
@@ -363,7 +362,7 @@ def benchmark_gated_hooks_fire(
             tested_flags.append(flag_name)
             try:
                 activations: dict[str, torch.Tensor] = {}
-                handles: list[tuple[str, object]] = []
+                bridge_hook_points: list[HookPoint] = []
                 target_hook_names = [
                     name
                     for name in bridge.hook_dict
@@ -375,8 +374,8 @@ def benchmark_gated_hooks_fire(
                 ]
                 for hname in target_hook_names:
                     hp = bridge.hook_dict[hname]
-                    h = hp.add_hook(make_capture_hook(activations, hname))  # type: ignore[func-returns-value]
-                    handles.append((hname, h))
+                    hp.add_hook(make_capture_hook(activations, hname))
+                    bridge_hook_points.append(hp)
 
                 with torch.no_grad():
                     if prepend_bos is not None:
@@ -384,9 +383,8 @@ def benchmark_gated_hooks_fire(
                     else:
                         _ = bridge(test_text)
 
-                for _, h in handles:
-                    if h is not None and hasattr(h, "remove"):
-                        h.remove()
+                for hp in bridge_hook_points:
+                    hp.remove_hooks()
 
                 # Bucket fired counts per stem.
                 for stem in hook_stems:
@@ -497,21 +495,20 @@ def benchmark_critical_forward_hooks(
         bridge_activations: Dict[str, torch.Tensor] = {}
 
         # Register hooks on bridge
-        bridge_handles = []
+        bridge_hook_points: list[HookPoint] = []
         for hook_name in critical_hooks:
             if hook_name in bridge.hook_dict:
                 hook_point = bridge.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_capture_hook(bridge_activations, hook_name))  # type: ignore[func-returns-value]
-                bridge_handles.append(handle)
+                hook_point.add_hook(make_capture_hook(bridge_activations, hook_name))
+                bridge_hook_points.append(hook_point)
 
         # Run bridge forward pass
         with torch.no_grad():
             _ = bridge(test_text)
 
         # Clean up hooks
-        for handle in bridge_handles:
-            if handle is not None:
-                handle.remove()
+        for hook_point in bridge_hook_points:
+            hook_point.remove_hooks()
 
         if reference_model is None:
             # No reference - just verify activations were captured
@@ -526,21 +523,20 @@ def benchmark_critical_forward_hooks(
         # Compare with reference model
         reference_activations: Dict[str, torch.Tensor] = {}
 
-        reference_handles = []
+        reference_hook_points: list[HookPoint] = []
         for hook_name in critical_hooks:
             if hook_name in reference_model.hook_dict:
                 hook_point = reference_model.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_capture_hook(reference_activations, hook_name))  # type: ignore[func-returns-value]
-                reference_handles.append(handle)
+                hook_point.add_hook(make_capture_hook(reference_activations, hook_name))
+                reference_hook_points.append(hook_point)
 
         # Run reference forward pass
         with torch.no_grad():
             _ = reference_model(test_text)
 
         # Clean up hooks
-        for handle in reference_handles:
-            if handle is not None:
-                handle.remove()
+        for hook_point in reference_hook_points:
+            hook_point.remove_hooks()
 
         # Compare activations — categorize by presence
         bridge_missing = []  # Hooks in reference but not in bridge (BAD)

--- a/transformer_lens/benchmarks/hook_structure.py
+++ b/transformer_lens/benchmarks/hook_structure.py
@@ -15,6 +15,7 @@ from transformer_lens.benchmarks.utils import (
     make_capture_hook,
     make_grad_capture_hook,
 )
+from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge import TransformerBridge
 
 
@@ -52,13 +53,13 @@ def benchmark_forward_hooks_structure(
             hook_names = list(bridge.hook_dict.keys())
 
         # Register hooks on bridge and track missing hooks
-        bridge_handles = []
+        bridge_hook_points: list[tuple[str, HookPoint]] = []
         missing_from_bridge = []
         for hook_name in hook_names:
             if hook_name in bridge.hook_dict:
                 hook_point = bridge.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_capture_hook(bridge_activations, hook_name))  # type: ignore[func-returns-value]
-                bridge_handles.append((hook_name, handle))
+                hook_point.add_hook(make_capture_hook(bridge_activations, hook_name))
+                bridge_hook_points.append((hook_name, hook_point))
             else:
                 missing_from_bridge.append(hook_name)
 
@@ -70,12 +71,11 @@ def benchmark_forward_hooks_structure(
                 _ = bridge(test_text)
 
         # Clean up bridge hooks
-        for hook_name, handle in bridge_handles:
-            if handle is not None:
-                handle.remove()
+        for _, hook_point in bridge_hook_points:
+            hook_point.remove_hooks()
 
         # Check for hooks that didn't fire
-        registered_hooks = {name for name, _ in bridge_handles}
+        registered_hooks = {name for name, _ in bridge_hook_points}
         hooks_that_didnt_fire = registered_hooks - set(bridge_activations.keys())
 
         if reference_model is None:
@@ -100,12 +100,12 @@ def benchmark_forward_hooks_structure(
             )
 
         # Register hooks on reference model
-        reference_handles = []
+        reference_hook_points: list[HookPoint] = []
         for hook_name in hook_names:
             if hook_name in reference_model.hook_dict:
                 hook_point = reference_model.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_capture_hook(reference_activations, hook_name))  # type: ignore[func-returns-value]
-                reference_handles.append(handle)
+                hook_point.add_hook(make_capture_hook(reference_activations, hook_name))
+                reference_hook_points.append(hook_point)
 
         # Run reference forward pass
         with torch.no_grad():
@@ -115,9 +115,8 @@ def benchmark_forward_hooks_structure(
                 _ = reference_model(test_text)
 
         # Clean up reference hooks
-        for handle in reference_handles:
-            if handle is not None:
-                handle.remove()
+        for hook_point in reference_hook_points:
+            hook_point.remove_hooks()
 
         # CRITICAL CHECK: Bridge must have all hooks that reference has
         if missing_from_bridge:
@@ -245,13 +244,13 @@ def benchmark_backward_hooks_structure(
         ]
 
         # Register backward hooks on bridge
-        bridge_handles = []
+        bridge_hook_points: list[tuple[str, HookPoint]] = []
         missing_from_bridge = []
         for hook_name in grad_hook_names:
             if hook_name in bridge.hook_dict:
                 hook_point = bridge.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_grad_capture_hook(bridge_grads, hook_name), dir="bwd")  # type: ignore[func-returns-value]
-                bridge_handles.append((hook_name, handle))
+                hook_point.add_hook(make_grad_capture_hook(bridge_grads, hook_name), dir="bwd")
+                bridge_hook_points.append((hook_name, hook_point))
             else:
                 missing_from_bridge.append(hook_name)
 
@@ -265,12 +264,11 @@ def benchmark_backward_hooks_structure(
         loss.backward()
 
         # Clean up bridge hooks
-        for hook_name, handle in bridge_handles:
-            if handle is not None:
-                handle.remove()
+        for _, hook_point in bridge_hook_points:
+            hook_point.remove_hooks(dir="bwd")
 
         # Check for hooks that didn't fire
-        registered_hooks = {name for name, _ in bridge_handles}
+        registered_hooks = {name for name, _ in bridge_hook_points}
         hooks_that_didnt_fire = registered_hooks - set(bridge_grads.keys())
 
         if reference_model is None:
@@ -295,12 +293,12 @@ def benchmark_backward_hooks_structure(
             )
 
         # Register backward hooks on reference
-        reference_handles = []
+        reference_hook_points: list[HookPoint] = []
         for hook_name in grad_hook_names:
             if hook_name in reference_model.hook_dict:
                 hook_point = reference_model.hook_dict[hook_name]
-                handle = hook_point.add_hook(make_grad_capture_hook(reference_grads, hook_name), dir="bwd")  # type: ignore[func-returns-value]
-                reference_handles.append(handle)
+                hook_point.add_hook(make_grad_capture_hook(reference_grads, hook_name), dir="bwd")
+                reference_hook_points.append(hook_point)
 
         # Run reference forward + backward pass
         if prepend_bos is not None:
@@ -312,9 +310,8 @@ def benchmark_backward_hooks_structure(
         ref_loss.backward()
 
         # Clean up reference hooks
-        for handle in reference_handles:
-            if handle is not None:
-                handle.remove()
+        for hook_point in reference_hook_points:
+            hook_point.remove_hooks(dir="bwd")
 
         # CRITICAL CHECK: Bridge must have all backward hooks that reference has
         if missing_from_bridge:


### PR DESCRIPTION
# Description

`HookPoint.add_hook` returns `None`, but the benchmark helpers stored its return value as a "handle" (silencing mypy with behind an `if handle is not None` guard). Since the value was always `None`, the guard was always false and the capture hooks were never removed.
    
Track the `HookPoint` that was registered on and clean up via `hook_point.remove_hooks()` (`dir="bwd"` for backward hooks), matching the existing idiom in `TransformerBridge.run_with_cache`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
