### PR TITLE
fix: wire `slow` pytest marker — exclude large-model tests from CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -169,7 +169,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
       - name: MPS Integration Tests
         run: >
-          uv run pytest tests/integration -v
+          uv run pytest tests/integration -v -m "not slow"
           --ignore=tests/integration/model_bridge/test_optimizer_compatibility.py
           --ignore=tests/integration/model_bridge/test_bridge_generation.py
           --ignore=tests/integration/model_bridge/test_bridge_integration.py

--- a/makefile
+++ b/makefile
@@ -21,19 +21,19 @@ check-format:
 	$(RUN) black --check .
 
 unit-test:
-	$(RUN) pytest tests/unit $(RERUN_ARGS)
+	$(RUN) pytest tests/unit -m "not slow" $(RERUN_ARGS)
 
 integration-test:
-	$(RUN) pytest tests/integration $(RERUN_ARGS)
+	$(RUN) pytest tests/integration -m "not slow" $(RERUN_ARGS)
 
 acceptance-test:
-	$(RUN) pytest tests/acceptance $(RERUN_ARGS)
+	$(RUN) pytest tests/acceptance -m "not slow" $(RERUN_ARGS)
 
 benchmark-test:
 	$(RUN) pytest tests/benchmarks $(RERUN_ARGS)
 
 coverage-report-test:
-	$(RUN) pytest --cov=transformer_lens/ --cov-report=html --cov-branch tests/integration tests/unit tests/acceptance $(RERUN_ARGS)
+	$(RUN) pytest --cov=transformer_lens/ --cov-report=html --cov-branch -m "not slow" tests/integration tests/unit tests/acceptance $(RERUN_ARGS)
 
 docstring-test:
 	$(RUN) pytest transformer_lens/ $(RERUN_ARGS)


### PR DESCRIPTION
## Problem

`pyproject.toml` registers the `slow` marker with the hint `deselect with '-m "not slow"'`, but no `make` target or CI step actually passes that flag. Any test decorated with `pytestmark = pytest.mark.slow` (e.g. the NemotronH integration test that requires loading an 18 GB checkpoint) runs unconditionally in every CI job, including `coverage-report-test`.

This was first noticed in #1434 where `test_nemotron_h_adapter.py` kept failing Full Code Coverage even after the marker was added.

## Fix

Add `-m "not slow"` to the four pytest invocations that run in CI:

- `make unit-test`
- `make integration-test`
- `make acceptance-test`
- `make coverage-report-test`

Also add it to the MPS integration test step in `checks.yml`, which currently uses `--ignore` flags as a workaround for the same problem.

## Testing

All existing tests continue to pass. Tests tagged `@pytest.mark.slow` can still be run explicitly with:

```bash
pytest -m slow tests/
```

or by running them directly by path.

Closes the CI gap identified in #1434.