### PR TITLE
Construct causal masks on the fly

### DIFF
--- a/tests/unit/components/test_attention.py
+++ b/tests/unit/components/test_attention.py
@@ -121,6 +121,120 @@ def test_attention_config_dict():
     assert attn.cfg.act_fn == "relu"
 
 
+def test_attention_does_not_allocate_full_causal_mask():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=4,
+        n_ctx=8192,
+        d_head=2,
+        n_heads=2,
+        act_fn="relu",
+    )
+
+    attn = Attention(cfg)
+
+    assert attn.mask.shape == (0, 0)
+    assert attn.state_dict()["mask"].numel() == 0
+
+
+def test_apply_causal_mask_global_matches_absolute_positions():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=4,
+        n_ctx=16,
+        d_head=2,
+        n_heads=2,
+        act_fn="relu",
+    )
+    attn = Attention(cfg)
+    attn_scores = torch.zeros((1, 1, 3, 5))
+
+    masked_scores = attn.apply_causal_mask(attn_scores, past_kv_pos_offset=2)
+
+    expected_allowed = torch.tensor(
+        [
+            [True, True, True, False, False],
+            [True, True, True, True, False],
+            [True, True, True, True, True],
+        ]
+    )
+    assert torch.equal(torch.isfinite(masked_scores[0, 0]), expected_allowed)
+
+
+def test_apply_causal_mask_local_matches_window():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=4,
+        n_ctx=16,
+        d_head=2,
+        n_heads=2,
+        act_fn="relu",
+        window_size=2,
+    )
+    attn = Attention(cfg, attn_type="local")
+    attn_scores = torch.zeros((1, 1, 3, 5))
+
+    masked_scores = attn.apply_causal_mask(attn_scores, past_kv_pos_offset=2)
+
+    expected_allowed = torch.tensor(
+        [
+            [False, True, True, False, False],
+            [False, False, True, True, False],
+            [False, False, False, True, True],
+        ]
+    )
+    assert torch.equal(torch.isfinite(masked_scores[0, 0]), expected_allowed)
+
+
+def test_apply_causal_mask_combines_padding_mask():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=4,
+        n_ctx=16,
+        d_head=2,
+        n_heads=2,
+        act_fn="relu",
+    )
+    attn = Attention(cfg)
+    attn_scores = torch.zeros((1, 1, 3, 5))
+    attention_mask = torch.tensor([[1, 1, 0, 1, 1]])
+
+    masked_scores = attn.apply_causal_mask(
+        attn_scores,
+        past_kv_pos_offset=2,
+        attention_mask=attention_mask,
+    )
+
+    expected_allowed = torch.tensor(
+        [
+            [True, True, False, False, False],
+            [True, True, False, True, False],
+            [True, True, False, True, True],
+        ]
+    )
+    assert torch.equal(torch.isfinite(masked_scores[0, 0]), expected_allowed)
+
+
+def test_attention_loads_legacy_full_mask_with_strict_true():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=4,
+        n_ctx=16,
+        d_head=2,
+        n_heads=2,
+        act_fn="relu",
+    )
+    attn = Attention(cfg)
+    state_dict = attn.state_dict()
+    state_dict["mask"] = torch.ones((cfg.n_ctx, cfg.n_ctx), dtype=torch.bool)
+
+    incompatible_keys = attn.load_state_dict(state_dict, strict=True)
+
+    assert incompatible_keys.missing_keys == []
+    assert incompatible_keys.unexpected_keys == []
+    assert attn.mask.shape == (0, 0)
+
+
 def test_remove_einsum_from_complex_attn_linear():
     batch = 64
     pos = 128

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -115,20 +115,15 @@ class AbstractAttention(ABC, nn.Module):
             self.k_norm = None
 
         self.attn_type = attn_type
-        # Create a max_ctx x max_ctx mask, with True iff that query position
-        # can attend to that key position (query is first axis, key is second axis)
-        causal_mask = torch.tril(torch.ones((self.cfg.n_ctx, self.cfg.n_ctx)).bool())
-        if self.attn_type == "global":
-            # For global attention, this is a lower triangular matrix - key <= query
-            self.register_buffer("mask", causal_mask)
-        elif self.attn_type == "local":
-            # For local, this is banded, query - window_size < key <= query
+        if self.attn_type == "local":
             if not isinstance(self.cfg.window_size, int):
                 raise ValueError("Window size must be an integer for local attention")
-            self.register_buffer("mask", torch.triu(causal_mask, 1 - self.cfg.window_size))
-        else:
+        elif self.attn_type != "global":
             raise ValueError(f"Invalid attention type: {self.attn_type}")
 
+        # Kept as a tiny buffer for state-dict/device compatibility. The actual
+        # causal mask is built at forward time for the current sequence length.
+        self.register_buffer("mask", torch.empty((0, 0), dtype=torch.bool))
         self.register_buffer("IGNORE", torch.tensor(-torch.inf))
 
         self.layer_id = layer_id
@@ -572,14 +567,13 @@ class AbstractAttention(ABC, nn.Module):
                 f"query_ctx_length {query_ctx_length} + past_kv_pos_offset {past_kv_pos_offset} != key_ctx_length {key_ctx_length} - you likely have a bug."
             )
 
-        # Dynamically extend mask if needed for long context
-        if key_ctx_length > self.mask.shape[0]:
-            self._extend_mask(key_ctx_length)
-
-        # Index back to front to ensure local attention works
-        final_mask = cast(torch.Tensor, self.mask)[
-            None, None, -query_ctx_length:, -key_ctx_length:
-        ]  # [1, 1, pos, pos]
+        mask_device = attention_mask.device if attention_mask is not None else attn_scores.device
+        final_mask = self._make_causal_mask(
+            query_ctx_length=query_ctx_length,
+            key_ctx_length=key_ctx_length,
+            past_kv_pos_offset=past_kv_pos_offset,
+            device=mask_device,
+        )
         if attention_mask is not None:
             # Apply a causal mask to the attention scores considering the padding
 
@@ -588,13 +582,36 @@ class AbstractAttention(ABC, nn.Module):
                 attention_mask, "batch offset_pos -> batch 1 1 offset_pos"
             )
 
-            final_mask = final_mask.to(attention_mask.device)
-
-            # Element-wise multiplication of the final mask and the attention mask and cast to boolean
-            final_mask = (final_mask * attention_mask).bool()  # [batch, head, pos, offset_pos]
+            final_mask = final_mask & attention_mask.bool()  # [batch, head, pos, offset_pos]
 
         attn_scores = attn_scores.to(final_mask.device)
-        return torch.where(final_mask, attn_scores, cast(torch.Tensor, self.IGNORE))
+        ignore = cast(torch.Tensor, self.IGNORE).to(final_mask.device)
+        return torch.where(final_mask, attn_scores, ignore)
+
+    def _make_causal_mask(
+        self,
+        query_ctx_length: int,
+        key_ctx_length: int,
+        past_kv_pos_offset: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Create the causal mask for the current attention-score shape."""
+        query_positions = torch.arange(
+            past_kv_pos_offset,
+            past_kv_pos_offset + query_ctx_length,
+            device=device,
+        )
+        key_positions = torch.arange(key_ctx_length, device=device)
+
+        final_mask = key_positions[None, :] <= query_positions[:, None]
+        if self.attn_type == "local":
+            if not isinstance(self.cfg.window_size, int):
+                raise ValueError("Window size must be an integer for local attention")
+            final_mask = final_mask & (
+                key_positions[None, :] > query_positions[:, None] - self.cfg.window_size
+            )
+
+        return final_mask[None, None, :, :]
 
     def calculate_sin_cos_rotary(
         self,
@@ -770,16 +787,33 @@ class AbstractAttention(ABC, nn.Module):
         self.rotary_cos = cos.to(self.rotary_cos.device)
 
     def _extend_mask(self, new_size: int):
-        """Extend causal mask to support longer contexts dynamically."""
-        causal_mask = torch.tril(torch.ones((new_size, new_size), device=self.mask.device).bool())
-        if self.attn_type == "global":
-            self.mask = causal_mask
-        elif self.attn_type == "local":
-            if not isinstance(self.cfg.window_size, int):
-                raise ValueError("Window size must be an integer for local attention")
-            self.mask = torch.triu(causal_mask, 1 - self.cfg.window_size)
-        else:
-            raise ValueError(f"Invalid attention type: {self.attn_type}")
+        """Deprecated no-op kept for external callers."""
+        del new_size
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        mask_key = prefix + "mask"
+        saved_mask = state_dict.get(mask_key)
+        if isinstance(saved_mask, torch.Tensor) and saved_mask.shape != self.mask.shape:
+            state_dict = state_dict.copy()
+            state_dict[mask_key] = self.mask
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
     @staticmethod
     def create_alibi_slope(

--- a/transformer_lens/pretrained/weight_conversions/nanogpt.py
+++ b/transformer_lens/pretrained/weight_conversions/nanogpt.py
@@ -45,9 +45,6 @@ def convert_nanogpt_weights(old_state_dict, cfg: HookedTransformerConfig):
             old_state_dict[f"{layer_key}.ln_2.weight"]
         )
 
-        new_state_dict[f"blocks.{layer}.attn.mask"] = torch.tril(
-            torch.ones((cfg.n_ctx, cfg.n_ctx)).bool()
-        )
         new_state_dict[f"blocks.{layer}.attn.IGNORE"] = torch.tensor(-torch.inf)
 
         W = old_state_dict[f"{layer_key}.attn.c_attn.weight"]


### PR DESCRIPTION
# Description

Construct HookedTransformer causal masks on the fly for the current attention-score shape instead of registering a full `(cfg.n_ctx, cfg.n_ctx)` mask buffer for every attention layer.

Fixes #479.

This revives the direction of #493, which was closed as abandoned rather than rejected. The change is intentionally narrow:

- keep `mask` registered as an empty bool buffer for state-dict/device compatibility
- build global/local causal masks inside `apply_causal_mask(...)` based on current query/key lengths and `past_kv_pos_offset`
- preserve strict loading of legacy state dicts by replacing old full-size saved masks with the new empty compatibility placeholder during load
- stop nanoGPT conversion from materializing full attention masks

I left the existing Qwen context-length caps unchanged. Those comments mention the old mask allocation problem, but lifting model-specific caps seems safer as a follow-up after model-specific validation.

Because this touches HookedTransformer attention internals, I am opening it as a draft and would appreciate maintainer feedback on whether this minimal per-attention implementation is preferred, or whether you would rather see a centralized model-level mask construction approach.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Validation

Local checks run:

```bash
uv run --no-sync pytest tests/unit/components/test_attention.py tests/unit/components/test_abstract_attention.py tests/integration/test_grouped_query_attention.py -q
make format
make check-format
uv run mypy .
git diff --check
```

Results:

- targeted pytest: `13 passed, 4 skipped`
- `make format`: passed
- `make check-format`: passed
- `uv run mypy .`: passed, `Success: no issues found in 298 source files`
- `git diff --check`: passed

I did not run the full `make test-pr` locally to avoid pulling larger model-test artifacts onto my machine; this draft PR is intended to let CI exercise the heavier suite.
