### PR TITLE
Bound initial rotary cache size

### DIFF
--- a/tests/unit/components/test_attention.py
+++ b/tests/unit/components/test_attention.py
@@ -137,6 +137,142 @@ def test_attention_does_not_allocate_full_causal_mask():
     assert attn.state_dict()["mask"].numel() == 0
 
 
+def test_rotary_embeddings_initial_cache_is_bounded():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=8,
+        n_ctx=8192,
+        d_head=4,
+        n_heads=2,
+        act_fn="relu",
+        positional_embedding_type="rotary",
+    )
+
+    attn = Attention(cfg)
+    rotary_dim = cfg.rotary_dim
+    assert rotary_dim is not None
+
+    assert attn.cfg.n_ctx == 8192
+    assert attn.rotary_sin.shape == (2048, rotary_dim)
+    assert attn.rotary_cos.shape == (2048, rotary_dim)
+
+
+def test_rotary_embeddings_initial_cache_matches_short_context():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=8,
+        n_ctx=128,
+        d_head=4,
+        n_heads=2,
+        act_fn="relu",
+        positional_embedding_type="rotary",
+    )
+
+    attn = Attention(cfg)
+    rotary_dim = cfg.rotary_dim
+    assert rotary_dim is not None
+
+    assert attn.rotary_sin.shape == (cfg.n_ctx, rotary_dim)
+    assert attn.rotary_cos.shape == (cfg.n_ctx, rotary_dim)
+
+
+def test_apply_rotary_extends_embeddings_on_demand():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=8,
+        n_ctx=4096,
+        d_head=4,
+        n_heads=2,
+        act_fn="relu",
+        positional_embedding_type="rotary",
+    )
+    attn = Attention(cfg)
+    rotary_dim = cfg.rotary_dim
+    assert rotary_dim is not None
+    x = torch.randn((1, 2, cfg.n_heads, cfg.d_head), dtype=cfg.dtype)
+
+    out = attn.apply_rotary(x, past_kv_pos_offset=2047)
+
+    expected_sin, expected_cos = attn.calculate_sin_cos_rotary(
+        rotary_dim,
+        2049,
+        base=cfg.rotary_base,
+        dtype=cfg.dtype,
+    )
+    assert out.shape == x.shape
+    assert attn.rotary_sin.shape == (2049, rotary_dim)
+    assert attn.rotary_cos.shape == (2049, rotary_dim)
+    torch.testing.assert_close(attn.rotary_sin, expected_sin)
+    torch.testing.assert_close(attn.rotary_cos, expected_cos)
+
+
+def test_local_rotary_extension_uses_local_base():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=8,
+        n_ctx=4096,
+        d_head=4,
+        n_heads=2,
+        act_fn="relu",
+        positional_embedding_type="rotary",
+        rotary_base=1_000_000,
+        rotary_base_local=10_000,
+        window_size=128,
+    )
+    attn = Attention(cfg, attn_type="local")
+    rotary_dim = cfg.rotary_dim
+    rotary_base_local = cfg.rotary_base_local
+    assert rotary_dim is not None
+    assert rotary_base_local is not None
+
+    attn._extend_rotary_embeddings(2050)
+
+    expected_local_sin, expected_local_cos = attn.calculate_sin_cos_rotary(
+        rotary_dim,
+        2050,
+        base=rotary_base_local,
+        dtype=cfg.dtype,
+    )
+    global_sin, _ = attn.calculate_sin_cos_rotary(
+        rotary_dim,
+        2050,
+        base=cfg.rotary_base,
+        dtype=cfg.dtype,
+    )
+    torch.testing.assert_close(attn.rotary_sin, expected_local_sin)
+    torch.testing.assert_close(attn.rotary_cos, expected_local_cos)
+    assert not torch.allclose(attn.rotary_sin, global_sin)
+
+
+def test_attention_loads_legacy_full_rotary_buffers_with_strict_true():
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=8,
+        n_ctx=4096,
+        d_head=4,
+        n_heads=2,
+        act_fn="relu",
+        positional_embedding_type="rotary",
+    )
+    attn = Attention(cfg)
+    rotary_dim = cfg.rotary_dim
+    assert rotary_dim is not None
+    state_dict = attn.state_dict()
+    state_dict["rotary_sin"], state_dict["rotary_cos"] = attn.calculate_sin_cos_rotary(
+        rotary_dim,
+        cfg.n_ctx,
+        base=cfg.rotary_base,
+        dtype=cfg.dtype,
+    )
+
+    incompatible_keys = attn.load_state_dict(state_dict, strict=True)
+
+    assert incompatible_keys.missing_keys == []
+    assert incompatible_keys.unexpected_keys == []
+    assert attn.rotary_sin.shape == (2048, rotary_dim)
+    assert attn.rotary_cos.shape == (2048, rotary_dim)
+
+
 def test_apply_causal_mask_global_matches_absolute_positions():
     cfg = HookedTransformerConfig(
         n_layers=1,

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -27,6 +27,8 @@ if is_bitsandbytes_available():
 
 
 class AbstractAttention(ABC, nn.Module):
+    ROTARY_INITIAL_CACHE_SIZE = 2048
+
     alibi: Union[torch.Tensor, None]
     q_norm: Optional[RMSNorm]
     k_norm: Optional[RMSNorm]
@@ -156,15 +158,11 @@ class AbstractAttention(ABC, nn.Module):
             self.hook_rot_q = HookPoint()
             if self.cfg.rotary_dim is None:  # keep mypy happy
                 raise ValueError("Rotary dim must be provided for rotary positional embeddings")
-            # Use per-layer RoPE base if specified (e.g., Gemma 3 uses 10k for local, 1M for global)
-            if self.cfg.rotary_base_local is not None and self.attn_type == "local":
-                rope_base = self.cfg.rotary_base_local
-            else:
-                rope_base = self.cfg.rotary_base
+            rotary_cache_size = min(self.cfg.n_ctx, self.ROTARY_INITIAL_CACHE_SIZE)
             sin, cos = self.calculate_sin_cos_rotary(
                 self.cfg.rotary_dim,
-                self.cfg.n_ctx,
-                base=rope_base,
+                rotary_cache_size,
+                base=self._rotary_base(),
                 dtype=self.cfg.dtype,
             )
             self.register_buffer("rotary_sin", sin)
@@ -613,6 +611,11 @@ class AbstractAttention(ABC, nn.Module):
 
         return final_mask[None, None, :, :]
 
+    def _rotary_base(self) -> Union[float, int]:
+        if self.cfg.rotary_base_local is not None and self.attn_type == "local":
+            return self.cfg.rotary_base_local
+        return self.cfg.rotary_base
+
     def calculate_sin_cos_rotary(
         self,
         rotary_dim: int,
@@ -768,9 +771,6 @@ class AbstractAttention(ABC, nn.Module):
 
     def _extend_rotary_embeddings(self, new_size: int):
         """Extend rotary embeddings to support longer contexts dynamically."""
-        # Get the RoPE base from config or use default
-        rope_base = getattr(self.cfg, "rotary_base", 10000)
-
         # Ensure rotary_dim is set
         assert self.cfg.rotary_dim is not None, "rotary_dim must be set for rotary embeddings"
 
@@ -778,7 +778,7 @@ class AbstractAttention(ABC, nn.Module):
         sin, cos = self.calculate_sin_cos_rotary(
             self.cfg.rotary_dim,
             new_size,
-            base=rope_base,
+            base=self._rotary_base(),
             dtype=self.cfg.dtype,
         )
 
@@ -800,11 +800,17 @@ class AbstractAttention(ABC, nn.Module):
         unexpected_keys,
         error_msgs,
     ):
-        mask_key = prefix + "mask"
-        saved_mask = state_dict.get(mask_key)
-        if isinstance(saved_mask, torch.Tensor) and saved_mask.shape != self.mask.shape:
-            state_dict = state_dict.copy()
-            state_dict[mask_key] = self.mask
+        for buffer_name in ("mask", "rotary_sin", "rotary_cos"):
+            buffer_key = prefix + buffer_name
+            saved_buffer = state_dict.get(buffer_key)
+            current_buffer = getattr(self, buffer_name, None)
+            if (
+                isinstance(saved_buffer, torch.Tensor)
+                and isinstance(current_buffer, torch.Tensor)
+                and saved_buffer.shape != current_buffer.shape
+            ):
+                state_dict = state_dict.copy()
+                state_dict[buffer_key] = current_buffer
         super()._load_from_state_dict(
             state_dict,
             prefix,


### PR DESCRIPTION
# Description

Follow-up/prep for #1453 based on maintainer feedback there.

`HookedTransformer` rotary attention currently precomputes persistent `rotary_sin` / `rotary_cos` buffers out to full `cfg.n_ctx` for every rotary attention layer during construction. For long-context configs, that means short-context users pay the full long-context rotary-cache memory cost up front.

This PR bounds the initial rotary precompute to `min(n_ctx, 2048)` and keeps the existing `apply_rotary` extension path responsible for growing the buffers on demand when a longer position is actually used. `cfg.n_ctx` still reflects the true supported context length.

It also fixes two compatibility details needed for making lazy extension the normal path:

- `_extend_rotary_embeddings` now uses the same local-vs-global RoPE base selection as construction, so local-attention layers use `rotary_base_local` when configured.
- `_load_from_state_dict` now replaces mismatched `rotary_sin` / `rotary_cos` buffers with the current buffers, mirroring the existing mask size shim, so older checkpoints with full-size rotary buffers can still load with `strict=True`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Validation

Local checks run:

```bash
uv run --no-sync pytest tests/unit/components/test_attention.py -q
make format
make check-format
uv run mypy .
make unit-test
git diff --check
make test-pr
```

Results:

- `tests/unit/components/test_attention.py`: `13 passed, 4 skipped`
- `make format`: passed
- `make check-format`: passed
- `uv run mypy .`: passed, `Success: no issues found in 299 source files`
- `make unit-test`: passed, `3220 passed, 31 skipped, 42 deselected, 9 xfailed`
- `git diff --check`: passed
- `make test-pr` progressed through:
  - unit: passed, `3220 passed, 31 skipped, 42 deselected, 9 xfailed`
  - docstring: passed, `18 passed, 25 skipped`
  - acceptance: passed, `137 passed, 83 skipped, 11 deselected, 1 rerun`
  - integration: blocked locally before test execution by a macOS temporary-venv import hang in the notebook pytest plugin path (`nbval` / `jupyter_client` / `zmq`). CI should run this in a clean environment.
