### PR TITLE
Add T5Gemma TransformerBridge adapter

### DIFF
--- a/tests/unit/model_bridge/supported_architectures/test_t5gemma_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_t5gemma_adapter.py
@@ -1,0 +1,631 @@
+"""Unit tests for T5GemmaArchitectureAdapter.
+
+Covered:
+- Config flags: normalization_type, positional_embedding_type, gated_mlp, rmsnorm_uses_offset,
+  fold_ln disabled.
+- Component-mapping top-level keys: encoder/decoder embed, rotary_emb, encoder_blocks /
+  decoder_blocks (standard Bridge names), final norms, unembed (lm_head.out_proj).
+- Encoder block (encoder_blocks): BlockBridge with Gemma-style pre/post norms, RoPE attention,
+  gated MLP; no cross_attn.
+- Decoder block (decoder_blocks): T5GemmaDecoderBlockBridge with self_attn, cross_attn (flagged
+  is_cross_attention=True), three ln pairs, gated MLP; intermediate hook points present.
+- Attention projections: q_proj/k_proj/v_proj/o_proj names.
+- MLP projections: gate_proj/up_proj/down_proj names.
+- lm_head path resolves to lm_head.out_proj (not lm_head directly).
+- RMSNorm offset flag: rmsnorm_uses_offset is True.
+- Factory registration: T5GemmaForConditionalGeneration in SUPPORTED_ARCHITECTURES.
+- Architecture classification: T5Gemma is in SEQ2SEQ_ARCHITECTURES.
+- Model registry: T5GemmaForConditionalGeneration in HF_SUPPORTED_ARCHITECTURES.
+- Config mapping: nested decoder sub-config extracts d_model, n_heads, n_layers correctly.
+- Key translation: convert_hf_key_to_tl_key maps representative HF keys to canonical TL keys.
+- Conversion table: weight_processing_conversions contains the exact keys that key translation
+  emits (with {i} placeholder), verifying conversions will actually fire.
+"""
+
+from typing import Any
+
+import pytest
+
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.factories.architecture_adapter_factory import (
+    SUPPORTED_ARCHITECTURES,
+)
+from transformer_lens.model_bridge.generalized_components import (
+    BlockBridge,
+    EmbeddingBridge,
+    GatedMLPBridge,
+    PositionEmbeddingsAttentionBridge,
+    RMSNormalizationBridge,
+    RotaryEmbeddingBridge,
+    UnembeddingBridge,
+)
+from transformer_lens.model_bridge.generalized_components.t5gemma_decoder_block import (
+    T5GemmaDecoderBlockBridge,
+)
+from transformer_lens.model_bridge.supported_architectures.t5gemma import (
+    T5GemmaArchitectureAdapter,
+)
+from transformer_lens.tools.model_registry import HF_SUPPORTED_ARCHITECTURES
+from transformer_lens.utilities.architectures import SEQ2SEQ_ARCHITECTURES
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _base_cfg(*, architecture: str = "T5GemmaForConditionalGeneration") -> TransformerBridgeConfig:
+    return TransformerBridgeConfig(
+        d_model=64,
+        d_head=16,
+        n_layers=2,
+        n_ctx=128,
+        n_heads=4,
+        n_key_value_heads=2,
+        d_vocab=256,
+        architecture=architecture,
+    )
+
+
+@pytest.fixture(scope="module")
+def cfg() -> TransformerBridgeConfig:
+    return _base_cfg()
+
+
+@pytest.fixture(scope="module")
+def adapter(cfg: TransformerBridgeConfig) -> T5GemmaArchitectureAdapter:
+    return T5GemmaArchitectureAdapter(cfg)
+
+
+def _mapping(adapter: T5GemmaArchitectureAdapter) -> dict:
+    m = adapter.component_mapping
+    assert m is not None
+    return m
+
+
+def _enc_block(adapter: T5GemmaArchitectureAdapter) -> Any:
+    return _mapping(adapter)["encoder_blocks"]
+
+
+def _dec_block(adapter: T5GemmaArchitectureAdapter) -> Any:
+    return _mapping(adapter)["decoder_blocks"]
+
+
+# ---------------------------------------------------------------------------
+# Config flags
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaAdapterConfig:
+    def test_normalization_type_is_rms(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert adapter.cfg.normalization_type == "RMS"
+
+    def test_positional_embedding_type_is_rotary(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert adapter.cfg.positional_embedding_type == "rotary"
+
+    def test_gated_mlp_is_true(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert adapter.cfg.gated_mlp is True
+
+    def test_rmsnorm_uses_offset_is_true(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert adapter.cfg.rmsnorm_uses_offset is True
+
+    def test_fold_ln_disabled(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert adapter.supports_fold_ln is False
+
+    def test_final_rms_is_true(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert adapter.cfg.final_rms is True
+
+
+# ---------------------------------------------------------------------------
+# Top-level mapping structure
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaComponentMapping:
+    EXPECTED_KEYS = {
+        "encoder_embed",
+        "encoder_rotary_emb",
+        "encoder_blocks",
+        "encoder_ln_final",
+        "decoder_embed",
+        "decoder_rotary_emb",
+        "decoder_blocks",
+        "decoder_ln_final",
+        "unembed",
+    }
+
+    def test_top_level_keys(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert set(_mapping(adapter).keys()) == self.EXPECTED_KEYS
+
+    def test_standard_block_names_used(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        # Bridge _setup_hook_compatibility only visits encoder_blocks / decoder_blocks.
+        # Using enc_blocks / dec_blocks would silently skip hook setup.
+        keys = set(_mapping(adapter).keys())
+        assert "encoder_blocks" in keys, "must use 'encoder_blocks', not 'enc_blocks'"
+        assert "decoder_blocks" in keys, "must use 'decoder_blocks', not 'dec_blocks'"
+        assert "enc_blocks" not in keys
+        assert "dec_blocks" not in keys
+
+    def test_encoder_embed_is_embedding_bridge(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["encoder_embed"], EmbeddingBridge)
+
+    def test_encoder_embed_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _mapping(adapter)["encoder_embed"].name == "model.encoder.embed_tokens"
+
+    def test_encoder_rotary_emb_is_rotary_bridge(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["encoder_rotary_emb"], RotaryEmbeddingBridge)
+
+    def test_encoder_rotary_emb_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _mapping(adapter)["encoder_rotary_emb"].name == "model.encoder.rotary_emb"
+
+    def test_encoder_blocks_is_block_bridge(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["encoder_blocks"], BlockBridge)
+
+    def test_encoder_blocks_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _mapping(adapter)["encoder_blocks"].name == "model.encoder.layers"
+
+    def test_encoder_ln_final_is_rms_norm(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["encoder_ln_final"], RMSNormalizationBridge)
+
+    def test_encoder_ln_final_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _mapping(adapter)["encoder_ln_final"].name == "model.encoder.norm"
+
+    def test_decoder_embed_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _mapping(adapter)["decoder_embed"].name == "model.decoder.embed_tokens"
+
+    def test_decoder_rotary_emb_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _mapping(adapter)["decoder_rotary_emb"].name == "model.decoder.rotary_emb"
+
+    def test_decoder_blocks_is_t5gemma_decoder_block_bridge(
+        self, adapter: T5GemmaArchitectureAdapter
+    ) -> None:
+        assert isinstance(_mapping(adapter)["decoder_blocks"], T5GemmaDecoderBlockBridge)
+
+    def test_decoder_blocks_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _mapping(adapter)["decoder_blocks"].name == "model.decoder.layers"
+
+    def test_decoder_ln_final_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _mapping(adapter)["decoder_ln_final"].name == "model.decoder.norm"
+
+    def test_unembed_is_unembedding_bridge(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert isinstance(_mapping(adapter)["unembed"], UnembeddingBridge)
+
+    def test_unembed_points_to_lm_head_out_proj(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _mapping(adapter)["unembed"].name == "lm_head.out_proj"
+
+
+# ---------------------------------------------------------------------------
+# Encoder block submodules
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaEncoderBlock:
+    EXPECTED_ENC_KEYS = {"ln1", "ln1_post", "attn", "ln2", "ln2_post", "mlp"}
+
+    def test_encoder_submodule_keys(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert set(_enc_block(adapter).submodules.keys()) == self.EXPECTED_ENC_KEYS
+
+    def test_encoder_has_no_cross_attn(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert "cross_attn" not in _enc_block(adapter).submodules
+
+    def test_encoder_ln1_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _enc_block(adapter).submodules["ln1"].name == "pre_self_attn_layernorm"
+
+    def test_encoder_ln1_post_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _enc_block(adapter).submodules["ln1_post"].name == "post_self_attn_layernorm"
+
+    def test_encoder_ln2_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _enc_block(adapter).submodules["ln2"].name == "pre_feedforward_layernorm"
+
+    def test_encoder_ln2_post_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _enc_block(adapter).submodules["ln2_post"].name == "post_feedforward_layernorm"
+
+    def test_encoder_attn_is_position_embeddings_bridge(
+        self, adapter: T5GemmaArchitectureAdapter
+    ) -> None:
+        assert isinstance(_enc_block(adapter).submodules["attn"], PositionEmbeddingsAttentionBridge)
+
+    def test_encoder_attn_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _enc_block(adapter).submodules["attn"].name == "self_attn"
+
+    def test_encoder_attn_qkvo_paths(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        subs = _enc_block(adapter).submodules["attn"].submodules
+        assert subs["q"].name == "q_proj"
+        assert subs["k"].name == "k_proj"
+        assert subs["v"].name == "v_proj"
+        assert subs["o"].name == "o_proj"
+
+    def test_encoder_mlp_is_gated(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert isinstance(_enc_block(adapter).submodules["mlp"], GatedMLPBridge)
+
+    def test_encoder_mlp_proj_paths(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        subs = _enc_block(adapter).submodules["mlp"].submodules
+        assert subs["gate"].name == "gate_proj"
+        assert subs["in"].name == "up_proj"
+        assert subs["out"].name == "down_proj"
+
+
+# ---------------------------------------------------------------------------
+# Decoder block submodules
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaDecoderBlock:
+    EXPECTED_DEC_KEYS = {
+        "ln1",
+        "ln1_post",
+        "self_attn",
+        "ln2",
+        "ln2_post",
+        "cross_attn",
+        "ln3",
+        "ln3_post",
+        "mlp",
+    }
+
+    def test_decoder_submodule_keys(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert set(_dec_block(adapter).submodules.keys()) == self.EXPECTED_DEC_KEYS
+
+    def test_decoder_self_attn_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _dec_block(adapter).submodules["self_attn"].name == "self_attn"
+
+    def test_decoder_cross_attn_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _dec_block(adapter).submodules["cross_attn"].name == "cross_attn"
+
+    def test_decoder_cross_attn_is_flagged(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _dec_block(adapter).submodules["cross_attn"].is_cross_attention is True
+
+    def test_decoder_self_attn_is_not_cross_attention(
+        self, adapter: T5GemmaArchitectureAdapter
+    ) -> None:
+        assert (
+            getattr(_dec_block(adapter).submodules["self_attn"], "is_cross_attention", False)
+            is False
+        )
+
+    def test_decoder_ln1_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _dec_block(adapter).submodules["ln1"].name == "pre_self_attn_layernorm"
+
+    def test_decoder_ln2_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _dec_block(adapter).submodules["ln2"].name == "pre_cross_attn_layernorm"
+
+    def test_decoder_ln3_hf_path(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        assert _dec_block(adapter).submodules["ln3"].name == "pre_feedforward_layernorm"
+
+    def test_decoder_self_attn_qkvo_paths(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        subs = _dec_block(adapter).submodules["self_attn"].submodules
+        assert subs["q"].name == "q_proj"
+        assert subs["k"].name == "k_proj"
+        assert subs["v"].name == "v_proj"
+        assert subs["o"].name == "o_proj"
+
+    def test_decoder_cross_attn_qkvo_paths(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        subs = _dec_block(adapter).submodules["cross_attn"].submodules
+        assert subs["q"].name == "q_proj"
+        assert subs["k"].name == "k_proj"
+        assert subs["v"].name == "v_proj"
+        assert subs["o"].name == "o_proj"
+
+    def test_decoder_mlp_proj_paths(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        subs = _dec_block(adapter).submodules["mlp"].submodules
+        assert subs["gate"].name == "gate_proj"
+        assert subs["in"].name == "up_proj"
+        assert subs["out"].name == "down_proj"
+
+
+# ---------------------------------------------------------------------------
+# T5GemmaDecoderBlockBridge intermediate hook points
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaDecoderBlockHookPoints:
+    def test_hook_resid_mid_exists(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        dec = _dec_block(adapter)
+        assert hasattr(dec, "hook_resid_mid")
+
+    def test_hook_resid_mid2_exists(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        dec = _dec_block(adapter)
+        assert hasattr(dec, "hook_resid_mid2")
+
+    def test_encoder_block_has_no_hook_resid_mid(self, adapter: T5GemmaArchitectureAdapter) -> None:
+        enc = _enc_block(adapter)
+        assert not hasattr(enc, "hook_resid_mid")
+
+
+# ---------------------------------------------------------------------------
+# Factory registration
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaFactoryRegistration:
+    def test_registered_in_supported_architectures(self) -> None:
+        assert "T5GemmaForConditionalGeneration" in SUPPORTED_ARCHITECTURES
+
+    def test_maps_to_t5gemma_adapter(self) -> None:
+        assert (
+            SUPPORTED_ARCHITECTURES["T5GemmaForConditionalGeneration"] is T5GemmaArchitectureAdapter
+        )
+
+
+# ---------------------------------------------------------------------------
+# Architecture classification
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaArchitectureClassification:
+    def test_is_in_seq2seq_architectures(self) -> None:
+        assert "T5GemmaForConditionalGeneration" in SEQ2SEQ_ARCHITECTURES
+
+
+# ---------------------------------------------------------------------------
+# Model registry
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaModelRegistry:
+    def test_is_in_hf_supported_architectures(self) -> None:
+        assert "T5GemmaForConditionalGeneration" in HF_SUPPORTED_ARCHITECTURES
+
+
+# ---------------------------------------------------------------------------
+# Config mapping from nested HF T5GemmaConfig
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaConfigMapping:
+    def test_config_mapping_extracts_decoder_dims(self) -> None:
+        """map_default_transformer_lens_config must read from the nested decoder sub-config."""
+        try:
+            from transformers import T5GemmaConfig
+
+            from transformer_lens.model_bridge.sources.transformers import (
+                map_default_transformer_lens_config,
+            )
+        except ImportError:
+            pytest.skip("transformers not installed")
+
+        enc_cfg = {
+            "hidden_size": 64,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 128,
+            "num_hidden_layers": 2,
+            "rms_norm_eps": 1e-6,
+            "dropout_rate": 0.0,
+            "hidden_activation": "gelu_pytorch_tanh",
+            "layer_types": ["full_attention", "full_attention"],
+            "head_dim": 16,
+            "rope_theta": 10000,
+            "rope_scaling": None,
+            "max_position_embeddings": 128,
+            "attention_bias": False,
+            "vocab_size": 256,
+            "pad_token_id": 0,
+        }
+        dec_cfg = dict(enc_cfg, is_decoder=True)
+        hf_config = T5GemmaConfig(encoder=enc_cfg, decoder=dec_cfg)
+        mapped = map_default_transformer_lens_config(hf_config)
+
+        assert mapped.d_model == 64
+        assert mapped.n_heads == 4
+        assert mapped.n_layers == 2
+        assert mapped.d_vocab == 256
+
+    def test_architecture_detected_from_model_type(self) -> None:
+        """determine_architecture_from_hf_config must map model_type 't5gemma'."""
+        try:
+            from transformers import T5GemmaConfig
+
+            from transformer_lens.model_bridge.sources.transformers import (
+                determine_architecture_from_hf_config,
+            )
+        except ImportError:
+            pytest.skip("transformers not installed")
+
+        enc_cfg = {
+            "hidden_size": 64,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 128,
+            "num_hidden_layers": 2,
+            "rms_norm_eps": 1e-6,
+            "dropout_rate": 0.0,
+            "hidden_activation": "gelu_pytorch_tanh",
+            "layer_types": ["full_attention", "full_attention"],
+            "head_dim": 16,
+            "rope_theta": 10000,
+            "rope_scaling": None,
+            "max_position_embeddings": 128,
+            "attention_bias": False,
+            "vocab_size": 256,
+            "pad_token_id": 0,
+        }
+        dec_cfg = dict(enc_cfg, is_decoder=True)
+        hf_config = T5GemmaConfig(encoder=enc_cfg, decoder=dec_cfg)
+        arch = determine_architecture_from_hf_config(hf_config)
+        assert arch == "T5GemmaForConditionalGeneration"
+
+
+# ---------------------------------------------------------------------------
+# Key translation: HF key → TL canonical key
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaKeyTranslation:
+    """Verify convert_hf_key_to_tl_key emits the exact keys that weight_processing_conversions
+    is indexed by (after the weight_processing regex replaces digits with {i}).
+
+    These tests use no HF model download — only the adapter's component_mapping.
+    """
+
+    @pytest.mark.parametrize(
+        "hf_key,expected_tl_key",
+        [
+            # Encoder self-attn
+            (
+                "model.encoder.layers.0.self_attn.q_proj.weight",
+                "encoder_blocks.0.self_attn.q_proj.weight",
+            ),
+            (
+                "model.encoder.layers.0.self_attn.k_proj.weight",
+                "encoder_blocks.0.self_attn.k_proj.weight",
+            ),
+            (
+                "model.encoder.layers.0.self_attn.v_proj.weight",
+                "encoder_blocks.0.self_attn.v_proj.weight",
+            ),
+            (
+                "model.encoder.layers.0.self_attn.o_proj.weight",
+                "encoder_blocks.0.self_attn.o_proj.weight",
+            ),
+            # Encoder RMSNorm
+            (
+                "model.encoder.layers.0.pre_self_attn_layernorm.weight",
+                "encoder_blocks.0.pre_self_attn_layernorm.weight",
+            ),
+            (
+                "model.encoder.layers.0.post_feedforward_layernorm.weight",
+                "encoder_blocks.0.post_feedforward_layernorm.weight",
+            ),
+            # Encoder MLP
+            (
+                "model.encoder.layers.0.mlp.gate_proj.weight",
+                "encoder_blocks.0.mlp.gate_proj.weight",
+            ),
+            (
+                "model.encoder.layers.0.mlp.down_proj.weight",
+                "encoder_blocks.0.mlp.down_proj.weight",
+            ),
+            # Decoder self-attn
+            (
+                "model.decoder.layers.0.self_attn.q_proj.weight",
+                "decoder_blocks.0.self_attn.q_proj.weight",
+            ),
+            (
+                "model.decoder.layers.0.self_attn.o_proj.weight",
+                "decoder_blocks.0.self_attn.o_proj.weight",
+            ),
+            # Decoder cross-attn
+            (
+                "model.decoder.layers.0.cross_attn.q_proj.weight",
+                "decoder_blocks.0.cross_attn.q_proj.weight",
+            ),
+            (
+                "model.decoder.layers.0.cross_attn.k_proj.weight",
+                "decoder_blocks.0.cross_attn.k_proj.weight",
+            ),
+            (
+                "model.decoder.layers.0.cross_attn.v_proj.weight",
+                "decoder_blocks.0.cross_attn.v_proj.weight",
+            ),
+            (
+                "model.decoder.layers.0.cross_attn.o_proj.weight",
+                "decoder_blocks.0.cross_attn.o_proj.weight",
+            ),
+            # Decoder RMSNorm
+            (
+                "model.decoder.layers.0.pre_cross_attn_layernorm.weight",
+                "decoder_blocks.0.pre_cross_attn_layernorm.weight",
+            ),
+            (
+                "model.decoder.layers.0.post_cross_attn_layernorm.weight",
+                "decoder_blocks.0.post_cross_attn_layernorm.weight",
+            ),
+            # Decoder MLP
+            (
+                "model.decoder.layers.0.mlp.gate_proj.weight",
+                "decoder_blocks.0.mlp.gate_proj.weight",
+            ),
+            (
+                "model.decoder.layers.0.mlp.up_proj.weight",
+                "decoder_blocks.0.mlp.up_proj.weight",
+            ),
+            (
+                "model.decoder.layers.0.mlp.down_proj.weight",
+                "decoder_blocks.0.mlp.down_proj.weight",
+            ),
+            # lm_head
+            ("lm_head.out_proj.weight", "unembed.weight"),
+        ],
+    )
+    def test_hf_key_translates_to_tl_key(
+        self,
+        adapter: T5GemmaArchitectureAdapter,
+        hf_key: str,
+        expected_tl_key: str,
+    ) -> None:
+        tl_key = adapter.convert_hf_key_to_tl_key(hf_key)
+        assert (
+            tl_key == expected_tl_key
+        ), f"HF key {hf_key!r} → {tl_key!r}, expected {expected_tl_key!r}"
+
+
+# ---------------------------------------------------------------------------
+# Conversion table keys match what key translation emits
+# ---------------------------------------------------------------------------
+
+
+class TestT5GemmaConversionTableAlignment:
+    """Verify the weight_processing_conversions dict is indexed by the exact keys that
+    convert_hf_key_to_tl_key emits (with index replaced by {i}).
+
+    This ensures conversions actually fire during weight loading.
+    """
+
+    @pytest.mark.parametrize(
+        "hf_key",
+        [
+            # Encoder self-attn q/k/v/o
+            "model.encoder.layers.0.self_attn.q_proj.weight",
+            "model.encoder.layers.0.self_attn.k_proj.weight",
+            "model.encoder.layers.0.self_attn.v_proj.weight",
+            "model.encoder.layers.0.self_attn.o_proj.weight",
+            # Encoder RMSNorm
+            "model.encoder.layers.0.pre_self_attn_layernorm.weight",
+            "model.encoder.layers.0.post_self_attn_layernorm.weight",
+            "model.encoder.layers.0.pre_feedforward_layernorm.weight",
+            "model.encoder.layers.0.post_feedforward_layernorm.weight",
+            # Encoder MLP
+            "model.encoder.layers.0.mlp.gate_proj.weight",
+            "model.encoder.layers.0.mlp.up_proj.weight",
+            "model.encoder.layers.0.mlp.down_proj.weight",
+            # Decoder self-attn q/k/v/o
+            "model.decoder.layers.0.self_attn.q_proj.weight",
+            "model.decoder.layers.0.self_attn.k_proj.weight",
+            "model.decoder.layers.0.self_attn.v_proj.weight",
+            "model.decoder.layers.0.self_attn.o_proj.weight",
+            # Decoder cross-attn q/k/v/o
+            "model.decoder.layers.0.cross_attn.q_proj.weight",
+            "model.decoder.layers.0.cross_attn.k_proj.weight",
+            "model.decoder.layers.0.cross_attn.v_proj.weight",
+            "model.decoder.layers.0.cross_attn.o_proj.weight",
+            # Decoder RMSNorm
+            "model.decoder.layers.0.pre_self_attn_layernorm.weight",
+            "model.decoder.layers.0.post_self_attn_layernorm.weight",
+            "model.decoder.layers.0.pre_cross_attn_layernorm.weight",
+            "model.decoder.layers.0.post_cross_attn_layernorm.weight",
+            "model.decoder.layers.0.pre_feedforward_layernorm.weight",
+            "model.decoder.layers.0.post_feedforward_layernorm.weight",
+            # Decoder MLP
+            "model.decoder.layers.0.mlp.gate_proj.weight",
+            "model.decoder.layers.0.mlp.up_proj.weight",
+            "model.decoder.layers.0.mlp.down_proj.weight",
+        ],
+    )
+    def test_conversion_table_has_key_for_hf_param(
+        self,
+        adapter: T5GemmaArchitectureAdapter,
+        hf_key: str,
+    ) -> None:
+        import re
+
+        tl_key = adapter.convert_hf_key_to_tl_key(hf_key)
+        placeholder_key = re.sub(r"blocks\.(\d+)\.", "blocks.{i}.", tl_key)
+        assert adapter.weight_processing_conversions is not None
+        in_table = (
+            placeholder_key in adapter.weight_processing_conversions
+            or placeholder_key.removesuffix(".weight") in adapter.weight_processing_conversions
+        )
+        assert in_table, (
+            f"No conversion entry for HF key {hf_key!r}. "
+            f"Translated TL key: {tl_key!r}, placeholder: {placeholder_key!r}"
+        )

--- a/transformer_lens/factories/architecture_adapter_factory.py
+++ b/transformer_lens/factories/architecture_adapter_factory.py
@@ -66,6 +66,7 @@ from transformer_lens.model_bridge.supported_architectures import (
     SmolLM3ArchitectureAdapter,
     StableLmArchitectureAdapter,
     T5ArchitectureAdapter,
+    T5GemmaArchitectureAdapter,
     XGLMArchitectureAdapter,
 )
 
@@ -128,6 +129,7 @@ SUPPORTED_ARCHITECTURES = {
     "StableLmForCausalLM": StableLmArchitectureAdapter,
     "T5ForConditionalGeneration": T5ArchitectureAdapter,
     "MT5ForConditionalGeneration": T5ArchitectureAdapter,
+    "T5GemmaForConditionalGeneration": T5GemmaArchitectureAdapter,
     "XGLMForCausalLM": XGLMArchitectureAdapter,
     "NanoGPTForCausalLM": NanogptArchitectureAdapter,
     "TransformerLensNative": NativeArchitectureAdapter,

--- a/transformer_lens/model_bridge/generalized_components/__init__.py
+++ b/transformer_lens/model_bridge/generalized_components/__init__.py
@@ -97,6 +97,9 @@ from transformer_lens.model_bridge.generalized_components.ssm_block import SSMBl
 from transformer_lens.model_bridge.generalized_components.ssm_mixer import SSMMixerBridge
 from transformer_lens.model_bridge.generalized_components.symbolic import SymbolicBridge
 from transformer_lens.model_bridge.generalized_components.t5_block import T5BlockBridge
+from transformer_lens.model_bridge.generalized_components.t5gemma_decoder_block import (
+    T5GemmaDecoderBlockBridge,
+)
 from transformer_lens.model_bridge.generalized_components.unembedding import (
     UnembeddingBridge,
 )
@@ -142,6 +145,7 @@ __all__ = [
     "SymbolicBridge",
     "UnembeddingBridge",
     "T5BlockBridge",
+    "T5GemmaDecoderBlockBridge",
     "SiglipVisionEncoderBridge",
     "SiglipVisionEncoderLayerBridge",
     "SSM2MixerBridge",

--- a/transformer_lens/model_bridge/generalized_components/t5gemma_decoder_block.py
+++ b/transformer_lens/model_bridge/generalized_components/t5gemma_decoder_block.py
@@ -1,0 +1,147 @@
+"""T5Gemma-specific decoder block bridge.
+
+T5GemmaDecoderLayer uses Gemma-style flat attribute access (not T5's .layer[] indexing).
+It has: self-attention + cross-attention + MLP, each with pre/post norms.
+This bridge monkey-patches the layer forward to insert intermediate hook points.
+"""
+from __future__ import annotations
+
+import types
+from typing import Any, Callable, Dict, Optional
+
+import torch
+
+from transformer_lens.hook_points import HookPoint
+from transformer_lens.model_bridge.generalized_components.base import (
+    GeneralizedComponent,
+)
+
+
+class T5GemmaDecoderBlockBridge(GeneralizedComponent):
+    """Bridge for T5Gemma decoder layers.
+
+    Inserts hook points between the three sub-components of each decoder layer:
+    - hook_in (hook_resid_pre): residual before self-attention pre-norm
+    - hook_resid_mid: residual after self-attention + residual add, before cross-attn pre-norm
+    - hook_resid_mid2: residual after cross-attention + residual add, before MLP pre-norm
+    - hook_out (hook_resid_post): residual after MLP + residual add
+    """
+
+    is_list_item: bool = True
+    hook_aliases = {
+        "hook_resid_pre": "hook_in",
+        "hook_resid_post": "hook_out",
+    }
+
+    def __init__(
+        self,
+        name: str,
+        config: Optional[Any] = None,
+        submodules: Optional[Dict[str, GeneralizedComponent]] = None,
+    ):
+        super().__init__(name, config, submodules=submodules or {})
+        self.hook_resid_mid = HookPoint()
+        self._register_hook("hook_resid_mid", self.hook_resid_mid)
+        self.hook_resid_mid2 = HookPoint()
+        self._register_hook("hook_resid_mid2", self.hook_resid_mid2)
+        self._original_block_forward: Optional[Callable[..., Any]] = None
+
+    def set_original_component(self, component: torch.nn.Module) -> None:
+        super().set_original_component(component)
+        self._patch_decoder_layer_forward()
+
+    def _patch_decoder_layer_forward(self) -> None:
+        """Monkey-patch T5GemmaDecoderLayer.forward to insert hook points.
+
+        The patched forward preserves the original residual-stream semantics but
+        fires hook_in, hook_resid_mid, hook_resid_mid2, and hook_out at the
+        canonical HookedTransformer positions.
+        """
+        if self.original_component is None:
+            return
+        self._original_block_forward = self.original_component.forward
+
+        hook_in = self.hook_in  # fires at hook_resid_pre
+        hook_resid_mid = self.hook_resid_mid
+        hook_resid_mid2 = self.hook_resid_mid2
+        hook_out = self.hook_out  # fires at hook_resid_post
+        original_forward = self._original_block_forward
+
+        def patched_forward(
+            layer_self,
+            hidden_states: torch.Tensor,
+            position_embeddings=None,
+            attention_mask=None,
+            position_ids=None,
+            past_key_values=None,
+            use_cache=None,
+            encoder_hidden_states=None,
+            encoder_attention_mask=None,
+            **kwargs: Any,
+        ) -> torch.Tensor:
+            hidden_states = hook_in(hidden_states)
+
+            # --- self-attention sub-layer ---
+            residual = hidden_states
+            hidden_states = layer_self.pre_self_attn_layernorm(hidden_states)
+            sa_out, _ = layer_self.self_attn(
+                hidden_states=hidden_states,
+                position_embeddings=position_embeddings,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=(
+                    past_key_values.self_attention_cache if past_key_values is not None else None
+                ),
+                use_cache=use_cache,
+                **kwargs,
+            )
+            hidden_states = layer_self.post_self_attn_layernorm(sa_out)
+            hidden_states = residual + layer_self.dropout(hidden_states)
+            hidden_states = hook_resid_mid(hidden_states)
+
+            # --- cross-attention sub-layer ---
+            residual = hidden_states
+            hidden_states = layer_self.pre_cross_attn_layernorm(hidden_states)
+            ca_out, _ = layer_self.cross_attn(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                attention_mask=encoder_attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                **kwargs,
+            )
+            hidden_states = layer_self.post_cross_attn_layernorm(ca_out)
+            hidden_states = residual + layer_self.dropout(hidden_states)
+            hidden_states = hook_resid_mid2(hidden_states)
+
+            # --- MLP sub-layer ---
+            residual = hidden_states
+            hidden_states = layer_self.pre_feedforward_layernorm(hidden_states)
+            hidden_states = layer_self.mlp(hidden_states)
+            hidden_states = layer_self.post_feedforward_layernorm(hidden_states)
+            hidden_states = residual + layer_self.dropout(hidden_states)
+            hidden_states = hook_out(hidden_states)
+
+            return hidden_states
+
+        self.original_component.forward = types.MethodType(patched_forward, self.original_component)
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        if self.original_component is None:
+            raise RuntimeError(
+                f"Original component not set for {self.name}. "
+                "Call set_original_component() first."
+            )
+        return self.original_component(*args, **kwargs)
+
+    def get_expected_parameter_names(self, prefix: str = "") -> list[str]:
+        param_names = []
+        for sub_name, sub_component in self.submodules.items():
+            sub_prefix = f"{prefix}.{sub_name}" if prefix else sub_name
+            param_names.extend(sub_component.get_expected_parameter_names(sub_prefix))
+        return param_names
+
+    def get_list_size(self) -> int:
+        if self.config is None:
+            return 0
+        return getattr(self.config, "n_layers", 0)

--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -54,6 +54,13 @@ def map_default_transformer_lens_config(hf_config):
     source_config = hf_config
     if hasattr(hf_config, "text_config") and hf_config.text_config is not None:
         source_config = hf_config.text_config
+    # T5Gemma: nested encoder/decoder sub-configs; use decoder (LM head is decoder-side)
+    elif (
+        hasattr(hf_config, "decoder")
+        and hf_config.decoder is not None
+        and hasattr(hf_config.decoder, "hidden_size")
+    ):
+        source_config = hf_config.decoder
 
     tl_config = copy.deepcopy(hf_config)
     if hasattr(source_config, "n_embd"):
@@ -244,6 +251,7 @@ def determine_architecture_from_hf_config(hf_config):
             "stablelm": "StableLmForCausalLM",
             "t5": "T5ForConditionalGeneration",
             "mt5": "MT5ForConditionalGeneration",
+            "t5gemma": "T5GemmaForConditionalGeneration",
         }
         if model_type in model_type_mappings:
             architectures.append(model_type_mappings[model_type])

--- a/transformer_lens/model_bridge/supported_architectures/__init__.py
+++ b/transformer_lens/model_bridge/supported_architectures/__init__.py
@@ -171,6 +171,9 @@ from transformer_lens.model_bridge.supported_architectures.stablelm import (
 from transformer_lens.model_bridge.supported_architectures.t5 import (
     T5ArchitectureAdapter,
 )
+from transformer_lens.model_bridge.supported_architectures.t5gemma import (
+    T5GemmaArchitectureAdapter,
+)
 from transformer_lens.model_bridge.supported_architectures.xglm import (
     XGLMArchitectureAdapter,
 )
@@ -232,5 +235,6 @@ __all__ = [
     "SmolLM3ArchitectureAdapter",
     "StableLmArchitectureAdapter",
     "T5ArchitectureAdapter",
+    "T5GemmaArchitectureAdapter",
     "XGLMArchitectureAdapter",
 ]

--- a/transformer_lens/model_bridge/supported_architectures/t5gemma.py
+++ b/transformer_lens/model_bridge/supported_architectures/t5gemma.py
@@ -1,0 +1,308 @@
+"""T5Gemma architecture adapter.
+
+T5GemmaForConditionalGeneration is an encoder-decoder model combining:
+- Gemma-style RoPE, GQA, gated MLP, and RMSNorm with offset (+1.0)
+- Encoder-decoder cross-attention in the decoder stack
+- Nested config: encoder/decoder dims live in cfg.encoder / cfg.decoder
+
+Key differences from plain T5:
+- Uses model.encoder.layers / model.decoder.layers (not .block)
+- No relative position bias; uses RoPE instead
+- All norms are Gemma-style (weight + 1.0)
+- lm_head is T5GemmaLMHead wrapping out_proj (no .weight at the top level)
+"""
+
+from typing import Any
+
+from transformer_lens.conversion_utils.conversion_steps import (
+    ArithmeticTensorConversion,
+    RearrangeTensorConversion,
+    TransposeTensorConversion,
+)
+from transformer_lens.conversion_utils.conversion_steps.arithmetic_tensor_conversion import (
+    OperationTypes,
+)
+from transformer_lens.conversion_utils.param_processing_conversion import (
+    ParamProcessingConversion,
+)
+from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+from transformer_lens.model_bridge.generalized_components import (
+    AttentionBridge,
+    BlockBridge,
+    EmbeddingBridge,
+    GatedMLPBridge,
+    LinearBridge,
+    PositionEmbeddingsAttentionBridge,
+    RMSNormalizationBridge,
+    RotaryEmbeddingBridge,
+    UnembeddingBridge,
+)
+from transformer_lens.model_bridge.generalized_components.t5gemma_decoder_block import (
+    T5GemmaDecoderBlockBridge,
+)
+
+
+class T5GemmaArchitectureAdapter(ArchitectureAdapter):
+    """Architecture adapter for T5GemmaForConditionalGeneration.
+
+    Encoder: BlockBridge over model.encoder.layers (Gemma-style, no cross-attn)
+    Decoder: T5GemmaDecoderBlockBridge over model.decoder.layers (adds cross-attn hooks)
+    """
+
+    def __init__(self, cfg: Any) -> None:
+        super().__init__(cfg)
+
+        self.supports_fold_ln = False
+
+        # Config flags used by bridge weight processing
+        self.cfg.normalization_type = "RMS"
+        self.cfg.positional_embedding_type = "rotary"
+        self.cfg.final_rms = True
+        self.cfg.gated_mlp = True
+        self.cfg.attn_only = False
+        self.cfg.uses_rms_norm = True
+        # T5Gemma uses Gemma-style (1.0 + weight) RMSNorm offset
+        self.cfg.rmsnorm_uses_offset = True
+
+        n_heads = self.cfg.n_heads
+        n_kv = getattr(self.cfg, "n_key_value_heads", None) or n_heads
+
+        self.weight_processing_conversions = {
+            # Encoder self-attention
+            "encoder_blocks.{i}.self_attn.q_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("(n h) m -> n m h", n=n_heads),
+            ),
+            "encoder_blocks.{i}.self_attn.k_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("(n h) m -> n m h", n=n_kv),
+            ),
+            "encoder_blocks.{i}.self_attn.v_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("(n h) m -> n m h", n=n_kv),
+            ),
+            "encoder_blocks.{i}.self_attn.o_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("m (n h) -> n h m", n=n_heads),
+            ),
+            # Encoder RMSNorm offset - HF stores raw weight; Gemma applies weight+1
+            "encoder_blocks.{i}.pre_self_attn_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            "encoder_blocks.{i}.post_self_attn_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            "encoder_blocks.{i}.pre_feedforward_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            "encoder_blocks.{i}.post_feedforward_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            # Encoder MLP (gated)
+            "encoder_blocks.{i}.mlp.gate_proj.weight": ParamProcessingConversion(
+                tensor_conversion=TransposeTensorConversion(),
+            ),
+            "encoder_blocks.{i}.mlp.up_proj.weight": ParamProcessingConversion(
+                tensor_conversion=TransposeTensorConversion(),
+            ),
+            "encoder_blocks.{i}.mlp.down_proj.weight": ParamProcessingConversion(
+                tensor_conversion=TransposeTensorConversion(),
+            ),
+            # Decoder self-attention
+            "decoder_blocks.{i}.self_attn.q_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("(n h) m -> n m h", n=n_heads),
+            ),
+            "decoder_blocks.{i}.self_attn.k_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("(n h) m -> n m h", n=n_kv),
+            ),
+            "decoder_blocks.{i}.self_attn.v_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("(n h) m -> n m h", n=n_kv),
+            ),
+            "decoder_blocks.{i}.self_attn.o_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("m (n h) -> n h m", n=n_heads),
+            ),
+            # Decoder cross-attention
+            "decoder_blocks.{i}.cross_attn.q_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("(n h) m -> n m h", n=n_heads),
+            ),
+            "decoder_blocks.{i}.cross_attn.k_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("(n h) m -> n m h", n=n_kv),
+            ),
+            "decoder_blocks.{i}.cross_attn.v_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("(n h) m -> n m h", n=n_kv),
+            ),
+            "decoder_blocks.{i}.cross_attn.o_proj.weight": ParamProcessingConversion(
+                tensor_conversion=RearrangeTensorConversion("m (n h) -> n h m", n=n_heads),
+            ),
+            # Decoder RMSNorm offset
+            "decoder_blocks.{i}.pre_self_attn_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            "decoder_blocks.{i}.post_self_attn_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            "decoder_blocks.{i}.pre_cross_attn_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            "decoder_blocks.{i}.post_cross_attn_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            "decoder_blocks.{i}.pre_feedforward_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            "decoder_blocks.{i}.post_feedforward_layernorm.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            # Decoder MLP (gated)
+            "decoder_blocks.{i}.mlp.gate_proj.weight": ParamProcessingConversion(
+                tensor_conversion=TransposeTensorConversion(),
+            ),
+            "decoder_blocks.{i}.mlp.up_proj.weight": ParamProcessingConversion(
+                tensor_conversion=TransposeTensorConversion(),
+            ),
+            "decoder_blocks.{i}.mlp.down_proj.weight": ParamProcessingConversion(
+                tensor_conversion=TransposeTensorConversion(),
+            ),
+            # Final layer norms
+            "encoder_ln_final.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            "decoder_ln_final.weight": ParamProcessingConversion(
+                tensor_conversion=ArithmeticTensorConversion(OperationTypes.ADDITION, 1.0),
+            ),
+            # Unembed
+            "unembed.weight": ParamProcessingConversion(
+                tensor_conversion=TransposeTensorConversion(),
+            ),
+        }
+
+        self.component_mapping = {
+            # Encoder embedding and positional
+            "encoder_embed": EmbeddingBridge(name="model.encoder.embed_tokens"),
+            "encoder_rotary_emb": RotaryEmbeddingBridge(name="model.encoder.rotary_emb"),
+            # Encoder layers - Gemma-style BlockBridge (pre/post norms, RoPE attention, gated MLP)
+            "encoder_blocks": BlockBridge(
+                name="model.encoder.layers",
+                config=self.cfg,
+                submodules={
+                    "ln1": RMSNormalizationBridge(name="pre_self_attn_layernorm", config=self.cfg),
+                    "ln1_post": RMSNormalizationBridge(
+                        name="post_self_attn_layernorm", config=self.cfg
+                    ),
+                    "attn": PositionEmbeddingsAttentionBridge(
+                        name="self_attn",
+                        config=self.cfg,
+                        submodules={
+                            "q": LinearBridge(name="q_proj"),
+                            "k": LinearBridge(name="k_proj"),
+                            "v": LinearBridge(name="v_proj"),
+                            "o": LinearBridge(name="o_proj"),
+                        },
+                        requires_attention_mask=True,
+                        requires_position_embeddings=True,
+                    ),
+                    "ln2": RMSNormalizationBridge(
+                        name="pre_feedforward_layernorm", config=self.cfg
+                    ),
+                    "ln2_post": RMSNormalizationBridge(
+                        name="post_feedforward_layernorm", config=self.cfg
+                    ),
+                    "mlp": GatedMLPBridge(
+                        name="mlp",
+                        config=self.cfg,
+                        submodules={
+                            "gate": LinearBridge(name="gate_proj"),
+                            "in": LinearBridge(name="up_proj"),
+                            "out": LinearBridge(name="down_proj"),
+                        },
+                    ),
+                },
+            ),
+            # Encoder final norm
+            "encoder_ln_final": RMSNormalizationBridge(name="model.encoder.norm", config=self.cfg),
+            # Decoder embedding and positional
+            "decoder_embed": EmbeddingBridge(name="model.decoder.embed_tokens"),
+            "decoder_rotary_emb": RotaryEmbeddingBridge(name="model.decoder.rotary_emb"),
+            # Decoder layers — T5GemmaDecoderBlockBridge (adds cross-attn + two mid hooks)
+            "decoder_blocks": T5GemmaDecoderBlockBridge(
+                name="model.decoder.layers",
+                config=self.cfg,
+                submodules={
+                    # Self-attention norms
+                    "ln1": RMSNormalizationBridge(name="pre_self_attn_layernorm", config=self.cfg),
+                    "ln1_post": RMSNormalizationBridge(
+                        name="post_self_attn_layernorm", config=self.cfg
+                    ),
+                    "self_attn": PositionEmbeddingsAttentionBridge(
+                        name="self_attn",
+                        config=self.cfg,
+                        submodules={
+                            "q": LinearBridge(name="q_proj"),
+                            "k": LinearBridge(name="k_proj"),
+                            "v": LinearBridge(name="v_proj"),
+                            "o": LinearBridge(name="o_proj"),
+                        },
+                        requires_attention_mask=True,
+                        requires_position_embeddings=True,
+                    ),
+                    # Cross-attention norms
+                    "ln2": RMSNormalizationBridge(name="pre_cross_attn_layernorm", config=self.cfg),
+                    "ln2_post": RMSNormalizationBridge(
+                        name="post_cross_attn_layernorm", config=self.cfg
+                    ),
+                    "cross_attn": AttentionBridge(
+                        name="cross_attn",
+                        config=self.cfg,
+                        submodules={
+                            "q": LinearBridge(name="q_proj"),
+                            "k": LinearBridge(name="k_proj"),
+                            "v": LinearBridge(name="v_proj"),
+                            "o": LinearBridge(name="o_proj"),
+                        },
+                        is_cross_attention=True,
+                    ),
+                    # MLP norms
+                    "ln3": RMSNormalizationBridge(
+                        name="pre_feedforward_layernorm", config=self.cfg
+                    ),
+                    "ln3_post": RMSNormalizationBridge(
+                        name="post_feedforward_layernorm", config=self.cfg
+                    ),
+                    "mlp": GatedMLPBridge(
+                        name="mlp",
+                        config=self.cfg,
+                        submodules={
+                            "gate": LinearBridge(name="gate_proj"),
+                            "in": LinearBridge(name="up_proj"),
+                            "out": LinearBridge(name="down_proj"),
+                        },
+                    ),
+                },
+            ),
+            # Decoder final norm
+            "decoder_ln_final": RMSNormalizationBridge(name="model.decoder.norm", config=self.cfg),
+            # lm_head is T5GemmaLMHead; the weight lives on its inner out_proj Linear
+            "unembed": UnembeddingBridge(name="lm_head.out_proj", config=self.cfg),
+        }
+
+    def setup_component_testing(self, hf_model: Any, bridge_model: Any = None) -> None:
+        """Set up rotary embedding references for T5Gemma component testing.
+
+        Both the encoder and decoder carry their own rotary_emb. We set the
+        reference on all PositionEmbeddingsAttentionBridge instances so that
+        component-level forward calls can compute RoPE correctly.
+        """
+        encoder_rotary = hf_model.model.encoder.rotary_emb
+        decoder_rotary = hf_model.model.decoder.rotary_emb
+
+        if hasattr(hf_model, "config") and hasattr(hf_model.config, "_attn_implementation"):
+            hf_model.config._attn_implementation = "eager"
+
+        if bridge_model is not None:
+            for block in getattr(bridge_model, "encoder_blocks", []):
+                if hasattr(block, "attn"):
+                    block.attn.set_rotary_emb(encoder_rotary)
+            for block in getattr(bridge_model, "decoder_blocks", []):
+                if hasattr(block, "self_attn"):
+                    block.self_attn.set_rotary_emb(decoder_rotary)
+
+        enc_attn = self.get_generalized_component("encoder_blocks.0.attn")
+        enc_attn.set_rotary_emb(encoder_rotary)
+        dec_self_attn = self.get_generalized_component("decoder_blocks.0.self_attn")
+        dec_self_attn.set_rotary_emb(decoder_rotary)

--- a/transformer_lens/tools/model_registry/__init__.py
+++ b/transformer_lens/tools/model_registry/__init__.py
@@ -99,6 +99,7 @@ HF_SUPPORTED_ARCHITECTURES: set[str] = {
     "StableLmForCausalLM",
     "T5ForConditionalGeneration",
     "MT5ForConditionalGeneration",
+    "T5GemmaForConditionalGeneration",
     "XGLMForCausalLM",
 }
 
@@ -159,6 +160,7 @@ CANONICAL_AUTHORS_BY_ARCH: dict[str, list[str]] = {
     "SmolLM3ForCausalLM": ["HuggingFaceTB"],
     "StableLmForCausalLM": ["stabilityai"],
     "T5ForConditionalGeneration": ["google-t5", "google", "Salesforce", "MBZUAI"],
+    "T5GemmaForConditionalGeneration": ["google"],
     "XGLMForCausalLM": ["facebook"],
 }
 

--- a/transformer_lens/tools/model_registry/generate_report.py
+++ b/transformer_lens/tools/model_registry/generate_report.py
@@ -52,6 +52,7 @@ ARCHITECTURE_DESCRIPTIONS: dict[str, str] = {
     "StableLmForCausalLM": "Stability AI's StableLM model",
     "SmolLM3ForCausalLM": "Hugging Face's SmolLM3 compact open model with NoPE layers",
     "T5ForConditionalGeneration": "Google's T5 encoder-decoder model (partial support)",
+    "T5GemmaForConditionalGeneration": "Google's T5Gemma encoder-decoder model with Gemma-style RoPE, GQA, and gated MLP",
     # Unsupported architectures
     "BertModel": "Google's BERT bidirectional encoder for understanding tasks",
     "BertForMaskedLM": "BERT with masked language modeling head",

--- a/transformer_lens/utilities/architectures.py
+++ b/transformer_lens/utilities/architectures.py
@@ -10,6 +10,7 @@ from typing import Optional
 SEQ2SEQ_ARCHITECTURES: set[str] = {
     "T5ForConditionalGeneration",
     "MT5ForConditionalGeneration",
+    "T5GemmaForConditionalGeneration",
     "BartForConditionalGeneration",
     "MBartForConditionalGeneration",
     "MarianMTModel",


### PR DESCRIPTION
# Description

Adds TransformerBridge support for `T5GemmaForConditionalGeneration`.

Fixes #1405

This PR adds:

* a new `T5GemmaArchitectureAdapter`
* a T5Gemma-specific decoder block bridge for decoder self-attention, cross-attention, and MLP residual hook points
* runtime registration for `T5GemmaForConditionalGeneration`
* seq2seq architecture classification
* model registry/reporting metadata
* focused unit coverage for component mapping, HF key translation, conversion-table alignment, registration, and decoder hook behavior

The adapter uses standard Bridge block names (`encoder_blocks` / `decoder_blocks`) so core hook setup and conversion paths are applied correctly. The decoder bridge exposes `hook_in`, `hook_resid_mid`, `hook_resid_mid2`, and `hook_out` around the decoder layer’s self-attention, cross-attention, and MLP residual updates.

## Type of change

* [x] New feature (non-breaking change which adds functionality)

### Screenshots

Not applicable.

# Checklist:

* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Testing

Ran locally:

```bash
uv run mypy .
uv run pytest tests/unit/model_bridge/supported_architectures/test_t5gemma_adapter.py -q
uv run pytest tests/unit/model_bridge/supported_architectures/test_t5_adapter.py tests/unit/model_bridge/supported_architectures/test_gemma2_adapter.py -q
uv run pytest tests/unit/tools/test_model_registry.py -k TestRegistrySyncedWithFactory -q
```

Results:

* `mypy`: success, no issues found in 287 source files
* T5Gemma adapter tests: 102 passed
* T5 + Gemma2 regression tests: 44 passed
* registry sync tests: 4 passed

Note: I did not run full HF checkpoint parity locally because the available T5Gemma checkpoints are gated. The PR includes local tests for representative HF key translation and conversion-table alignment to cover the main adapter-loading failure modes without requiring a gated model download.
