### PR TITLE
Port Tracr demo to TransformerBridge

### DIFF
--- a/demos/Tracr_to_Transformer_Lens_Demo.ipynb
+++ b/demos/Tracr_to_Transformer_Lens_Demo.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "source": [
     "# Tracr to TransformerLens Converter\n",
-    "[Tracr](https://github.com/deepmind/tracr) is a cool new DeepMind tool that compiles a written program in RASP to transformer weights. TransformerLens is a library I've written to easily do mechanistic interpretability on a transformer and to poke around at its internals. This is a (hacky!) script to convert Tracr weights from the JAX form to a TransformerLens HookedTransformer in PyTorch.\n",
+    "[Tracr](https://github.com/google-deepmind/tracr) compiles RASP programs to transformer weights. TransformerLens exposes transformer internals through hooks and activation caches. This notebook converts a Tracr-assembled model into a `TransformerBridge` native model in PyTorch, then checks that the Bridge logits and intermediate activations match Tracr.\n",
     "\n",
     "See [the TransformerLens tutorial](https://neelnanda.io/transformer-lens-demo) to get started"
    ]
@@ -25,7 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Python version must be >=3.8 (my fork of Tracr is a bit more backwards compatible, original library is at least 3.9)"
+    "Python version must be >=3.10 for current TransformerLens development installs."
    ]
   },
   {
@@ -47,25 +47,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running as a Jupyter notebook - intended for development only!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    import google.colab\n",
     "    IN_COLAB = True\n",
     "    print(\"Running as a Colab notebook\")\n",
-    "    %pip install transformer_lens\n",
-    "    # Fork of Tracr that's backward compatible with Python 3.8\n",
-    "    %pip install git+https://github.com/neelnanda-io/Tracr\n",
+    "    %pip install git+https://github.com/TransformerLensOrg/TransformerLens.git@dev\n",
+    "    %pip install git+https://github.com/google-deepmind/tracr.git\n",
     "    \n",
     "except:\n",
     "    IN_COLAB = False\n",
@@ -73,31 +64,25 @@
     "    # from IPython import get_ipython\n",
     "\n",
     "    # ipython = get_ipython()\n",
-    "    # # Code to automatically update the HookedTransformer code as its edited without restarting the kernel\n",
+    "    # # Code to automatically update the TransformerLens code as its edited without restarting the kernel\n",
     "    # ipython.run_line_magic(\"load_ext\", \"autoreload\")\n",
     "    # ipython.run_line_magic(\"autoreload\", \"2\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/python38/lib/python3.8/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from transformer_lens import HookedTransformer, HookedTransformerConfig\n",
-    "import einops\n",
-    "import torch\n",
     "import numpy as np\n",
+    "import torch\n",
     "\n",
+    "from transformer_lens.model_bridge import TransformerBridge\n",
+    "from transformer_lens.utilities.tracr import (\n",
+    "    make_tracr_transformer_bridge_config,\n",
+    "    make_tracr_transformer_bridge_state_dict,\n",
+    ")\n",
     "from tracr.rasp import rasp\n",
     "from tracr.compiler import compiling"
    ]
@@ -112,18 +97,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:absl:Creating a SequenceMap with both inputs being the same SOp is discouraged. You should use a Map instead.\n",
-      "WARNING:jax._src.lib.xla_bridge:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "def make_length():\n",
@@ -134,7 +110,7 @@
     "length = make_length()  # `length` is not a primitive in our implementation.\n",
     "opp_index = length - rasp.indices - 1\n",
     "flip = rasp.Select(rasp.indices, opp_index, rasp.Comparison.EQ)\n",
-    "reverse = rasp.Aggregate(flip, rasp.tokens)\n",
+    "reverse = rasp.Aggregate(flip, rasp.tokens).named(\"reverse\")\n",
     "\n",
     "bos = \"BOS\"\n",
     "model = compiling.compile_rasp_to_model(\n",
@@ -152,51 +128,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Extract the model config from the Tracr model, and create a blank HookedTransformer object"
+    "Extract the model config from the Tracr model, and create a blank `TransformerBridge` native model."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "\n",
-    "# %%\n",
-    "\n",
-    "n_heads = model.model_config.num_heads\n",
-    "n_layers = model.model_config.num_layers\n",
-    "d_head = model.model_config.key_size\n",
-    "d_mlp = model.model_config.mlp_hidden_size\n",
-    "act_fn = \"relu\"\n",
-    "normalization_type = \"LN\"  if model.model_config.layer_norm else None\n",
-    "attention_type = \"causal\"  if model.model_config.causal else \"bidirectional\"\n",
-    "\n",
-    "\n",
-    "n_ctx = model.params[\"pos_embed\"]['embeddings'].shape[0]\n",
-    "# Equivalent to length of vocab, with BOS and PAD at the end\n",
-    "d_vocab = model.params[\"token_embed\"]['embeddings'].shape[0]\n",
-    "# Residual stream width, I don't know of an easy way to infer it from the above config.\n",
-    "d_model = model.params[\"token_embed\"]['embeddings'].shape[1]\n",
-    "\n",
-    "# Equivalent to length of vocab, WITHOUT BOS and PAD at the end because we never care about these outputs\n",
-    "# In practice, we always feed the logits into an argmax\n",
-    "d_vocab_out = model.params[\"token_embed\"]['embeddings'].shape[0] - 2\n",
-    "\n",
-    "cfg = HookedTransformerConfig(\n",
-    "    n_layers=n_layers,\n",
-    "    d_model=d_model,\n",
-    "    d_head=d_head,\n",
-    "    n_ctx=n_ctx,\n",
-    "    d_vocab=d_vocab,\n",
-    "    d_vocab_out=d_vocab_out,\n",
-    "    d_mlp=d_mlp,\n",
-    "    n_heads=n_heads,\n",
-    "    act_fn=act_fn,\n",
-    "    attention_dir=attention_type,\n",
-    "    normalization_type=normalization_type,\n",
-    ")\n",
-    "tl_model = HookedTransformer(cfg)"
+    "cfg = make_tracr_transformer_bridge_config(model)\n",
+    "tl_model = TransformerBridge.boot_native(cfg)"
    ]
   },
   {
@@ -204,84 +147,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Extract the state dict, and do some reshaping so that everything has a n_heads dimension"
+    "Extract the state dict. The helper reconstructs Tracr's categorical unembed from the output basis labels, so it still works when the final RASP expression is explicitly named and its residual coordinates are not first."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "dict_keys(['pos_embed.W_pos', 'embed.W_E', 'unembed.W_U', 'blocks.0.attn.W_K', 'blocks.0.attn.b_K', 'blocks.0.attn.W_Q', 'blocks.0.attn.b_Q', 'blocks.0.attn.W_V', 'blocks.0.attn.b_V', 'blocks.0.attn.W_O', 'blocks.0.attn.b_O', 'blocks.0.mlp.W_in', 'blocks.0.mlp.b_in', 'blocks.0.mlp.W_out', 'blocks.0.mlp.b_out', 'blocks.1.attn.W_K', 'blocks.1.attn.b_K', 'blocks.1.attn.W_Q', 'blocks.1.attn.b_Q', 'blocks.1.attn.W_V', 'blocks.1.attn.b_V', 'blocks.1.attn.W_O', 'blocks.1.attn.b_O', 'blocks.1.mlp.W_in', 'blocks.1.mlp.b_in', 'blocks.1.mlp.W_out', 'blocks.1.mlp.b_out', 'blocks.2.attn.W_K', 'blocks.2.attn.b_K', 'blocks.2.attn.W_Q', 'blocks.2.attn.b_Q', 'blocks.2.attn.W_V', 'blocks.2.attn.b_V', 'blocks.2.attn.W_O', 'blocks.2.attn.b_O', 'blocks.2.mlp.W_in', 'blocks.2.mlp.b_in', 'blocks.2.mlp.W_out', 'blocks.2.mlp.b_out', 'blocks.3.attn.W_K', 'blocks.3.attn.b_K', 'blocks.3.attn.W_Q', 'blocks.3.attn.b_Q', 'blocks.3.attn.W_V', 'blocks.3.attn.b_V', 'blocks.3.attn.W_O', 'blocks.3.attn.b_O', 'blocks.3.mlp.W_in', 'blocks.3.mlp.b_in', 'blocks.3.mlp.W_out', 'blocks.3.mlp.b_out'])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
-    "# %%\n",
-    "sd = {}\n",
-    "sd[\"pos_embed.W_pos\"] = model.params[\"pos_embed\"]['embeddings']\n",
-    "sd[\"embed.W_E\"] = model.params[\"token_embed\"]['embeddings']\n",
-    "# Equivalent to max_seq_len plus one, for the BOS\n",
-    "\n",
-    "# The unembed is just a projection onto the first few elements of the residual stream, these store output tokens\n",
-    "# This is a NumPy array, the rest are Jax Arrays, but w/e it's fine.\n",
-    "sd[\"unembed.W_U\"] = np.eye(d_model, d_vocab_out)\n",
-    "\n",
-    "for l in range(n_layers):\n",
-    "    sd[f\"blocks.{l}.attn.W_K\"] = einops.rearrange(\n",
-    "        model.params[f\"transformer/layer_{l}/attn/key\"][\"w\"],\n",
-    "        \"d_model (n_heads d_head) -> n_heads d_model d_head\",\n",
-    "        d_head = d_head,\n",
-    "        n_heads = n_heads\n",
-    "    )\n",
-    "    sd[f\"blocks.{l}.attn.b_K\"] = einops.rearrange(\n",
-    "        model.params[f\"transformer/layer_{l}/attn/key\"][\"b\"],\n",
-    "        \"(n_heads d_head) -> n_heads d_head\",\n",
-    "        d_head = d_head,\n",
-    "        n_heads = n_heads\n",
-    "    )\n",
-    "    sd[f\"blocks.{l}.attn.W_Q\"] = einops.rearrange(\n",
-    "        model.params[f\"transformer/layer_{l}/attn/query\"][\"w\"],\n",
-    "        \"d_model (n_heads d_head) -> n_heads d_model d_head\",\n",
-    "        d_head = d_head,\n",
-    "        n_heads = n_heads\n",
-    "    )\n",
-    "    sd[f\"blocks.{l}.attn.b_Q\"] = einops.rearrange(\n",
-    "        model.params[f\"transformer/layer_{l}/attn/query\"][\"b\"],\n",
-    "        \"(n_heads d_head) -> n_heads d_head\",\n",
-    "        d_head = d_head,\n",
-    "        n_heads = n_heads\n",
-    "    )\n",
-    "    sd[f\"blocks.{l}.attn.W_V\"] = einops.rearrange(\n",
-    "        model.params[f\"transformer/layer_{l}/attn/value\"][\"w\"],\n",
-    "        \"d_model (n_heads d_head) -> n_heads d_model d_head\",\n",
-    "        d_head = d_head,\n",
-    "        n_heads = n_heads\n",
-    "    )\n",
-    "    sd[f\"blocks.{l}.attn.b_V\"] = einops.rearrange(\n",
-    "        model.params[f\"transformer/layer_{l}/attn/value\"][\"b\"],\n",
-    "        \"(n_heads d_head) -> n_heads d_head\",\n",
-    "        d_head = d_head,\n",
-    "        n_heads = n_heads\n",
-    "    )\n",
-    "    sd[f\"blocks.{l}.attn.W_O\"] = einops.rearrange(\n",
-    "        model.params[f\"transformer/layer_{l}/attn/linear\"][\"w\"],\n",
-    "        \"(n_heads d_head) d_model -> n_heads d_head d_model\",\n",
-    "        d_head = d_head,\n",
-    "        n_heads = n_heads\n",
-    "    )\n",
-    "    sd[f\"blocks.{l}.attn.b_O\"] = model.params[f\"transformer/layer_{l}/attn/linear\"][\"b\"]\n",
-    "\n",
-    "    sd[f\"blocks.{l}.mlp.W_in\"] = model.params[f\"transformer/layer_{l}/mlp/linear_1\"][\"w\"]\n",
-    "    sd[f\"blocks.{l}.mlp.b_in\"] = model.params[f\"transformer/layer_{l}/mlp/linear_1\"][\"b\"]\n",
-    "    sd[f\"blocks.{l}.mlp.W_out\"] = model.params[f\"transformer/layer_{l}/mlp/linear_2\"][\"w\"]\n",
-    "    sd[f\"blocks.{l}.mlp.b_out\"] = model.params[f\"transformer/layer_{l}/mlp/linear_2\"][\"b\"]\n",
-    "print(sd.keys())\n"
+    "sd = make_tracr_transformer_bridge_state_dict(model, output_label=\"reverse\")\n",
+    "print(sd.keys())"
    ]
   },
   {
@@ -294,27 +171,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "_IncompatibleKeys(missing_keys=['blocks.0.attn.mask', 'blocks.0.attn.IGNORE', 'blocks.1.attn.mask', 'blocks.1.attn.IGNORE', 'blocks.2.attn.mask', 'blocks.2.attn.IGNORE', 'blocks.3.attn.mask', 'blocks.3.attn.IGNORE', 'unembed.b_U'], unexpected_keys=[])"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "\n",
-    "for k, v in sd.items():\n",
-    "    # I cannot figure out a neater way to go from a Jax array to a numpy array lol\n",
-    "    sd[k] = torch.tensor(np.array(v))\n",
-    "\n",
-    "tl_model.load_state_dict(sd, strict=False)\n"
+    "tl_model.load_state_dict(sd, strict=False)"
    ]
   },
   {
@@ -357,18 +218,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Original Decoding: ['BOS', 3, 2, 1]\n",
-      "TransformerLens Replicated Decoding: ['BOS', 3, 2, 1]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "input = [bos, 1, 2, 3]\n",
@@ -376,10 +228,9 @@
     "print(\"Original Decoding:\", out.decoded)\n",
     "\n",
     "input_tokens_tensor = create_model_input(input)\n",
-    "logits = tl_model(input_tokens_tensor)\n",
+    "logits = tl_model(input_tokens_tensor, return_type=\"logits\")\n",
     "decoded_output = decode_model_output(logits)\n",
-    "print(\"TransformerLens Replicated Decoding:\", decoded_output)\n",
-    "# %%\n"
+    "print(\"TransformerLens Bridge Replicated Decoding:\", decoded_output)"
    ]
   },
   {
@@ -392,30 +243,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Layer 0 Attn Out Equality Check: True\n",
-      "Layer 0 MLP Out Equality Check: True\n",
-      "Layer 1 Attn Out Equality Check: True\n",
-      "Layer 1 MLP Out Equality Check: True\n",
-      "Layer 2 Attn Out Equality Check: True\n",
-      "Layer 2 MLP Out Equality Check: True\n",
-      "Layer 3 Attn Out Equality Check: True\n",
-      "Layer 3 MLP Out Equality Check: True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "logits, cache = tl_model.run_with_cache(input_tokens_tensor)\n",
+    "logits, cache = tl_model.run_with_cache(input_tokens_tensor, return_type=\"logits\")\n",
     "\n",
     "for layer in range(tl_model.cfg.n_layers):\n",
-    "    print(f\"Layer {layer} Attn Out Equality Check:\", np.isclose(cache[\"attn_out\", layer].detach().cpu().numpy(), np.array(out.layer_outputs[2*layer])).all())\n",
-    "    print(f\"Layer {layer} MLP Out Equality Check:\", np.isclose(cache[\"mlp_out\", layer].detach().cpu().numpy(), np.array(out.layer_outputs[2*layer+1])).all())"
+    "    attn_out = cache[f\"blocks.{layer}.attn.hook_out\"].detach().cpu().numpy()\n",
+    "    mlp_out = cache[f\"blocks.{layer}.mlp.hook_out\"].detach().cpu().numpy()\n",
+    "    print(f\"Layer {layer} Attn Out Equality Check:\", np.isclose(attn_out, np.array(out.layer_outputs[2*layer])).all())\n",
+    "    print(f\"Layer {layer} MLP Out Equality Check:\", np.isclose(mlp_out, np.array(out.layer_outputs[2*layer+1])).all())"
    ]
   },
   {
@@ -423,59 +261,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Look how pretty and ordered the final residual stream is!\n",
-    "\n",
-    "(The logits are the first 3 dimensions of the residual stream, and we can see that they're flipped!)"
+    "The final residual stream is now decoded through the named `reverse:*` output directions, rather than by assuming the output logits occupy the first few residual dimensions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<html>\n",
-       "<head><meta charset=\"utf-8\" /></head>\n",
-       "<body>\n",
-       "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-       "        <script src=\"https://cdn.plot.ly/plotly-2.17.1.min.js\"></script>                <div id=\"966ceaba-5cf4-47a0-853d-6aa7f9a77be2\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"966ceaba-5cf4-47a0-853d-6aa7f9a77be2\")) {                    Plotly.newPlot(                        \"966ceaba-5cf4-47a0-853d-6aa7f9a77be2\",                        [{\"coloraxis\":\"coloraxis\",\"name\":\"0\",\"y\":[\"BOS\",\"1\",\"2\",\"3\"],\"z\":[[5.388877752920962e-07,5.388877752920962e-07,5.388877752920962e-07,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0],[2.9040084139481115e-13,2.9040084139481115e-13,0.9999994039535522,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.25,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0],[2.9040084139481115e-13,0.9999994039535522,2.9040084139481115e-13,0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.25,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0],[0.9999994039535522,2.9040084139481115e-13,2.9040084139481115e-13,0.0,0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.25,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0]],\"type\":\"heatmap\",\"xaxis\":\"x\",\"yaxis\":\"y\",\"hovertemplate\":\"Residual Stream: %{x}<br>Position: %{y}<br>color: %{z}<extra></extra>\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"scaleanchor\":\"y\",\"constrain\":\"domain\",\"title\":{\"text\":\"Residual Stream\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"autorange\":\"reversed\",\"constrain\":\"domain\",\"title\":{\"text\":\"Position\"}},\"coloraxis\":{\"colorscale\":[[0.0,\"rgb(247,251,255)\"],[0.125,\"rgb(222,235,247)\"],[0.25,\"rgb(198,219,239)\"],[0.375,\"rgb(158,202,225)\"],[0.5,\"rgb(107,174,214)\"],[0.625,\"rgb(66,146,198)\"],[0.75,\"rgb(33,113,181)\"],[0.875,\"rgb(8,81,156)\"],[1.0,\"rgb(8,48,107)\"]]},\"margin\":{\"t\":60}},                        {\"responsive\": true}                    ).then(function(){\n",
-       "                            \n",
-       "var gd = document.getElementById('966ceaba-5cf4-47a0-853d-6aa7f9a77be2');\n",
-       "var x = new MutationObserver(function (mutations, observer) {{\n",
-       "        var display = window.getComputedStyle(gd).display;\n",
-       "        if (!display || display === 'none') {{\n",
-       "            console.log([gd, 'removed!']);\n",
-       "            Plotly.purge(gd);\n",
-       "            observer.disconnect();\n",
-       "        }}\n",
-       "}});\n",
-       "\n",
-       "// Listen for the removal of the full notebook cells\n",
-       "var notebookContainer = gd.closest('#notebook-container');\n",
-       "if (notebookContainer) {{\n",
-       "    x.observe(notebookContainer, {childList: true});\n",
-       "}}\n",
-       "\n",
-       "// Listen for the clearing of the current output cell\n",
-       "var outputEl = gd.closest('.output');\n",
-       "if (outputEl) {{\n",
-       "    x.observe(outputEl, {childList: true});\n",
-       "}}\n",
-       "\n",
-       "                        })                };                            </script>        </div>\n",
-       "</body>\n",
-       "</html>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import plotly.express as px\n",
-    "px.imshow(cache[\"resid_post\", -1].detach().cpu().numpy()[0],\n",
+    "final_residual = cache[f\"blocks.{tl_model.cfg.n_layers - 1}.hook_out\"].detach().cpu().numpy()[0]\n",
+    "px.imshow(final_residual,\n",
     "color_continuous_scale=\"Blues\", labels={\"x\":\"Residual Stream\", \"y\":\"Position\"}, y=[str(i) for i in input]).show(\"colab\" if IN_COLAB else \"\")"
    ]
   }

--- a/tests/unit/model_bridge/test_native_features.py
+++ b/tests/unit/model_bridge/test_native_features.py
@@ -6,6 +6,7 @@ field unlocks (gated MLP, RMS norm, GQA, soft-cap, rotary, attn_only) — these
 features make boot_native useful as a regression target for the bridge's
 real machinery, not just a flat GPT-2 toy.
 """
+
 from __future__ import annotations
 
 import torch
@@ -17,6 +18,9 @@ from transformer_lens.model_bridge.generalized_components import (
     MLPBridge,
     NormalizationBridge,
     RMSNormalizationBridge,
+)
+from transformer_lens.model_bridge.generalized_components.base import (
+    GeneralizedComponent,
 )
 from transformer_lens.model_bridge.sources.native.model import (
     NativeGatedMLP,
@@ -235,6 +239,22 @@ def test_final_rms_only_swaps_the_final_norm():
     assert isinstance(ln_final_bridge, RMSNormalizationBridge)
     assert isinstance(ln_final_bridge.original_component, NativeRMSNorm)
     _ = _forward(bridge)
+
+
+def test_no_norm_uses_identity_modules_with_hooks():
+    cfg = _cfg(normalization_type=None)
+    bridge = TransformerBridge.boot_native(cfg)
+
+    assert isinstance(bridge.blocks[0].ln1, GeneralizedComponent)
+    assert not isinstance(bridge.blocks[0].ln1, NormalizationBridge)
+    assert isinstance(bridge.blocks[0].ln1.original_component, torch.nn.Identity)
+    assert isinstance(bridge.blocks[0].ln2.original_component, torch.nn.Identity)
+    assert isinstance(bridge.ln_final.original_component, torch.nn.Identity)
+
+    inputs = torch.randint(0, cfg.d_vocab, (2, cfg.n_ctx))
+    _, cache = bridge.run_with_cache(inputs, return_type="logits")
+    assert torch.equal(cache["blocks.0.ln1.hook_in"], cache["blocks.0.ln1.hook_out"])
+    assert torch.equal(cache["ln_final.hook_in"], cache["ln_final.hook_out"])
 
 
 def test_ln_default_uses_layernorm():
@@ -571,6 +591,34 @@ def test_init_modes_diverge_from_each_other():
 
 
 # -- attention_mask -----------------------------------------------------------
+
+
+def test_attention_dir_causal_masks_future_tokens():
+    cfg = _cfg(attention_dir="causal")
+    bridge = TransformerBridge.boot_native(cfg)
+    inputs = torch.randint(0, cfg.d_vocab, (2, cfg.n_ctx))
+
+    _, cache = bridge.run_with_cache(inputs, return_type="logits")
+    pattern = cache["blocks.0.attn.hook_pattern"]
+    future_mask = torch.triu(torch.ones(cfg.n_ctx, cfg.n_ctx, dtype=torch.bool), diagonal=1)
+
+    assert torch.allclose(
+        pattern[:, :, future_mask],
+        torch.zeros_like(pattern[:, :, future_mask]),
+        atol=1e-6,
+    )
+
+
+def test_attention_dir_bidirectional_allows_future_tokens():
+    cfg = _cfg(attention_dir="bidirectional")
+    bridge = TransformerBridge.boot_native(cfg)
+    inputs = torch.randint(0, cfg.d_vocab, (2, cfg.n_ctx))
+
+    _, cache = bridge.run_with_cache(inputs, return_type="logits")
+    pattern = cache["blocks.0.attn.hook_pattern"]
+
+    assert pattern[:, :, 0, 1:].gt(0).all()
+    assert torch.allclose(pattern.sum(dim=-1), torch.ones_like(pattern.sum(dim=-1)), atol=1e-6)
 
 
 def test_attention_mask_2d_padding_changes_output():

--- a/tests/unit/test_tracr_conversion.py
+++ b/tests/unit/test_tracr_conversion.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from transformer_lens.utilities.tracr import (
+    infer_tracr_output_label,
+    make_tracr_categorical_unembed,
+    make_tracr_transformer_bridge_config,
+    make_tracr_transformer_bridge_state_dict,
+)
+
+
+class _CategoricalEncoder:
+    def __init__(self, encoding_map):
+        self.encoding_map = encoding_map
+
+
+def _fake_tracr_model() -> SimpleNamespace:
+    d_model = 8
+    d_vocab = 5
+    d_vocab_out = 3
+    n_ctx = 4
+    d_head = 2
+    n_heads = 2
+    d_mlp = 6
+    n_layers = 1
+
+    params = {
+        "token_embed": {"embeddings": np.arange(d_vocab * d_model).reshape(d_vocab, d_model)},
+        "pos_embed": {"embeddings": np.arange(n_ctx * d_model).reshape(n_ctx, d_model)},
+    }
+    for layer in range(n_layers):
+        prefix = f"transformer/layer_{layer}"
+        params.update(
+            {
+                f"{prefix}/attn/key": {
+                    "w": np.arange(d_model * n_heads * d_head).reshape(d_model, n_heads * d_head),
+                    "b": np.arange(n_heads * d_head),
+                },
+                f"{prefix}/attn/query": {
+                    "w": np.arange(d_model * n_heads * d_head).reshape(d_model, n_heads * d_head)
+                    + 100,
+                    "b": np.arange(n_heads * d_head) + 100,
+                },
+                f"{prefix}/attn/value": {
+                    "w": np.arange(d_model * n_heads * d_head).reshape(d_model, n_heads * d_head)
+                    + 200,
+                    "b": np.arange(n_heads * d_head) + 200,
+                },
+                f"{prefix}/attn/linear": {
+                    "w": np.arange(n_heads * d_head * d_model).reshape(n_heads * d_head, d_model)
+                    + 300,
+                    "b": np.arange(d_model) + 300,
+                },
+                f"{prefix}/mlp/linear_1": {
+                    "w": np.arange(d_model * d_mlp).reshape(d_model, d_mlp) + 400,
+                    "b": np.arange(d_mlp) + 400,
+                },
+                f"{prefix}/mlp/linear_2": {
+                    "w": np.arange(d_mlp * d_model).reshape(d_mlp, d_model) + 500,
+                    "b": np.arange(d_model) + 500,
+                },
+            }
+        )
+
+    return SimpleNamespace(
+        params=params,
+        residual_labels=[
+            "aggregate_1:1",
+            "aggregate_1:2",
+            "aggregate_1:3",
+            "indices:0",
+            "reverse:1",
+            "reverse:2",
+            "reverse:3",
+            "tokens:BOS",
+        ],
+        output_encoder=_CategoricalEncoder({1: 0, 2: 1, 3: 2}),
+        model_config=SimpleNamespace(
+            num_heads=n_heads,
+            num_layers=n_layers,
+            key_size=d_head,
+            mlp_hidden_size=d_mlp,
+            layer_norm=False,
+            causal=False,
+        ),
+    )
+
+
+def test_categorical_unembed_uses_named_output_basis():
+    model = _fake_tracr_model()
+
+    unembed = make_tracr_categorical_unembed(model, output_label="reverse")
+
+    assert unembed.shape == (8, 3)
+    np.testing.assert_array_equal(unembed[:4], np.zeros((4, 3)))
+    np.testing.assert_array_equal(unembed[4:7], np.eye(3))
+
+
+def test_infer_output_label_rejects_ambiguous_prefixes():
+    model = _fake_tracr_model()
+
+    with pytest.raises(ValueError, match="Pass output_label explicitly"):
+        infer_tracr_output_label(model)
+
+
+def test_bridge_config_matches_tracr_metadata():
+    cfg = make_tracr_transformer_bridge_config(_fake_tracr_model())
+
+    assert cfg.d_model == 8
+    assert cfg.d_vocab == 5
+    assert cfg.d_vocab_out == 3
+    assert cfg.d_head == 2
+    assert cfg.n_heads == 2
+    assert cfg.d_mlp == 6
+    assert cfg.normalization_type is None
+    assert cfg.attention_dir == "bidirectional"
+
+
+def test_bridge_state_dict_transposes_tracr_weights_and_reconstructs_unembed():
+    model = _fake_tracr_model()
+
+    state_dict = make_tracr_transformer_bridge_state_dict(
+        model, output_label="reverse", dtype=torch.float64
+    )
+
+    assert state_dict["tok_embed.weight"].shape == (5, 8)
+    assert state_dict["pos.weight"].shape == (4, 8)
+    assert state_dict["head.weight"].shape == (3, 8)
+    assert state_dict["layers.0.attn.q.weight"].shape == (4, 8)
+    assert state_dict["layers.0.mlp.fc_in.weight"].shape == (6, 8)
+    assert state_dict["layers.0.mlp.fc_out.weight"].shape == (8, 6)
+    assert state_dict["layers.0.attn.q.weight"].dtype == torch.float64
+
+    np.testing.assert_array_equal(
+        state_dict["layers.0.attn.q.weight"].numpy(),
+        model.params["transformer/layer_0/attn/query"]["w"].T,
+    )
+    np.testing.assert_array_equal(
+        state_dict["layers.0.mlp.fc_out.weight"].numpy(),
+        model.params["transformer/layer_0/mlp/linear_2"]["w"].T,
+    )
+    np.testing.assert_array_equal(
+        state_dict["head.weight"].numpy(),
+        np.array(
+            [
+                [0, 0, 0, 0, 1, 0, 0, 0],
+                [0, 0, 0, 0, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0, 0, 1, 0],
+            ]
+        ),
+    )
+
+
+def test_bridge_state_dict_rejects_layer_norm_tracr_models():
+    model = _fake_tracr_model()
+    model.model_config.layer_norm = True
+
+    with pytest.raises(NotImplementedError, match="layer_norm=True"):
+        make_tracr_transformer_bridge_state_dict(model, output_label="reverse")

--- a/transformer_lens/config/transformer_bridge_config.py
+++ b/transformer_lens/config/transformer_bridge_config.py
@@ -48,7 +48,7 @@ class TransformerBridgeConfig(TransformerLensConfig):
         window_size: Optional[int] = None,
         attn_types: Optional[list] = None,
         init_mode: str = "gpt2",
-        normalization_type: str = "LN",
+        normalization_type: Optional[str] = "LN",
         n_devices: int = 1,
         attention_dir: str = "causal",
         attn_only: bool = False,

--- a/transformer_lens/model_bridge/sources/native/init.py
+++ b/transformer_lens/model_bridge/sources/native/init.py
@@ -8,6 +8,7 @@ go to 1, all biases to 0.
 Determinism uses a scoped ``torch.Generator``, not ``torch.manual_seed``, so
 seeded init does not perturb the caller's global RNG.
 """
+
 from __future__ import annotations
 
 import math
@@ -100,6 +101,8 @@ def _init_norm(norm: nn.Module) -> None:
     elif isinstance(norm, nn.LayerNorm):
         nn.init.ones_(norm.weight)
         nn.init.zeros_(norm.bias)
+    elif isinstance(norm, nn.Identity):
+        pass
     else:
         raise TypeError(f"Unknown normalization type: {type(norm).__name__}")
 

--- a/transformer_lens/model_bridge/sources/native/model.py
+++ b/transformer_lens/model_bridge/sources/native/model.py
@@ -6,6 +6,7 @@ Cfg-driven features: ``normalization_type`` (LN / RMS / RMSPre), ``final_rms``,
 ``rotary_dim`` / ``rotary_base`` / ``rope_scaling`` (linear PI, dynamic/NTK,
 llama3 by-parts).
 """
+
 from __future__ import annotations
 
 import math
@@ -30,8 +31,17 @@ _ACTIVATIONS: dict[str, _Activation] = {
 }
 
 
+def _normalization_type(cfg: TransformerBridgeConfig) -> str | None:
+    normalization_type = cfg.normalization_type
+    return None if normalization_type is None else normalization_type.upper()
+
+
 def _uses_rms_norm(cfg: TransformerBridgeConfig) -> bool:
-    return (cfg.normalization_type or "LN").upper() in ("RMS", "RMSPRE")
+    return _normalization_type(cfg) in ("RMS", "RMSPRE")
+
+
+def _uses_no_norm(cfg: TransformerBridgeConfig) -> bool:
+    return _normalization_type(cfg) is None
 
 
 def _positional_kind(cfg: TransformerBridgeConfig) -> str:
@@ -58,7 +68,13 @@ class NativeRMSNorm(nn.Module):
 def _make_norm(cfg: TransformerBridgeConfig, *, force_rms: bool = False) -> nn.Module:
     if force_rms or _uses_rms_norm(cfg):
         return NativeRMSNorm(cfg.d_model, eps=cfg.eps)
+    if _uses_no_norm(cfg):
+        return nn.Identity()
     return nn.LayerNorm(cfg.d_model, eps=cfg.eps)
+
+
+def _uses_causal_attention(cfg: TransformerBridgeConfig) -> bool:
+    return cfg.attention_dir == "causal"
 
 
 def _resolve_rope_scaling(
@@ -228,6 +244,7 @@ class NativeAttention(nn.Module):
         self.scale = scale
         self.rotary = rotary
         self.attn_scores_soft_cap = float(cfg.attn_scores_soft_cap)
+        self.causal = _uses_causal_attention(cfg)
 
     def forward(
         self,
@@ -256,7 +273,10 @@ class NativeAttention(nn.Module):
             c = self.attn_scores_soft_cap
             scores = c * torch.tanh(scores / c)
 
-        block_mask = self.causal_mask[:seq, :seq]
+        if self.causal:
+            block_mask = self.causal_mask[:seq, :seq]
+        else:
+            block_mask = torch.zeros(seq, seq, dtype=torch.bool, device=scores.device)
         if attention_mask is not None:
             block_mask = self._combine_attention_mask(block_mask, attention_mask, batch=batch)
         scores = scores.masked_fill(block_mask, float("-inf"))

--- a/transformer_lens/model_bridge/supported_architectures/native.py
+++ b/transformer_lens/model_bridge/supported_architectures/native.py
@@ -3,6 +3,7 @@
 Component mapping adapts to cfg: gated MLP → ``GatedMLPBridge``, RMS norm →
 ``RMSNormalizationBridge``, rotary drops ``pos_embed``, ``attn_only`` drops MLP.
 """
+
 from typing import Any
 
 from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
@@ -18,10 +19,17 @@ from transformer_lens.model_bridge.generalized_components import (
     RMSNormalizationBridge,
     UnembeddingBridge,
 )
+from transformer_lens.model_bridge.generalized_components.base import (
+    GeneralizedComponent,
+)
 
 
 def _uses_rms(cfg: Any) -> bool:
     return (getattr(cfg, "normalization_type", None) or "LN").upper() in ("RMS", "RMSPRE")
+
+
+def _uses_no_norm(cfg: Any) -> bool:
+    return getattr(cfg, "normalization_type", None) is None
 
 
 def _is_rotary(cfg: Any) -> bool:
@@ -31,6 +39,8 @@ def _is_rotary(cfg: Any) -> bool:
 def _make_norm_bridge(name: str, cfg: Any, *, force_rms: bool = False):
     if force_rms or _uses_rms(cfg):
         return RMSNormalizationBridge(name=name, config=cfg)
+    if _uses_no_norm(cfg):
+        return GeneralizedComponent(name=name, config=cfg)
     return NormalizationBridge(name=name, config=cfg)
 
 

--- a/transformer_lens/utilities/tracr.py
+++ b/transformer_lens/utilities/tracr.py
@@ -1,0 +1,200 @@
+"""Utilities for loading Tracr-assembled models into TransformerBridge.
+
+These helpers are intentionally duck-typed so importing TransformerLens does not
+pull in Tracr, JAX, or Haiku. Pass in a Tracr ``AssembledTransformerModel`` from
+``tracr.compiler.compiling.compile_rasp_to_model``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+import torch
+
+from transformer_lens.config.transformer_bridge_config import TransformerBridgeConfig
+
+
+def infer_tracr_output_label(model: Any) -> str:
+    """Infer the RASP output label used in ``model.residual_labels``.
+
+    Tracr stores residual basis labels as strings like ``"reverse:3"`` while
+    its categorical output encoder stores only values and output-column ids.
+    The output label is the unique residual-label prefix whose value set exactly
+    matches the output encoder's categorical value set.
+    """
+    encoding_map = _categorical_output_encoding_map(model)
+    output_values = {str(value) for value in encoding_map}
+    values_by_label: dict[str, set[str]] = {}
+
+    for residual_label in _residual_labels(model):
+        label, separator, value = residual_label.rpartition(":")
+        if not separator:
+            continue
+        values_by_label.setdefault(label, set()).add(value)
+
+    candidates = [label for label, values in values_by_label.items() if values == output_values]
+    if len(candidates) != 1:
+        raise ValueError(
+            "Could not infer Tracr output label from residual labels. Pass "
+            f"output_label explicitly. Candidates: {candidates!r}."
+        )
+    return candidates[0]
+
+
+def make_tracr_categorical_unembed(
+    model: Any,
+    output_label: str | None = None,
+    *,
+    dtype: np.dtype = np.dtype("float32"),
+) -> np.ndarray:
+    """Return Tracr's categorical unembed matrix in TL format.
+
+    The returned matrix has shape ``[d_model, d_vocab_out]`` and projects the
+    residual stream onto the output-basis coordinates selected by Tracr's
+    categorical output encoder. This avoids assuming those coordinates are the
+    first residual dimensions.
+    """
+    encoding_map = _categorical_output_encoding_map(model)
+    output_label = output_label if output_label is not None else infer_tracr_output_label(model)
+    label_to_residual_index = {label: index for index, label in enumerate(_residual_labels(model))}
+    unembed = np.zeros((len(label_to_residual_index), len(encoding_map)), dtype=dtype)
+
+    for output_value, output_index in encoding_map.items():
+        residual_label = f"{output_label}:{output_value}"
+        if residual_label not in label_to_residual_index:
+            raise ValueError(
+                f"Could not find output basis label {residual_label!r} in "
+                "model.residual_labels. Pass the final RASP expression label "
+                "as output_label."
+            )
+        unembed[label_to_residual_index[residual_label], int(output_index)] = 1
+
+    return unembed
+
+
+def make_tracr_transformer_bridge_config(model: Any) -> TransformerBridgeConfig:
+    """Build a ``TransformerBridgeConfig`` matching a categorical Tracr model."""
+    model_config = model.model_config
+    d_model = _param_array(model, "token_embed", "embeddings").shape[1]
+    d_vocab = _param_array(model, "token_embed", "embeddings").shape[0]
+    n_ctx = _param_array(model, "pos_embed", "embeddings").shape[0]
+
+    return TransformerBridgeConfig(
+        n_layers=model_config.num_layers,
+        d_model=d_model,
+        d_head=model_config.key_size,
+        n_ctx=n_ctx,
+        d_vocab=d_vocab,
+        d_vocab_out=len(_categorical_output_encoding_map(model)),
+        d_mlp=model_config.mlp_hidden_size,
+        n_heads=model_config.num_heads,
+        act_fn="relu",
+        attention_dir="causal" if model_config.causal else "bidirectional",
+        normalization_type="LN" if model_config.layer_norm else None,
+    )
+
+
+def make_tracr_transformer_bridge_state_dict(
+    model: Any,
+    output_label: str | None = None,
+    *,
+    dtype: torch.dtype = torch.float32,
+) -> dict[str, torch.Tensor]:
+    """Build a ``TransformerBridge.boot_native`` state dict from Tracr weights.
+
+    The state-dict keys use the native PyTorch module names accepted by
+    ``TransformerBridge.load_state_dict`` after ``boot_native``.
+    """
+    if model.model_config.layer_norm:
+        raise NotImplementedError(
+            "Tracr layer_norm=True models are not supported by this converter yet."
+        )
+
+    n_layers = model.model_config.num_layers
+    state_dict: dict[str, torch.Tensor] = {
+        "tok_embed.weight": _tensor(model, "token_embed", "embeddings", dtype=dtype),
+        "pos.weight": _tensor(model, "pos_embed", "embeddings", dtype=dtype),
+        "head.weight": torch.tensor(
+            make_tracr_categorical_unembed(model, output_label).T,
+            dtype=dtype,
+        ),
+    }
+
+    for layer in range(n_layers):
+        prefix = f"transformer/layer_{layer}"
+        state_dict.update(
+            {
+                f"layers.{layer}.attn.k.weight": _tensor(
+                    model, f"{prefix}/attn/key", "w", dtype=dtype
+                ).T,
+                f"layers.{layer}.attn.k.bias": _tensor(
+                    model, f"{prefix}/attn/key", "b", dtype=dtype
+                ),
+                f"layers.{layer}.attn.q.weight": _tensor(
+                    model, f"{prefix}/attn/query", "w", dtype=dtype
+                ).T,
+                f"layers.{layer}.attn.q.bias": _tensor(
+                    model, f"{prefix}/attn/query", "b", dtype=dtype
+                ),
+                f"layers.{layer}.attn.v.weight": _tensor(
+                    model, f"{prefix}/attn/value", "w", dtype=dtype
+                ).T,
+                f"layers.{layer}.attn.v.bias": _tensor(
+                    model, f"{prefix}/attn/value", "b", dtype=dtype
+                ),
+                f"layers.{layer}.attn.o.weight": _tensor(
+                    model, f"{prefix}/attn/linear", "w", dtype=dtype
+                ).T,
+                f"layers.{layer}.attn.o.bias": _tensor(
+                    model, f"{prefix}/attn/linear", "b", dtype=dtype
+                ),
+                f"layers.{layer}.mlp.fc_in.weight": _tensor(
+                    model, f"{prefix}/mlp/linear_1", "w", dtype=dtype
+                ).T,
+                f"layers.{layer}.mlp.fc_in.bias": _tensor(
+                    model, f"{prefix}/mlp/linear_1", "b", dtype=dtype
+                ),
+                f"layers.{layer}.mlp.fc_out.weight": _tensor(
+                    model, f"{prefix}/mlp/linear_2", "w", dtype=dtype
+                ).T,
+                f"layers.{layer}.mlp.fc_out.bias": _tensor(
+                    model, f"{prefix}/mlp/linear_2", "b", dtype=dtype
+                ),
+            }
+        )
+
+    return state_dict
+
+
+def _categorical_output_encoding_map(model: Any) -> Mapping[Any, int]:
+    output_encoder = getattr(model, "output_encoder", None)
+    encoding_map = getattr(output_encoder, "encoding_map", None)
+    if not isinstance(encoding_map, Mapping):
+        raise NotImplementedError(
+            "Only categorical Tracr outputs are supported; expected "
+            "model.output_encoder.encoding_map."
+        )
+    return encoding_map
+
+
+def _residual_labels(model: Any) -> list[str]:
+    residual_labels = getattr(model, "residual_labels", None)
+    if residual_labels is None:
+        raise ValueError("Expected Tracr model to expose residual_labels.")
+    return list(residual_labels)
+
+
+def _param_array(model: Any, module_name: str, param_name: str) -> np.ndarray:
+    return np.asarray(model.params[module_name][param_name])
+
+
+def _tensor(
+    model: Any,
+    module_name: str,
+    param_name: str,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    return torch.tensor(_param_array(model, module_name, param_name), dtype=dtype)


### PR DESCRIPTION
# Description

Fixes #481.

Ports the Tracr conversion demo from legacy `HookedTransformer` construction to `TransformerBridge.boot_native`. The focused code change adds a duck-typed Tracr conversion helper that reconstructs the categorical unembed from `residual_labels` and `output_encoder.encoding_map`, so named final RASP expressions such as `reverse` no longer depend on occupying the first residual coordinates.

To make the demo load through the native Bridge path, this also adds the two native primitives required by Tracr-shaped models: no-normalization blocks for `layer_norm=False`, and bidirectional attention for `causal=False`. No Tracr, JAX, or Haiku runtime dependency is added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in the checks run locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Validation

- `python3 -m py_compile transformer_lens/utilities/tracr.py transformer_lens/model_bridge/sources/native/model.py transformer_lens/model_bridge/supported_architectures/native.py transformer_lens/config/transformer_bridge_config.py tests/unit/test_tracr_conversion.py tests/unit/model_bridge/test_native_features.py`
- `python3 -m json.tool demos/Tracr_to_Transformer_Lens_Demo.ipynb >/dev/null`
- `/Users/Abhi/.local/bin/uv run --no-project --with pycln pycln --check --all transformer_lens/utilities/tracr.py transformer_lens/model_bridge/supported_architectures/native.py tests/unit/test_tracr_conversion.py tests/unit/model_bridge/test_native_features.py --exclude "__init__.py"`
- `/Users/Abhi/.local/bin/uv run --no-project --with isort isort --check-only transformer_lens/utilities/tracr.py transformer_lens/model_bridge/supported_architectures/native.py tests/unit/test_tracr_conversion.py tests/unit/model_bridge/test_native_features.py`
- `/Users/Abhi/.local/bin/uv run --no-project --with black black --check --target-version py312 transformer_lens/utilities/tracr.py transformer_lens/model_bridge/supported_architectures/native.py tests/unit/test_tracr_conversion.py tests/unit/model_bridge/test_native_features.py`
- `git diff --check`

Not run locally: Torch-backed pytest/nbval. This local clone did not have Torch installed; targeted no-sync pytest reached `tests/conftest.py` and failed with `ModuleNotFoundError: No module named 'torch'`. Full unit/notebook execution is left to CI rather than doing a large local dependency sync.