### PR TITLE
Support CPU device_map in TransformerBridge

### DIFF
--- a/tests/acceptance/model_bridge/test_multi_gpu_bridge.py
+++ b/tests/acceptance/model_bridge/test_multi_gpu_bridge.py
@@ -206,6 +206,17 @@ class TestBootParamValidation:
         with pytest.raises(ValueError, match="mutually exclusive"):
             TransformerBridge.boot_transformers("gpt2", device="cpu", device_map="auto")
 
+    def test_explicit_cpu_device_map_boots_and_runs(self):
+        bridge = TransformerBridge.boot_transformers("gpt2", device_map={"": "cpu"})
+
+        assert bridge.cfg.device == "cpu"
+        assert bridge.cfg.n_devices == 1
+        tokens = torch.tensor([[bridge.tokenizer.eos_token_id]])
+        with torch.no_grad():
+            logits = bridge(tokens)
+        assert logits.shape == (1, 1, bridge.cfg.d_vocab_out)
+        assert logits.device.type == "cpu"
+
     def test_preloaded_with_device_map_rejected(self, gpt2_bridge):
         # Passing both hf_model= and device_map/n_devices is ambiguous — the device_map
         # would be silently ignored. We raise so the caller isn't surprised.

--- a/tests/acceptance/model_bridge/test_multi_gpu_bridge.py
+++ b/tests/acceptance/model_bridge/test_multi_gpu_bridge.py
@@ -11,6 +11,7 @@ import torch
 
 from transformer_lens.model_bridge import TransformerBridge
 from transformer_lens.utilities.multi_gpu import (
+    cast_floating_params_to_dtype,
     count_unique_devices,
     find_embedding_device,
     resolve_device_map,
@@ -80,14 +81,20 @@ class TestResolveDeviceMap:
         assert dm == "balanced"
         assert mm == user_mm
 
-    def test_cpu_value_in_device_map_rejected(self):
-        bad: Dict[str, Union[str, int]] = {"transformer.h.0": "cpu"}
-        with pytest.raises(ValueError, match="not supported"):
-            resolve_device_map(None, bad, None)
+    def test_cpu_value_in_device_map_passes_through(self):
+        explicit: Dict[str, Union[str, int]] = {"transformer.h.0": "cpu"}
+        dm, mm = resolve_device_map(None, explicit, None)
+        assert dm is explicit
+        assert mm is None
 
     def test_disk_value_in_device_map_rejected(self):
         bad: Dict[str, Union[str, int]] = {"transformer.h.0": "disk"}
-        with pytest.raises(ValueError, match="not supported"):
+        with pytest.raises(ValueError, match="not supported yet"):
+            resolve_device_map(None, bad, None)
+
+    def test_meta_value_in_device_map_rejected(self):
+        bad: Dict[str, Union[str, int]] = {"transformer.h.0": "meta"}
+        with pytest.raises(ValueError, match="not supported yet"):
             resolve_device_map(None, bad, None)
 
 
@@ -153,6 +160,45 @@ class TestCountUniqueDevices:
             hf_device_map = {"a": 0, "b": 0, "c": 1, "d": 1, "e": 2}
 
         assert count_unique_devices(Stub()) == 3
+
+
+class TestCastFloatingParamsToDtype:
+    def test_casts_cpu_and_disk_offloaded_params(self, tmp_path):
+        from accelerate.big_modeling import dispatch_model
+        from accelerate.utils import align_module_device
+
+        class StubModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.first = torch.nn.Linear(3, 3, dtype=torch.float32)
+                self.second = torch.nn.Linear(3, 2, dtype=torch.float32)
+
+        model = StubModel()
+        dispatch_model(
+            model,
+            device_map={"first": "cpu", "second": "disk"},
+            offload_dir=str(tmp_path),
+        )
+
+        assert model.first.weight.device.type == "cpu"
+        assert model.second.weight.device.type == "meta"
+
+        cast_floating_params_to_dtype(model, torch.float16)
+
+        assert model.first.weight.dtype == torch.float16
+        assert model.second.weight.device.type == "meta"
+        assert model.second.weight.dtype == torch.float16
+        with align_module_device(model.second):
+            assert model.second.weight.device.type == "cpu"
+            assert model.second.weight.dtype == torch.float16
+
+    def test_skips_plain_meta_params(self):
+        module = torch.nn.Linear(3, 2, device="meta", dtype=torch.float32)
+
+        cast_floating_params_to_dtype(module, torch.float16)
+
+        assert module.weight.device.type == "meta"
+        assert module.weight.dtype == torch.float32
 
 
 class TestBootParamValidation:

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -253,9 +253,11 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                 BitsAndBytesConfig). When provided, load_weights is ignored. If the pre-loaded
                 model was built with a ``device_map``, ``cfg.device`` and ``cfg.n_devices`` are
                 derived from its ``hf_device_map`` automatically.
-            device_map: HuggingFace-style device map for multi-GPU inference. Pass ``"auto"``,
-                ``"balanced"``, ``"sequential"``, or an explicit ``{submodule_path: device}`` dict.
-                Mutually exclusive with ``device``.
+            device_map: HuggingFace-style device map for dispatched inference. Pass ``"auto"``,
+                ``"balanced"``, ``"sequential"``, or an explicit ``{submodule_path: device}``
+                dict. Explicit maps may include CPU targets; disk / meta offload targets are
+                still rejected because Bridge component wrappers need additional offload-hook
+                routing work. Mutually exclusive with ``device``.
             n_devices: Convenience shortcut: split the model across this many CUDA devices.
                 Translated to a ``max_memory`` dict over devices 0..n_devices-1 and passed as
                 ``device_map`` to HF. Requires CUDA with at least this many visible devices.

--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -391,8 +391,9 @@ def boot(
             models loaded with custom configurations (e.g., quantization via BitsAndBytesConfig).
             When provided, load_weights is ignored.
         device_map: HuggingFace-style device map (``"auto"``, ``"balanced"``, dict, etc.) for
-            multi-GPU inference. Passed straight to ``from_pretrained``. Mutually exclusive
-            with ``device``.
+            dispatched inference. Explicit maps may include CPU targets; disk / meta offload
+            targets are still rejected because Bridge component wrappers need additional
+            offload-hook routing work. Mutually exclusive with ``device``.
         n_devices: Convenience: split the model across this many CUDA devices (translated to a
             ``max_memory`` dict internally). Requires CUDA with at least this many visible devices.
         max_memory: Optional per-device memory budget for HF's dispatcher.
@@ -590,6 +591,7 @@ def boot(
     # device_map + max_memory pair here so downstream code only needs to check the
     # resolved values.
     from transformer_lens.utilities.multi_gpu import (
+        cast_floating_params_to_dtype,
         count_unique_devices,
         find_embedding_device,
         resolve_device_map,
@@ -665,24 +667,34 @@ def boot(
         # Skip explicit .to(device) when accelerate has placed weights via device_map.
         if resolved_device_map is None and device is not None:
             hf_model = hf_model.to(device)
-        # Cast params to dtype; preserve float32 buffers (e.g., RotaryEmbedding.inv_freq)
-        for param in hf_model.parameters():
-            if param.is_floating_point() and param.dtype != dtype:
-                param.data = param.data.to(dtype=dtype)
+        # Cast params to dtype; preserve float32 buffers (e.g., RotaryEmbedding.inv_freq).
+        # Use module-level alignment so Accelerate can temporarily materialize offloaded
+        # parameters before we touch them.
+        cast_floating_params_to_dtype(hf_model, dtype)
     # Derive cfg.device / cfg.n_devices from hf_device_map when present. This covers:
     #   - fresh loads with a resolved device_map (set above)
     #   - pre-loaded hf_model that the caller dispatched themselves (e.g., device_map="auto")
     hf_device_map_post = getattr(hf_model, "hf_device_map", None)
     if hf_device_map_post:
-        # Pre-loaded path can still smuggle CPU/disk offload in; validate here too.
+        # CPU placement is supported. Disk / meta offload still needs a separate Bridge
+        # hook-routing pass because wrapped subcomponents can bypass Accelerate hooks.
         offload_values = {str(v).lower() for v in hf_device_map_post.values() if isinstance(v, str)}
-        forbidden = offload_values & {"cpu", "disk", "meta"}
-        if forbidden and ((n_devices is not None and n_devices > 1) or device_map is not None):
-            # Fresh-load path: we set the device_map ourselves, so this shouldn't happen —
-            # but if the user asked for n_devices>1 and somehow got CPU offload, surface it.
+        unsupported = offload_values & {"disk", "meta"}
+        if unsupported:
             raise ValueError(
-                f"hf_device_map contains unsupported offload targets: {sorted(forbidden)}. "
-                "v1 multi-device support is GPU-only."
+                f"hf_device_map contains unsupported offload targets: {sorted(unsupported)}. "
+                "TransformerBridge currently supports CPU device_map targets, but disk / meta "
+                "offload can bypass Accelerate hooks inside wrapped Bridge components."
+            )
+        if (
+            "cpu" in offload_values
+            and device_map is None
+            and n_devices is not None
+            and n_devices > 1
+        ):
+            raise ValueError(
+                "hf_device_map contains CPU targets. n_devices is GPU-only; pass device_map "
+                "explicitly for CPU placement."
             )
     embedding_device = find_embedding_device(hf_model)
     if embedding_device is not None:

--- a/transformer_lens/utilities/multi_gpu.py
+++ b/transformer_lens/utilities/multi_gpu.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import torch
+from torch import nn
 
 if TYPE_CHECKING:
     from transformer_lens.config.hooked_transformer_config import (
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
     )
 else:
     ConfigType = Any
+
+_UNSUPPORTED_OFFLOAD_DEVICE_MAP_VALUES = {"disk", "meta"}
 
 AvailableDeviceMemory = list[tuple[int, int]]
 """
@@ -146,30 +149,6 @@ def get_device_for_block_index(
     return torch.device(device.type, device_index)
 
 
-_UNSUPPORTED_DEVICE_MAP_VALUES = {"cpu", "disk", "meta"}
-"""v1 multi-GPU scope is GPU-only. CPU offload and disk offload cause dtype-cast loops to
-silently miss offloaded params (meta tensors), and cross-layer hook routing has different
-semantics. Reject them explicitly until a v2 scopes those paths."""
-
-
-def _validate_device_map_values(
-    device_map: Union[str, Dict[str, Union[str, int]]],
-) -> None:
-    """Reject CPU / disk / meta values in a user-supplied device_map dict."""
-    if isinstance(device_map, str):
-        # "balanced_low_0" is fine — still GPU-only; "cpu" as a string-form device_map
-        # would tell HF to put everything on CPU, which is single-device and meaningless
-        # as a multi-GPU config. We allow strings through; HF will validate them.
-        return
-    for key, value in device_map.items():
-        normalized = str(value).lower() if isinstance(value, str) else None
-        if normalized in _UNSUPPORTED_DEVICE_MAP_VALUES:
-            raise ValueError(
-                f"device_map[{key!r}]={value!r} is not supported. Multi-device bridge "
-                f"support is GPU-only in v1; CPU / disk / meta offload routes are excluded."
-            )
-
-
 def resolve_device_map(
     n_devices: Optional[int],
     device_map: Optional[Union[str, Dict[str, Union[str, int]]]],
@@ -181,8 +160,10 @@ def resolve_device_map(
     Returns ``(device_map, max_memory)`` tuple ready to pass into ``model_kwargs``.
 
     Semantics:
-        - Explicit ``device_map`` wins; it's validated and passed through unchanged (user-
-          provided ``max_memory`` is passed through too).
+        - Explicit ``device_map`` wins and is passed through unchanged (user-provided
+          ``max_memory`` is passed through too). CPU targets are supported; disk / meta
+          offload targets are still rejected because Bridge component wrappers can bypass
+          Accelerate's offload hooks during forward passes.
         - ``n_devices=None`` or ``1``: returns ``(None, None)`` — single-device path.
         - ``n_devices > 1``: returns ``("balanced", {0: "auto", ..., n-1: "auto"})``.
           ``"balanced"`` is accelerate's string directive for balanced layer dispatch;
@@ -205,6 +186,36 @@ def resolve_device_map(
         dict(max_memory) if max_memory else {i: "auto" for i in range(n_devices)}
     )
     return "balanced", resolved_max_memory
+
+
+def _validate_device_map_values(
+    device_map: Union[str, Dict[str, Union[str, int]]],
+) -> None:
+    """Reject explicit disk / meta values in a user-supplied device_map dict."""
+    if isinstance(device_map, str):
+        return
+    for key, value in device_map.items():
+        normalized = str(value).lower() if isinstance(value, str) else None
+        if normalized in _UNSUPPORTED_OFFLOAD_DEVICE_MAP_VALUES:
+            raise ValueError(
+                f"device_map[{key!r}]={value!r} is not supported yet. TransformerBridge "
+                "currently supports CPU device_map targets, but disk / meta offload can "
+                "bypass Accelerate hooks inside wrapped Bridge components."
+            )
+
+
+def cast_floating_params_to_dtype(model: nn.Module, dtype: torch.dtype) -> None:
+    """Cast materialized floating parameters while preserving Accelerate offload hooks."""
+    from accelerate.utils import align_module_device
+
+    for module in model.modules():
+        with align_module_device(module):
+            for param in module.parameters(recurse=False):
+                if not param.is_floating_point() or param.dtype == dtype:
+                    continue
+                if param.device.type == "meta":
+                    continue
+                param.data = param.data.to(dtype=dtype)
 
 
 def find_embedding_device(hf_model: Any) -> Optional[torch.device]:


### PR DESCRIPTION
# Description

Part of #1280.

This PR enables explicit CPU targets in `TransformerBridge` `device_map` dictionaries. Previously `resolve_device_map` rejected `"cpu"`, `"disk"`, and `"meta"` uniformly; this changes the boundary so CPU placement is passed through to HuggingFace while `disk` / `meta` remain rejected with a clearer error.

It also replaces the raw `hf_model.parameters()` dtype-cast loop with `cast_floating_params_to_dtype()`, which uses `accelerate.utils.align_module_device()` at the module level. That keeps dtype casting safe around Accelerate-managed offload placeholders and preserves float32 buffers.

This intentionally does **not** claim full disk/meta offload support yet. During local smoke testing, an explicit GPT-2 map with one block on `disk` loaded successfully but forward hit a `meta` tensor inside a Bridge-wrapped component, meaning disk/meta support needs a separate hook-routing fix.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Validation

- `make format`
- `make check-format`
- `uv run mypy .`
- `uv run pytest tests/acceptance/model_bridge/test_multi_gpu_bridge.py -q`
- Smoke: `TransformerBridge.boot_transformers("gpt2", device_map={"": "cpu"})` followed by a one-token forward pass
