### PR TITLE
Use Qwen config context lengths

### DIFF
--- a/tests/unit/test_loading_from_pretrained_utilities.py
+++ b/tests/unit/test_loading_from_pretrained_utilities.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -93,6 +94,63 @@ def test_n_ctx_override_larger_than_default_warns(mock_warning: mock.MagicMock):
         "trained on sequences this long and may produce unreliable results. "
         "Ensure you have sufficient memory for this context length."
     )
+
+
+def _minimal_qwen_config(architecture: str, **overrides: object) -> SimpleNamespace:
+    values = {
+        "architectures": [architecture],
+        "hidden_size": 128,
+        "num_attention_heads": 4,
+        "intermediate_size": 512,
+        "num_hidden_layers": 2,
+        "layer_norm_epsilon": 1e-6,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 1000,
+        "scale_attn_weights": True,
+        "initializer_range": 0.02,
+        "kv_channels": 32,
+        "num_key_value_heads": 4,
+        "hidden_act": "silu",
+        "rope_theta": 1000000.0,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@mock.patch("transformer_lens.loading_from_pretrained.AutoConfig.from_pretrained")
+def test_qwen_uses_hf_seq_length_for_n_ctx(mock_from_pretrained: mock.MagicMock):
+    mock_from_pretrained.return_value = _minimal_qwen_config(
+        "QWenLMHeadModel",
+        seq_length=8192,
+        max_position_embeddings=32768,
+    )
+
+    cfg = get_pretrained_model_config("Qwen/Qwen-7B")
+
+    assert cfg.n_ctx == 8192
+
+
+@mock.patch("transformer_lens.loading_from_pretrained.AutoConfig.from_pretrained")
+@pytest.mark.parametrize(
+    ("model_name", "max_position_embeddings"),
+    [
+        ("Qwen/Qwen1.5-0.5B", 32768),
+        ("Qwen/Qwen2-0.5B", 131072),
+    ],
+)
+def test_qwen2_uses_hf_max_position_embeddings_for_n_ctx(
+    mock_from_pretrained: mock.MagicMock,
+    model_name: str,
+    max_position_embeddings: int,
+):
+    mock_from_pretrained.return_value = _minimal_qwen_config(
+        "Qwen2ForCausalLM",
+        max_position_embeddings=max_position_embeddings,
+    )
+
+    cfg = get_pretrained_model_config(model_name)
+
+    assert cfg.n_ctx == max_position_embeddings
 
 
 # --- Architecture config tests ---

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -740,7 +740,8 @@ def convert_hf_model_config(model_name: str, **kwargs: Any) -> dict[str, Any]:
             "n_heads": hf_config.num_attention_heads,
             "d_mlp": hf_config.intermediate_size // 2,
             "n_layers": hf_config.num_hidden_layers,
-            "n_ctx": 2048,  # Capped bc the actual ctx length is 30k and the attn mask would be too big
+            # QWenLMHeadModel uses seq_length in its remote-code attention/rotary logic.
+            "n_ctx": hf_config.seq_length,
             "eps": hf_config.layer_norm_epsilon,
             "d_vocab": hf_config.vocab_size,
             "act_fn": "silu",
@@ -765,7 +766,7 @@ def convert_hf_model_config(model_name: str, **kwargs: Any) -> dict[str, Any]:
             "n_key_value_heads": hf_config.num_key_value_heads,
             "d_mlp": hf_config.intermediate_size,
             "n_layers": hf_config.num_hidden_layers,
-            "n_ctx": 2048,  # Capped bc the actual ctx length is 30k and the attn mask would be too big
+            "n_ctx": hf_config.max_position_embeddings,
             "eps": hf_config.rms_norm_eps,
             "d_vocab": hf_config.vocab_size,
             "act_fn": hf_config.hidden_act,


### PR DESCRIPTION
# Description

Follow-up to #1450.

Now that `HookedTransformer` builds causal masks on the fly, two Qwen config paths still had stale `n_ctx = 2048` caps whose comments said the cap existed because the full attention mask would be too large.

This PR removes those mask-era caps:

- `QWenLMHeadModel` now uses `hf_config.seq_length`
- `Qwen2ForCausalLM` now uses `hf_config.max_position_embeddings`

I intentionally left `Qwen3ForCausalLM` unchanged. Its `2048` value came from the later Qwen3 support PR and does not have the same stale attention-mask comment, so changing it should be a separate validation decision if desired.

One tradeoff worth calling out: this removes the old quadratic mask allocation problem, but long-context rotary models still precompute rotary sin/cos buffers proportional to `n_ctx`. That is much smaller than the old `(n_ctx, n_ctx)` mask allocation, but Qwen2 models can expose very large context lengths. Users can still pass `n_ctx=...` to choose a smaller context length if needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Validation

Local checks run:

```bash
uv run --no-sync pytest tests/unit/test_loading_from_pretrained_utilities.py -q
uv run --no-sync python - <<'PY'
from transformer_lens.loading_from_pretrained import get_pretrained_model_config

for model in [
    "Qwen/Qwen-7B",
    "Qwen/Qwen1.5-0.5B",
    "Qwen/Qwen2-0.5B",
]:
    cfg = get_pretrained_model_config(model, trust_remote_code=True)
    print(f"{model}: architecture={cfg.original_architecture}, n_ctx={cfg.n_ctx}")
PY
make format
make check-format
uv run mypy .
git diff --check
```

Results:

- `tests/unit/test_loading_from_pretrained_utilities.py`: `11 passed`
- real config smoke check:
  - `Qwen/Qwen-7B`: `n_ctx=8192`
  - `Qwen/Qwen1.5-0.5B`: `n_ctx=32768`
  - `Qwen/Qwen2-0.5B`: `n_ctx=131072`
- `make format`: passed
- `make check-format`: passed
- `uv run mypy .`: passed, `Success: no issues found in 299 source files`
- `git diff --check`: passed
