### PR TITLE
Grow rotary cache with headroom

### DIFF
--- a/tests/unit/components/test_attention.py
+++ b/tests/unit/components/test_attention.py
@@ -195,15 +195,46 @@ def test_apply_rotary_extends_embeddings_on_demand():
 
     expected_sin, expected_cos = attn.calculate_sin_cos_rotary(
         rotary_dim,
-        2049,
+        cfg.n_ctx,
         base=cfg.rotary_base,
         dtype=cfg.dtype,
     )
     assert out.shape == x.shape
-    assert attn.rotary_sin.shape == (2049, rotary_dim)
-    assert attn.rotary_cos.shape == (2049, rotary_dim)
+    assert attn.rotary_sin.shape == (cfg.n_ctx, rotary_dim)
+    assert attn.rotary_cos.shape == (cfg.n_ctx, rotary_dim)
     torch.testing.assert_close(attn.rotary_sin, expected_sin)
     torch.testing.assert_close(attn.rotary_cos, expected_cos)
+
+
+def test_apply_rotary_extends_with_headroom_for_token_generation(monkeypatch):
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=8,
+        n_ctx=8192,
+        d_head=4,
+        n_heads=2,
+        act_fn="relu",
+        positional_embedding_type="rotary",
+    )
+    attn = Attention(cfg)
+    rotary_dim = cfg.rotary_dim
+    assert rotary_dim is not None
+    x = torch.randn((1, 1, cfg.n_heads, cfg.d_head), dtype=cfg.dtype)
+    extension_sizes = []
+    original_extend = attn._extend_rotary_embeddings
+
+    def record_extension(new_size):
+        extension_sizes.append(new_size)
+        original_extend(new_size)
+
+    monkeypatch.setattr(attn, "_extend_rotary_embeddings", record_extension)
+
+    attn.apply_rotary(x, past_kv_pos_offset=2048)
+    attn.apply_rotary(x, past_kv_pos_offset=2049)
+
+    assert extension_sizes == [4096]
+    assert attn.rotary_sin.shape == (4096, rotary_dim)
+    assert attn.rotary_cos.shape == (4096, rotary_dim)
 
 
 def test_local_rotary_extension_uses_local_base():

--- a/transformer_lens/components/abstract_attention.py
+++ b/transformer_lens/components/abstract_attention.py
@@ -750,7 +750,11 @@ class AbstractAttention(ABC, nn.Module):
         # Dynamically extend rotary embeddings if needed for long context
         max_pos_needed = past_kv_pos_offset + x_pos
         if max_pos_needed > self.rotary_cos.shape[0]:
-            self._extend_rotary_embeddings(max_pos_needed)
+            new_size = min(
+                self.cfg.n_ctx,
+                max(max_pos_needed, 2 * self.rotary_cos.shape[0]),
+            )
+            self._extend_rotary_embeddings(new_size)
 
         if attention_mask is None:
             rotary_cos = cast(torch.Tensor, self.rotary_cos)[


### PR DESCRIPTION
# Description

Follow-up to #1455 based on maintainer feedback there.

`apply_rotary` extends `rotary_sin` / `rotary_cos` when generation or long prompts need positions beyond the current cache. After #1455, the initial cache is intentionally bounded, so lazy extension is now the normal path for long-context models.

Before this PR, the extension target was exactly `max_pos_needed`. That is fine for a long-prompt prefill, but token-by-token generation past the cache boundary can grow one position at a time and recompute the full rotary cache on each step.

This PR grows the rotary cache with headroom instead:

```python
min(cfg.n_ctx, max(max_pos_needed, 2 * current_cache_size))
```

That keeps the cache bounded by the configured context length, still handles large jumps immediately, and reduces token-by-token extension frequency from every step to logarithmically many growth events.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Validation

Local checks run:

```bash
uv run --no-sync pytest tests/unit/components/test_attention.py -q
make format
make check-format
uv run mypy .
make unit-test
git diff --check
```

Results:

- `tests/unit/components/test_attention.py`: `14 passed, 4 skipped`
- `make format`: passed, no file rewrites
- `make check-format`: passed
- `uv run mypy .`: passed, `Success: no issues found in 299 source files`
- `make unit-test`: passed, `3224 passed, 31 skipped, 42 deselected, 9 xfailed`
- `git diff --check`: passed
