### PR TITLE
SSM Interp Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,12 @@ cover:
 
 Verification lives in the integration tests at
 `tests/integration/model_bridge/test_mamba_adapter.py` and
-`tests/integration/model_bridge/test_mamba2_adapter.py` (81 tests total). The
-`verify_models` benchmark suite does not currently cover SSM architectures — the
-benchmark has transformer-shaped assumptions (hook path patterns, layer norm
-folding, block submodule dispatch) that would need a dedicated refactor. SSM
-benchmark coverage will be revisited if hybrid architectures like Jamba or
-Falcon-H1 become priority or a user explicitly requests it.
+`tests/integration/model_bridge/test_mamba2_adapter.py` (81 tests total), and the
+`verify_models` benchmark suite now covers the SSM and hybrid families. Mamba-1,
+Mamba-2, gated-delta-net (Qwen3.5 / Qwen3-Next), NemotronH, and GraniteMoeHybrid
+all declare `applicable_phases = [1, 2, 3, 4]`, so their forward parity (P1, vs raw
+HF), hook/cache coverage (P2/P3, which skip the HookedTransformer comparison SSMs
+lack), and generation quality (P4) are benchmarked like any transformer.
 
 ## Credits
 

--- a/docs/source/content/ssm_interpretability.md
+++ b/docs/source/content/ssm_interpretability.md
@@ -1,0 +1,117 @@
+# SSM / Recurrent-Model Interpretability
+
+TransformerBridge exposes a family-agnostic interpretability surface for state-space
+and linear-attention models — Mamba-1, Mamba-2, gated-delta-net (Qwen3.5 / Qwen3-Next),
+and the SSM hybrids (NemotronH, GraniteMoeHybrid). The same three `ActivationCache`
+methods work across every family, dispatching to each block's SSM mixer regardless of
+which slot it occupies (`.mixer` for Mamba, `.linear_attn` for gated-delta-net) and
+skipping a hybrid's passthrough (attention / MLP / MoE) layers automatically.
+
+> These features are **bridge-only** — there is no `HookedTransformer` counterpart for
+> SSM models. Load with `TransformerBridge.boot_transformers(...)`.
+
+---
+
+## Discovery
+
+```python
+bridge = TransformerBridge.boot_transformers("state-spaces/mamba-130m-hf")
+_, cache = bridge.run_with_cache(tokens, use_cache=False)
+
+cache.ssm_layers()          # -> [0, 1, 2, ...]  block indices whose mixer is recurrent
+```
+
+`ssm_layers()` is purely structural (no dependence on `cfg.layers_block_type`): a
+hybrid's attention/MLP layers are excluded, so on NemotronH you get only the Mamba
+layers.
+
+## Read-only analysis (no forward re-run)
+
+Both methods reconstruct their quantities post-hoc from cached hooks. They return a
+single tensor when *every* block is an SSM layer, else a `{layer_idx: tensor}` dict
+over the SSM layers.
+
+```python
+# Effective ("hidden") attention  M = L ⊙ (C Bᵀ)   [batch, heads, seq, seq]
+M = cache.compute_ssm_effective_attention()          # all SSM layers
+M0 = cache.compute_ssm_effective_attention(layer=0)  # one layer
+
+# Recurrent state trajectory S_t
+S = cache.compute_ssm_state()                        # all SSM layers
+S5 = cache.compute_ssm_state(layer=5, time_step=-1)  # one layer, final step (memory-bounded)
+```
+
+State shape is family-specific (Mamba-1 is per-channel; Mamba-2 and gated-delta-net
+are per-head), so `compute_ssm_state()` returns a dict except when one mixer type
+covers every block.
+
+> **`use_cache=False` is required for gated-delta-net.** Its interior hooks
+> (`hook_q/k/v`, `hook_beta`, `hook_log_decay`) fire only on the hooked prefill path;
+> the default cached path exposes only `hook_in`/`hook_out`, and the reconstruction
+> methods then raise. Mamba reconstructs from `in_proj`/`conv1d` hooks either way, but
+> passing `use_cache=False` uniformly is safe.
+
+## Canonical hook vocabulary
+
+Every family exposes the same state-mutation names (defined once, in
+`SSMStateHookMixin`), so interp tooling can address the same quantity across families:
+
+| Hook | Meaning | Kind |
+|---|---|---|
+| `hook_ssm_state` | post-scan recurrent-state trajectory `S_t` | real HookPoint (fires on the eager-scan path) |
+| `hook_ssm_write` | per-step write influence | **real** for Mamba-1/2 (`dt·(x⊗B)`); **alias → `hook_beta`** for gated-delta-net (state-dependent write) |
+
+Additional canonical aliases resolve per family where the quantity exists:
+`hook_ssm_out`, `hook_ssm_B`, `hook_ssm_C`, `hook_ssm_decay`, `hook_ssm_dt`.
+
+---
+
+## Causal intervention: the `eager_scan` opt-in
+
+By default the mixer runs HF's fused recurrence kernel, which is opaque — the state
+trajectory is never materialized, so it cannot be patched. Setting `eager_scan = True`
+on a realized SSM mixer swaps the kernel for a readable Python scan that fires
+`hook_ssm_state` (and, for the input-linear families, `hook_ssm_write`), so you can
+read and edit the state mid-recurrence.
+
+```python
+from transformer_lens.model_bridge.generalized_components.ssm_protocol import find_ssm_mixer
+
+# Enable on every realized SSM mixer (skips hybrid passthrough slots).
+mixers = [m for b in bridge.blocks if (m := find_ssm_mixer(b)) is not None]
+for m in mixers:
+    m.eager_scan = True
+
+# hook path uses the mixer's slot name: `.mixer` (Mamba) or `.linear_attn` (gated-delta-net)
+STATE = "blocks.0.mixer.hook_ssm_state"
+
+def zero_state(state, hook):
+    return torch.zeros_like(state)   # ablate the whole recurrent state
+
+logits = bridge.run_with_hooks(tokens, use_cache=False, fwd_hooks=[(STATE, zero_state)])
+
+for m in mixers:
+    m.eager_scan = False             # restore the default (bit-identical) fused path
+```
+
+**Two intervention semantics** (mirroring Mamba-Knockout and state-patching):
+
+- Patching **`hook_ssm_state`** changes only the *same-position* readout
+  (`y_t = C_t·S_t` or `S_t^T q_t`); it does not alter the forward recurrence.
+- Patching **`hook_ssm_write`** re-runs the recurrence, so the edit **propagates** to
+  every later state. For gated-delta-net this is the write-strength gate
+  (`hook_beta`), so zeroing it suppresses all writes.
+
+### Caveats
+
+| | |
+|---|---|
+| **Prefill only** | The eager scan runs when `cache_params is None` (i.e. `use_cache=False`, no generation step). Autoregressive decode falls back to the fused kernel. |
+| **Numerical** | The Python scan matches the fused kernel only to floating-point tolerance (≈1e-6 fp32), never bit-for-bit. |
+| **Cost** | O(seq) Python with an O(batch·seq·…) state tensor — orders of magnitude slower/heavier than the kernel. Use short sequences. |
+| **Default untouched** | With `eager_scan = False` (the default), `run_with_cache` is bit-identical to HF and `hook_ssm_state` does not fire. |
+
+> See [`ssm2_mixer.py`](../../../transformer_lens/model_bridge/generalized_components/ssm2_mixer.py),
+> [`ssm_mixer.py`](../../../transformer_lens/model_bridge/generalized_components/ssm_mixer.py), and
+> [`gated_delta_net.py`](../../../transformer_lens/model_bridge/generalized_components/gated_delta_net.py)
+> for the per-family recurrences and reconstruction identities.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -56,6 +56,7 @@ content/citation
 content/contributing
 content/hook_system
 content/compatibility_mode
+content/ssm_interpretability
 content/debugging_numerical_divergence
 generated/demos/Main_Demo
 generated/demos/Exploratory_Analysis_Demo

--- a/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
+++ b/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
@@ -332,7 +332,9 @@ def _build_granite_bridge(device="cpu"):
         hf.config, "GraniteMoeHybridForCausalLM", "granitemoehybrid-tiny", torch.float32
     )
     bridge = TransformerBridge(
-        model=hf, adapter=GraniteMoeHybridArchitectureAdapter(bridge_config), tokenizer=_MockTokenizer()
+        model=hf,
+        adapter=GraniteMoeHybridArchitectureAdapter(bridge_config),
+        tokenizer=_MockTokenizer(),
     )
     if device != "cpu":
         hf.to(device)

--- a/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
+++ b/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
@@ -19,6 +19,8 @@ Coverage focus (Phase 0, SSM mixer access normalization):
 - Attention / shared-MLP / MoE hooks still fire (rename did not disturb them).
 """
 
+import contextlib
+
 import pytest
 import torch
 from transformers import AutoModelForCausalLM
@@ -285,3 +287,123 @@ class TestGraniteMoeHybridSSMState:
         max_diff = (y_actual - y.reshape(1, seq_len, -1)).abs().max().item()
         scale = max(y_actual.abs().max().item(), 1e-8)
         assert max_diff / scale < 1e-4, f"state reconstruction rel diff {max_diff / scale:.2e}"
+
+
+@contextlib.contextmanager
+def _granite_eager(bridge):
+    """Enable the eager-scan intervention path on Granite's Mamba-2 mixer layers."""
+    for i in MAMBA_LAYERS:
+        bridge.blocks[i].mixer.eager_scan = True
+    try:
+        yield bridge
+    finally:
+        for i in MAMBA_LAYERS:
+            bridge.blocks[i].mixer.eager_scan = False
+
+
+def _build_granite_bridge(device="cpu"):
+    """Fresh tiny Granite bridge on the given device (for device-parametrized tests)."""
+    cfg = GraniteMoeHybridConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=32,
+        shared_intermediate_size=32,
+        num_hidden_layers=3,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=64,
+        layer_types=LAYER_TYPES,
+        mamba_n_heads=8,
+        mamba_n_groups=2,
+        mamba_d_state=16,
+        mamba_d_head=16,
+        mamba_d_conv=4,
+        mamba_expand=2,
+        mamba_chunk_size=16,
+        position_embedding_type="rope",
+        rope_parameters={"rope_type": "default", "rope_theta": 10000.0},
+    )
+    cfg.architectures = ["GraniteMoeHybridForCausalLM"]
+    torch.manual_seed(0)
+    hf = AutoModelForCausalLM.from_config(cfg).to(torch.float32).eval()
+    bridge_config = build_bridge_config_from_hf(
+        hf.config, "GraniteMoeHybridForCausalLM", "granitemoehybrid-tiny", torch.float32
+    )
+    bridge = TransformerBridge(
+        model=hf, adapter=GraniteMoeHybridArchitectureAdapter(bridge_config), tokenizer=_MockTokenizer()
+    )
+    if device != "cpu":
+        hf.to(device)
+    return bridge
+
+
+def _available_devices():
+    devices = ["cpu"]
+    if torch.cuda.is_available():
+        devices.append("cuda")
+    if torch.backends.mps.is_available():
+        devices.append("mps")
+    return devices
+
+
+class TestGraniteMoeHybridEagerScanIntervention:
+    """Phase 4 eager-scan intervention on Granite's Mamba-2 mixer layers (hybrid):
+    hooks fire on the Mamba layers only, interventions propagate to logits, and the
+    default path is untouched. Eager scan needs use_cache=False (prefill)."""
+
+    def test_default_path_has_no_eager_hooks(self, bridge, tokens):
+        with torch.no_grad():
+            _, c = bridge.run_with_cache(tokens)
+        assert "blocks.0.mixer.hook_ssm_write" not in c
+
+    def test_eager_hooks_fire_on_mamba_layers_only(self, bridge, tokens):
+        with _granite_eager(bridge), torch.no_grad():
+            _, c = bridge.run_with_cache(tokens, use_cache=False)
+        for i in MAMBA_LAYERS:
+            assert f"blocks.{i}.mixer.hook_ssm_write" in c
+            assert f"blocks.{i}.mixer.hook_ssm_state" in c
+        assert f"blocks.{ATTN_LAYER}.mixer.hook_ssm_write" not in c  # attention layer: no mixer
+
+    def test_eager_scan_matches_fused(self, bridge, tokens):
+        with torch.no_grad():
+            fused = bridge(tokens)
+        with _granite_eager(bridge), torch.no_grad():
+            eager = bridge.run_with_hooks(tokens, use_cache=False, fwd_hooks=[])
+        rel = (eager - fused).abs().max().item() / max(fused.abs().max().item(), 1e-8)
+        assert rel < 1e-4, f"Granite eager vs fused rel diff {rel:.2e}"
+
+    def test_write_knockout_changes_logits(self, bridge, tokens):
+        def knockout(writes, hook):
+            writes = writes.clone()
+            writes[:, 2] = 0.0
+            return writes
+
+        with _granite_eager(bridge), torch.no_grad():
+            base = bridge.run_with_hooks(tokens, use_cache=False, fwd_hooks=[])
+            patched = bridge.run_with_hooks(
+                tokens, use_cache=False, fwd_hooks=[("blocks.0.mixer.hook_ssm_write", knockout)]
+            )
+        assert (patched - base).abs().max().item() > 1e-6
+
+
+@pytest.mark.parametrize("device", _available_devices())
+def test_granite_eager_scan_device_correctness(device):
+    """Regression for the eager-scan device fix: ssm_state must be created on the
+    input's device. Parametrized over every available device (cpu + cuda/mps)."""
+    bridge = _build_granite_bridge(device)
+    toks = torch.tensor([[1, 2, 3, 4, 5]], device=device)
+    with torch.no_grad():
+        fused = bridge(toks)
+    for i in MAMBA_LAYERS:
+        bridge.blocks[i].mixer.eager_scan = True
+    with torch.no_grad():
+        _, cache = bridge.run_with_cache(toks, use_cache=False)
+        eager = bridge.run_with_hooks(toks, use_cache=False, fwd_hooks=[])
+
+    dev_type = torch.device(device).type
+    assert eager.device.type == dev_type
+    assert cache["blocks.0.mixer.hook_ssm_write"].device.type == dev_type
+    rel = (eager.cpu() - fused.cpu()).abs().max().item() / max(fused.abs().max().item(), 1e-8)
+    assert rel < 1e-4, f"eager vs fused rel diff on {device}: {rel:.2e}"

--- a/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
+++ b/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
@@ -35,10 +35,6 @@ from transformer_lens.model_bridge.sources._bridge_builder import (
 from transformer_lens.model_bridge.supported_architectures.granite_moe_hybrid import (
     GraniteMoeHybridArchitectureAdapter,
 )
-from transformer_lens.model_bridge.supported_architectures.mamba2 import (
-    compute_effective_attention,
-    compute_ssm_state,
-)
 
 LAYER_TYPES = ["mamba", "attention", "mamba"]
 MAMBA_LAYERS = [0, 2]
@@ -179,28 +175,28 @@ class TestGraniteMoeHybridEffectiveAttention:
         seq_len = tokens.shape[1]
         mixer = bridge.blocks[MAMBA_LAYERS[0]].mixer
         n_heads = mixer.original_component.num_heads
-        M = compute_effective_attention(bridge, cache, layer=MAMBA_LAYERS[0])
+        M = cache.compute_ssm_effective_attention(layer=MAMBA_LAYERS[0])
         assert isinstance(M, torch.Tensor)
         assert M.shape == (1, n_heads, seq_len, seq_len)
         assert torch.isfinite(M).all()
 
     def test_single_layer_is_causal(self, bridge: TransformerBridge, cache) -> None:
-        M = compute_effective_attention(bridge, cache, layer=MAMBA_LAYERS[0])
+        M = cache.compute_ssm_effective_attention(layer=MAMBA_LAYERS[0])
         seq_len = M.shape[-1]
         upper = torch.triu(torch.ones(seq_len, seq_len, dtype=torch.bool), diagonal=1)
         assert torch.all(M[..., upper] == 0), "effective attention must be lower-triangular"
 
     def test_all_layers_returns_per_ssm_layer_dict(self, bridge: TransformerBridge, cache) -> None:
         # Heterogeneous hybrid -> dict keyed by SSM layer index (attention layer skipped).
-        M_all = compute_effective_attention(bridge, cache)
+        M_all = cache.compute_ssm_effective_attention()
         assert isinstance(M_all, dict)
         assert sorted(M_all.keys()) == MAMBA_LAYERS
         for idx, M in M_all.items():
-            assert torch.equal(M, compute_effective_attention(bridge, cache, layer=idx))
+            assert torch.equal(M, cache.compute_ssm_effective_attention(layer=idx))
 
     def test_attention_layer_index_raises_typeerror(self, bridge: TransformerBridge, cache) -> None:
         with pytest.raises(TypeError):
-            compute_effective_attention(bridge, cache, layer=ATTN_LAYER)
+            cache.compute_ssm_effective_attention(layer=ATTN_LAYER)
 
     def test_reconstruction_matches_ssm_output(
         self, bridge: TransformerBridge, cache, tokens
@@ -223,7 +219,7 @@ class TestGraniteMoeHybridEffectiveAttention:
             oc.ssm_state_size,
         )
 
-        M_full = compute_effective_attention(bridge, cache, layer=layer, include_dt_scaling=True)
+        M_full = cache.compute_ssm_effective_attention(layer=layer, include_dt_scaling=True)
 
         conv_out = cache[f"blocks.{layer}.mixer.conv1d.hook_out"][..., :seq_len].float()
         conv_activated = torch.nn.functional.silu(conv_out).transpose(1, 2)
@@ -266,7 +262,7 @@ class TestGraniteMoeHybridSSMState:
 
     def test_attention_layer_raises_typeerror(self, bridge: TransformerBridge, cache) -> None:
         with pytest.raises(TypeError):
-            compute_ssm_state(bridge, cache, layer=ATTN_LAYER)
+            cache.compute_ssm_state(layer=ATTN_LAYER)
 
     def test_reconstructs_ssm_output(self, bridge: TransformerBridge, cache, tokens) -> None:
         """y = C·S + D·x reconstructs HF's SSM output — proves hybrid dims are right."""

--- a/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
+++ b/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
@@ -350,6 +350,31 @@ def _available_devices():
     return devices
 
 
+class TestGraniteMoeHybridProcessedParity:
+    """Phase-3 parity guard: processed (compat-mode) bridge vs raw HF via log_softmax.
+
+    The forward test only checks UNPROCESSED delegation (==0.0); this pins the PROCESSED
+    path so a compat-mode regression is caught in CI without the full-size checkpoint.
+    Granite is RMSNorm + fold_ln-off, so the centering rewrite must be output-invariant.
+    """
+
+    def test_compat_mode_logits_match_raw_hf(self):
+        bridge = _build_granite_bridge()
+        tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
+        with torch.no_grad():
+            raw = bridge(tokens)
+        bridge.enable_compatibility_mode(disable_warnings=True)
+        with torch.no_grad():
+            proc = bridge(tokens)
+        raw_lsm = torch.log_softmax(raw.float(), dim=-1)
+        proc_lsm = torch.log_softmax(proc.float(), dim=-1)
+        max_diff = (raw_lsm - proc_lsm).abs().max().item()
+        assert max_diff < 1e-4, (
+            f"compat-mode processed vs raw-HF log_softmax max_diff {max_diff:.2e} — the "
+            "weight-centering rewrite must be output-invariant in fp32 (P3 logits_equivalence)."
+        )
+
+
 class TestGraniteMoeHybridEagerScanIntervention:
     """Phase 4 eager-scan intervention on Granite's Mamba-2 mixer layers (hybrid):
     hooks fire on the Mamba layers only, interventions propagate to logits, and the

--- a/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
+++ b/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
@@ -37,6 +37,7 @@ from transformer_lens.model_bridge.supported_architectures.granite_moe_hybrid im
 )
 from transformer_lens.model_bridge.supported_architectures.mamba2 import (
     compute_effective_attention,
+    compute_ssm_state,
 )
 
 LAYER_TYPES = ["mamba", "attention", "mamba"]
@@ -245,3 +246,46 @@ class TestGraniteMoeHybridEffectiveAttention:
             "attention dims are inconsistent with HF's SSM output (likely reading "
             "attention dims off the shared cfg instead of the mamba module)."
         )
+
+
+class TestGraniteMoeHybridSSMState:
+    """compute_ssm_state works across the hybrid: per-SSM-layer dict, correct dims."""
+
+    def test_single_layer_shape(self, bridge: TransformerBridge, cache, tokens) -> None:
+        seq_len = tokens.shape[1]
+        oc = bridge.blocks[MAMBA_LAYERS[0]].mixer.original_component
+        S = cache.compute_ssm_state(layer=MAMBA_LAYERS[0])
+        assert isinstance(S, torch.Tensor)
+        assert S.shape == (1, oc.num_heads, seq_len, oc.head_dim, oc.ssm_state_size)
+        assert torch.isfinite(S).all()
+
+    def test_all_layers_returns_per_ssm_layer_dict(self, bridge: TransformerBridge, cache) -> None:
+        S_all = cache.compute_ssm_state()
+        assert isinstance(S_all, dict)
+        assert sorted(S_all.keys()) == MAMBA_LAYERS
+
+    def test_attention_layer_raises_typeerror(self, bridge: TransformerBridge, cache) -> None:
+        with pytest.raises(TypeError):
+            compute_ssm_state(bridge, cache, layer=ATTN_LAYER)
+
+    def test_reconstructs_ssm_output(self, bridge: TransformerBridge, cache, tokens) -> None:
+        """y = C·S + D·x reconstructs HF's SSM output — proves hybrid dims are right."""
+        layer = MAMBA_LAYERS[0]
+        seq_len = tokens.shape[1]
+        mixer = bridge.blocks[layer].mixer
+        oc = mixer.original_component
+        nh, hd, ns, ng = oc.num_heads, oc.head_dim, oc.ssm_state_size, oc.n_groups
+
+        S = cache.compute_ssm_state(layer=layer)
+        conv = cache[f"blocks.{layer}.mixer.conv1d.hook_out"][..., :seq_len].float()
+        conv_act = torch.nn.functional.silu(conv).transpose(1, 2)
+        x_flat, _, C_flat = conv_act.split([oc.intermediate_size, ng * ns, ng * ns], dim=-1)
+        x = x_flat.view(1, seq_len, nh, hd)
+        C_h = C_flat.view(1, seq_len, ng, ns).repeat_interleave(nh // ng, dim=2)
+        D = mixer.D.float()
+
+        y = torch.einsum("bthn,bhtpn->bthp", C_h, S) + D[None, None, :, None] * x
+        y_actual = cache[f"blocks.{layer}.mixer.inner_norm.hook_in"].float()
+        max_diff = (y_actual - y.reshape(1, seq_len, -1)).abs().max().item()
+        scale = max(y_actual.abs().max().item(), 1e-8)
+        assert max_diff / scale < 1e-4, f"state reconstruction rel diff {max_diff / scale:.2e}"

--- a/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
+++ b/tests/integration/model_bridge/test_granite_moe_hybrid_adapter.py
@@ -1,0 +1,247 @@
+"""Integration tests for the GraniteMoeHybrid architecture adapter.
+
+GraniteMoeHybrid is a hybrid Mamba-2 + Attention + shared-MLP + sparse-MoE
+model: each layer is *either* a Mamba SSM mixer *or* GQA attention, and every
+layer additionally has a shared MLP and an optional MoE. Unlike NemotronH it is
+a multi-slot transformer block (ln1/ln2/attn/mixer/shared_mlp/moe), not a
+single-mixer SSMBlockBridge.
+
+Uses a tiny programmatic config with real (random) CPU weights — no network
+access or weight downloads (mirrors tests/unit/model_bridge/test_gpt_oss_moe.py
+and test_qwen3_moe_bridge.py for the from_config + direct-constructor pattern).
+
+Coverage focus (Phase 0, SSM mixer access normalization):
+- The Mamba-2 mixer is reachable at the canonical ``.mixer`` slot on SSM layers.
+- compute_effective_attention runs on a Granite SSM layer and reconstructs the
+  SSM output (proves dims are sourced from the wrapped HF mixer, not the shared
+  cfg whose n_heads/state_size hold the *attention* dims on a hybrid).
+- The all-layers helper returns a per-SSM-layer dict on a heterogeneous hybrid.
+- Attention / shared-MLP / MoE hooks still fire (rename did not disturb them).
+"""
+
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+from transformers.models.granitemoehybrid import GraniteMoeHybridConfig
+
+from transformer_lens.model_bridge.bridge import TransformerBridge
+from transformer_lens.model_bridge.generalized_components import (
+    GatedRMSNormBridge,
+    SSM2MixerBridge,
+)
+from transformer_lens.model_bridge.sources._bridge_builder import (
+    build_bridge_config_from_hf,
+)
+from transformer_lens.model_bridge.supported_architectures.granite_moe_hybrid import (
+    GraniteMoeHybridArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.mamba2 import (
+    compute_effective_attention,
+)
+
+LAYER_TYPES = ["mamba", "attention", "mamba"]
+MAMBA_LAYERS = [0, 2]
+ATTN_LAYER = 1
+
+
+class _MockTokenizer:
+    """Stand-in to satisfy TransformerBridge(tokenizer=...) without a Hub call."""
+
+    pass
+
+
+@pytest.fixture(scope="module")
+def hf_model():
+    cfg = GraniteMoeHybridConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=32,
+        shared_intermediate_size=32,
+        num_hidden_layers=3,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=64,
+        layer_types=LAYER_TYPES,
+        mamba_n_heads=8,
+        mamba_n_groups=2,
+        mamba_d_state=16,
+        mamba_d_head=16,
+        mamba_d_conv=4,
+        mamba_expand=2,
+        mamba_chunk_size=16,
+        position_embedding_type="rope",
+        rope_parameters={"rope_type": "default", "rope_theta": 10000.0},
+    )
+    cfg.architectures = ["GraniteMoeHybridForCausalLM"]
+    torch.manual_seed(0)
+    return AutoModelForCausalLM.from_config(cfg).to(torch.float32).eval()
+
+
+@pytest.fixture(scope="module")
+def bridge(hf_model):
+    bridge_config = build_bridge_config_from_hf(
+        hf_model.config, "GraniteMoeHybridForCausalLM", "granitemoehybrid-tiny", torch.float32
+    )
+    adapter = GraniteMoeHybridArchitectureAdapter(bridge_config)
+    return TransformerBridge(model=hf_model, adapter=adapter, tokenizer=_MockTokenizer())
+
+
+@pytest.fixture(scope="module")
+def tokens():
+    return torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
+
+
+@pytest.fixture(scope="module")
+def cache(bridge, tokens):
+    with torch.no_grad():
+        _, c = bridge.run_with_cache(tokens)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Structure: Mamba mixer is reachable at the canonical .mixer slot
+# ---------------------------------------------------------------------------
+
+
+class TestGraniteMoeHybridStructure:
+    def test_block_count(self, bridge: TransformerBridge) -> None:
+        assert len(bridge.blocks) == len(LAYER_TYPES)
+
+    def test_layers_block_type_surfaced(self, bridge: TransformerBridge) -> None:
+        assert getattr(bridge.cfg, "layers_block_type", None) == LAYER_TYPES
+
+    def test_mamba_layers_expose_ssm2_mixer(self, bridge: TransformerBridge) -> None:
+        for i in MAMBA_LAYERS:
+            mixer = getattr(bridge.blocks[i], "mixer", None)
+            assert isinstance(mixer, SSM2MixerBridge), f"block {i} missing .mixer"
+
+    def test_attention_layer_has_no_mixer_slot(self, bridge: TransformerBridge) -> None:
+        # The mamba bridge is optional and skipped on attention layers, so the
+        # structural `.mixer` slot must be absent there (blocks_with relies on this).
+        assert "mixer" not in bridge.blocks[ATTN_LAYER]._modules
+        assert "attn" in bridge.blocks[ATTN_LAYER]._modules
+
+    def test_inner_norm_is_gated(self, bridge: TransformerBridge) -> None:
+        mixer = bridge.blocks[MAMBA_LAYERS[0]].mixer
+        assert isinstance(mixer.inner_norm, GatedRMSNormBridge)
+
+
+# ---------------------------------------------------------------------------
+# Forward parity: bridge delegates fully, so logits match HF exactly
+# ---------------------------------------------------------------------------
+
+
+class TestGraniteMoeHybridForwardPass:
+    def test_forward_matches_hf_exactly(
+        self, bridge: TransformerBridge, hf_model, tokens: torch.Tensor
+    ) -> None:
+        with torch.no_grad():
+            bridge_out = bridge(tokens)
+            hf_out = hf_model(tokens).logits
+        max_diff = (bridge_out.float() - hf_out.float()).abs().max().item()
+        assert max_diff == 0.0, (
+            f"Bridge vs HF forward max diff = {max_diff:.2e}. Expected 0 because "
+            "the bridge delegates the full forward to HF."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hook coverage: rename to .mixer did not disturb attn / shared_mlp / moe hooks
+# ---------------------------------------------------------------------------
+
+
+class TestGraniteMoeHybridHookCoverage:
+    def test_mamba_mixer_submodule_hooks_fire(self, cache) -> None:
+        for i in MAMBA_LAYERS:
+            for submod in ("in_proj", "conv1d"):
+                assert f"blocks.{i}.mixer.{submod}.hook_out" in cache
+            assert f"blocks.{i}.mixer.inner_norm.hook_in" in cache
+
+    def test_attention_hooks_fire_on_attention_layer(self, cache) -> None:
+        assert f"blocks.{ATTN_LAYER}.attn.hook_out" in cache
+
+    def test_shared_mlp_and_moe_hooks_fire(self, cache) -> None:
+        # Every layer has a shared MLP and a sparse MoE; both must still hook.
+        assert f"blocks.{MAMBA_LAYERS[0]}.shared_mlp.hook_out" in cache
+        assert f"blocks.{MAMBA_LAYERS[0]}.moe.hook_out" in cache
+
+
+# ---------------------------------------------------------------------------
+# Effective attention: the Phase 0 acceptance surface
+# ---------------------------------------------------------------------------
+
+
+class TestGraniteMoeHybridEffectiveAttention:
+    def test_single_layer_shape(self, bridge: TransformerBridge, cache, tokens) -> None:
+        seq_len = tokens.shape[1]
+        mixer = bridge.blocks[MAMBA_LAYERS[0]].mixer
+        n_heads = mixer.original_component.num_heads
+        M = compute_effective_attention(bridge, cache, layer=MAMBA_LAYERS[0])
+        assert isinstance(M, torch.Tensor)
+        assert M.shape == (1, n_heads, seq_len, seq_len)
+        assert torch.isfinite(M).all()
+
+    def test_single_layer_is_causal(self, bridge: TransformerBridge, cache) -> None:
+        M = compute_effective_attention(bridge, cache, layer=MAMBA_LAYERS[0])
+        seq_len = M.shape[-1]
+        upper = torch.triu(torch.ones(seq_len, seq_len, dtype=torch.bool), diagonal=1)
+        assert torch.all(M[..., upper] == 0), "effective attention must be lower-triangular"
+
+    def test_all_layers_returns_per_ssm_layer_dict(self, bridge: TransformerBridge, cache) -> None:
+        # Heterogeneous hybrid -> dict keyed by SSM layer index (attention layer skipped).
+        M_all = compute_effective_attention(bridge, cache)
+        assert isinstance(M_all, dict)
+        assert sorted(M_all.keys()) == MAMBA_LAYERS
+        for idx, M in M_all.items():
+            assert torch.equal(M, compute_effective_attention(bridge, cache, layer=idx))
+
+    def test_attention_layer_index_raises_typeerror(self, bridge: TransformerBridge, cache) -> None:
+        with pytest.raises(TypeError):
+            compute_effective_attention(bridge, cache, layer=ATTN_LAYER)
+
+    def test_reconstruction_matches_ssm_output(
+        self, bridge: TransformerBridge, cache, tokens
+    ) -> None:
+        """M @ x + D*x must reconstruct the SSM output (inner_norm.hook_in).
+
+        Non-tautological: HF computes the SSM output via an independent chunked
+        path. Agreement to float32 precision proves compute_effective_attention
+        sourced the correct *Mamba* dims from the wrapped module — on a hybrid the
+        shared cfg holds attention dims, so a cfg-based read would produce garbage.
+        """
+        layer = MAMBA_LAYERS[0]
+        seq_len = tokens.shape[1]
+        mixer = bridge.blocks[layer].mixer
+        oc = mixer.original_component
+        num_heads, head_dim = oc.num_heads, oc.head_dim
+        intermediate_size, n_groups, state_size = (
+            oc.intermediate_size,
+            oc.n_groups,
+            oc.ssm_state_size,
+        )
+
+        M_full = compute_effective_attention(bridge, cache, layer=layer, include_dt_scaling=True)
+
+        conv_out = cache[f"blocks.{layer}.mixer.conv1d.hook_out"][..., :seq_len].float()
+        conv_activated = torch.nn.functional.silu(conv_out).transpose(1, 2)
+        hidden_x, _, _ = conv_activated.split(
+            [intermediate_size, n_groups * state_size, n_groups * state_size], dim=-1
+        )
+        batch = hidden_x.shape[0]
+        x_per_head = hidden_x.view(batch, seq_len, num_heads, head_dim)
+
+        D = mixer.D.float()
+        y_pred = torch.einsum("bhij,bjhd->bihd", M_full, x_per_head)
+        y_pred = y_pred + D[None, None, :, None] * x_per_head
+        y_pred_flat = y_pred.reshape(batch, seq_len, -1)
+
+        y_actual = cache[f"blocks.{layer}.mixer.inner_norm.hook_in"].float()
+        max_diff = (y_actual - y_pred_flat).abs().max().item()
+        scale = max(y_actual.abs().max().item(), 1e-8)
+        assert max_diff / scale < 1e-4, (
+            f"Reconstruction mismatch: rel {max_diff / scale:.2e}. The effective "
+            "attention dims are inconsistent with HF's SSM output (likely reading "
+            "attention dims off the shared cfg instead of the mamba module)."
+        )

--- a/tests/integration/model_bridge/test_mamba2_adapter.py
+++ b/tests/integration/model_bridge/test_mamba2_adapter.py
@@ -562,3 +562,117 @@ class TestMamba2StopAtLayer:
         expected = cache["blocks.7.hook_in"]
         assert torch.allclose(stopped, expected)
         assert stopped.shape == (1, 4, mamba2_bridge.cfg.d_model)
+
+
+class TestMamba2SSMState:
+    """compute_ssm_state reconstructs the recurrent state S read-only from cache.
+
+    S_t = dA_t · S_{t-1} + dt_t · (x_t ⊗ B_t). Two independent checks: a naive
+    fp64 eager recurrence (validates the vectorized cumsum/einsum), and the
+    y = C·S + D·x reconstruction against HF's chunked SSD output (validates the
+    whole reconstruction against a numerically-independent path).
+    """
+
+    SEQ_LEN = 8
+
+    @pytest.fixture(scope="class")
+    def cache(self, mamba2_bridge):
+        tokens = torch.arange(1, self.SEQ_LEN + 1).unsqueeze(0)
+        with torch.no_grad():
+            _, cache = mamba2_bridge.run_with_cache(tokens)
+        return cache
+
+    @staticmethod
+    def _ssd_inputs(cache, mixer, layer, seq_len):
+        """Re-extract dt, per-head x/B/C, A, D from cache — independent of the impl."""
+        oc = mixer.original_component
+        nh, hd, ns, ng = oc.num_heads, oc.head_dim, oc.ssm_state_size, oc.n_groups
+        in_proj = cache[f"blocks.{layer}.mixer.in_proj.hook_out"].float()
+        conv = cache[f"blocks.{layer}.mixer.conv1d.hook_out"][..., :seq_len].float()
+        dt = torch.nn.functional.softplus(in_proj[..., -nh:] + mixer.dt_bias.float())
+        dt = torch.clamp(dt, float(oc.time_step_limit[0]), float(oc.time_step_limit[1]))
+        conv_act = torch.nn.functional.silu(conv).transpose(1, 2)
+        x_flat, B_flat, C_flat = conv_act.split([oc.intermediate_size, ng * ns, ng * ns], dim=-1)
+        x = x_flat.view(1, seq_len, nh, hd)
+        B_h = B_flat.view(1, seq_len, ng, ns).repeat_interleave(nh // ng, dim=2)
+        C_h = C_flat.view(1, seq_len, ng, ns).repeat_interleave(nh // ng, dim=2)
+        A = -torch.exp(mixer.A_log.float())
+        return dt, x, B_h, C_h, A, mixer.D.float()
+
+    def test_shape(self, cache, mamba2_bridge):
+        mixer = mamba2_bridge.blocks[0].mixer
+        oc = mixer.original_component
+        S = mixer.compute_ssm_state(cache, layer_idx=0)
+        assert S.shape == (1, oc.num_heads, self.SEQ_LEN, oc.head_dim, oc.ssm_state_size)
+        assert torch.isfinite(S).all()
+
+    def test_matches_fp64_eager_recurrence(self, cache, mamba2_bridge):
+        """The vectorized state must match a naive fp64 step-by-step recurrence."""
+        mixer = mamba2_bridge.blocks[0].mixer
+        S = mixer.compute_ssm_state(cache, layer_idx=0)
+
+        dt, x, B_h, _, A, _ = self._ssd_inputs(cache, mixer, 0, self.SEQ_LEN)
+        dt, x, B_h, A = dt.double(), x.double(), B_h.double(), A.double()
+        b, nh = S.shape[0], S.shape[1]
+        hd, ns = S.shape[3], S.shape[4]
+        state = torch.zeros(b, nh, hd, ns, dtype=torch.float64)
+        ref = torch.zeros(b, nh, self.SEQ_LEN, hd, ns, dtype=torch.float64)
+        for t in range(self.SEQ_LEN):
+            dA = torch.exp(dt[:, t, :] * A[None, :])  # [b, nh]
+            write = dt[:, t, :, None, None] * x[:, t, :, :, None] * B_h[:, t, :, None, :]
+            state = dA[:, :, None, None] * state + write
+            ref[:, :, t] = state
+
+        max_diff = (S.double() - ref).abs().max().item()
+        scale = max(ref.abs().max().item(), 1e-8)
+        assert (
+            max_diff / scale < 1e-5
+        ), f"S vs fp64 eager recurrence rel diff {max_diff / scale:.2e}"
+
+    def test_reconstructs_ssm_output(self, cache, mamba2_bridge):
+        """y = C·S + D·x must reconstruct HF's SSM output (inner_norm.hook_in)."""
+        mixer = mamba2_bridge.blocks[0].mixer
+        S = mixer.compute_ssm_state(cache, layer_idx=0)
+        _, x, _, C_h, _, D = self._ssd_inputs(cache, mixer, 0, self.SEQ_LEN)
+
+        y = torch.einsum("bthn,bhtpn->bthp", C_h, S) + D[None, None, :, None] * x
+        y_pred = y.reshape(1, self.SEQ_LEN, -1)
+        y_actual = cache["blocks.0.mixer.inner_norm.hook_in"].float()
+        max_diff = (y_actual - y_pred).abs().max().item()
+        scale = max(y_actual.abs().max().item(), 1e-8)
+        assert max_diff / scale < 1e-5, (
+            f"y=C·S+D·x reconstruction rel diff {max_diff / scale:.2e}; the state "
+            "is inconsistent with HF's independently-computed SSM output."
+        )
+
+    def test_time_step_matches_full_slice(self, cache, mamba2_bridge):
+        mixer = mamba2_bridge.blocks[0].mixer
+        S = mixer.compute_ssm_state(cache, layer_idx=0)
+        S_t = mixer.compute_ssm_state(cache, layer_idx=0, time_step=3)
+        assert S_t.shape == (S.shape[0], S.shape[1], S.shape[3], S.shape[4])
+        assert torch.equal(S_t, S[:, :, 3])
+
+    def test_cache_method_matches_mixer(self, cache, mamba2_bridge):
+        S_mixer = mamba2_bridge.blocks[0].mixer.compute_ssm_state(cache, layer_idx=0)
+        assert torch.equal(cache.compute_ssm_state(layer=0), S_mixer)
+
+    def test_cache_all_layers_stacks(self, cache, mamba2_bridge):
+        # Pure Mamba-2 is homogeneous, so all-layers stacks along a new dim 0.
+        S_all = cache.compute_ssm_state()
+        assert torch.is_tensor(S_all)
+        assert S_all.shape[0] == mamba2_bridge.cfg.n_layers
+
+    def test_module_wrapper_matches_mixer(self, cache, mamba2_bridge):
+        from transformer_lens.model_bridge.supported_architectures.mamba2 import (
+            compute_ssm_state,
+        )
+
+        S_mixer = mamba2_bridge.blocks[0].mixer.compute_ssm_state(cache, layer_idx=0)
+        assert torch.equal(compute_ssm_state(mamba2_bridge, cache, layer=0), S_mixer)
+
+    def test_raises_on_empty_cache(self, mamba2_bridge):
+        from transformer_lens.ActivationCache import ActivationCache
+
+        empty = ActivationCache({}, model=mamba2_bridge)
+        with pytest.raises(RuntimeError, match="in cache"):
+            mamba2_bridge.blocks[0].mixer.compute_ssm_state(empty, layer_idx=0)

--- a/tests/integration/model_bridge/test_mamba2_adapter.py
+++ b/tests/integration/model_bridge/test_mamba2_adapter.py
@@ -16,6 +16,8 @@ hooked tensors are projection inputs/outputs, which are per-step and not
 mutated by the cache machinery.
 """
 
+import contextlib
+
 import pytest
 import torch
 
@@ -390,12 +392,9 @@ class TestMamba2EffectiveAttention:
         assert not torch.allclose(M0, M5)
 
 
-class TestMamba2EffectiveAttentionHelper:
-    """Tests for the mamba2.compute_effective_attention helper function.
-
-    The helper wraps the mixer method so callers don't repeat the layer index
-    and can request all layers at once.
-    """
+class TestMamba2EffectiveAttentionDispatch:
+    """cache.compute_ssm_effective_attention wraps the mixer method so callers
+    don't repeat the layer index and can request all layers at once."""
 
     @pytest.fixture(scope="class")
     def bridge_cache(self, mamba2_bridge):
@@ -405,37 +404,22 @@ class TestMamba2EffectiveAttentionHelper:
         return mamba2_bridge, cache
 
     def test_single_layer_matches_mixer_method(self, bridge_cache):
-        """helper(bridge, cache, layer=i) must match the underlying mixer call."""
-        from transformer_lens.model_bridge.supported_architectures.mamba2 import (
-            compute_effective_attention,
-        )
-
         bridge, cache = bridge_cache
         for layer in [0, 5, 23]:
-            M_helper = compute_effective_attention(bridge, cache, layer=layer)
+            M_helper = cache.compute_ssm_effective_attention(layer=layer)
             M_direct = bridge.blocks[layer].mixer.compute_effective_attention(
                 cache, layer_idx=layer
             )
             assert torch.equal(M_helper, M_direct)
 
     def test_all_layers_shape(self, bridge_cache, mamba2_bridge):
-        """helper(bridge, cache) with layer=None stacks all layers."""
-        from transformer_lens.model_bridge.supported_architectures.mamba2 import (
-            compute_effective_attention,
-        )
-
-        bridge, cache = bridge_cache
-        M_all = compute_effective_attention(bridge, cache)
+        _, cache = bridge_cache
+        M_all = cache.compute_ssm_effective_attention()
         assert M_all.shape == (mamba2_bridge.cfg.n_layers, 1, mamba2_bridge.cfg.n_heads, 5, 5)
 
     def test_all_layers_matches_individual_calls(self, bridge_cache):
-        """Stacked all-layers tensor must match per-layer calls along dim 0."""
-        from transformer_lens.model_bridge.supported_architectures.mamba2 import (
-            compute_effective_attention,
-        )
-
         bridge, cache = bridge_cache
-        M_all = compute_effective_attention(bridge, cache)
+        M_all = cache.compute_ssm_effective_attention()
         for layer in [0, 12, 23]:
             M_single = bridge.blocks[layer].mixer.compute_effective_attention(
                 cache, layer_idx=layer
@@ -443,15 +427,20 @@ class TestMamba2EffectiveAttentionHelper:
             assert torch.equal(M_all[layer], M_single)
 
     def test_include_dt_scaling_propagates(self, bridge_cache):
-        """The include_dt_scaling flag must flow through the helper to the mixer."""
+        _, cache = bridge_cache
+        M_att = cache.compute_ssm_effective_attention(layer=0, include_dt_scaling=False)
+        M_full = cache.compute_ssm_effective_attention(layer=0, include_dt_scaling=True)
+        assert not torch.allclose(M_att, M_full)
+
+    def test_deprecated_module_wrapper_warns_and_delegates(self, bridge_cache):
         from transformer_lens.model_bridge.supported_architectures.mamba2 import (
             compute_effective_attention,
         )
 
         bridge, cache = bridge_cache
-        M_att = compute_effective_attention(bridge, cache, layer=0, include_dt_scaling=False)
-        M_full = compute_effective_attention(bridge, cache, layer=0, include_dt_scaling=True)
-        assert not torch.allclose(M_att, M_full)
+        with pytest.warns(DeprecationWarning):
+            M_dep = compute_effective_attention(bridge, cache, layer=0)
+        assert torch.equal(M_dep, cache.compute_ssm_effective_attention(layer=0))
 
 
 class TestMamba2ParameterAccess:
@@ -662,13 +651,15 @@ class TestMamba2SSMState:
         assert torch.is_tensor(S_all)
         assert S_all.shape[0] == mamba2_bridge.cfg.n_layers
 
-    def test_module_wrapper_matches_mixer(self, cache, mamba2_bridge):
+    def test_deprecated_module_wrapper_warns_and_delegates(self, cache, mamba2_bridge):
         from transformer_lens.model_bridge.supported_architectures.mamba2 import (
             compute_ssm_state,
         )
 
         S_mixer = mamba2_bridge.blocks[0].mixer.compute_ssm_state(cache, layer_idx=0)
-        assert torch.equal(compute_ssm_state(mamba2_bridge, cache, layer=0), S_mixer)
+        with pytest.warns(DeprecationWarning):
+            S_dep = compute_ssm_state(mamba2_bridge, cache, layer=0)
+        assert torch.equal(S_dep, S_mixer)
 
     def test_raises_on_empty_cache(self, mamba2_bridge):
         from transformer_lens.ActivationCache import ActivationCache
@@ -676,3 +667,107 @@ class TestMamba2SSMState:
         empty = ActivationCache({}, model=mamba2_bridge)
         with pytest.raises(RuntimeError, match="in cache"):
             mamba2_bridge.blocks[0].mixer.compute_ssm_state(empty, layer_idx=0)
+
+
+@contextlib.contextmanager
+def _eager_scan(bridge):
+    """Enable the opt-in eager-scan intervention path on every mixer, then reset."""
+    for blk in bridge.blocks:
+        blk.mixer.eager_scan = True
+    try:
+        yield bridge
+    finally:
+        for blk in bridge.blocks:
+            blk.mixer.eager_scan = False
+
+
+class TestMamba2EagerScanIntervention:
+    """Phase 4: opt-in eager-scan path exposes hook_ssm_write / hook_ssm_state for
+    interventions (write-knockout, state-patch) that propagate to logits, while the
+    default run_with_cache path is untouched. Eager scan requires use_cache=False
+    (so cache_params is None — prefill only)."""
+
+    TOKENS = torch.tensor([[1, 2, 3, 4, 5, 6]])
+
+    def test_default_path_has_no_eager_hooks(self, mamba2_bridge):
+        with torch.no_grad():
+            _, cache = mamba2_bridge.run_with_cache(self.TOKENS)
+        assert "blocks.0.mixer.hook_ssm_write" not in cache
+        assert "blocks.0.mixer.hook_ssm_state" not in cache
+
+    def test_eager_requires_use_cache_false(self, mamba2_bridge):
+        """With eager on but a default (stateful) forward, cache_params is present
+        so the eager path is skipped and the hooks do not fire."""
+        with _eager_scan(mamba2_bridge), torch.no_grad():
+            _, cache = mamba2_bridge.run_with_cache(self.TOKENS)  # default use_cache
+        assert "blocks.0.mixer.hook_ssm_write" not in cache
+
+    def test_eager_scan_matches_fused_logits(self, mamba2_bridge):
+        with torch.no_grad():
+            fused = mamba2_bridge(self.TOKENS)
+        with _eager_scan(mamba2_bridge), torch.no_grad():
+            eager = mamba2_bridge(self.TOKENS, use_cache=False)
+        rel = (eager - fused).abs().max().item() / max(fused.abs().max().item(), 1e-8)
+        assert rel < 1e-4, f"eager scan vs fused kernel rel diff {rel:.2e}"
+
+    def test_eager_scan_matches_fused_padded_batch(self, mamba2_bridge):
+        """Padded batch: the eager path must mirror HF's padding mask (applied both
+        before in_proj and after the conv) to stay at parity."""
+        ids = torch.tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]])
+        mask = torch.tensor([[1, 1, 1, 1, 1], [1, 1, 1, 1, 0]])
+        with torch.no_grad():
+            fused = mamba2_bridge(ids, attention_mask=mask)
+        with _eager_scan(mamba2_bridge), torch.no_grad():
+            eager = mamba2_bridge(ids, attention_mask=mask, use_cache=False)
+        rel = (eager - fused).abs().max().item() / max(fused.abs().max().item(), 1e-8)
+        assert rel < 1e-4, f"padded-batch eager vs fused rel diff {rel:.2e}"
+
+    def test_eager_hooks_fire_with_use_cache_false(self, mamba2_bridge):
+        with _eager_scan(mamba2_bridge), torch.no_grad():
+            _, cache = mamba2_bridge.run_with_cache(self.TOKENS, use_cache=False)
+        oc = mamba2_bridge.blocks[0].mixer.original_component
+        seq = self.TOKENS.shape[1]
+        expected = (1, seq, oc.num_heads, oc.head_dim, oc.ssm_state_size)
+        assert cache["blocks.0.mixer.hook_ssm_write"].shape == expected
+        assert cache["blocks.0.mixer.hook_ssm_state"].shape == expected
+
+    def test_write_knockout_changes_logits(self, mamba2_bridge):
+        with _eager_scan(mamba2_bridge), torch.no_grad():
+            base = mamba2_bridge(self.TOKENS, use_cache=False)
+
+            def knockout(writes, hook):
+                writes = writes.clone()
+                writes[:, 2] = 0.0  # input position 2 writes nothing — column knockout
+                return writes
+
+            patched = mamba2_bridge.run_with_hooks(
+                self.TOKENS,
+                use_cache=False,
+                fwd_hooks=[("blocks.0.mixer.hook_ssm_write", knockout)],
+            )
+        assert (patched - base).abs().max().item() > 1e-6
+
+    def test_state_patch_changes_logits(self, mamba2_bridge):
+        with _eager_scan(mamba2_bridge), torch.no_grad():
+            base = mamba2_bridge(self.TOKENS, use_cache=False)
+
+            def patch(state, hook):
+                state = state.clone()
+                state[:, 3] = 0.0
+                return state
+
+            patched = mamba2_bridge.run_with_hooks(
+                self.TOKENS,
+                use_cache=False,
+                fwd_hooks=[("blocks.0.mixer.hook_ssm_state", patch)],
+            )
+        assert (patched - base).abs().max().item() > 1e-6
+
+    def test_disabling_restores_fused_path(self, mamba2_bridge):
+        with torch.no_grad():
+            fused_before = mamba2_bridge(self.TOKENS)
+        with _eager_scan(mamba2_bridge), torch.no_grad():
+            mamba2_bridge(self.TOKENS, use_cache=False)
+        with torch.no_grad():
+            fused_after = mamba2_bridge(self.TOKENS)
+        assert torch.equal(fused_before, fused_after)

--- a/tests/integration/model_bridge/test_mamba2_adapter.py
+++ b/tests/integration/model_bridge/test_mamba2_adapter.py
@@ -710,6 +710,41 @@ class TestMamba2EagerScanIntervention:
         rel = (eager - fused).abs().max().item() / max(fused.abs().max().item(), 1e-8)
         assert rel < 1e-4, f"eager scan vs fused kernel rel diff {rel:.2e}"
 
+    def test_eager_scan_matches_fp64_step_reference(self, mamba2_bridge):
+        """The eager scan's write/state must match an independent fp64 step recurrence.
+
+        ``test_eager_scan_matches_fused_logits`` pins the eager scan to HF's fused
+        kernel — but a shared discretization error would pass both. This pins the
+        eager scan's own ``hook_ssm_write`` / ``hook_ssm_state`` to a naive fp64
+        step-by-step recurrence built independently from the cached in_proj/conv1d
+        outputs (``S_t = dA_t·S_{t-1} + dt_t·(x_t⊗B_t)``), so it is a genuine
+        correctness gate on the eager scan, not just kernel agreement.
+        """
+        seq = self.TOKENS.shape[1]
+        with _eager_scan(mamba2_bridge), torch.no_grad():
+            _, cache = mamba2_bridge.run_with_cache(self.TOKENS, use_cache=False)
+        mixer = mamba2_bridge.blocks[0].mixer
+        write_hook = cache["blocks.0.mixer.hook_ssm_write"].double()
+        state_hook = cache["blocks.0.mixer.hook_ssm_state"].double()
+
+        dt, x, B_h, _, A, _ = TestMamba2SSMState._ssd_inputs(cache, mixer, 0, seq)
+        dt, x, B_h, A = dt.double(), x.double(), B_h.double(), A.double()
+        b, nh, hd, ns = state_hook.shape[0], state_hook.shape[2], state_hook.shape[3], state_hook.shape[4]
+
+        state = torch.zeros(b, nh, hd, ns, dtype=torch.float64)
+        ref_write = torch.zeros(b, seq, nh, hd, ns, dtype=torch.float64)
+        ref_state = torch.zeros(b, seq, nh, hd, ns, dtype=torch.float64)
+        for t in range(seq):
+            dA = torch.exp(dt[:, t, :] * A[None, :])  # [b, nh]
+            write = dt[:, t, :, None, None] * x[:, t, :, :, None] * B_h[:, t, :, None, :]
+            ref_write[:, t] = write
+            state = dA[:, :, None, None] * state + write
+            ref_state[:, t] = state
+
+        for name, got, ref in (("write", write_hook, ref_write), ("state", state_hook, ref_state)):
+            rel = (got - ref).abs().max().item() / max(ref.abs().max().item(), 1e-8)
+            assert rel < 1e-5, f"eager {name} vs fp64 step reference rel diff {rel:.2e}"
+
     def test_eager_scan_matches_fused_padded_batch(self, mamba2_bridge):
         """Padded batch: the eager path must mirror HF's padding mask (applied both
         before in_proj and after the conv) to stay at parity."""

--- a/tests/integration/model_bridge/test_mamba2_adapter.py
+++ b/tests/integration/model_bridge/test_mamba2_adapter.py
@@ -729,7 +729,12 @@ class TestMamba2EagerScanIntervention:
 
         dt, x, B_h, _, A, _ = TestMamba2SSMState._ssd_inputs(cache, mixer, 0, seq)
         dt, x, B_h, A = dt.double(), x.double(), B_h.double(), A.double()
-        b, nh, hd, ns = state_hook.shape[0], state_hook.shape[2], state_hook.shape[3], state_hook.shape[4]
+        b, nh, hd, ns = (
+            state_hook.shape[0],
+            state_hook.shape[2],
+            state_hook.shape[3],
+            state_hook.shape[4],
+        )
 
         state = torch.zeros(b, nh, hd, ns, dtype=torch.float64)
         ref_write = torch.zeros(b, seq, nh, hd, ns, dtype=torch.float64)

--- a/tests/integration/model_bridge/test_mamba_adapter.py
+++ b/tests/integration/model_bridge/test_mamba_adapter.py
@@ -330,3 +330,117 @@ class TestMambaStatefulGeneration:
             "Mid-layer mutation had no effect on generation — the stateful "
             "loop may be bypassing the bridge's forward() path."
         )
+
+
+class TestMamba1EffectiveAttention:
+    """Mamba-1's S6 scan as per-channel effective attention M.
+
+    Two checks: M·x + D·x matches an fp64 eager recurrence (matrix-algebra
+    correctness), and the full mixer output reconstructed through gate + out_proj
+    matches HF's cached hook_out (ties M to HF's numerically-independent forward).
+    """
+
+    SEQ_LEN = 6
+
+    @pytest.fixture(scope="class")
+    def cache(self, mamba_bridge):
+        tokens = torch.arange(1, self.SEQ_LEN + 1).unsqueeze(0)
+        with torch.no_grad():
+            _, cache = mamba_bridge.run_with_cache(tokens)
+        return cache
+
+    @staticmethod
+    def _inputs(cache, mixer, layer, seq_len):
+        """Re-extract x (post-conv SiLU), B, C, dt, A, D, gate — independent of the impl."""
+        import torch.nn.functional as F
+
+        oc = mixer.original_component
+        d_inner, state, dt_rank = oc.intermediate_size, oc.ssm_state_size, oc.time_step_rank
+        conv = cache[f"blocks.{layer}.mixer.conv1d.hook_out"][..., :seq_len].float()
+        x_proj = cache[f"blocks.{layer}.mixer.x_proj.hook_out"].float()
+        dt_proj = cache[f"blocks.{layer}.mixer.dt_proj.hook_out"].float()
+        in_proj = cache[f"blocks.{layer}.mixer.in_proj.hook_out"].float()
+        x = F.silu(conv)  # [b, d_inner, seq]
+        _ts, B, C = x_proj.split([dt_rank, state, state], dim=-1)
+        dt = F.softplus(dt_proj).transpose(1, 2)  # [b, d_inner, seq]
+        A = -torch.exp(mixer.A_log.float())
+        gate = in_proj.transpose(1, 2)[:, d_inner:, :]  # [b, d_inner, seq]
+        return x, B, C, dt, A, mixer.D.float(), gate
+
+    def test_shape(self, cache, mamba_bridge):
+        mixer = mamba_bridge.blocks[0].mixer
+        oc = mixer.original_component
+        M = mixer.compute_effective_attention(cache, layer_idx=0)
+        assert M.shape == (1, oc.intermediate_size, self.SEQ_LEN, self.SEQ_LEN)
+        assert torch.isfinite(M).all()
+
+    def test_per_state_coord_sums_to_default(self, cache, mamba_bridge):
+        mixer = mamba_bridge.blocks[0].mixer
+        oc = mixer.original_component
+        M = mixer.compute_effective_attention(cache, layer_idx=0, include_dt_scaling=True)
+        M_coord = mixer.compute_effective_attention(
+            cache, layer_idx=0, include_dt_scaling=True, per_state_coord=True
+        )
+        assert M_coord.shape == (
+            1,
+            oc.intermediate_size,
+            oc.ssm_state_size,
+            self.SEQ_LEN,
+            self.SEQ_LEN,
+        )
+        assert torch.allclose(M_coord.sum(dim=2), M, atol=1e-6)
+
+    def test_causal(self, cache, mamba_bridge):
+        M = mamba_bridge.blocks[0].mixer.compute_effective_attention(cache, layer_idx=0)
+        upper = torch.triu(torch.ones(self.SEQ_LEN, self.SEQ_LEN, dtype=torch.bool), diagonal=1)
+        assert torch.all(M[..., upper] == 0), "effective attention must be causal"
+
+    def test_matches_fp64_eager_recurrence(self, cache, mamba_bridge):
+        """M·x + D·x must match a naive fp64 step-by-step S6 recurrence."""
+        mixer = mamba_bridge.blocks[0].mixer
+        M = mixer.compute_effective_attention(cache, layer_idx=0, include_dt_scaling=True)
+        x, B, C, dt, A, D, _ = self._inputs(cache, mixer, 0, self.SEQ_LEN)
+        y_pred = torch.einsum("bcij,bcj->bci", M, x) + D[None, :, None] * x
+
+        A, B, C, x, dt = A.double(), B.double(), C.double(), x.double(), dt.double()
+        b, d_inner = x.shape[0], x.shape[1]
+        ssm = torch.zeros(b, d_inner, A.shape[1], dtype=torch.float64)
+        y_ref = torch.zeros(b, d_inner, self.SEQ_LEN, dtype=torch.float64)
+        for i in range(self.SEQ_LEN):
+            dA = torch.exp(A[None] * dt[:, :, i, None])  # [b, d_inner, state]
+            dBu = dt[:, :, i, None] * B[:, i, None, :] * x[:, :, i, None]
+            ssm = dA * ssm + dBu
+            y_ref[:, :, i] = torch.einsum("bcn,bn->bc", ssm, C[:, i, :])
+        y_ref = y_ref + D[None, :, None].double() * x
+
+        rel = (y_pred.double() - y_ref).abs().max().item() / max(y_ref.abs().max().item(), 1e-8)
+        assert rel < 1e-5, f"M·x reconstruction vs fp64 eager scan rel diff {rel:.2e}"
+
+    def test_reconstructs_mixer_output(self, cache, mamba_bridge):
+        """out_proj((M·x + D·x)·silu(gate)) must reconstruct HF's mixer output."""
+        import torch.nn.functional as F
+
+        mixer = mamba_bridge.blocks[0].mixer
+        M = mixer.compute_effective_attention(cache, layer_idx=0, include_dt_scaling=True)
+        x, _, _, _, _, D, gate = self._inputs(cache, mixer, 0, self.SEQ_LEN)
+        y = torch.einsum("bcij,bcj->bci", M, x) + D[None, :, None] * x
+        out = mixer.original_component.out_proj((y * F.silu(gate)).transpose(1, 2))
+        hook_out = cache["blocks.0.mixer.hook_out"].float()
+        rel = (out - hook_out).abs().max().item() / max(hook_out.abs().max().item(), 1e-8)
+        assert rel < 1e-5, (
+            f"reconstructed mixer output vs hook_out rel diff {rel:.2e}; M is "
+            "inconsistent with HF's independently-computed forward."
+        )
+
+    def test_include_dt_scaling_changes_output(self, cache, mamba_bridge):
+        mixer = mamba_bridge.blocks[0].mixer
+        M_att = mixer.compute_effective_attention(cache, layer_idx=0, include_dt_scaling=False)
+        M_full = mixer.compute_effective_attention(cache, layer_idx=0, include_dt_scaling=True)
+        assert not torch.allclose(M_att, M_full)
+
+    def test_raises_on_empty_cache(self, mamba_bridge):
+        from transformer_lens.ActivationCache import ActivationCache
+
+        empty = ActivationCache({}, model=mamba_bridge)
+        with pytest.raises(RuntimeError, match="in cache"):
+            mamba_bridge.blocks[0].mixer.compute_effective_attention(empty, layer_idx=0)

--- a/tests/integration/model_bridge/test_mamba_adapter.py
+++ b/tests/integration/model_bridge/test_mamba_adapter.py
@@ -650,3 +650,180 @@ class TestMamba1EagerScanIntervention:
         with torch.no_grad():
             fused_after = mamba_bridge(self.TOKENS)
         assert torch.equal(fused_before, fused_after)
+
+
+class _DummyTok:
+    pass
+
+
+def _build_synthetic_mamba_bridge():
+    """Tiny random-init Mamba-1 bridge (from_config, no download) for CI-runnable tests."""
+    from transformers import AutoModelForCausalLM
+    from transformers.models.mamba import MambaConfig
+
+    from transformer_lens.model_bridge.sources._bridge_builder import (
+        build_bridge_config_from_hf,
+    )
+    from transformer_lens.model_bridge.supported_architectures.mamba import (
+        MambaArchitectureAdapter,
+    )
+
+    torch.manual_seed(0)
+    cfg = MambaConfig(
+        vocab_size=128,
+        hidden_size=32,
+        state_size=16,
+        num_hidden_layers=2,
+        expand=2,
+        time_step_rank=4,
+        conv_kernel=4,
+    )
+    cfg.architectures = ["MambaForCausalLM"]
+    hf = AutoModelForCausalLM.from_config(cfg).eval()
+    bridge_cfg = build_bridge_config_from_hf(
+        hf.config, "MambaForCausalLM", "m1-tiny", torch.float32
+    )
+    return TransformerBridge(hf, MambaArchitectureAdapter(bridge_cfg), tokenizer=_DummyTok())
+
+
+class TestMamba1EagerScanFp64Reference:
+    """Independent fp64 correctness gate on the Mamba-1 eager scan (_eager_scan_forward).
+
+    Pins the eager scan's hook_ssm_write / hook_ssm_state to a naive fp64 step recurrence
+    built from the cached submodule outputs — distinct from both the fused-kernel parity
+    test and the read-path fp64 tests, so a shared discretization error can't pass. Uses
+    synthetic weights (from_config) so it runs in stock CI without a model download.
+    """
+
+    SEQ_LEN = 7
+    LAYER = 0
+
+    @pytest.fixture(scope="class")
+    def bridge(self):
+        return _build_synthetic_mamba_bridge()
+
+    @pytest.fixture(scope="class")
+    def eager_cache(self, bridge):
+        tokens = torch.randint(1, 128, (2, self.SEQ_LEN))
+        with _eager_scan(bridge), torch.no_grad():
+            _, cache = bridge.run_with_cache(tokens, use_cache=False)
+        return cache
+
+    def _fp64_reference(self, bridge, cache):
+        """Reconstruct (writes, state) in fp64 from cached submodule hooks.
+
+        Independent reimplementation of the S6 write term + recurrence; reads the same
+        HF submodule outputs the eager scan reuses (so their hooks fire), not the eager
+        code. Returns channel-first ``[b, d_inner, seq, state]`` tensors.
+        """
+        import torch.nn.functional as F
+
+        oc = bridge.blocks[self.LAYER].mixer.original_component
+        d_inner, state, dt_rank = oc.intermediate_size, oc.ssm_state_size, oc.time_step_rank
+        p = f"blocks.{self.LAYER}.mixer"
+
+        conv = cache[f"{p}.conv1d.hook_out"][..., : self.SEQ_LEN].double()  # [b, d_inner, seq]
+        x = F.silu(conv)  # HF act (silu) on the trimmed conv output
+        xp = cache[f"{p}.x_proj.hook_out"].double()  # [b, seq, dt_rank + 2*state]
+        _, B, _C = xp.split([dt_rank, state, state], dim=-1)  # B: [b, seq, state]
+        dtp = cache[f"{p}.dt_proj.hook_out"].double()  # [b, seq, d_inner] (pre-softplus)
+        dt = F.softplus(dtp).transpose(1, 2)  # [b, d_inner, seq]
+        A = -torch.exp(bridge.blocks[self.LAYER].mixer.A_log.double())  # [d_inner, state]
+
+        writes = (dt * x)[:, :, :, None] * B[:, None, :, :]  # [b, d_inner, seq, state]
+        b = writes.shape[0]
+        ssm = torch.zeros(b, d_inner, state, dtype=torch.float64)
+        states = []
+        for t in range(self.SEQ_LEN):
+            ssm = torch.exp(A[None] * dt[:, :, t, None]) * ssm + writes[:, :, t]
+            states.append(ssm)
+        return writes, torch.stack(states, dim=2)  # [b, d_inner, seq, state]
+
+    def test_eager_write_matches_fp64_reference(self, bridge, eager_cache):
+        writes_ref, _ = self._fp64_reference(bridge, eager_cache)
+        got = eager_cache[f"blocks.{self.LAYER}.mixer.hook_ssm_write"].double()
+        rel = (got - writes_ref).abs().max().item() / max(writes_ref.abs().max().item(), 1e-12)
+        assert rel < 1e-5, f"eager hook_ssm_write vs fp64 reference rel diff {rel:.2e}"
+
+    def test_eager_state_matches_fp64_reference(self, bridge, eager_cache):
+        _, state_ref = self._fp64_reference(bridge, eager_cache)
+        got = eager_cache[f"blocks.{self.LAYER}.mixer.hook_ssm_state"].double()
+        rel = (got - state_ref).abs().max().item() / max(state_ref.abs().max().item(), 1e-12)
+        assert rel < 1e-5, f"eager hook_ssm_state vs fp64 reference rel diff {rel:.2e}"
+
+    def test_write_knockout_propagates_forward(self, bridge):
+        """Zeroing hook_ssm_write at position k must change the state at every position
+        >= k (the recurrence carries it forward) and leave positions < k untouched."""
+        tokens = torch.randint(1, 128, (1, self.SEQ_LEN))
+        k = 3
+        state_key = f"blocks.{self.LAYER}.mixer.hook_ssm_state"
+        write_key = f"blocks.{self.LAYER}.mixer.hook_ssm_write"
+
+        def knock(writes, hook):
+            writes = writes.clone()
+            writes[:, :, k] = 0.0
+            return writes
+
+        captured = {}
+
+        def grab(state, hook):
+            captured["s"] = state.detach().clone()
+            return state
+
+        with _eager_scan(bridge), torch.no_grad():
+            _, base_cache = bridge.run_with_cache(tokens, use_cache=False)
+            base_state = base_cache[state_key]
+            bridge.run_with_hooks(
+                tokens, use_cache=False, fwd_hooks=[(write_key, knock), (state_key, grab)]
+            )
+        patched_state = captured["s"]
+        # positions before k unchanged; positions at/after k changed
+        assert torch.allclose(patched_state[:, :, :k], base_state[:, :, :k], atol=1e-6)
+        assert (patched_state[:, :, k:] - base_state[:, :, k:]).abs().max().item() > 1e-6
+
+    def test_state_patch_is_same_position_only(self, bridge):
+        """Patching hook_ssm_state at position k changes only the same-position mixer
+        output (y_t = C_t·S_t is a post-scan readout — it does not re-run the scan)."""
+        tokens = torch.randint(1, 128, (1, self.SEQ_LEN))
+        k = 3
+        state_key = f"blocks.{self.LAYER}.mixer.hook_ssm_state"
+        out_key = f"blocks.{self.LAYER}.mixer.hook_out"
+
+        def patch(state, hook):
+            state = state.clone()
+            state[:, :, k] = 0.0
+            return state
+
+        base_out, patched_out = {}, {}
+
+        def grab_base(o, hook):
+            base_out["o"] = o.detach().clone()
+            return o
+
+        def grab_patched(o, hook):
+            patched_out["o"] = o.detach().clone()
+            return o
+
+        with _eager_scan(bridge), torch.no_grad():
+            bridge.run_with_hooks(tokens, use_cache=False, fwd_hooks=[(out_key, grab_base)])
+            bridge.run_with_hooks(
+                tokens, use_cache=False, fwd_hooks=[(state_key, patch), (out_key, grab_patched)]
+            )
+        delta = (patched_out["o"] - base_out["o"]).abs()
+        assert delta[:, k].max().item() > 1e-6, "same-position output must change"
+        other = torch.cat([delta[:, :k], delta[:, k + 1 :]], dim=1)
+        assert other.max().item() < 1e-6, "other positions must be untouched (no propagation)"
+
+    def test_batch1_padded_matches_hf(self, bridge):
+        """Batch-1 with a padding mask must match HF: MambaMixer masks whenever
+        attention_mask is present (no batch>1 guard, unlike Mamba-2)."""
+        tokens = torch.tensor([[1, 2, 3, 4, 0]])
+        mask = torch.tensor([[1, 1, 1, 1, 0]])
+        with torch.no_grad():
+            fused = bridge(tokens, attention_mask=mask)
+            with _eager_scan(bridge):
+                eager = bridge.run_with_hooks(
+                    tokens, use_cache=False, attention_mask=mask, fwd_hooks=[]
+                )
+        rel = (eager - fused).abs().max().item() / max(fused.abs().max().item(), 1e-8)
+        assert rel < 1e-4, f"batch-1 padded eager vs HF fused rel diff {rel:.2e}"

--- a/tests/integration/model_bridge/test_mamba_adapter.py
+++ b/tests/integration/model_bridge/test_mamba_adapter.py
@@ -623,7 +623,9 @@ class TestMamba1EagerScanIntervention:
         with _eager_scan(mamba_bridge), torch.no_grad():
             base = mamba_bridge.run_with_hooks(self.TOKENS, use_cache=False, fwd_hooks=[])
             patched = mamba_bridge.run_with_hooks(
-                self.TOKENS, use_cache=False, fwd_hooks=[("blocks.0.mixer.hook_ssm_write", knockout)]
+                self.TOKENS,
+                use_cache=False,
+                fwd_hooks=[("blocks.0.mixer.hook_ssm_write", knockout)],
             )
         assert (patched - base).abs().max().item() > 1e-6
 

--- a/tests/integration/model_bridge/test_mamba_adapter.py
+++ b/tests/integration/model_bridge/test_mamba_adapter.py
@@ -18,6 +18,8 @@ machinery. If a future phase adds per-step SSM state hooks (compatibility mode),
 those hooks MUST `.clone()` captured state tensors.
 """
 
+import contextlib
+
 import pytest
 import torch
 
@@ -549,3 +551,100 @@ class TestMamba1SSMState:
         empty = ActivationCache({}, model=mamba_bridge)
         with pytest.raises(RuntimeError, match="in cache"):
             mamba_bridge.blocks[0].mixer.compute_ssm_state(empty, layer_idx=0)
+
+
+@contextlib.contextmanager
+def _eager_scan(bridge):
+    """Enable the opt-in eager-scan intervention path on every Mamba-1 mixer."""
+    for block in bridge.blocks:
+        block.mixer.eager_scan = True
+    try:
+        yield bridge
+    finally:
+        for block in bridge.blocks:
+            block.mixer.eager_scan = False
+
+
+class TestMamba1EagerScanIntervention:
+    """Phase 4 (Mamba-1): opt-in eager S6 scan exposes hook_ssm_write / hook_ssm_state
+    for interventions that propagate to logits, while the default path is untouched.
+    Eager scan needs use_cache=False (prefill; cache_params is None)."""
+
+    TOKENS = torch.tensor([[1, 2, 3, 4, 5, 6]])
+
+    def test_default_path_has_no_eager_hooks(self, mamba_bridge):
+        with torch.no_grad():
+            _, cache = mamba_bridge.run_with_cache(self.TOKENS)
+        assert "blocks.0.mixer.hook_ssm_write" not in cache
+        assert "blocks.0.mixer.hook_ssm_state" not in cache
+
+    def test_eager_requires_use_cache_false(self, mamba_bridge):
+        with _eager_scan(mamba_bridge), torch.no_grad():
+            _, cache = mamba_bridge.run_with_cache(self.TOKENS)  # default use_cache
+        assert "blocks.0.mixer.hook_ssm_write" not in cache
+
+    def test_eager_scan_matches_fused_logits(self, mamba_bridge):
+        with torch.no_grad():
+            fused = mamba_bridge(self.TOKENS)
+        with _eager_scan(mamba_bridge), torch.no_grad():
+            eager = mamba_bridge.run_with_hooks(self.TOKENS, use_cache=False, fwd_hooks=[])
+        rel = (eager - fused).abs().max().item() / max(fused.abs().max().item(), 1e-8)
+        assert rel < 1e-4, f"eager scan vs HF kernel rel diff {rel:.2e}"
+
+    def test_eager_scan_matches_fused_padded_batch(self, mamba_bridge):
+        """Padded batch: eager path mirrors HF's channel-first padding mask (before
+        and after the conv)."""
+        ids = torch.tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]])
+        mask = torch.tensor([[1, 1, 1, 1, 1], [1, 1, 1, 1, 0]])
+        with torch.no_grad():
+            fused = mamba_bridge(ids, attention_mask=mask)
+        with _eager_scan(mamba_bridge), torch.no_grad():
+            eager = mamba_bridge.run_with_hooks(
+                ids, use_cache=False, attention_mask=mask, fwd_hooks=[]
+            )
+        rel = (eager - fused).abs().max().item() / max(fused.abs().max().item(), 1e-8)
+        assert rel < 1e-4, f"padded-batch eager vs fused rel diff {rel:.2e}"
+
+    def test_eager_hooks_fire_with_use_cache_false(self, mamba_bridge):
+        with _eager_scan(mamba_bridge), torch.no_grad():
+            _, cache = mamba_bridge.run_with_cache(self.TOKENS, use_cache=False)
+        oc = mamba_bridge.blocks[0].mixer.original_component
+        seq = self.TOKENS.shape[1]
+        expected = (1, oc.intermediate_size, seq, oc.ssm_state_size)
+        assert cache["blocks.0.mixer.hook_ssm_write"].shape == expected
+        assert cache["blocks.0.mixer.hook_ssm_state"].shape == expected
+
+    def test_write_knockout_changes_logits(self, mamba_bridge):
+        def knockout(writes, hook):
+            writes = writes.clone()
+            writes[:, :, 2] = 0.0  # channel-first: zero all channels' write at position 2
+            return writes
+
+        with _eager_scan(mamba_bridge), torch.no_grad():
+            base = mamba_bridge.run_with_hooks(self.TOKENS, use_cache=False, fwd_hooks=[])
+            patched = mamba_bridge.run_with_hooks(
+                self.TOKENS, use_cache=False, fwd_hooks=[("blocks.0.mixer.hook_ssm_write", knockout)]
+            )
+        assert (patched - base).abs().max().item() > 1e-6
+
+    def test_state_patch_changes_logits(self, mamba_bridge):
+        def patch(state, hook):
+            state = state.clone()
+            state[:, :, 3] = 0.0
+            return state
+
+        with _eager_scan(mamba_bridge), torch.no_grad():
+            base = mamba_bridge.run_with_hooks(self.TOKENS, use_cache=False, fwd_hooks=[])
+            patched = mamba_bridge.run_with_hooks(
+                self.TOKENS, use_cache=False, fwd_hooks=[("blocks.0.mixer.hook_ssm_state", patch)]
+            )
+        assert (patched - base).abs().max().item() > 1e-6
+
+    def test_disabling_restores_fused_path(self, mamba_bridge):
+        with torch.no_grad():
+            fused_before = mamba_bridge(self.TOKENS)
+        with _eager_scan(mamba_bridge), torch.no_grad():
+            mamba_bridge.run_with_hooks(self.TOKENS, use_cache=False, fwd_hooks=[])
+        with torch.no_grad():
+            fused_after = mamba_bridge(self.TOKENS)
+        assert torch.equal(fused_before, fused_after)

--- a/tests/integration/model_bridge/test_mamba_adapter.py
+++ b/tests/integration/model_bridge/test_mamba_adapter.py
@@ -444,3 +444,108 @@ class TestMamba1EffectiveAttention:
         empty = ActivationCache({}, model=mamba_bridge)
         with pytest.raises(RuntimeError, match="in cache"):
             mamba_bridge.blocks[0].mixer.compute_effective_attention(empty, layer_idx=0)
+
+
+class TestMamba1SSMState:
+    """Mamba-1 recurrent-state reconstruction (Phase 4.5): read-parity with Mamba-2.
+
+    The vectorized state must match a naive fp64 step-by-step S6 scan, and
+    ``y = C·S + D·x`` reconstructed through gate + out_proj must match HF's cached
+    ``hook_out`` (ties S to HF's numerically-independent forward).
+    """
+
+    SEQ_LEN = 6
+
+    @pytest.fixture(scope="class")
+    def cache(self, mamba_bridge):
+        tokens = torch.arange(1, self.SEQ_LEN + 1).unsqueeze(0)
+        with torch.no_grad():
+            _, cache = mamba_bridge.run_with_cache(tokens)
+        return cache
+
+    @staticmethod
+    def _inputs(cache, mixer, layer, seq_len):
+        """Re-extract x (post-conv SiLU), B, C, dt, A, D, gate — independent of the impl."""
+        import torch.nn.functional as F
+
+        oc = mixer.original_component
+        d_inner, state, dt_rank = oc.intermediate_size, oc.ssm_state_size, oc.time_step_rank
+        conv = cache[f"blocks.{layer}.mixer.conv1d.hook_out"][..., :seq_len].float()
+        x_proj = cache[f"blocks.{layer}.mixer.x_proj.hook_out"].float()
+        dt_proj = cache[f"blocks.{layer}.mixer.dt_proj.hook_out"].float()
+        in_proj = cache[f"blocks.{layer}.mixer.in_proj.hook_out"].float()
+        x = F.silu(conv)  # [b, d_inner, seq]
+        _ts, B, C = x_proj.split([dt_rank, state, state], dim=-1)
+        dt = F.softplus(dt_proj).transpose(1, 2)  # [b, d_inner, seq]
+        A = -torch.exp(mixer.A_log.float())
+        gate = in_proj.transpose(1, 2)[:, d_inner:, :]  # [b, d_inner, seq]
+        return x, B, C, dt, A, mixer.D.float(), gate
+
+    def test_shape(self, cache, mamba_bridge):
+        mixer = mamba_bridge.blocks[0].mixer
+        oc = mixer.original_component
+        S = mixer.compute_ssm_state(cache, layer_idx=0)
+        assert S.shape == (1, oc.intermediate_size, self.SEQ_LEN, oc.ssm_state_size)
+        assert torch.isfinite(S).all()
+
+    def test_matches_fp64_eager_recurrence(self, cache, mamba_bridge):
+        """The vectorized state must match a naive fp64 step-by-step S6 scan."""
+        mixer = mamba_bridge.blocks[0].mixer
+        S = mixer.compute_ssm_state(cache, layer_idx=0)
+
+        x, B, _, dt, A, _, _ = self._inputs(cache, mixer, 0, self.SEQ_LEN)
+        A, B, x, dt = A.double(), B.double(), x.double(), dt.double()
+        b, d_inner = x.shape[0], x.shape[1]
+        ssm = torch.zeros(b, d_inner, A.shape[1], dtype=torch.float64)
+        ref = torch.zeros(b, d_inner, self.SEQ_LEN, A.shape[1], dtype=torch.float64)
+        for i in range(self.SEQ_LEN):
+            dA = torch.exp(A[None] * dt[:, :, i, None])  # [b, d_inner, state]
+            dBu = dt[:, :, i, None] * B[:, i, None, :] * x[:, :, i, None]
+            ssm = dA * ssm + dBu
+            ref[:, :, i] = ssm
+
+        rel = (S.double() - ref).abs().max().item() / max(ref.abs().max().item(), 1e-8)
+        assert rel < 1e-5, f"S vs fp64 eager recurrence rel diff {rel:.2e}"
+
+    def test_reconstructs_mixer_output(self, cache, mamba_bridge):
+        """out_proj((C·S + D·x)·silu(gate)) must reconstruct HF's mixer output."""
+        import torch.nn.functional as F
+
+        mixer = mamba_bridge.blocks[0].mixer
+        S = mixer.compute_ssm_state(cache, layer_idx=0)  # [b, channels, seq, state]
+        x, _, C, _, _, D, gate = self._inputs(cache, mixer, 0, self.SEQ_LEN)
+        y = torch.einsum("bcts,bts->bct", S, C) + D[None, :, None] * x
+        out = mixer.original_component.out_proj((y * F.silu(gate)).transpose(1, 2))
+        hook_out = cache["blocks.0.mixer.hook_out"].float()
+        rel = (out - hook_out).abs().max().item() / max(hook_out.abs().max().item(), 1e-8)
+        assert rel < 1e-5, (
+            f"C·S+D·x reconstruction vs hook_out rel diff {rel:.2e}; the state is "
+            "inconsistent with HF's independently-computed forward."
+        )
+
+    def test_time_step_matches_full_slice(self, cache, mamba_bridge):
+        mixer = mamba_bridge.blocks[0].mixer
+        S = mixer.compute_ssm_state(cache, layer_idx=0)
+        S_t = mixer.compute_ssm_state(cache, layer_idx=0, time_step=3)
+        assert S_t.shape == (S.shape[0], S.shape[1], S.shape[3])
+        # Same math; the full ("bcsij") and single-step ("bcsj") einsums differ only
+        # in fp reduction order (measured ~1 fp32 ULP), so allclose, not equal.
+        assert torch.allclose(S[:, :, 3], S_t, atol=1e-6)
+
+    def test_cache_method_matches_mixer(self, cache, mamba_bridge):
+        direct = mamba_bridge.blocks[0].mixer.compute_ssm_state(cache, layer_idx=0)
+        via_cache = cache.compute_ssm_state(layer=0)
+        assert torch.equal(direct, via_cache)
+
+    def test_cache_all_layers_stacks(self, cache, mamba_bridge):
+        S_all = cache.compute_ssm_state()  # pure Mamba-1 → every block is SSM → stacked
+        assert torch.is_tensor(S_all)
+        assert S_all.shape[0] == mamba_bridge.cfg.n_layers
+        assert torch.equal(S_all[0], cache.compute_ssm_state(layer=0))
+
+    def test_raises_on_empty_cache(self, mamba_bridge):
+        from transformer_lens.ActivationCache import ActivationCache
+
+        empty = ActivationCache({}, model=mamba_bridge)
+        with pytest.raises(RuntimeError, match="in cache"):
+            mamba_bridge.blocks[0].mixer.compute_ssm_state(empty, layer_idx=0)

--- a/tests/integration/model_bridge/test_mamba_adapter.py
+++ b/tests/integration/model_bridge/test_mamba_adapter.py
@@ -362,7 +362,7 @@ class TestMamba1EffectiveAttention:
         x_proj = cache[f"blocks.{layer}.mixer.x_proj.hook_out"].float()
         dt_proj = cache[f"blocks.{layer}.mixer.dt_proj.hook_out"].float()
         in_proj = cache[f"blocks.{layer}.mixer.in_proj.hook_out"].float()
-        x = F.silu(conv)  # [b, d_inner, seq]
+        x = oc.act(conv)  # [b, d_inner, seq]
         _ts, B, C = x_proj.split([dt_rank, state, state], dim=-1)
         dt = F.softplus(dt_proj).transpose(1, 2)  # [b, d_inner, seq]
         A = -torch.exp(mixer.A_log.float())
@@ -419,14 +419,14 @@ class TestMamba1EffectiveAttention:
         assert rel < 1e-5, f"M·x reconstruction vs fp64 eager scan rel diff {rel:.2e}"
 
     def test_reconstructs_mixer_output(self, cache, mamba_bridge):
-        """out_proj((M·x + D·x)·silu(gate)) must reconstruct HF's mixer output."""
-        import torch.nn.functional as F
-
+        """out_proj((M·x + D·x)·act(gate)) must reconstruct HF's mixer output."""
         mixer = mamba_bridge.blocks[0].mixer
         M = mixer.compute_effective_attention(cache, layer_idx=0, include_dt_scaling=True)
         x, _, _, _, _, D, gate = self._inputs(cache, mixer, 0, self.SEQ_LEN)
         y = torch.einsum("bcij,bcj->bci", M, x) + D[None, :, None] * x
-        out = mixer.original_component.out_proj((y * F.silu(gate)).transpose(1, 2))
+        out = mixer.original_component.out_proj(
+            (y * mixer.original_component.act(gate)).transpose(1, 2)
+        )
         hook_out = cache["blocks.0.mixer.hook_out"].float()
         rel = (out - hook_out).abs().max().item() / max(hook_out.abs().max().item(), 1e-8)
         assert rel < 1e-5, (
@@ -476,7 +476,7 @@ class TestMamba1SSMState:
         x_proj = cache[f"blocks.{layer}.mixer.x_proj.hook_out"].float()
         dt_proj = cache[f"blocks.{layer}.mixer.dt_proj.hook_out"].float()
         in_proj = cache[f"blocks.{layer}.mixer.in_proj.hook_out"].float()
-        x = F.silu(conv)  # [b, d_inner, seq]
+        x = oc.act(conv)  # [b, d_inner, seq]
         _ts, B, C = x_proj.split([dt_rank, state, state], dim=-1)
         dt = F.softplus(dt_proj).transpose(1, 2)  # [b, d_inner, seq]
         A = -torch.exp(mixer.A_log.float())
@@ -510,14 +510,14 @@ class TestMamba1SSMState:
         assert rel < 1e-5, f"S vs fp64 eager recurrence rel diff {rel:.2e}"
 
     def test_reconstructs_mixer_output(self, cache, mamba_bridge):
-        """out_proj((C·S + D·x)·silu(gate)) must reconstruct HF's mixer output."""
-        import torch.nn.functional as F
-
+        """out_proj((C·S + D·x)·act(gate)) must reconstruct HF's mixer output."""
         mixer = mamba_bridge.blocks[0].mixer
         S = mixer.compute_ssm_state(cache, layer_idx=0)  # [b, channels, seq, state]
         x, _, C, _, _, D, gate = self._inputs(cache, mixer, 0, self.SEQ_LEN)
         y = torch.einsum("bcts,bts->bct", S, C) + D[None, :, None] * x
-        out = mixer.original_component.out_proj((y * F.silu(gate)).transpose(1, 2))
+        out = mixer.original_component.out_proj(
+            (y * mixer.original_component.act(gate)).transpose(1, 2)
+        )
         hook_out = cache["blocks.0.mixer.hook_out"].float()
         rel = (out - hook_out).abs().max().item() / max(hook_out.abs().max().item(), 1e-8)
         assert rel < 1e-5, (
@@ -723,7 +723,7 @@ class TestMamba1EagerScanFp64Reference:
         p = f"blocks.{self.LAYER}.mixer"
 
         conv = cache[f"{p}.conv1d.hook_out"][..., : self.SEQ_LEN].double()  # [b, d_inner, seq]
-        x = F.silu(conv)  # HF act (silu) on the trimmed conv output
+        x = oc.act(conv)  # HF act on the trimmed conv output
         xp = cache[f"{p}.x_proj.hook_out"].double()  # [b, seq, dt_rank + 2*state]
         _, B, _C = xp.split([dt_rank, state, state], dim=-1)  # B: [b, seq, state]
         dtp = cache[f"{p}.dt_proj.hook_out"].double()  # [b, seq, d_inner] (pre-softplus)

--- a/tests/integration/model_bridge/test_nemotron_h_adapter.py
+++ b/tests/integration/model_bridge/test_nemotron_h_adapter.py
@@ -1,12 +1,12 @@
 """Integration tests for the NemotronH architecture adapter.
 
-Verifies forward-pass and generation parity against nvidia/Nemotron-H-8B-Base:
+Verifies forward-pass and generation parity against nvidia/NVIDIA-Nemotron-Nano-9B-v2:
 - Forward-pass logits match HF exactly (bridge delegates the full forward to HF)
 - Greedy multi-token generation matches HF bit-for-bit (exercises DynamicCache
   state handling across attention, Mamba-2, MLP, and MoE layers)
 - Sanity checks: config flags, block count, hook coverage
 
-Note: requires ~18 GB RAM (CPU) or ~16 GB VRAM (GPU) to load the 8B checkpoint.
+Note: requires ~36 GB RAM (CPU, fp32) or ~18 GB VRAM (GPU, bf16) to load the 9B checkpoint.
 On a machine with less memory, skip with:
     pytest -m "not slow" tests/integration/model_bridge/test_nemotron_h_adapter.py
 
@@ -28,7 +28,7 @@ from transformer_lens.model_bridge.generalized_components import (
 
 pytestmark = pytest.mark.slow
 
-MODEL = "nvidia/Nemotron-H-8B-Base"
+MODEL = "nvidia/NVIDIA-Nemotron-Nano-9B-v2"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -82,7 +82,7 @@ class TestNemotronHBridgeCreation:
         assert isinstance(nemotron_bridge.ln_final, RMSNormalizationBridge)
 
     def test_block_count(self, nemotron_bridge: TransformerBridge) -> None:
-        # Nemotron-H-8B has 56 layers
+        # Nemotron-Nano-9B-v2 has 56 layers
         assert len(nemotron_bridge.blocks) == 56
 
     def test_blocks_are_ssm_block_bridge(self, nemotron_bridge: TransformerBridge) -> None:

--- a/tests/integration/model_bridge/test_nemotron_h_tiny.py
+++ b/tests/integration/model_bridge/test_nemotron_h_tiny.py
@@ -52,7 +52,9 @@ def bridge():
     )
     cfg.architectures = ["NemotronHForCausalLM"]
     hf = AutoModelForCausalLM.from_config(cfg).to(torch.float32).eval()
-    bridge_cfg = build_bridge_config_from_hf(hf.config, "NemotronHForCausalLM", "nh-tiny", torch.float32)
+    bridge_cfg = build_bridge_config_from_hf(
+        hf.config, "NemotronHForCausalLM", "nh-tiny", torch.float32
+    )
     return TransformerBridge(hf, NemotronHArchitectureAdapter(bridge_cfg), tokenizer=_Tok())
 
 

--- a/tests/integration/model_bridge/test_nemotron_h_tiny.py
+++ b/tests/integration/model_bridge/test_nemotron_h_tiny.py
@@ -1,7 +1,7 @@
-"""Tiny from_config NemotronH integration tests — CI coverage without the 8B checkpoint.
+"""Tiny from_config NemotronH integration tests — CI coverage without a real checkpoint.
 
-The full nvidia/Nemotron-H-8B-Base parity suite (test_nemotron_h_adapter.py) is
-``@pytest.mark.slow`` and needs ~18 GB, so it does not run in normal CI. This file
+The full nvidia/NVIDIA-Nemotron-Nano-9B-v2 parity suite (test_nemotron_h_adapter.py) is
+``@pytest.mark.slow`` and needs ~36 GB, so it does not run in normal CI. This file
 builds a tiny synthetic NemotronH (real random CPU weights, no Hub download) that
 exercises the same surfaces — the single passthrough ``.mixer`` slot on every
 layer, forward parity, hook coverage, and the family-agnostic SSM dispatch.

--- a/tests/integration/model_bridge/test_nemotron_h_tiny.py
+++ b/tests/integration/model_bridge/test_nemotron_h_tiny.py
@@ -1,0 +1,133 @@
+"""Tiny from_config NemotronH integration tests — CI coverage without the 8B checkpoint.
+
+The full nvidia/Nemotron-H-8B-Base parity suite (test_nemotron_h_adapter.py) is
+``@pytest.mark.slow`` and needs ~18 GB, so it does not run in normal CI. This file
+builds a tiny synthetic NemotronH (real random CPU weights, no Hub download) that
+exercises the same surfaces — the single passthrough ``.mixer`` slot on every
+layer, forward parity, hook coverage, and the family-agnostic SSM dispatch.
+"""
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+from transformers.models.nemotron_h import NemotronHConfig
+
+from transformer_lens.model_bridge.bridge import TransformerBridge
+from transformer_lens.model_bridge.generalized_components import (
+    SSM2MixerBridge,
+    SSMBlockBridge,
+)
+from transformer_lens.model_bridge.sources._bridge_builder import (
+    build_bridge_config_from_hf,
+)
+from transformer_lens.model_bridge.supported_architectures.nemotron_h import (
+    NemotronHArchitectureAdapter,
+)
+
+LAYERS = ["mamba", "attention", "mamba", "mlp"]
+MAMBA_LAYERS = [0, 2]
+ATTN_LAYER = 1
+
+
+class _Tok:
+    pass
+
+
+@pytest.fixture(scope="module")
+def bridge():
+    torch.manual_seed(0)
+    cfg = NemotronHConfig(
+        vocab_size=256,
+        hidden_size=64,
+        layers_block_type=LAYERS,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        ssm_state_size=16,
+        mamba_num_heads=4,
+        mamba_head_dim=16,
+        n_groups=2,
+        conv_kernel=4,
+        expand=2,
+        intermediate_size=128,
+        chunk_size=8,
+    )
+    cfg.architectures = ["NemotronHForCausalLM"]
+    hf = AutoModelForCausalLM.from_config(cfg).to(torch.float32).eval()
+    bridge_cfg = build_bridge_config_from_hf(hf.config, "NemotronHForCausalLM", "nh-tiny", torch.float32)
+    return TransformerBridge(hf, NemotronHArchitectureAdapter(bridge_cfg), tokenizer=_Tok())
+
+
+@pytest.fixture(scope="module")
+def tokens():
+    return torch.tensor([[1, 2, 3, 4, 5]])
+
+
+@pytest.fixture(scope="module")
+def cache(bridge, tokens):
+    with torch.no_grad():
+        _, c = bridge.run_with_cache(tokens)
+    return c
+
+
+class TestNemotronHTinyStructure:
+    def test_block_count(self, bridge):
+        assert len(bridge.blocks) == len(LAYERS)
+
+    def test_blocks_are_ssm_block_bridge(self, bridge):
+        assert isinstance(bridge.blocks[0], SSMBlockBridge)
+
+    def test_every_block_wires_ssm2_mixer_passthrough(self, bridge):
+        # NemotronH wires one SSM2MixerBridge .mixer per layer, for all types.
+        for i in range(len(LAYERS)):
+            assert isinstance(bridge.blocks[i].mixer, SSM2MixerBridge)
+
+    def test_layers_block_type_populated(self, bridge):
+        assert getattr(bridge.cfg, "layers_block_type", None) == LAYERS
+
+
+class TestNemotronHTinyForwardPass:
+    def test_forward_matches_hf_exactly(self, bridge, tokens):
+        with torch.no_grad():
+            bridge_out = bridge(tokens)
+            hf_out = bridge.original_model(tokens).logits
+        assert (bridge_out.float() - hf_out.float()).abs().max().item() == 0.0
+
+    def test_no_nan_longer_sequence(self, bridge):
+        with torch.no_grad():
+            out = bridge(torch.arange(1, 17).unsqueeze(0))
+        assert not torch.isnan(out).any()
+
+
+class TestNemotronHTinyHookCoverage:
+    def test_block_hooks_fire(self, cache):
+        for i in range(len(LAYERS)):
+            assert f"blocks.{i}.hook_in" in cache
+            assert f"blocks.{i}.hook_out" in cache
+
+    def test_mamba_submodule_hooks_fire(self, cache):
+        for i in MAMBA_LAYERS:
+            for submod in ("in_proj", "conv1d", "out_proj"):
+                assert f"blocks.{i}.mixer.{submod}.hook_out" in cache
+
+    def test_no_transformer_specific_hooks(self, cache):
+        forbidden = ("hook_resid_mid", "hook_attn_out", "hook_mlp_out")
+        assert [k for k in cache if any(f in k for f in forbidden)] == []
+
+
+class TestNemotronHTinyDispatch:
+    def test_ssm_layers_excludes_passthrough(self, cache):
+        # Structural passthrough exclusion: only the real Mamba layers, no attn/mlp.
+        assert cache.ssm_layers() == MAMBA_LAYERS
+
+    def test_effective_attention_per_ssm_layer_dict(self, cache):
+        M = cache.compute_ssm_effective_attention()
+        assert isinstance(M, dict)
+        assert sorted(M.keys()) == MAMBA_LAYERS
+
+    def test_ssm_state_per_ssm_layer_dict(self, cache):
+        S = cache.compute_ssm_state()
+        assert isinstance(S, dict)
+        assert sorted(S.keys()) == MAMBA_LAYERS
+
+    def test_attention_layer_raises_typeerror(self, cache):
+        with pytest.raises(TypeError):
+            cache.compute_ssm_effective_attention(layer=ATTN_LAYER)

--- a/tests/integration/model_bridge/test_ssm_effective_attention_dispatch.py
+++ b/tests/integration/model_bridge/test_ssm_effective_attention_dispatch.py
@@ -1,0 +1,363 @@
+"""Phase 3: family-agnostic SSM effective-attention dispatch + canonical hook vocabulary.
+
+Builds tiny synthetic models (no Hub access) for each SSM family and verifies:
+- SSMMixerProtocol conformance (Mamba-1, Mamba-2, gated-delta-net; not attention),
+- cache.ssm_layers / cache.compute_ssm_effective_attention dispatch across families,
+- option forwarding (per_state_coord Mamba-1 only; include_dt_scaling not on GDN),
+- the additive canonical hook vocabulary resolving cross-family via run_with_cache.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from transformer_lens.model_bridge.bridge import TransformerBridge
+from transformer_lens.model_bridge.generalized_components import (
+    SSM2MixerBridge,
+    SSMMixerBridge,
+    SSMMixerProtocol,
+    find_ssm_mixer,
+)
+from transformer_lens.model_bridge.sources._bridge_builder import (
+    build_bridge_config_from_hf,
+)
+
+try:
+    from transformers import Qwen3_5ForCausalLM, Qwen3_5TextConfig
+
+    _QWEN3_5_AVAILABLE = True
+except ImportError:
+    _QWEN3_5_AVAILABLE = False
+
+
+class _Tok:
+    pass
+
+
+def _boot(hf_model, arch):
+    cfg = build_bridge_config_from_hf(hf_model.config, arch, "tiny", torch.float32)
+    from transformer_lens.factories.architecture_adapter_factory import (
+        ArchitectureAdapterFactory,
+    )
+
+    adapter = ArchitectureAdapterFactory.select_architecture_adapter(cfg)
+    return TransformerBridge(model=hf_model, adapter=adapter, tokenizer=_Tok())
+
+
+@pytest.fixture(scope="module")
+def mamba1_bridge():
+    from transformers import AutoModelForCausalLM
+    from transformers.models.mamba import MambaConfig
+
+    torch.manual_seed(0)
+    c = MambaConfig(
+        vocab_size=128,
+        hidden_size=32,
+        state_size=16,
+        num_hidden_layers=2,
+        expand=2,
+        time_step_rank=4,
+        conv_kernel=4,
+    )
+    c.architectures = ["MambaForCausalLM"]
+    return _boot(AutoModelForCausalLM.from_config(c).eval(), "MambaForCausalLM")
+
+
+@pytest.fixture(scope="module")
+def mamba2_bridge():
+    from transformers import AutoModelForCausalLM
+    from transformers.models.mamba2 import Mamba2Config
+
+    torch.manual_seed(0)
+    c = Mamba2Config(
+        vocab_size=128,
+        hidden_size=32,
+        num_hidden_layers=2,
+        state_size=16,
+        expand=2,
+        head_dim=16,
+        num_heads=4,
+        n_groups=2,
+        conv_kernel=4,
+        chunk_size=8,
+    )
+    c.architectures = ["Mamba2ForCausalLM"]
+    return _boot(AutoModelForCausalLM.from_config(c).eval(), "Mamba2ForCausalLM")
+
+
+@pytest.fixture(scope="module")
+def granite_bridge():
+    from transformers import AutoModelForCausalLM
+    from transformers.models.granitemoehybrid import GraniteMoeHybridConfig
+
+    torch.manual_seed(0)
+    c = GraniteMoeHybridConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=32,
+        shared_intermediate_size=32,
+        num_hidden_layers=3,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=64,
+        layer_types=["mamba", "attention", "mamba"],
+        mamba_n_heads=8,
+        mamba_n_groups=2,
+        mamba_d_state=16,
+        mamba_d_head=16,
+        mamba_d_conv=4,
+        mamba_expand=2,
+        mamba_chunk_size=16,
+        position_embedding_type="rope",
+        rope_parameters={"rope_type": "default", "rope_theta": 10000.0},
+    )
+    c.architectures = ["GraniteMoeHybridForCausalLM"]
+    return _boot(AutoModelForCausalLM.from_config(c).eval(), "GraniteMoeHybridForCausalLM")
+
+
+@pytest.fixture(scope="module")
+def nemotronh_bridge():
+    """Tiny NemotronH (Mamba-2 + attention + MLP hybrid) — exercises the single
+    passthrough ``.mixer`` slot wired on every layer."""
+    from transformers import AutoModelForCausalLM
+    from transformers.models.nemotron_h import NemotronHConfig
+
+    torch.manual_seed(0)
+    c = NemotronHConfig(
+        vocab_size=256,
+        hidden_size=64,
+        layers_block_type=["mamba", "attention", "mamba", "mlp"],
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        ssm_state_size=16,
+        mamba_num_heads=4,
+        mamba_head_dim=16,
+        n_groups=2,
+        conv_kernel=4,
+        expand=2,
+        intermediate_size=128,
+        chunk_size=8,
+    )
+    c.architectures = ["NemotronHForCausalLM"]
+    return _boot(AutoModelForCausalLM.from_config(c).eval(), "NemotronHForCausalLM")
+
+
+@pytest.fixture(scope="module")
+def qwen35_bridge():
+    from transformer_lens.config.transformer_bridge_config import (
+        TransformerBridgeConfig,
+    )
+    from transformer_lens.model_bridge.supported_architectures.qwen3_5 import (
+        Qwen3_5ArchitectureAdapter,
+    )
+
+    torch.manual_seed(0)
+    c = Qwen3_5TextConfig(
+        hidden_size=128,
+        num_hidden_layers=8,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        intermediate_size=256,
+        vocab_size=512,
+        full_attention_interval=4,
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=32,
+        linear_value_head_dim=32,
+        linear_num_key_heads=4,
+        linear_num_value_heads=4,
+        rope_parameters={
+            "rope_theta": 10000.0,
+            "partial_rotary_factor": 0.25,
+            "rope_type": "default",
+        },
+    )
+    m = Qwen3_5ForCausalLM(c).eval()
+    bcfg = TransformerBridgeConfig(
+        d_model=128,
+        d_head=32,
+        n_heads=4,
+        n_layers=8,
+        n_ctx=2048,
+        d_vocab=512,
+        n_key_value_heads=2,
+        architecture="Qwen3_5ForCausalLM",
+    )
+    return TransformerBridge(m, Qwen3_5ArchitectureAdapter(bcfg), tokenizer=MagicMock())
+
+
+TOKENS = torch.tensor([[1, 2, 3, 4, 5]])
+
+
+# ---------------------------------------------------------------------------
+# SSMMixerProtocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestSSMMixerProtocol:
+    def test_mamba2_conforms(self, mamba2_bridge):
+        assert isinstance(mamba2_bridge.blocks[0].mixer, SSMMixerProtocol)
+
+    def test_mamba1_conforms(self, mamba1_bridge):
+        assert isinstance(mamba1_bridge.blocks[0].mixer, SSMMixerProtocol)
+
+    def test_attention_does_not_conform(self, granite_bridge):
+        # Block 1 is an attention layer — no SSM mixer.
+        assert not isinstance(granite_bridge.blocks[1].attn, SSMMixerProtocol)
+
+    def test_find_ssm_mixer_on_attention_layer_is_none(self, granite_bridge):
+        assert find_ssm_mixer(granite_bridge.blocks[1]) is None
+
+    def test_find_ssm_mixer_on_ssm_layer(self, granite_bridge):
+        assert isinstance(find_ssm_mixer(granite_bridge.blocks[0]), SSM2MixerBridge)
+
+    def test_nemotronh_passthrough_mixer_is_not_found(self, nemotronh_bridge):
+        """NemotronH wires a passthrough SSM2MixerBridge .mixer on EVERY layer; it
+        conforms to the protocol by method presence, but find_ssm_mixer must reject
+        the no-op wrapper on attention / MLP layers (layer_types = mamba/attn/mamba/mlp)."""
+        assert isinstance(find_ssm_mixer(nemotronh_bridge.blocks[0]), SSM2MixerBridge)  # mamba
+        assert find_ssm_mixer(nemotronh_bridge.blocks[1]) is None  # attention passthrough
+        assert find_ssm_mixer(nemotronh_bridge.blocks[3]) is None  # mlp passthrough
+
+    @pytest.mark.skipif(not _QWEN3_5_AVAILABLE, reason="Qwen3_5 not available")
+    def test_gated_delta_net_conforms(self, qwen35_bridge):
+        assert isinstance(qwen35_bridge.blocks[0].linear_attn, SSMMixerProtocol)
+
+
+# ---------------------------------------------------------------------------
+# cache.ssm_layers
+# ---------------------------------------------------------------------------
+
+
+class TestSSMLayers:
+    def test_mamba2_all_layers(self, mamba2_bridge):
+        with torch.no_grad():
+            _, cache = mamba2_bridge.run_with_cache(TOKENS)
+        assert cache.ssm_layers() == [0, 1]
+
+    def test_granite_only_mamba_layers(self, granite_bridge):
+        with torch.no_grad():
+            _, cache = granite_bridge.run_with_cache(TOKENS)
+        assert cache.ssm_layers() == [0, 2]
+
+    def test_nemotronh_excludes_passthrough_layers(self, nemotronh_bridge):
+        # Structural detection must drop the passthrough .mixer on attn/mlp layers
+        # without relying on cfg.layers_block_type (which is empty in this path).
+        with torch.no_grad():
+            _, cache = nemotronh_bridge.run_with_cache(TOKENS)
+        assert cache.ssm_layers() == [0, 2]
+
+    def test_mixer_type_filter(self, granite_bridge):
+        with torch.no_grad():
+            _, cache = granite_bridge.run_with_cache(TOKENS)
+        assert cache.ssm_layers(mixer_type=SSM2MixerBridge) == [0, 2]
+        assert cache.ssm_layers(mixer_type=SSMMixerBridge) == []
+
+    @pytest.mark.skipif(not _QWEN3_5_AVAILABLE, reason="Qwen3_5 not available")
+    def test_qwen35_linear_attn_layers(self, qwen35_bridge):
+        with torch.no_grad():
+            _, cache = qwen35_bridge.run_with_cache(TOKENS, use_cache=False)
+        # full_attention_interval=4 -> full-attn at 3 and 7, linear-attn elsewhere
+        assert cache.ssm_layers() == [0, 1, 2, 4, 5, 6]
+
+
+# ---------------------------------------------------------------------------
+# cache.compute_ssm_effective_attention dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSSMEffectiveAttention:
+    def test_mamba2_stacks_and_matches_direct(self, mamba2_bridge):
+        with torch.no_grad():
+            _, cache = mamba2_bridge.run_with_cache(TOKENS)
+        M_all = cache.compute_ssm_effective_attention()
+        assert torch.is_tensor(M_all)
+        assert M_all.shape[0] == mamba2_bridge.cfg.n_layers
+        assert torch.equal(M_all[0], cache.compute_ssm_effective_attention(layer=0))
+
+    def test_granite_returns_dict(self, granite_bridge):
+        with torch.no_grad():
+            _, cache = granite_bridge.run_with_cache(TOKENS)
+        M_all = cache.compute_ssm_effective_attention()
+        assert isinstance(M_all, dict)
+        assert sorted(M_all.keys()) == [0, 2]
+        direct = granite_bridge.blocks[0].mixer.compute_effective_attention(cache, layer_idx=0)
+        assert torch.equal(M_all[0], direct)
+
+    def test_layer_without_mixer_raises_typeerror(self, granite_bridge):
+        with torch.no_grad():
+            _, cache = granite_bridge.run_with_cache(TOKENS)
+        with pytest.raises(TypeError):
+            cache.compute_ssm_effective_attention(layer=1)  # attention layer
+
+    def test_nemotronh_dispatch_and_passthrough_contract(self, nemotronh_bridge):
+        """All-layers returns only the mamba layers; the single-layer path on a
+        passthrough (attention) layer raises the documented TypeError, not the
+        mixer's internal "needs ... in cache" RuntimeError."""
+        with torch.no_grad():
+            _, cache = nemotronh_bridge.run_with_cache(TOKENS)
+        M_all = cache.compute_ssm_effective_attention()
+        assert isinstance(M_all, dict)
+        assert sorted(M_all.keys()) == [0, 2]
+        direct = nemotronh_bridge.blocks[0].mixer.compute_effective_attention(cache, layer_idx=0)
+        assert torch.equal(M_all[0], direct)
+        with pytest.raises(TypeError):
+            cache.compute_ssm_effective_attention(layer=1)  # passthrough attention layer
+
+    def test_per_state_coord_mamba1(self, mamba1_bridge):
+        with torch.no_grad():
+            _, cache = mamba1_bridge.run_with_cache(TOKENS)
+        M = cache.compute_ssm_effective_attention(layer=0, per_state_coord=True)
+        assert M.ndim == 5  # [batch, channels, state, seq, seq]
+
+    def test_per_state_coord_unsupported_raises(self, mamba2_bridge):
+        with torch.no_grad():
+            _, cache = mamba2_bridge.run_with_cache(TOKENS)
+        with pytest.raises(ValueError, match="per_state_coord"):
+            cache.compute_ssm_effective_attention(per_state_coord=True)
+
+    @pytest.mark.skipif(not _QWEN3_5_AVAILABLE, reason="Qwen3_5 not available")
+    def test_qwen35_dict_and_include_dt_scaling_unsupported(self, qwen35_bridge):
+        with torch.no_grad():
+            _, cache = qwen35_bridge.run_with_cache(TOKENS, use_cache=False)
+        M_all = cache.compute_ssm_effective_attention()
+        assert isinstance(M_all, dict)
+        assert sorted(M_all.keys()) == [0, 1, 2, 4, 5, 6]
+        with pytest.raises(ValueError, match="include_dt_scaling"):
+            cache.compute_ssm_effective_attention(include_dt_scaling=True)
+
+
+# ---------------------------------------------------------------------------
+# Canonical hook vocabulary (3b) — survives the hybrid alias resolution
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalHookVocabulary:
+    @pytest.mark.skipif(not _QWEN3_5_AVAILABLE, reason="Qwen3_5 not available")
+    def test_hook_ssm_out_resolves_cross_family(self, granite_bridge, qwen35_bridge):
+        """The critical test: one canonical name resolves on a Mamba-2 hybrid SSM
+        layer AND a gated-delta-net layer via run_with_cache (different slots)."""
+        with torch.no_grad():
+            _, cg = granite_bridge.run_with_cache(TOKENS)
+            _, cq = qwen35_bridge.run_with_cache(TOKENS, use_cache=False)
+        assert "blocks.0.mixer.hook_ssm_out" in cg
+        assert "blocks.0.linear_attn.hook_ssm_out" in cq
+
+    @pytest.mark.skipif(not _QWEN3_5_AVAILABLE, reason="Qwen3_5 not available")
+    def test_gated_delta_net_canonical_aliases(self, qwen35_bridge):
+        with torch.no_grad():
+            _, cq = qwen35_bridge.run_with_cache(TOKENS, use_cache=False)
+        p = "blocks.0.linear_attn"
+        assert torch.equal(cq[f"{p}.hook_ssm_decay"], cq[f"{p}.hook_log_decay"])
+        assert torch.equal(cq[f"{p}.hook_ssm_C"], cq[f"{p}.hook_q"])
+        assert torch.equal(cq[f"{p}.hook_ssm_B"], cq[f"{p}.hook_k"])
+        assert torch.equal(cq[f"{p}.hook_ssm_write"], cq[f"{p}.hook_beta"])
+
+    def test_mamba1_hook_ssm_dt_alias(self, mamba1_bridge):
+        with torch.no_grad():
+            _, cache = mamba1_bridge.run_with_cache(TOKENS)
+        assert torch.equal(
+            cache["blocks.0.mixer.hook_ssm_dt"], cache["blocks.0.mixer.dt_proj.hook_out"]
+        )

--- a/tests/integration/model_bridge/test_ssm_effective_attention_dispatch.py
+++ b/tests/integration/model_bridge/test_ssm_effective_attention_dispatch.py
@@ -409,6 +409,8 @@ class TestComputeSsmStateDispatch:
     def test_full_attention_layer_raises_typeerror(self, qwen35_bridge):
         with torch.no_grad():
             _, cache = qwen35_bridge.run_with_cache(TOKENS, use_cache=False)
-        attn_layer = next(i for i in range(qwen35_bridge.cfg.n_layers) if i not in cache.ssm_layers())
+        attn_layer = next(
+            i for i in range(qwen35_bridge.cfg.n_layers) if i not in cache.ssm_layers()
+        )
         with pytest.raises(TypeError, match="gated-delta-net"):
             cache.compute_ssm_state(layer=attn_layer)

--- a/tests/integration/model_bridge/test_ssm_effective_attention_dispatch.py
+++ b/tests/integration/model_bridge/test_ssm_effective_attention_dispatch.py
@@ -361,3 +361,41 @@ class TestCanonicalHookVocabulary:
         assert torch.equal(
             cache["blocks.0.mixer.hook_ssm_dt"], cache["blocks.0.mixer.dt_proj.hook_out"]
         )
+
+
+# ---------------------------------------------------------------------------
+# cache.compute_ssm_state (Phase 4.5) — family-agnostic over Mamba-1 / Mamba-2,
+# excluding gated-delta-net (no recurrent-state reconstruction).
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSsmStateDispatch:
+    def test_mamba1_reachable_via_cache(self, mamba1_bridge):
+        with torch.no_grad():
+            _, cache = mamba1_bridge.run_with_cache(TOKENS)
+        S = cache.compute_ssm_state()  # pure Mamba-1 → stacked
+        assert torch.is_tensor(S)
+        assert S.shape[0] == mamba1_bridge.cfg.n_layers
+        assert torch.equal(S[0], cache.compute_ssm_state(layer=0))
+
+    def test_mamba2_reachable_via_cache(self, mamba2_bridge):
+        with torch.no_grad():
+            _, cache = mamba2_bridge.run_with_cache(TOKENS)
+        S = cache.compute_ssm_state()
+        assert torch.is_tensor(S)
+        assert S.shape[0] == mamba2_bridge.cfg.n_layers
+
+    def test_granite_returns_per_ssm_layer_dict(self, granite_bridge):
+        with torch.no_grad():
+            _, cache = granite_bridge.run_with_cache(TOKENS)
+        S = cache.compute_ssm_state()
+        assert isinstance(S, dict)
+        assert sorted(S.keys()) == [0, 2]
+
+    @pytest.mark.skipif(not _QWEN3_5_AVAILABLE, reason="Qwen3_5 not available")
+    def test_gated_delta_net_has_no_state(self, qwen35_bridge):
+        with torch.no_grad():
+            _, cache = qwen35_bridge.run_with_cache(TOKENS, use_cache=False)
+        # GDN conforms to the effective-attention protocol but has no S_t.
+        with pytest.raises(TypeError, match="Mamba-1 / Mamba-2"):
+            cache.compute_ssm_state(layer=0)

--- a/tests/integration/model_bridge/test_ssm_effective_attention_dispatch.py
+++ b/tests/integration/model_bridge/test_ssm_effective_attention_dispatch.py
@@ -364,8 +364,8 @@ class TestCanonicalHookVocabulary:
 
 
 # ---------------------------------------------------------------------------
-# cache.compute_ssm_state (Phase 4.5) — family-agnostic over Mamba-1 / Mamba-2,
-# excluding gated-delta-net (no recurrent-state reconstruction).
+# cache.compute_ssm_state (Phase 4.5) — family-agnostic over Mamba-1 / Mamba-2
+# and gated-delta-net (each reconstructs its own recurrent state).
 # ---------------------------------------------------------------------------
 
 
@@ -393,9 +393,22 @@ class TestComputeSsmStateDispatch:
         assert sorted(S.keys()) == [0, 2]
 
     @pytest.mark.skipif(not _QWEN3_5_AVAILABLE, reason="Qwen3_5 not available")
-    def test_gated_delta_net_has_no_state(self, qwen35_bridge):
+    def test_gated_delta_net_reachable_via_cache(self, qwen35_bridge):
         with torch.no_grad():
             _, cache = qwen35_bridge.run_with_cache(TOKENS, use_cache=False)
-        # GDN conforms to the effective-attention protocol but has no S_t.
-        with pytest.raises(TypeError, match="Mamba-1 / Mamba-2"):
-            cache.compute_ssm_state(layer=0)
+        # Hybrid (full-attn layers interleaved) → dict over the linear-attn layers.
+        S = cache.compute_ssm_state()
+        assert isinstance(S, dict)
+        assert cache.ssm_layers() == sorted(S.keys())
+        layer = cache.ssm_layers()[0]
+        # [batch, seq, n_v_heads, head_k_dim, head_v_dim]
+        assert S[layer].ndim == 5
+        assert torch.equal(S[layer], cache.compute_ssm_state(layer=layer))
+
+    @pytest.mark.skipif(not _QWEN3_5_AVAILABLE, reason="Qwen3_5 not available")
+    def test_full_attention_layer_raises_typeerror(self, qwen35_bridge):
+        with torch.no_grad():
+            _, cache = qwen35_bridge.run_with_cache(TOKENS, use_cache=False)
+        attn_layer = next(i for i in range(qwen35_bridge.cfg.n_layers) if i not in cache.ssm_layers())
+        with pytest.raises(TypeError, match="gated-delta-net"):
+            cache.compute_ssm_state(layer=attn_layer)

--- a/tests/integration/model_bridge/test_ssm_real_weights.py
+++ b/tests/integration/model_bridge/test_ssm_real_weights.py
@@ -106,7 +106,11 @@ class TestRealWeightSSMSurface:
 
     def test_compute_ssm_state_finite(self, cache, tokens):
         state = cache.compute_ssm_state()
-        mats = list(state.values()) if isinstance(state, dict) else [state[i] for i in range(state.shape[0])]
+        mats = (
+            list(state.values())
+            if isinstance(state, dict)
+            else [state[i] for i in range(state.shape[0])]
+        )
         assert len(mats) == len(cache.ssm_layers())
         for S in mats:
             assert torch.isfinite(S).all()

--- a/tests/integration/model_bridge/test_ssm_real_weights.py
+++ b/tests/integration/model_bridge/test_ssm_real_weights.py
@@ -1,0 +1,152 @@
+"""Availability-gated real-weight integration tests for the SSM / recurrent families.
+
+The from_config tiny tests (test_mamba_adapter / test_mamba2_adapter /
+test_nemotron_h_tiny / test_granite_moe_hybrid_adapter and the Qwen3_5 unit tests)
+exercise the plumbing on random init. These load *real trained checkpoints* and run
+the same interp surface — family-agnostic SSM-layer discovery, recurrent-state
+reconstruction, effective attention, and the opt-in eager-scan intervention path —
+where the numerics differ from random init.
+
+Every model is loaded through the ``bridge`` fixture, which SKIPS (never fails) when
+the checkpoint or network is unavailable, the installed transformers lacks the
+architecture, or there isn't enough memory. Point any family at a locally-cached
+checkpoint with its env var (e.g. ``TL_MAMBA1_MODEL``); families without a small
+official checkpoint (NemotronH 8B, Qwen3-Next 80B, …) skip in normal environments.
+
+All ``slow`` so ``make integration-test`` (``-m "not slow"``) never downloads.
+"""
+import gc
+import os
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from transformer_lens.model_bridge.bridge import TransformerBridge
+
+pytestmark = pytest.mark.slow
+
+
+@dataclass(frozen=True)
+class _Case:
+    label: str
+    env: str
+    default: str  # canonical HF id, or "" for env-only (no small official checkpoint)
+
+
+# Ordered by how likely the checkpoint is small enough to actually run in CI.
+CASES = [
+    _Case("mamba1", "TL_MAMBA1_MODEL", "state-spaces/mamba-130m-hf"),
+    _Case("mamba2", "TL_MAMBA2_MODEL", "AntonV/mamba2-130m-hf"),
+    _Case("granite", "TL_GRANITE_MODEL", "ibm-granite/granite-4.0-tiny-preview"),
+    _Case("nemotron_h", "TL_NEMOTRON_H_MODEL", "nvidia/Nemotron-H-8B-Base"),
+    _Case("qwen3_next", "TL_QWEN3_NEXT_MODEL", "Qwen/Qwen3-Next-80B-A3B-Instruct"),
+    _Case("qwen3_5", "TL_QWEN3_5_MODEL", ""),
+]
+
+
+def _device() -> str:
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+@pytest.fixture(scope="module", params=CASES, ids=lambda c: c.label)
+def bridge(request):
+    """Load one family's real checkpoint, or skip if it can't be obtained."""
+    case: _Case = request.param
+    model_id = os.environ.get(case.env, case.default)
+    if not model_id:
+        pytest.skip(f"no default checkpoint for {case.label}; set {case.env} to run")
+    try:
+        # float32 (not bf16) so the reconstruction-faithfulness tolerances hold.
+        br = TransformerBridge.boot_transformers(model_id, device=_device(), dtype=torch.float32)
+    except pytest.skip.Exception:
+        raise
+    except Exception as e:  # availability gate: network / missing arch / OOM / gated repo
+        pytest.skip(f"{case.label} checkpoint {model_id!r} unavailable: {type(e).__name__}: {e}")
+    yield br
+    del br
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    gc.collect()
+
+
+@pytest.fixture(scope="module")
+def tokens():
+    # Small ids valid for every real vocab; short seq keeps the O(seq^2)/O(seq) work cheap.
+    return torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
+
+
+@pytest.fixture(scope="module")
+def cache(bridge, tokens):
+    # use_cache=False forces the hooked prefill path so gated-delta-net interior hooks fire.
+    with torch.no_grad():
+        _, c = bridge.run_with_cache(tokens.to(_device()), use_cache=False)
+    return c
+
+
+def _realized_ssm_mixers(bridge):
+    """The realized SSM mixers (find_ssm_mixer excludes hybrid passthrough slots)."""
+    from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
+        find_ssm_mixer,
+    )
+
+    out = []
+    for block in bridge.blocks:
+        mixer = find_ssm_mixer(block)
+        if mixer is not None:
+            out.append(mixer)
+    return out
+
+
+class TestRealWeightSSMSurface:
+    def test_ssm_layers_nonempty(self, cache):
+        layers = cache.ssm_layers()
+        assert layers == sorted(layers)
+        assert len(layers) > 0, "a recurrent model must expose at least one SSM layer"
+
+    def test_compute_ssm_state_finite(self, cache, tokens):
+        state = cache.compute_ssm_state()
+        mats = list(state.values()) if isinstance(state, dict) else [state[i] for i in range(state.shape[0])]
+        assert len(mats) == len(cache.ssm_layers())
+        for S in mats:
+            assert torch.isfinite(S).all()
+            # batch dim leads; a seq axis of the right length is present somewhere.
+            assert S.shape[0] == tokens.shape[0]
+            assert tokens.shape[1] in tuple(S.shape)
+
+    def test_effective_attention_finite_causal(self, cache, tokens):
+        M = cache.compute_ssm_effective_attention()
+        mats = list(M.values()) if isinstance(M, dict) else [M[i] for i in range(M.shape[0])]
+        seq = tokens.shape[1]
+        upper = torch.triu(torch.ones(seq, seq, dtype=torch.bool), diagonal=1)
+        for m in mats:
+            assert m.shape[-1] == m.shape[-2] == seq
+            assert torch.isfinite(m).all()
+            assert torch.all(m[..., upper] == 0), "effective attention must be causal"
+
+    def test_eager_scan_matches_fused(self, bridge, tokens):
+        """Reimplemented eager recurrence must reproduce the fused-kernel logits.
+
+        Enables eager_scan on every realized SSM mixer (Mamba-1/2, gated-delta-net,
+        and the SSM2-wired hybrid mixers) and compares to the default fused path on
+        real trained weights — the end-to-end faithfulness gate for the intervention
+        surface.
+        """
+        mixers = [m for m in _realized_ssm_mixers(bridge) if hasattr(type(m), "eager_scan")]
+        if not mixers:
+            pytest.skip("no eager-scan-capable SSM mixers in this model")
+
+        toks = tokens.to(_device())
+        with torch.no_grad():
+            fused = bridge(toks, use_cache=False)
+            for m in mixers:
+                m.eager_scan = True
+            try:
+                eager = bridge(toks, use_cache=False)
+            finally:
+                for m in mixers:
+                    m.eager_scan = False
+        rel = (eager.float() - fused.float()).abs().max().item() / max(
+            fused.float().abs().max().item(), 1e-8
+        )
+        assert rel < 2e-2, f"eager vs fused logit parity rel diff {rel:.2e}"

--- a/tests/integration/model_bridge/test_ssm_real_weights.py
+++ b/tests/integration/model_bridge/test_ssm_real_weights.py
@@ -39,7 +39,7 @@ CASES = [
     _Case("mamba1", "TL_MAMBA1_MODEL", "state-spaces/mamba-130m-hf"),
     _Case("mamba2", "TL_MAMBA2_MODEL", "AntonV/mamba2-130m-hf"),
     _Case("granite", "TL_GRANITE_MODEL", "ibm-granite/granite-4.0-tiny-preview"),
-    _Case("nemotron_h", "TL_NEMOTRON_H_MODEL", "nvidia/Nemotron-H-8B-Base"),
+    _Case("nemotron_h", "TL_NEMOTRON_H_MODEL", "nvidia/NVIDIA-Nemotron-Nano-9B-v2"),
     _Case("qwen3_next", "TL_QWEN3_NEXT_MODEL", "Qwen/Qwen3-Next-80B-A3B-Instruct"),
     _Case("qwen3_5", "TL_QWEN3_5_MODEL", ""),
 ]

--- a/tests/mps/test_mps_ssm_eager_scan.py
+++ b/tests/mps/test_mps_ssm_eager_scan.py
@@ -1,0 +1,82 @@
+"""MPS regression test for the SSM2 eager-scan intervention path (device correctness).
+
+The eager scan builds its recurrent ``ssm_state`` accumulator explicitly; if that
+tensor is created on the default CPU device instead of the input's device, the
+recurrence ``decay * ssm_state + writes`` crashes on any non-CPU model. This test
+guards that on Metal. Skips on non-MPS runners; runs in the `mps-checks` CI job.
+"""
+
+import gc
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(
+    not torch.backends.mps.is_available(),
+    reason="MPS not available on this runner — skipping Apple Silicon SSM tests",
+)
+
+
+class _Tok:
+    pass
+
+
+def _tiny_mamba2_bridge():
+    """Tiny synthetic Mamba-2 bridge (float32, no Hub download), built on CPU."""
+    from transformers import AutoModelForCausalLM
+    from transformers.models.mamba2 import Mamba2Config
+
+    from transformer_lens.model_bridge.bridge import TransformerBridge
+    from transformer_lens.model_bridge.sources._bridge_builder import (
+        build_bridge_config_from_hf,
+    )
+    from transformer_lens.model_bridge.supported_architectures.mamba2 import (
+        Mamba2ArchitectureAdapter,
+    )
+
+    torch.manual_seed(0)
+    cfg = Mamba2Config(
+        vocab_size=128,
+        hidden_size=32,
+        num_hidden_layers=2,
+        state_size=16,
+        expand=2,
+        head_dim=16,
+        num_heads=4,
+        n_groups=2,
+        conv_kernel=4,
+        chunk_size=8,
+    )
+    cfg.architectures = ["Mamba2ForCausalLM"]
+    hf = AutoModelForCausalLM.from_config(cfg).to(torch.float32).eval()
+    bridge_cfg = build_bridge_config_from_hf(hf.config, "Mamba2ForCausalLM", "x", torch.float32)
+    return TransformerBridge(hf, Mamba2ArchitectureAdapter(bridge_cfg), tokenizer=_Tok())
+
+
+def test_mps_eager_scan_runs_on_metal():
+    """eager_scan=True must run on MPS (ssm_state created on the input's device) and
+    match the CPU fused kernel, with the intervention hooks firing on Metal."""
+    bridge = _tiny_mamba2_bridge()
+    tokens = torch.tensor([[1, 2, 3, 4, 5]])
+    with torch.no_grad():
+        cpu_fused = bridge(tokens)
+
+    bridge.original_model.to("mps")
+    for block in bridge.blocks:
+        block.mixer.eager_scan = True
+    tokens_mps = tokens.to("mps")
+
+    with torch.no_grad():
+        out = bridge(tokens_mps, use_cache=False)  # would crash pre-fix (CPU ssm_state)
+        _, cache = bridge.run_with_cache(tokens_mps, use_cache=False)
+
+    assert out.device.type == "mps", f"eager-scan output not on MPS: {out.device}"
+    assert cache["blocks.0.mixer.hook_ssm_write"].device.type == "mps"
+    assert cache["blocks.0.mixer.hook_ssm_state"].device.type == "mps"
+
+    rel = (out.cpu() - cpu_fused).abs().max().item() / max(cpu_fused.abs().max().item(), 1e-8)
+    assert rel < 1e-3, f"MPS eager scan diverges from CPU fused kernel: rel {rel:.2e}"
+
+    del bridge
+    torch.mps.empty_cache()
+    gc.collect()

--- a/tests/unit/model_bridge/supported_architectures/test_granite_moe_hybrid_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_granite_moe_hybrid_adapter.py
@@ -7,6 +7,7 @@ from transformer_lens.model_bridge.generalized_components import (
     BlockBridge,
     DepthwiseConv1DBridge,
     EmbeddingBridge,
+    GatedRMSNormBridge,
     LinearBridge,
     MLPBridge,
     MoEBridge,
@@ -89,6 +90,11 @@ class TestGraniteMoeHybridAdapterConfig:
         assert adapter.cfg.uses_rms_norm is True
         assert adapter.cfg.default_prepend_bos is False
 
+    def test_layers_block_type_surfaced(self, adapter: GraniteMoeHybridArchitectureAdapter) -> None:
+        # Sourced from HF's `layer_types`; exposed uniformly as `layers_block_type`
+        # (matching NemotronH) so analysis tools can find the Mamba layers.
+        assert getattr(adapter.cfg, "layers_block_type", None) == LAYER_TYPES
+
     def test_non_rope_position_embedding_disables_rotary_mapping(self) -> None:
         adapter = GraniteMoeHybridArchitectureAdapter(
             _make_cfg(position_embedding_type="nope", num_experts=4)
@@ -142,7 +148,7 @@ class TestGraniteMoeHybridAdapterComponentMapping:
             "ln1",
             "ln2",
             "attn",
-            "mamba",
+            "mixer",
             "shared_mlp",
             "moe",
         }
@@ -150,14 +156,15 @@ class TestGraniteMoeHybridAdapterComponentMapping:
         assert isinstance(blocks.submodules["ln1"], RMSNormalizationBridge)
         assert isinstance(blocks.submodules["ln2"], RMSNormalizationBridge)
         assert isinstance(blocks.submodules["attn"], PositionEmbeddingsAttentionBridge)
-        assert isinstance(blocks.submodules["mamba"], SSM2MixerBridge)
+        assert isinstance(blocks.submodules["mixer"], SSM2MixerBridge)
         assert isinstance(blocks.submodules["shared_mlp"], MLPBridge)
         assert isinstance(blocks.submodules["moe"], MoEBridge)
 
         assert blocks.submodules["ln1"].name == "input_layernorm"
         assert blocks.submodules["ln2"].name == "post_attention_layernorm"
         assert blocks.submodules["attn"].name == "self_attn"
-        assert blocks.submodules["mamba"].name == "mamba"
+        # Canonical `.mixer` dict key; HF submodule path stays `.mamba`.
+        assert blocks.submodules["mixer"].name == "mamba"
         assert blocks.submodules["shared_mlp"].name == "shared_mlp"
         assert blocks.submodules["moe"].name == "block_sparse_moe"
 
@@ -176,17 +183,18 @@ class TestGraniteMoeHybridAdapterComponentMapping:
             assert isinstance(submodule, LinearBridge)
 
     def test_mamba_mapping(self, adapter: GraniteMoeHybridArchitectureAdapter) -> None:
-        mamba = adapter.component_mapping["blocks"].submodules["mamba"]
-        assert mamba.optional is True
-        assert set(mamba.submodules.keys()) == {"in_proj", "conv1d", "inner_norm"}
+        mixer = adapter.component_mapping["blocks"].submodules["mixer"]
+        assert mixer.optional is True
+        assert set(mixer.submodules.keys()) == {"in_proj", "conv1d", "inner_norm"}
 
-        assert isinstance(mamba.submodules["in_proj"], LinearBridge)
-        assert isinstance(mamba.submodules["conv1d"], DepthwiseConv1DBridge)
-        assert isinstance(mamba.submodules["inner_norm"], LinearBridge)
+        assert isinstance(mixer.submodules["in_proj"], LinearBridge)
+        assert isinstance(mixer.submodules["conv1d"], DepthwiseConv1DBridge)
+        # HF's inner norm is the gated two-input MambaRMSNormGated, not a plain linear.
+        assert isinstance(mixer.submodules["inner_norm"], GatedRMSNormBridge)
 
-        assert mamba.submodules["in_proj"].name == "in_proj"
-        assert mamba.submodules["conv1d"].name == "conv1d"
-        assert mamba.submodules["inner_norm"].name == "norm"
+        assert mixer.submodules["in_proj"].name == "in_proj"
+        assert mixer.submodules["conv1d"].name == "conv1d"
+        assert mixer.submodules["inner_norm"].name == "norm"
 
     def test_shared_mlp_mapping(self, adapter: GraniteMoeHybridArchitectureAdapter) -> None:
         shared_mlp = adapter.component_mapping["blocks"].submodules["shared_mlp"]

--- a/tests/unit/model_bridge/supported_architectures/test_nemotron_h_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_nemotron_h_adapter.py
@@ -113,9 +113,8 @@ class TestNemotronHAdapterConfig:
         # intermediate=32, n_groups=2, ssm_state_size=4 → 32 + 2*2*4 = 48
         assert getattr(adapter.cfg, "conv_dim", None) == 48
 
-    def test_applicable_phases_empty(self) -> None:
-        # verify_models is transformer-shaped; SSM hybrids skip it.
-        assert NemotronHArchitectureAdapter.applicable_phases == []
+    def test_applicable_phases_full(self) -> None:
+        assert NemotronHArchitectureAdapter.applicable_phases == [1, 2, 3, 4]
 
     def test_weight_processing_conversions_empty(
         self, adapter: NemotronHArchitectureAdapter

--- a/tests/unit/model_bridge/supported_architectures/test_qwen3_5_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_qwen3_5_adapter.py
@@ -1059,3 +1059,95 @@ class TestQwen3_5GatedDeltaNetEagerScan:
                 _ = bridge(tokens, use_cache=False)
             after = bridge(tokens, use_cache=False)
         assert torch.equal(first, after)
+
+
+def _make_tiny_gqa_bridge():
+    """Qwen3_5 bridge with n_v_heads (4) > n_k_heads (2) to exercise the GDN GQA branch.
+
+    The default _make_tiny_bridge uses n_k==n_v==4, so the repeat_interleave GQA
+    expansion in GatedDeltaNetBridge._hooked_forward never runs. Here Q/K carry 2
+    heads and V carries 4, so the recurrence path must expand Q/K 2x.
+    """
+    from unittest.mock import MagicMock
+
+    from transformer_lens.config.transformer_bridge_config import (
+        TransformerBridgeConfig,
+    )
+    from transformer_lens.model_bridge import TransformerBridge
+    from transformer_lens.model_bridge.supported_architectures.qwen3_5 import (
+        Qwen3_5ArchitectureAdapter,
+    )
+
+    cfg = Qwen3_5TextConfig(
+        hidden_size=128,
+        num_hidden_layers=8,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        intermediate_size=256,
+        vocab_size=512,
+        full_attention_interval=4,
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=32,
+        linear_value_head_dim=32,
+        linear_num_key_heads=2,  # < value heads -> GQA expansion required
+        linear_num_value_heads=4,
+        rope_parameters={
+            "rope_theta": 10000.0,
+            "partial_rotary_factor": 0.25,
+            "rope_type": "default",
+        },
+    )
+    hf_model = _Qwen3_5ForCausalLM(cfg).eval()
+    bridge_cfg = TransformerBridgeConfig(
+        d_model=128,
+        d_head=32,
+        n_heads=4,
+        n_layers=8,
+        n_ctx=2048,
+        d_vocab=512,
+        n_key_value_heads=2,
+        architecture="Qwen3_5ForCausalLM",
+    )
+    return (
+        TransformerBridge(hf_model, Qwen3_5ArchitectureAdapter(bridge_cfg), tokenizer=MagicMock()),
+        hf_model,
+    )
+
+
+@pytest.mark.skipif(
+    not _QWEN3_5_AVAILABLE,
+    reason="Qwen3_5TextConfig / Qwen3_5ForCausalLM not available in installed transformers",
+)
+class TestQwen3_5GatedDeltaNetGQA:
+    """Cover the GDN GQA expansion (n_v_heads > n_k_heads) in CI, not just env-gated
+    real-weight tests. Forward parity requires the Q/K repeat_interleave to be correct."""
+
+    LINEAR_LAYER = 0
+
+    def test_gqa_branch_engaged_and_parity(self):
+        import torch
+
+        bridge, hf = _make_tiny_gqa_bridge()
+        assert hf.config.linear_num_value_heads > hf.config.linear_num_key_heads  # GQA active
+        torch.manual_seed(0)
+        tokens = torch.randint(0, 512, (1, 10))
+        with torch.no_grad():
+            bridge_logits = bridge(tokens, use_cache=False)
+            hf_logits = hf(tokens).logits
+        rel = (bridge_logits.float() - hf_logits.float()).abs().max().item() / max(
+            hf_logits.float().abs().max().item(), 1e-8
+        )
+        assert rel < 1e-4, f"GQA GDN forward parity rel diff {rel:.2e}"
+
+    def test_gqa_hook_head_counts(self):
+        """hook_q is pre-GQA (n_k_heads); hook_recurrence_out is post-expansion (n_v_heads)."""
+        import torch
+
+        bridge, hf = _make_tiny_gqa_bridge()
+        tokens = torch.randint(0, 512, (1, 8))
+        with torch.no_grad():
+            _, cache = bridge.run_with_cache(tokens, use_cache=False)
+        p = f"blocks.{self.LINEAR_LAYER}.linear_attn"
+        assert cache[f"{p}.hook_q"].shape[2] == hf.config.linear_num_key_heads
+        assert cache[f"{p}.hook_recurrence_out"].shape[2] == hf.config.linear_num_value_heads

--- a/tests/unit/model_bridge/supported_architectures/test_qwen3_5_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_qwen3_5_adapter.py
@@ -785,3 +785,277 @@ class TestQwen3_5GatedDeltaNetEffectiveAttention:
             f"L2-norm approximation divergence {rel:.3f} outside the documented ~1.0 "
             "band for the random-init fixture; update the docstring if the model changed."
         )
+
+
+@pytest.mark.skipif(
+    not _QWEN3_5_AVAILABLE,
+    reason="Qwen3_5TextConfig / Qwen3_5ForCausalLM not available in installed transformers",
+)
+class TestQwen3_5GatedDeltaNetState:
+    """Faithful recurrent-state reconstruction + eager-scan interventions for GDN.
+
+    Unlike compute_effective_attention (a gated-linear-attention heuristic that drops
+    key removal), compute_ssm_state replays the *full* delta rule, so ``S_t^T q_t``
+    must reconstruct the fused kernel's hook_recurrence_out to fp tolerance.
+    """
+
+    LINEAR_LAYER = 0  # full-attn lands at 3 and 7 (interval=4); 0 is GatedDeltaNet
+    SEQ_LEN = 10
+
+    @pytest.fixture(scope="class")
+    def bridge(self):
+        br, _ = _make_tiny_bridge()
+        return br
+
+    @pytest.fixture(scope="class")
+    def cache(self, bridge):
+        import torch
+
+        torch.manual_seed(0)
+        tokens = torch.randint(0, 512, (2, self.SEQ_LEN))
+        with torch.no_grad():
+            _, cache = bridge.run_with_cache(tokens, use_cache=False)
+        return cache
+
+    @staticmethod
+    def _ref_scan(cache, layer, dtype):
+        """Independent gated-delta-rule scan from cached hooks (not the impl).
+
+        Uses the kernel's L2-norm convention (eps=1e-6) so the only differences vs
+        the impl are reduction order (fp32) and precision (fp64).
+        """
+        import torch
+
+        def l2norm(x):
+            return x / torch.sqrt((x * x).sum(-1, keepdim=True) + 1e-6)
+
+        prefix = f"blocks.{layer}.linear_attn"
+        q = cache[f"{prefix}.hook_q"].to(dtype)
+        k = cache[f"{prefix}.hook_k"].to(dtype)
+        v = cache[f"{prefix}.hook_v"].to(dtype)
+        beta = cache[f"{prefix}.hook_beta"].to(dtype)
+        g = cache[f"{prefix}.hook_log_decay"].to(dtype)
+        n_v = v.shape[2]
+        if q.shape[2] < n_v:
+            rep = n_v // q.shape[2]
+            q, k = q.repeat_interleave(rep, dim=2), k.repeat_interleave(rep, dim=2)
+        q = l2norm(q) * (q.shape[-1] ** -0.5)
+        k = l2norm(k)
+        b, seq, _, kd = q.shape
+        vd = v.shape[-1]
+        state = torch.zeros(b, n_v, kd, vd, dtype=dtype)
+        states, outs = [], []
+        for t in range(seq):
+            state = state * g[:, t].exp()[:, :, None, None]
+            kv = (state * k[:, t][:, :, :, None]).sum(-2)
+            delta = (v[:, t] - kv) * beta[:, t][:, :, None]
+            state = state + k[:, t][:, :, :, None] * delta[:, :, None, :]
+            states.append(state)
+            outs.append((state * q[:, t][:, :, :, None]).sum(-2))
+        return torch.stack(states, 1), torch.stack(outs, 1)
+
+    def test_requires_use_cache_false(self, bridge):
+        """Default cache path omits interior hooks -> compute_ssm_state raises."""
+        import torch
+
+        tokens = torch.randint(0, 512, (1, self.SEQ_LEN))
+        with torch.no_grad():
+            _, cache = bridge.run_with_cache(tokens)  # default: cache allocated
+        mixer = bridge.blocks[self.LINEAR_LAYER].linear_attn
+        with pytest.raises(RuntimeError, match="in cache"):
+            mixer.compute_ssm_state(cache, layer_idx=self.LINEAR_LAYER)
+
+    def test_state_shape(self, bridge, cache):
+        mixer = bridge.blocks[self.LINEAR_LAYER].linear_attn
+        S = mixer.compute_ssm_state(cache, layer_idx=self.LINEAR_LAYER)
+        # [batch, seq, n_v_heads, head_k_dim, head_v_dim]
+        assert S.ndim == 5
+        assert S.shape[1] == self.SEQ_LEN
+        assert S.shape[2] == cache[f"blocks.{self.LINEAR_LAYER}.linear_attn.hook_v"].shape[2]
+
+    def test_reconstructs_recurrence_out(self, bridge, cache):
+        """o_t = S_t^T q_t must match the fused kernel's hook_recurrence_out (faithful)."""
+        import torch
+
+        mixer = bridge.blocks[self.LINEAR_LAYER].linear_attn
+        S = mixer.compute_ssm_state(cache, layer_idx=self.LINEAR_LAYER)
+        # o_t from the impl's own state, using the impl's normalized/scaled q.
+        prefix = f"blocks.{self.LINEAR_LAYER}.linear_attn"
+        q = cache[f"{prefix}.hook_q"].float()
+        n_v = cache[f"{prefix}.hook_v"].shape[2]
+        if q.shape[2] < n_v:
+            q = q.repeat_interleave(n_v // q.shape[2], dim=2)
+        q = mixer._l2norm(q) * (q.shape[-1] ** -0.5)
+        o = torch.einsum("bshkv,bshk->bshv", S, q)
+        rec = cache[f"{prefix}.hook_recurrence_out"].float()
+        rel = (o - rec).abs().max().item() / max(rec.abs().max().item(), 1e-8)
+        assert rel < 1e-4, f"delta-rule state reconstruction rel diff {rel:.2e}"
+
+    def test_impl_matches_independent_reference(self, bridge, cache):
+        """The impl state must match an independent reimplementation of the scan.
+
+        The impl works in fp32 by design, so it is compared to a fp32 reference at
+        tight tolerance (independent-algorithm check, only reduction-order noise).
+        The residual against a fp64 reference is then shown to be no larger than
+        fp32's own rounding gap — i.e. the impl adds no error beyond its working
+        precision (an actual algorithm bug would be O(1), not fp32-scale).
+        """
+        import torch
+
+        mixer = bridge.blocks[self.LINEAR_LAYER].linear_attn
+        S = mixer.compute_ssm_state(cache, layer_idx=self.LINEAR_LAYER).float()
+        S_ref32, _ = self._ref_scan(cache, self.LINEAR_LAYER, torch.float32)
+        S_ref64, _ = self._ref_scan(cache, self.LINEAR_LAYER, torch.float64)
+
+        denom = max(S_ref64.abs().max().item(), 1e-12)
+        rel32 = (S - S_ref32).abs().max().item() / denom
+        assert rel32 < 1e-5, f"impl vs independent fp32 reference rel diff {rel32:.2e}"
+
+        # fp64 gap of the impl vs fp64 gap of the fp32 reference: comparable ⇒ fp32 noise.
+        impl_vs_fp64 = (S.double() - S_ref64).abs().max().item() / denom
+        ref_fp32_vs_fp64 = (S_ref32.double() - S_ref64).abs().max().item() / denom
+        assert impl_vs_fp64 <= 4 * ref_fp32_vs_fp64 + 1e-6, (
+            f"impl fp64 gap {impl_vs_fp64:.2e} exceeds fp32 rounding gap "
+            f"{ref_fp32_vs_fp64:.2e} — not attributable to fp32 accumulation"
+        )
+
+    def test_time_step_matches_full(self, bridge, cache):
+        import torch
+
+        mixer = bridge.blocks[self.LINEAR_LAYER].linear_attn
+        S = mixer.compute_ssm_state(cache, layer_idx=self.LINEAR_LAYER)
+        for t in (0, self.SEQ_LEN // 2, self.SEQ_LEN - 1):
+            St = mixer.compute_ssm_state(cache, layer_idx=self.LINEAR_LAYER, time_step=t)
+            assert torch.equal(St, S[:, t])
+
+
+@pytest.mark.skipif(
+    not _QWEN3_5_AVAILABLE,
+    reason="Qwen3_5TextConfig / Qwen3_5ForCausalLM not available in installed transformers",
+)
+class TestQwen3_5GatedDeltaNetEagerScan:
+    """Opt-in eager_scan path: fused-kernel parity, hook_ssm_state interventions."""
+
+    LINEAR_LAYER = 0
+    SEQ_LEN = 10
+
+    @pytest.fixture(scope="class")
+    def bridge(self):
+        br, _ = _make_tiny_bridge()
+        return br
+
+    @pytest.fixture(scope="class")
+    def tokens(self):
+        import torch
+
+        torch.manual_seed(0)
+        return torch.randint(0, 512, (2, self.SEQ_LEN))
+
+    @staticmethod
+    def _eager(bridge):
+        import contextlib
+
+        from transformer_lens.model_bridge.generalized_components import (
+            GatedDeltaNetBridge,
+        )
+
+        @contextlib.contextmanager
+        def _ctx():
+            mixers = [
+                b.linear_attn
+                for b in bridge.blocks
+                if isinstance(getattr(b, "linear_attn", None), GatedDeltaNetBridge)
+            ]
+            for m in mixers:
+                m.eager_scan = True
+            try:
+                yield
+            finally:
+                for m in mixers:
+                    m.eager_scan = False
+
+        return _ctx()
+
+    def test_default_path_has_no_state_hook(self, bridge, tokens):
+        import torch
+
+        with torch.no_grad():
+            _, cache = bridge.run_with_cache(tokens, use_cache=False)
+        assert not any("hook_ssm_state" in k for k in cache)
+
+    def test_eager_scan_matches_fused(self, bridge, tokens):
+        """Eager delta-rule scan reproduces the fused-kernel logits to fp tolerance."""
+        import torch
+
+        with torch.no_grad():
+            base = bridge(tokens, use_cache=False)
+            with self._eager(bridge):
+                eager = bridge(tokens, use_cache=False)
+        rel = (eager.float() - base.float()).abs().max().item() / max(
+            base.float().abs().max().item(), 1e-8
+        )
+        assert rel < 1e-3, f"eager vs fused logit parity rel diff {rel:.2e}"
+
+    def test_eager_scan_fires_state_hook(self, bridge, tokens):
+        import torch
+
+        captured = {}
+
+        def _grab(t, hook):
+            captured["shape"] = tuple(t.shape)
+            return t
+
+        with self._eager(bridge):
+            with torch.no_grad():
+                bridge.run_with_hooks(
+                    tokens,
+                    use_cache=False,
+                    fwd_hooks=[(f"blocks.{self.LINEAR_LAYER}.linear_attn.hook_ssm_state", _grab)],
+                )
+        assert captured.get("shape") is not None
+        assert captured["shape"][1] == self.SEQ_LEN and len(captured["shape"]) == 5
+
+    def test_state_patch_changes_logits(self, bridge, tokens):
+        """Zeroing the state trajectory (hook_ssm_state) must change the output."""
+        import torch
+
+        def _zero(t, hook):
+            return torch.zeros_like(t)
+
+        with self._eager(bridge):
+            with torch.no_grad():
+                base = bridge(tokens, use_cache=False)
+                patched = bridge.run_with_hooks(
+                    tokens,
+                    use_cache=False,
+                    fwd_hooks=[(f"blocks.{self.LINEAR_LAYER}.linear_attn.hook_ssm_state", _zero)],
+                )
+        assert (patched.float() - base.float()).abs().max().item() > 1e-4
+
+    def test_write_knockout_via_beta_alias(self, bridge, tokens):
+        """hook_ssm_write (alias -> hook_beta) knockout propagates through the scan."""
+        import torch
+
+        def _zero(t, hook):
+            return torch.zeros_like(t)
+
+        with self._eager(bridge):
+            with torch.no_grad():
+                base = bridge(tokens, use_cache=False)
+                ko = bridge.run_with_hooks(
+                    tokens,
+                    use_cache=False,
+                    fwd_hooks=[(f"blocks.{self.LINEAR_LAYER}.linear_attn.hook_ssm_write", _zero)],
+                )
+        assert (ko.float() - base.float()).abs().max().item() > 1e-4
+
+    def test_disabling_restores_default(self, bridge, tokens):
+        """Toggling eager_scan off must return bit-identical fused-path logits."""
+        import torch
+
+        with torch.no_grad():
+            first = bridge(tokens, use_cache=False)
+            with self._eager(bridge):
+                _ = bridge(tokens, use_cache=False)
+            after = bridge(tokens, use_cache=False)
+        assert torch.equal(first, after)

--- a/tests/unit/model_bridge/supported_architectures/test_qwen3_5_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_qwen3_5_adapter.py
@@ -680,3 +680,108 @@ class TestQwen3_5Integration:
                 f"Expected {hook_name} shape ({batch}, {seq}, {d_model}), "
                 f"got {activations[0].shape}"
             )
+
+
+@pytest.mark.skipif(
+    not _QWEN3_5_AVAILABLE,
+    reason="Qwen3_5TextConfig / Qwen3_5ForCausalLM not available in installed transformers",
+)
+class TestQwen3_5GatedDeltaNetEffectiveAttention:
+    """Faithfulness gate for GatedDeltaNetBridge.compute_effective_attention.
+
+    The reconstruction is a documented heuristic: (1) interior hooks fire only on
+    the hooked prefill path (use_cache=False); (2) the hooked Q/K are pre-norm
+    while the kernel L2-normalizes them; (3) the gated-linear-attention form omits
+    the delta rule's key-removal term. These tests pin the measured divergences.
+    """
+
+    LINEAR_LAYER = 0  # full-attn lands at 3 and 7 (interval=4); 0 is GatedDeltaNet
+    SEQ_LEN = 12
+
+    @pytest.fixture(scope="class")
+    def bridge(self):
+        br, _ = _make_tiny_bridge()
+        return br
+
+    @pytest.fixture(scope="class")
+    def cache(self, bridge):
+        import torch
+
+        torch.manual_seed(0)
+        tokens = torch.randint(0, 512, (1, self.SEQ_LEN))
+        with torch.no_grad():
+            # use_cache=False forces the hooked prefill path so interior hooks fire.
+            _, cache = bridge.run_with_cache(tokens, use_cache=False)
+        return cache
+
+    @staticmethod
+    def _build_M(cache, layer, *, l2norm, dtype):
+        """Recompute M from cached hooks, independent of the bridge impl."""
+        import torch
+        import torch.nn.functional as F
+
+        prefix = f"blocks.{layer}.linear_attn"
+        q = cache[f"{prefix}.hook_q"].to(dtype)
+        k = cache[f"{prefix}.hook_k"].to(dtype)
+        beta = cache[f"{prefix}.hook_beta"].to(dtype)
+        g = cache[f"{prefix}.hook_log_decay"].to(dtype)
+        if l2norm:
+            q, k = F.normalize(q, p=2, dim=-1), F.normalize(k, p=2, dim=-1)
+        if q.shape[2] < beta.shape[-1]:
+            rep = beta.shape[-1] // q.shape[2]
+            q, k = q.repeat_interleave(rep, dim=2), k.repeat_interleave(rep, dim=2)
+        qk = torch.matmul(q.permute(0, 2, 1, 3), k.permute(0, 2, 1, 3).transpose(-2, -1))
+        cum = torch.cumsum(g.permute(0, 2, 1), dim=-1)
+        L_log = cum[:, :, :, None] - cum[:, :, None, :]
+        seq = q.shape[1]
+        mask = torch.tril(torch.ones(seq, seq, dtype=torch.bool))
+        L = torch.where(mask[None, None], torch.exp(L_log), torch.zeros_like(L_log))
+        return qk * beta.permute(0, 2, 1)[:, :, None, :] * L
+
+    def test_requires_use_cache_false(self, bridge):
+        """Default cache path omits interior hooks -> compute_effective_attention raises."""
+        import torch
+
+        tokens = torch.randint(0, 512, (1, self.SEQ_LEN))
+        with torch.no_grad():
+            _, cache = bridge.run_with_cache(tokens)  # default: cache allocated
+        mixer = bridge.blocks[self.LINEAR_LAYER].linear_attn
+        with pytest.raises(RuntimeError, match="in cache"):
+            mixer.compute_effective_attention(cache, layer_idx=self.LINEAR_LAYER)
+
+    def test_shape_causal_finite(self, bridge, cache):
+        import torch
+
+        mixer = bridge.blocks[self.LINEAR_LAYER].linear_attn
+        M = mixer.compute_effective_attention(cache, layer_idx=self.LINEAR_LAYER)
+        assert M.ndim == 4 and M.shape[-1] == M.shape[-2] == self.SEQ_LEN
+        assert torch.isfinite(M).all()
+        upper = torch.triu(torch.ones(self.SEQ_LEN, self.SEQ_LEN, dtype=torch.bool), diagonal=1)
+        assert torch.all(M[..., upper] == 0), "effective attention must be causal"
+
+    def test_impl_matches_fp64_reference(self, bridge, cache):
+        """The impl must match its own fp64 recomputation (no numerical/algorithm bug)."""
+        import torch
+
+        mixer = bridge.blocks[self.LINEAR_LAYER].linear_attn
+        M = mixer.compute_effective_attention(cache, layer_idx=self.LINEAR_LAYER)
+        M_ref = self._build_M(cache, self.LINEAR_LAYER, l2norm=False, dtype=torch.float64)
+        rel = (M.double() - M_ref).abs().max().item() / max(M_ref.abs().max().item(), 1e-12)
+        assert rel < 1e-5, f"impl vs fp64 pre-norm reference rel diff {rel:.2e}"
+
+    def test_l2norm_approximation_divergence_measured(self, bridge, cache):
+        """Pin the L2-norm approximation divergence (documented in the docstring).
+
+        The hooked Q/K are pre-norm; the kernel L2-normalizes them. On the random-
+        init fixture (small, non-uniform Q/K norms) the relative divergence is ~1.0.
+        """
+        import torch
+
+        M_prenorm = self._build_M(cache, self.LINEAR_LAYER, l2norm=False, dtype=torch.float64)
+        M_l2 = self._build_M(cache, self.LINEAR_LAYER, l2norm=True, dtype=torch.float64)
+        rel = (M_prenorm - M_l2).abs().max().item() / max(M_l2.abs().max().item(), 1e-12)
+        assert torch.isfinite(torch.tensor(rel))
+        assert 0.5 < rel < 1.5, (
+            f"L2-norm approximation divergence {rel:.3f} outside the documented ~1.0 "
+            "band for the random-init fixture; update the docstring if the model changed."
+        )

--- a/tests/unit/tools/model_registry/test_verify_gates.py
+++ b/tests/unit/tools/model_registry/test_verify_gates.py
@@ -1,0 +1,100 @@
+"""Cheap pure-function unit tests for the verify_models control-gates.
+
+These gates were previously exercised only by multi-hour real-model runs, so a slot-name
+drift or a phase-filter regression would slip through CI. They are pure functions, so we
+pin them directly:
+- ``_phases_to_run`` — restricts requested phases to the adapter's ``applicable_phases``
+  (SSM/recurrent families now run all four); phases 7/8 always pass through.
+- ``_extract_phase_scores`` — per-phase pass-rate, with SKIPPED results excluded.
+- ``_is_ssm_mixer_internal`` — the component-benchmark skip for SSM mixer internals.
+"""
+from types import SimpleNamespace
+
+from transformer_lens.benchmarks.component_outputs import _is_ssm_mixer_internal
+from transformer_lens.benchmarks.utils import BenchmarkSeverity
+from transformer_lens.tools.model_registry.verify_models import (
+    _extract_phase_scores,
+    _phases_to_run,
+)
+
+SSM_ARCHS = ["MambaForCausalLM", "Mamba2ForCausalLM", "NemotronHForCausalLM"]
+
+
+class TestPhasesToRun:
+    def test_ssm_families_run_all_four_phases(self):
+        # Regression guard: SSM/hybrid families are no longer skipped or [4]-only.
+        for arch in SSM_ARCHS:
+            assert _phases_to_run(arch, [1, 2, 3, 4]) == [1, 2, 3, 4]
+
+    def test_phases_7_and_8_always_pass_through(self):
+        # 7/8 are gated by is_multimodal/is_audio elsewhere, never filtered here.
+        assert _phases_to_run("MambaForCausalLM", [1, 7, 8]) == [1, 7, 8]
+
+    def test_unknown_architecture_defaults_to_all_phases(self):
+        assert _phases_to_run("NotARealArchitecture", [1, 2, 3, 4]) == [1, 2, 3, 4]
+
+    def test_restricted_architecture_is_filtered(self):
+        # Find any adapter with a restricted applicable_phases and confirm filtering.
+        from transformer_lens.factories.architecture_adapter_factory import (
+            SUPPORTED_ARCHITECTURES,
+        )
+
+        restricted = None
+        for name, adapter in SUPPORTED_ARCHITECTURES.items():
+            phases = getattr(adapter, "applicable_phases", [1, 2, 3, 4])
+            if phases and set(phases) != {1, 2, 3, 4}:
+                restricted = (name, phases)
+                break
+        if restricted is None:
+            return  # no restricted-phase adapter in the registry; nothing to assert
+        name, phases = restricted
+        result = _phases_to_run(name, [1, 2, 3, 4])
+        assert result == [p for p in [1, 2, 3, 4] if p in phases]
+        assert set(result) <= set(phases)
+
+
+def _result(phase, passed, severity, details=None):
+    return SimpleNamespace(phase=phase, passed=passed, severity=severity, details=details)
+
+
+class TestExtractPhaseScores:
+    def test_skipped_results_excluded_from_score(self):
+        # A SKIPPED centering test (passed=False) must NOT drag the phase down — this is
+        # exactly the SSM P3=90 bug. One real PASS + one SKIPPED → 100.
+        results = [
+            _result(3, True, BenchmarkSeverity.INFO),
+            _result(3, False, BenchmarkSeverity.SKIPPED),
+        ]
+        assert _extract_phase_scores(results)[3] == 100.0
+
+    def test_mixed_pass_fail_averaged(self):
+        results = [
+            _result(1, True, BenchmarkSeverity.INFO),
+            _result(1, False, BenchmarkSeverity.DANGER),
+        ]
+        assert _extract_phase_scores(results)[1] == 50.0
+
+    def test_all_skipped_phase_omitted(self):
+        results = [_result(2, False, BenchmarkSeverity.SKIPPED)]
+        assert 2 not in _extract_phase_scores(results)
+
+    def test_phase4_uses_quality_score_from_details(self):
+        results = [_result(4, True, BenchmarkSeverity.INFO, details={"score": 87.5})]
+        assert _extract_phase_scores(results)[4] == 87.5
+
+
+class TestIsSSMMixerInternal:
+    def test_mixer_and_linear_attn_internals_skipped(self):
+        assert _is_ssm_mixer_internal("blocks.0.mixer.conv1d")
+        assert _is_ssm_mixer_internal("blocks.5.mixer.in_proj")
+        assert _is_ssm_mixer_internal("blocks.0.linear_attn.conv1d")
+        assert _is_ssm_mixer_internal("blocks.0.mixer.conv1d.weight")
+
+    def test_mixer_node_itself_is_tested(self):
+        # The mixer node (path ending in the slot) is still benchmarked end-to-end.
+        assert not _is_ssm_mixer_internal("blocks.0.mixer")
+        assert not _is_ssm_mixer_internal("blocks.0.linear_attn")
+
+    def test_transformer_components_untouched(self):
+        for path in ("blocks.0.attn.q", "blocks.0.mlp.out", "embed", "unembed", "ln_final"):
+            assert not _is_ssm_mixer_internal(path)

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -754,7 +754,7 @@ class ActivationCache:
             # Sum over d_head to get the contribution of each head to the residual stream
             self.cache_dict[f"blocks.{layer}.attn.hook_result"] = result.sum(dim=-2)
 
-    def ssm_layers(self, mixer_type: Optional[type] = None) -> List[int]:
+    def ssm_layers(self, mixer_type: Optional[Union[type, Tuple[type, ...]]] = None) -> List[int]:
         """Return the block indices whose mixer is an SSM / recurrent mixer.
 
         Family-agnostic and purely structural: finds each block's *realized* SSM
@@ -788,7 +788,7 @@ class ActivationCache:
     def _over_ssm_layers(
         self,
         fn: Callable[[Any, int], torch.Tensor],
-        mixer_type: Optional[type] = None,
+        mixer_type: Optional[Union[type, Tuple[type, ...]]] = None,
     ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
         """Apply ``fn(mixer, layer_idx)`` over every SSM layer; stack or dict.
 
@@ -883,30 +883,37 @@ class ActivationCache:
     ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
         """Reconstruct the recurrent SSM state ``S`` from this cache.
 
-        The single discovery surface for Mamba-2 recurrent state (only
-        ``SSM2MixerBridge`` reconstructs it), mirroring ``compute_head_results``.
-        Read-only post-hoc reconstruction from the cached in_proj/conv1d hooks (no
-        forward re-run); requires a Mamba-2 / Mamba-2-hybrid bridge cached via
-        ``run_with_cache``. See ``SSM2MixerBridge.compute_ssm_state`` for the
+        The single discovery surface for Mamba-1 / Mamba-2 recurrent state (both
+        ``SSMMixerBridge`` and ``SSM2MixerBridge`` reconstruct it; gated-delta-net
+        has no ``S_t`` reconstruction and is excluded), mirroring
+        ``compute_head_results``. Read-only post-hoc reconstruction from cached
+        hooks (no forward re-run); requires an SSM / SSM-hybrid bridge cached via
+        ``run_with_cache``. See the mixer's ``compute_ssm_state`` for the
         recurrence, shapes, and the ``time_step`` memory bound.
 
         Args:
-            layer: Specific block index, or None for every Mamba-2 layer.
+            layer: Specific block index, or None for every Mamba (SSM-state) layer.
             time_step: Optional single position (memory-bounded); None for all.
 
         Returns:
             A per-layer state tensor for a single ``layer``; for ``layer=None`` a
-            stacked tensor (dim 0 = layer) when every block is a Mamba-2 layer,
-            else a ``{layer_idx: state}`` dict over the Mamba-2 layers.
+            stacked tensor (dim 0 = layer) when every block is a Mamba layer, else
+            a ``{layer_idx: state}`` dict over the Mamba layers.
 
         Raises:
-            TypeError: If the requested ``layer`` has no Mamba-2 mixer.
-            RuntimeError: If ``layer=None`` finds no Mamba-2 layers.
+            TypeError: If the requested ``layer`` has no state-reconstructing Mamba mixer.
+            RuntimeError: If ``layer=None`` finds no such layers.
         """
-        from transformer_lens.model_bridge.generalized_components import SSM2MixerBridge
+        from transformer_lens.model_bridge.generalized_components import (
+            SSM2MixerBridge,
+            SSMMixerBridge,
+        )
         from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
             find_ssm_mixer,
         )
+
+        # Both Mamba families reconstruct S_t; gated-delta-net has no compute_ssm_state.
+        state_mixers = (SSMMixerBridge, SSM2MixerBridge)
 
         def _call(mixer: Any, layer_idx: int) -> torch.Tensor:
             state: torch.Tensor = cast(Any, mixer).compute_ssm_state(
@@ -916,12 +923,13 @@ class ActivationCache:
 
         if layer is not None:
             single = find_ssm_mixer(self.model.blocks[layer])
-            if not isinstance(single, SSM2MixerBridge):
+            if not isinstance(single, state_mixers):
                 raise TypeError(
-                    f"Block {layer} has no Mamba-2 mixer; compute_ssm_state is Mamba-2 only."
+                    f"Block {layer} has no state-reconstructing Mamba mixer; "
+                    "compute_ssm_state supports Mamba-1 / Mamba-2 (not gated-delta-net)."
                 )
             return _call(single, layer)
-        return self._over_ssm_layers(_call, mixer_type=SSM2MixerBridge)
+        return self._over_ssm_layers(_call, mixer_type=state_mixers)
 
     def stack_head_results(
         self,

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -17,6 +17,7 @@ import logging
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -37,7 +38,6 @@ from transformer_lens.utilities import Slice, SliceInput, warn_if_mps
 
 if TYPE_CHECKING:
     from transformer_lens.HookedTransformer import HookedTransformer
-    from transformer_lens.model_bridge.bridge import TransformerBridge
 
 
 def _normalize_projection_to_2d(
@@ -754,37 +754,6 @@ class ActivationCache:
             # Sum over d_head to get the contribution of each head to the residual stream
             self.cache_dict[f"blocks.{layer}.attn.hook_result"] = result.sum(dim=-2)
 
-    def compute_ssm_state(
-        self,
-        layer: Optional[int] = None,
-        time_step: Optional[int] = None,
-    ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
-        """Reconstruct the recurrent SSM state ``S`` from this cache.
-
-        The single discovery surface for Mamba-2 / SSM recurrent state, mirroring
-        ``compute_head_results``. Read-only post-hoc reconstruction from the
-        cached in_proj/conv1d hooks (no forward re-run); requires a
-        ``TransformerBridge`` with SSM layers, cached via ``run_with_cache``. See
-        ``SSM2MixerBridge.compute_ssm_state`` for the recurrence, shapes, and the
-        ``time_step`` memory bound.
-
-        Args:
-            layer: Specific block index, or None for every SSM layer.
-            time_step: Optional single position (memory-bounded); None for all.
-
-        Returns:
-            A per-layer state tensor for a single ``layer``; for ``layer=None`` a
-            stacked tensor (dim 0 = layer) when every block is an SSM layer, else
-            a ``{layer_idx: state}`` dict over the SSM layers.
-        """
-        from transformer_lens.model_bridge.supported_architectures.mamba2 import (
-            compute_ssm_state,
-        )
-
-        return compute_ssm_state(
-            cast("TransformerBridge", self.model), self, layer=layer, time_step=time_step
-        )
-
     def ssm_layers(self, mixer_type: Optional[type] = None) -> List[int]:
         """Return the block indices whose mixer is an SSM / recurrent mixer.
 
@@ -815,6 +784,36 @@ class ActivationCache:
                 continue
             layers.append(i)
         return layers
+
+    def _over_ssm_layers(
+        self,
+        fn: Callable[[Any, int], torch.Tensor],
+        mixer_type: Optional[type] = None,
+    ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
+        """Apply ``fn(mixer, layer_idx)`` over every SSM layer; stack or dict.
+
+        The single SSM layer-enumeration used by both ``compute_ssm_state`` and
+        ``compute_ssm_effective_attention``. Returns a stacked tensor (dim 0 =
+        layer) when *every* block is an SSM layer, else a ``{layer_idx: result}``
+        dict over the SSM layers (heterogeneous hybrids).
+        """
+        from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
+            find_ssm_mixer,
+        )
+
+        bridge = self.model
+        indices = self.ssm_layers(mixer_type=mixer_type)
+        if not indices:
+            raise RuntimeError(
+                "No SSM mixer layers found. Use an SSM / hybrid bridge and "
+                "run_with_cache first (gated-delta-net needs use_cache=False)."
+            )
+        results: Dict[int, torch.Tensor] = {
+            i: fn(cast(Any, find_ssm_mixer(bridge.blocks[i])), i) for i in indices
+        }
+        if indices == list(range(len(bridge.blocks))):
+            return torch.stack([results[i] for i in indices], dim=0)
+        return results
 
     def compute_ssm_effective_attention(
         self,
@@ -870,30 +869,59 @@ class ActivationCache:
             result: torch.Tensor = fn(cache=self, layer_idx=layer_idx, **kwargs)
             return result
 
-        bridge = self.model
         if layer is not None:
-            single = find_ssm_mixer(bridge.blocks[layer])
+            single = find_ssm_mixer(self.model.blocks[layer])
             if single is None:
                 raise TypeError(f"Block {layer} has no SSM mixer (no compute_effective_attention).")
             return _call(single, layer)
+        return self._over_ssm_layers(_call)
 
-        indices = self.ssm_layers()
-        if not indices:
-            raise RuntimeError(
-                "compute_ssm_effective_attention found no SSM layers. Use an SSM "
-                "or hybrid bridge and run_with_cache first (gated-delta-net needs "
-                "run_with_cache(..., use_cache=False))."
+    def compute_ssm_state(
+        self,
+        layer: Optional[int] = None,
+        time_step: Optional[int] = None,
+    ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
+        """Reconstruct the recurrent SSM state ``S`` from this cache.
+
+        The single discovery surface for Mamba-2 recurrent state (only
+        ``SSM2MixerBridge`` reconstructs it), mirroring ``compute_head_results``.
+        Read-only post-hoc reconstruction from the cached in_proj/conv1d hooks (no
+        forward re-run); requires a Mamba-2 / Mamba-2-hybrid bridge cached via
+        ``run_with_cache``. See ``SSM2MixerBridge.compute_ssm_state`` for the
+        recurrence, shapes, and the ``time_step`` memory bound.
+
+        Args:
+            layer: Specific block index, or None for every Mamba-2 layer.
+            time_step: Optional single position (memory-bounded); None for all.
+
+        Returns:
+            A per-layer state tensor for a single ``layer``; for ``layer=None`` a
+            stacked tensor (dim 0 = layer) when every block is a Mamba-2 layer,
+            else a ``{layer_idx: state}`` dict over the Mamba-2 layers.
+
+        Raises:
+            TypeError: If the requested ``layer`` has no Mamba-2 mixer.
+            RuntimeError: If ``layer=None`` finds no Mamba-2 layers.
+        """
+        from transformer_lens.model_bridge.generalized_components import SSM2MixerBridge
+        from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
+            find_ssm_mixer,
+        )
+
+        def _call(mixer: Any, layer_idx: int) -> torch.Tensor:
+            state: torch.Tensor = cast(Any, mixer).compute_ssm_state(
+                self, layer_idx=layer_idx, time_step=time_step
             )
-        results: Dict[int, torch.Tensor] = {}
-        for i in indices:
-            mixer = find_ssm_mixer(bridge.blocks[i])
-            assert mixer is not None  # ssm_layers only returns blocks with a mixer
-            results[i] = _call(mixer, i)
+            return state
 
-        n_blocks = len(bridge.blocks)
-        if indices == list(range(n_blocks)):
-            return torch.stack([results[i] for i in range(n_blocks)], dim=0)
-        return results
+        if layer is not None:
+            single = find_ssm_mixer(self.model.blocks[layer])
+            if not isinstance(single, SSM2MixerBridge):
+                raise TypeError(
+                    f"Block {layer} has no Mamba-2 mixer; compute_ssm_state is Mamba-2 only."
+                )
+            return _call(single, layer)
+        return self._over_ssm_layers(_call, mixer_type=SSM2MixerBridge)
 
     def stack_head_results(
         self,

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -785,6 +785,116 @@ class ActivationCache:
             cast("TransformerBridge", self.model), self, layer=layer, time_step=time_step
         )
 
+    def ssm_layers(self, mixer_type: Optional[type] = None) -> List[int]:
+        """Return the block indices whose mixer is an SSM / recurrent mixer.
+
+        Family-agnostic and purely structural: finds each block's *realized* SSM
+        mixer in its variant slot (``.mixer`` / ``.linear_attn`` / …) via
+        ``find_ssm_mixer``, which excludes a hybrid's passthrough ``.mixer`` on
+        non-SSM layers (e.g. NemotronH attention/MLP/MoE) — no dependence on
+        ``cfg.layers_block_type``.
+
+        Args:
+            mixer_type: Optional concrete bridge class to filter to (e.g.
+                ``SSM2MixerBridge`` for only Mamba-2 layers).
+
+        Returns:
+            Ascending list of SSM block indices.
+        """
+        from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
+            find_ssm_mixer,
+        )
+
+        bridge = self.model
+        layers: List[int] = []
+        for i, block in enumerate(bridge.blocks):
+            mixer = find_ssm_mixer(block)
+            if mixer is None:
+                continue
+            if mixer_type is not None and not isinstance(mixer, mixer_type):
+                continue
+            layers.append(i)
+        return layers
+
+    def compute_ssm_effective_attention(
+        self,
+        layer: Optional[int] = None,
+        include_dt_scaling: bool = False,
+        per_state_coord: bool = False,
+    ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
+        """Materialize SSM effective attention for one or all SSM layers, any family.
+
+        The single discovery surface for effective attention across Mamba-1,
+        Mamba-2, and gated-delta-net layers; dispatches to each layer's mixer
+        ``compute_effective_attention`` regardless of family. Family-specific
+        options are forwarded only to mixers whose signature accepts them.
+
+        Args:
+            layer: Specific block index, or None for every SSM layer.
+            include_dt_scaling: Forwarded to Mamba-1/Mamba-2 mixers (the
+                reconstruction form); gated-delta-net does not accept it.
+            per_state_coord: Forwarded to Mamba-1 only (per-state-coordinate
+                matrices). Setting it True for another family raises ValueError.
+
+        Returns:
+            A per-layer matrix for a single ``layer``; for ``layer=None`` a
+            stacked tensor (dim 0 = layer) when every block is an SSM layer, else
+            a ``{layer_idx: matrix}`` dict over the SSM layers.
+
+        Raises:
+            TypeError: If the requested ``layer`` has no SSM mixer.
+            ValueError: If an option is set that the target mixer does not support.
+            RuntimeError: If ``layer=None`` finds no SSM layers.
+        """
+        import inspect
+
+        from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
+            find_ssm_mixer,
+        )
+
+        def _call(mixer: Any, layer_idx: int) -> torch.Tensor:
+            fn = cast(Any, mixer).compute_effective_attention
+            params = inspect.signature(fn).parameters
+            kwargs: Dict[str, Any] = {}
+            for name, value in (
+                ("include_dt_scaling", include_dt_scaling),
+                ("per_state_coord", per_state_coord),
+            ):
+                if name in params:
+                    kwargs[name] = value
+                elif value:
+                    raise ValueError(
+                        f"{type(mixer).__name__}.compute_effective_attention does not "
+                        f"support {name}=True."
+                    )
+            result: torch.Tensor = fn(cache=self, layer_idx=layer_idx, **kwargs)
+            return result
+
+        bridge = self.model
+        if layer is not None:
+            single = find_ssm_mixer(bridge.blocks[layer])
+            if single is None:
+                raise TypeError(f"Block {layer} has no SSM mixer (no compute_effective_attention).")
+            return _call(single, layer)
+
+        indices = self.ssm_layers()
+        if not indices:
+            raise RuntimeError(
+                "compute_ssm_effective_attention found no SSM layers. Use an SSM "
+                "or hybrid bridge and run_with_cache first (gated-delta-net needs "
+                "run_with_cache(..., use_cache=False))."
+            )
+        results: Dict[int, torch.Tensor] = {}
+        for i in indices:
+            mixer = find_ssm_mixer(bridge.blocks[i])
+            assert mixer is not None  # ssm_layers only returns blocks with a mixer
+            results[i] = _call(mixer, i)
+
+        n_blocks = len(bridge.blocks)
+        if indices == list(range(n_blocks)):
+            return torch.stack([results[i] for i in range(n_blocks)], dim=0)
+        return results
+
     def stack_head_results(
         self,
         layer: int = -1,

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -883,28 +883,32 @@ class ActivationCache:
     ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
         """Reconstruct the recurrent SSM state ``S`` from this cache.
 
-        The single discovery surface for Mamba-1 / Mamba-2 recurrent state (both
-        ``SSMMixerBridge`` and ``SSM2MixerBridge`` reconstruct it; gated-delta-net
-        has no ``S_t`` reconstruction and is excluded), mirroring
+        The single discovery surface for recurrent state across families —
+        ``SSMMixerBridge`` (Mamba-1), ``SSM2MixerBridge`` (Mamba-2) and
+        ``GatedDeltaNetBridge`` (gated delta rule) each reconstruct it — mirroring
         ``compute_head_results``. Read-only post-hoc reconstruction from cached
         hooks (no forward re-run); requires an SSM / SSM-hybrid bridge cached via
-        ``run_with_cache``. See the mixer's ``compute_ssm_state`` for the
-        recurrence, shapes, and the ``time_step`` memory bound.
+        ``run_with_cache`` (gated-delta-net additionally needs ``use_cache=False``
+        so its interior hooks fire). See the mixer's ``compute_ssm_state`` for the
+        recurrence, shapes, and the ``time_step`` memory bound; state shape is
+        family-specific, so ``layer=None`` returns a dict except when every block
+        shares one mixer type.
 
         Args:
-            layer: Specific block index, or None for every Mamba (SSM-state) layer.
+            layer: Specific block index, or None for every SSM-state layer.
             time_step: Optional single position (memory-bounded); None for all.
 
         Returns:
             A per-layer state tensor for a single ``layer``; for ``layer=None`` a
-            stacked tensor (dim 0 = layer) when every block is a Mamba layer, else
-            a ``{layer_idx: state}`` dict over the Mamba layers.
+            stacked tensor (dim 0 = layer) when every block is an SSM-state layer,
+            else a ``{layer_idx: state}`` dict over those layers.
 
         Raises:
-            TypeError: If the requested ``layer`` has no state-reconstructing Mamba mixer.
+            TypeError: If the requested ``layer`` has no state-reconstructing mixer.
             RuntimeError: If ``layer=None`` finds no such layers.
         """
         from transformer_lens.model_bridge.generalized_components import (
+            GatedDeltaNetBridge,
             SSM2MixerBridge,
             SSMMixerBridge,
         )
@@ -912,8 +916,8 @@ class ActivationCache:
             find_ssm_mixer,
         )
 
-        # Both Mamba families reconstruct S_t; gated-delta-net has no compute_ssm_state.
-        state_mixers = (SSMMixerBridge, SSM2MixerBridge)
+        # Every recurrent family reconstructs S_t from its cached interior hooks.
+        state_mixers = (SSMMixerBridge, SSM2MixerBridge, GatedDeltaNetBridge)
 
         def _call(mixer: Any, layer_idx: int) -> torch.Tensor:
             state: torch.Tensor = cast(Any, mixer).compute_ssm_state(
@@ -925,8 +929,8 @@ class ActivationCache:
             single = find_ssm_mixer(self.model.blocks[layer])
             if not isinstance(single, state_mixers):
                 raise TypeError(
-                    f"Block {layer} has no state-reconstructing Mamba mixer; "
-                    "compute_ssm_state supports Mamba-1 / Mamba-2 (not gated-delta-net)."
+                    f"Block {layer} has no state-reconstructing SSM mixer; "
+                    "compute_ssm_state supports Mamba-1 / Mamba-2 / gated-delta-net."
                 )
             return _call(single, layer)
         return self._over_ssm_layers(_call, mixer_type=state_mixers)

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -37,6 +37,7 @@ from transformer_lens.utilities import Slice, SliceInput, warn_if_mps
 
 if TYPE_CHECKING:
     from transformer_lens.HookedTransformer import HookedTransformer
+    from transformer_lens.model_bridge.bridge import TransformerBridge
 
 
 def _normalize_projection_to_2d(
@@ -752,6 +753,37 @@ class ActivationCache:
 
             # Sum over d_head to get the contribution of each head to the residual stream
             self.cache_dict[f"blocks.{layer}.attn.hook_result"] = result.sum(dim=-2)
+
+    def compute_ssm_state(
+        self,
+        layer: Optional[int] = None,
+        time_step: Optional[int] = None,
+    ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
+        """Reconstruct the recurrent SSM state ``S`` from this cache.
+
+        The single discovery surface for Mamba-2 / SSM recurrent state, mirroring
+        ``compute_head_results``. Read-only post-hoc reconstruction from the
+        cached in_proj/conv1d hooks (no forward re-run); requires a
+        ``TransformerBridge`` with SSM layers, cached via ``run_with_cache``. See
+        ``SSM2MixerBridge.compute_ssm_state`` for the recurrence, shapes, and the
+        ``time_step`` memory bound.
+
+        Args:
+            layer: Specific block index, or None for every SSM layer.
+            time_step: Optional single position (memory-bounded); None for all.
+
+        Returns:
+            A per-layer state tensor for a single ``layer``; for ``layer=None`` a
+            stacked tensor (dim 0 = layer) when every block is an SSM layer, else
+            a ``{layer_idx: state}`` dict over the SSM layers.
+        """
+        from transformer_lens.model_bridge.supported_architectures.mamba2 import (
+            compute_ssm_state,
+        )
+
+        return compute_ssm_state(
+            cast("TransformerBridge", self.model), self, layer=layer, time_step=time_step
+        )
 
     def stack_head_results(
         self,

--- a/transformer_lens/benchmarks/component_outputs.py
+++ b/transformer_lens/benchmarks/component_outputs.py
@@ -387,6 +387,13 @@ class ComponentBenchmarker:
         if component_path in skip_components:
             return
 
+        # Skip an SSM/recurrent mixer's internal submodules: they wrap the identical HF
+        # module (parity already covered by forward_pass_logits) and take SSM-internal
+        # shapes (channel-first conv, d_inner/dt_rank), not the [b, seq, d_model] residual
+        # the isolated harness feeds. The mixer node itself is still tested against HF.
+        if any(slot in component_path.split(".")[:-1] for slot in ("mixer", "linear_attn")):
+            return
+
         # Skip MLP components that don't exist as separate modules in HF (name=None)
         # These are virtual components where fc1/fc2 are directly on the layer
         # Component testing doesn't work for these because get_component returns the parent layer

--- a/transformer_lens/benchmarks/component_outputs.py
+++ b/transformer_lens/benchmarks/component_outputs.py
@@ -196,6 +196,16 @@ class BenchmarkReport:
         print("=" * 80 + "\n")
 
 
+def _is_ssm_mixer_internal(component_path: str) -> bool:
+    """True for a submodule *inside* an SSM/recurrent mixer slot (``.mixer``/``.linear_attn``).
+
+    Such submodules wrap the identical HF module (parity is covered by forward_pass_logits)
+    and take SSM-internal shapes, not the ``[b, seq, d_model]`` residual the isolated harness
+    feeds — so they are skipped. The mixer node itself (path ending in the slot) is not.
+    """
+    return any(slot in component_path.split(".")[:-1] for slot in ("mixer", "linear_attn"))
+
+
 class ComponentBenchmarker:
     """Benchmarking utility for testing TransformerBridge components against HuggingFace."""
 
@@ -387,11 +397,9 @@ class ComponentBenchmarker:
         if component_path in skip_components:
             return
 
-        # Skip an SSM/recurrent mixer's internal submodules: they wrap the identical HF
-        # module (parity already covered by forward_pass_logits) and take SSM-internal
-        # shapes (channel-first conv, d_inner/dt_rank), not the [b, seq, d_model] residual
-        # the isolated harness feeds. The mixer node itself is still tested against HF.
-        if any(slot in component_path.split(".")[:-1] for slot in ("mixer", "linear_attn")):
+        # SSM/recurrent mixer internal submodules can't be tested in isolation (see
+        # _is_ssm_mixer_internal); the mixer node itself is still tested against HF.
+        if _is_ssm_mixer_internal(component_path):
             return
 
         # Skip MLP components that don't exist as separate modules in HF (name=None)

--- a/transformer_lens/benchmarks/hook_registration.py
+++ b/transformer_lens/benchmarks/hook_registration.py
@@ -394,6 +394,12 @@ def benchmark_gated_hooks_fire(
                         name.rsplit(".", 1)[-1] == stem for name in target_hook_names
                     ):
                         failed.append((flag_name, stem))
+            except NotImplementedError as e:
+                # Some architectures reject the split path only at forward time (e.g.
+                # gated q_proj: Qwen3.5 / Qwen3-Next). Treat like the setter-time gate —
+                # skipped (applicability gate is intentional), not failed.
+                tested_flags.remove(flag_name)
+                skipped.append((flag_name, str(e).split("\n", 1)[0][:120]))
             finally:
                 setter(False)
 

--- a/transformer_lens/benchmarks/weight_processing.py
+++ b/transformer_lens/benchmarks/weight_processing.py
@@ -559,11 +559,12 @@ def benchmark_attention_output_centering(
 
         attn_blocks = bridge.blocks_with("attn")
         if not attn_blocks:
+            # Attention-less (pure SSM) or hybrids whose attention lives inside a
+            # passthrough mixer (NemotronH): nothing to center — skip, don't fail.
             return BenchmarkResult(
                 name="attention_output_centering",
-                severity=BenchmarkSeverity.WARNING,
-                message="No blocks have attention submodule",
-                passed=False,
+                severity=BenchmarkSeverity.SKIPPED,
+                message="No blocks expose an attention submodule (SSM / passthrough-mixer hybrid)",
             )
 
         # Check W_O accessibility on first attention block
@@ -642,17 +643,20 @@ def benchmark_mlp_output_centering(
         from transformer_lens.model_bridge.generalized_components.moe import MoEBridge
 
         mlp_module = None
-        block = bridge.blocks[0]
-        for name in ("mlp", "shared_mlp"):
-            if name in block._modules:
-                mlp_module = block._modules[name]
+        for block in bridge.blocks:
+            for name in ("mlp", "shared_mlp"):
+                if name in block._modules:
+                    mlp_module = block._modules[name]
+                    break
+            if mlp_module is not None:
                 break
         if mlp_module is None:
+            # Pure SSM, or a hybrid whose MLP lives inside a passthrough mixer:
+            # no standalone MLP to center — skip, don't fail.
             return BenchmarkResult(
                 name="mlp_output_centering",
-                severity=BenchmarkSeverity.WARNING,
-                message="No MLP submodule found on block 0",
-                passed=False,
+                severity=BenchmarkSeverity.SKIPPED,
+                message="No block exposes an MLP submodule (SSM / passthrough-mixer hybrid)",
             )
 
         if isinstance(mlp_module, MoEBridge):

--- a/transformer_lens/model_bridge/generalized_components/__init__.py
+++ b/transformer_lens/model_bridge/generalized_components/__init__.py
@@ -99,6 +99,10 @@ from transformer_lens.model_bridge.generalized_components.siglip_vision_encoder 
 from transformer_lens.model_bridge.generalized_components.ssm2_mixer import SSM2MixerBridge
 from transformer_lens.model_bridge.generalized_components.ssm_block import SSMBlockBridge
 from transformer_lens.model_bridge.generalized_components.ssm_mixer import SSMMixerBridge
+from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
+    SSMMixerProtocol,
+    find_ssm_mixer,
+)
 from transformer_lens.model_bridge.generalized_components.symbolic import SymbolicBridge
 from transformer_lens.model_bridge.generalized_components.t5_block import T5BlockBridge
 from transformer_lens.model_bridge.generalized_components.t5gemma_decoder_block import (
@@ -155,6 +159,8 @@ __all__ = [
     "SiglipVisionEncoderBridge",
     "SiglipVisionEncoderLayerBridge",
     "SSM2MixerBridge",
+    "SSMMixerProtocol",
+    "find_ssm_mixer",
     "SSMBlockBridge",
     "SSMMixerBridge",
     "VisionProjectionBridge",

--- a/transformer_lens/model_bridge/generalized_components/__init__.py
+++ b/transformer_lens/model_bridge/generalized_components/__init__.py
@@ -101,6 +101,7 @@ from transformer_lens.model_bridge.generalized_components.ssm_block import SSMBl
 from transformer_lens.model_bridge.generalized_components.ssm_mixer import SSMMixerBridge
 from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
     SSMMixerProtocol,
+    SSMStateHookMixin,
     find_ssm_mixer,
 )
 from transformer_lens.model_bridge.generalized_components.symbolic import SymbolicBridge
@@ -160,6 +161,7 @@ __all__ = [
     "SiglipVisionEncoderLayerBridge",
     "SSM2MixerBridge",
     "SSMMixerProtocol",
+    "SSMStateHookMixin",
     "find_ssm_mixer",
     "SSMBlockBridge",
     "SSMMixerBridge",

--- a/transformer_lens/model_bridge/generalized_components/gated_delta_net.py
+++ b/transformer_lens/model_bridge/generalized_components/gated_delta_net.py
@@ -4,18 +4,16 @@ Reimplements forward (prefill only) to expose mech-interp-relevant intermediate
 states. Falls back to HF native forward during autoregressive generation where
 cache state management is required.
 """
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import Any, Dict, Optional
 
 import torch
 import torch.nn.functional as F
 
+from transformer_lens.ActivationCache import ActivationCache
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
-
-if TYPE_CHECKING:
-    from transformer_lens.ActivationCache import ActivationCache
 
 
 class GatedDeltaNetBridge(GeneralizedComponent):
@@ -229,28 +227,38 @@ class GatedDeltaNetBridge(GeneralizedComponent):
 
     def compute_effective_attention(
         self,
-        cache: "ActivationCache",
+        cache: ActivationCache,
         layer_idx: int,
     ) -> torch.Tensor:
-        """Materialize the effective attention matrix from cached hook values.
+        """Materialize a heuristic effective-attention matrix from cached hooks.
 
-        The gated delta rule recurrence is::
+        Uses the gated-linear-attention form of the recurrence (the exact gated
+        *delta* rule additionally removes the key being written)::
 
-            S_t = exp(g_t) * S_{t-1} + beta_t * v_t @ k_t^T
+            S_t ≈ exp(g_t) * S_{t-1} + beta_t * v_t @ k_t^T
             o_t = S_t^T @ q_t
-
-        The effective attention M[i,j] = contribution of input j to output i::
-
             M[i,j] = (q_i^T @ k_j) * beta_j * prod_{t=j+1}^{i} exp(g_t)
 
-        **Approximation note:** The fused kernel applies L2-normalization to Q
-        and K internally (``use_qk_l2norm_in_kernel=True``). The hooked Q/K are
-        pre-normalization, so this reconstruction diverges when Q/K norms vary
-        significantly across positions/heads. Accuracy is best when Q/K norms
-        are roughly uniform (common after training converges).
+        so ``M`` is an interpretability heuristic, not a faithful output decomposition.
+
+        Requires the interior hooks (hook_q/k/beta/log_decay), which fire only on
+        the hooked prefill path: call ``run_with_cache(tokens, use_cache=False)``
+        so ``cache_params`` is None. The default cached path exposes only
+        hook_in/hook_out and this method then raises.
+
+        **Measured divergence (tiny random-init test fixture, seed-stable):**
+
+        - *L2-norm gap.* The fused kernel L2-normalizes Q/K internally
+          (``use_qk_l2norm_in_kernel=True``) but the hooked Q/K are pre-norm, so
+          ``M`` differs from the normalized form by ≈1.0 relative when Q/K norms
+          are small/non-uniform (the random-init regime); the gap shrinks toward 0
+          as norms equalize after training.
+        - *Delta-rule omission.* Even with normalized Q/K, ``M @ V`` reconstructs
+          the fused-kernel ``hook_recurrence_out`` only to O(1) relative error
+          because the key-removal term is dropped.
 
         Args:
-            cache: ActivationCache from ``run_with_cache``.
+            cache: ActivationCache from ``run_with_cache(..., use_cache=False)``.
             layer_idx: Block index for this linear_attn layer.
 
         Returns:

--- a/transformer_lens/model_bridge/generalized_components/gated_delta_net.py
+++ b/transformer_lens/model_bridge/generalized_components/gated_delta_net.py
@@ -14,9 +14,12 @@ from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
+from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
+    SSMStateHookMixin,
+)
 
 
-class GatedDeltaNetBridge(GeneralizedComponent):
+class GatedDeltaNetBridge(SSMStateHookMixin, GeneralizedComponent):
     """Bridge for GatedDeltaNet linear-attention with full hook decomposition.
 
     Hooks (prefill, in execution order):
@@ -35,6 +38,11 @@ class GatedDeltaNetBridge(GeneralizedComponent):
             per v-head [batch, seq, n_v_heads]
         hook_recurrence_out: output of linear recurrence [batch, seq, n_v_heads, head_v_dim]
         hook_gate_input: z tensor (pre-silu) for GatedRMSNorm [batch, seq, n_v_heads, head_v_dim]
+        hook_ssm_state: recurrent state trajectory S_t [batch, seq, n_v_heads, head_k_dim,
+            head_v_dim] — fires ONLY on the opt-in eager-scan path (eager_scan=True),
+            which swaps the fused kernel for a Python delta-rule scan so S_t can be
+            read/patched. hook_ssm_write (alias -> hook_beta) is the write strength and
+            propagates through the scan.
         hook_out: final output to residual stream [batch, seq, d_model]
 
     During generation (cache_params present), only hook_in/hook_out fire.
@@ -88,6 +96,8 @@ class GatedDeltaNetBridge(GeneralizedComponent):
         # Recurrence output + gated norm input
         self.hook_recurrence_out = HookPoint()
         self.hook_gate_input = HookPoint()
+        # hook_ssm_state + eager_scan come from SSMStateHookMixin; hook_ssm_write is
+        # an alias onto hook_beta (the delta rule's write is state-dependent).
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         if self.original_component is None:
@@ -208,17 +218,23 @@ class GatedDeltaNetBridge(GeneralizedComponent):
             query = query.repeat_interleave(repeat, dim=2)
             key = key.repeat_interleave(repeat, dim=2)
 
-        # --- Core linear recurrence (opaque fused kernel) ---
-        core_out, _ = hf.chunk_gated_delta_rule(
-            query,
-            key,
-            value,
-            g=g,
-            beta=beta,
-            initial_state=None,
-            output_final_state=False,
-            use_qk_l2norm_in_kernel=True,
-        )
+        # --- Core linear recurrence ---
+        # Default: HF's opaque fused kernel. eager_scan: a Python delta-rule scan
+        # that fires hook_ssm_state so the state trajectory can be intervened on.
+        if self.eager_scan:
+            _, core_out = self._gated_delta_scan(query, key, value, g, beta, fire_hook=True)
+            core_out = core_out.to(value.dtype)
+        else:
+            core_out, _ = hf.chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=None,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=True,
+            )
         core_out = self.hook_recurrence_out(core_out)
 
         # --- Gated RMSNorm: norm(core_out) * silu(z) ---
@@ -233,6 +249,142 @@ class GatedDeltaNetBridge(GeneralizedComponent):
         # --- Output projection ---
         output = hf.out_proj(core_out)
         return self.hook_out(output)
+
+    @staticmethod
+    def _l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+        """Match the kernel's internal Q/K L2 normalization (use_qk_l2norm_in_kernel)."""
+        return x / torch.sqrt((x * x).sum(-1, keepdim=True) + eps)
+
+    def _gated_delta_scan(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        fire_hook: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Eager gated-delta-rule recurrence — the readable form of the fused kernel.
+
+        Reproduces HF ``torch_recurrent_gated_delta_rule``: L2-normalize Q/K, scale
+        Q by ``1/sqrt(head_k_dim)``, then per step::
+
+            S_t = exp(g_t) · S_{t-1}                          (decay)
+            delta_t = (v_t - S_t^T k_t) · beta_t              (delta rule: remove then write)
+            S_t = S_t + k_t ⊗ delta_t                         -> hook_ssm_state trajectory
+            o_t = S_t^T q_t
+
+        Q/K are assumed already GQA-expanded to ``n_v_heads``. Matches the fused
+        kernel only to fp tolerance (≈1e-6 fp32), never bit-for-bit; O(seq) Python.
+
+        Args:
+            query, key: ``[batch, seq, n_v_heads, head_k_dim]`` (post-conv, pre-norm).
+            value: ``[batch, seq, n_v_heads, head_v_dim]``.
+            g: log-space decay ``[batch, seq, n_v_heads]`` (NEGATIVE; decay = exp(g)).
+            beta: write strength ``[batch, seq, n_v_heads]``.
+            fire_hook: if True, fire ``hook_ssm_state`` on the trajectory and
+                recompute ``o_t`` from the (possibly patched) state.
+
+        Returns:
+            ``(state_traj, core_out)`` — state ``[batch, seq, n_v_heads, head_k_dim,
+            head_v_dim]`` and output ``[batch, seq, n_v_heads, head_v_dim]``.
+        """
+        q = self._l2norm(query.float())
+        k = self._l2norm(key.float())
+        v = value.float()
+        q = q * (q.shape[-1] ** -0.5)
+        g_f = g.float()
+        beta_f = beta.float()
+
+        batch, seq_len, n_v, k_dim = q.shape
+        v_dim = v.shape[-1]
+        state = torch.zeros(batch, n_v, k_dim, v_dim, dtype=q.dtype, device=q.device)
+        states = []
+        outs = []
+        for t in range(seq_len):
+            q_t, k_t, v_t = q[:, t], k[:, t], v[:, t]  # [batch, n_v, dim]
+            decay = g_f[:, t].exp()[:, :, None, None]  # [batch, n_v, 1, 1]
+            beta_t = beta_f[:, t][:, :, None]  # [batch, n_v, 1]
+            state = state * decay
+            kv_mem = (state * k_t[:, :, :, None]).sum(dim=-2)  # [batch, n_v, v_dim]
+            delta = (v_t - kv_mem) * beta_t
+            state = state + k_t[:, :, :, None] * delta[:, :, None, :]
+            states.append(state)
+            outs.append((state * q_t[:, :, :, None]).sum(dim=-2))
+
+        state_traj = torch.stack(states, dim=1)  # [batch, seq, n_v, k_dim, v_dim]
+        if fire_hook:
+            state_traj = self.hook_ssm_state(state_traj)
+            # Recompute o_t = S_t^T q_t from the (possibly patched) trajectory.
+            core_out = torch.einsum("bshkv,bshk->bshv", state_traj, q)
+        else:
+            core_out = torch.stack(outs, dim=1)  # [batch, seq, n_v, v_dim]
+        return state_traj, core_out
+
+    def compute_ssm_state(
+        self,
+        cache: ActivationCache,
+        layer_idx: int,
+        time_step: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Reconstruct the recurrent state ``S`` of the gated delta rule from cache.
+
+        Read-only: replays the eager delta-rule scan (``_gated_delta_scan``) on the
+        cached hook_q/k/v/beta/log_decay — no ``forward()`` re-run. Faithful (the
+        full delta rule, key-removal included), unlike ``compute_effective_attention``
+        which is a gated-linear-attention heuristic that drops key removal.
+
+        Requires the interior hooks, which fire only on the hooked prefill path:
+        call ``run_with_cache(tokens, use_cache=False)`` so ``cache_params`` is None.
+
+        On padded batches the cached hooks are unmasked, so ``S`` is exact only at
+        non-pad positions; pad-position state is out of contract.
+
+        Args:
+            cache: ActivationCache from ``run_with_cache(..., use_cache=False)``.
+            layer_idx: Block index for this linear_attn layer.
+            time_step: If given, return only ``S`` at that position
+                (``[batch, n_v_heads, head_k_dim, head_v_dim]``). None returns
+                every step.
+
+        Returns:
+            ``[batch, seq, n_v_heads, head_k_dim, head_v_dim]`` for all steps, or
+            ``[batch, n_v_heads, head_k_dim, head_v_dim]`` for a single ``time_step``.
+
+        Memory is O(batch · n_v_heads · seq · head_k_dim · head_v_dim); pass
+        ``time_step`` (or short sequences) when that is too large.
+        """
+        prefix = f"blocks.{layer_idx}.linear_attn"
+        q_key = f"{prefix}.hook_q"
+        k_key = f"{prefix}.hook_k"
+        v_key = f"{prefix}.hook_v"
+        beta_key = f"{prefix}.hook_beta"
+        decay_key = f"{prefix}.hook_log_decay"
+
+        for key in (q_key, k_key, v_key, beta_key, decay_key):
+            if key not in cache:
+                raise RuntimeError(
+                    f"compute_ssm_state needs {key!r} in cache. Run "
+                    "run_with_cache(tokens, use_cache=False) on the bridge first."
+                )
+
+        q = cache[q_key].float()  # [batch, seq, n_k_heads, head_k_dim]
+        k = cache[k_key].float()
+        v = cache[v_key].float()  # [batch, seq, n_v_heads, head_v_dim]
+        beta = cache[beta_key].float()  # [batch, seq, n_v_heads]
+        g = cache[decay_key].float()  # [batch, seq, n_v_heads]
+
+        # GQA expansion to n_v_heads (Q/K carry n_k_heads).
+        n_v = v.shape[2]
+        if q.shape[2] < n_v:
+            repeat = n_v // q.shape[2]
+            q = q.repeat_interleave(repeat, dim=2)
+            k = k.repeat_interleave(repeat, dim=2)
+
+        state_traj, _ = self._gated_delta_scan(q, k, v, g, beta, fire_hook=False)
+        if time_step is not None:
+            return state_traj[:, time_step]
+        return state_traj
 
     def compute_effective_attention(
         self,

--- a/transformer_lens/model_bridge/generalized_components/gated_delta_net.py
+++ b/transformer_lens/model_bridge/generalized_components/gated_delta_net.py
@@ -46,6 +46,15 @@ class GatedDeltaNetBridge(GeneralizedComponent):
     hook_aliases = {
         "hook_linear_attn_in": "hook_in",
         "hook_linear_attn_out": "hook_out",
+        # Canonical SSM vocabulary (additive) — maps onto GDN's existing hooks so
+        # interp tools can find these quantities by the same name across families.
+        # Semantic mapping: q reads the state (~C), k writes to it (~B), the gate
+        # g is the decay, beta is the per-step write strength.
+        "hook_ssm_out": "hook_out",
+        "hook_ssm_C": "hook_q",
+        "hook_ssm_B": "hook_k",
+        "hook_ssm_decay": "hook_log_decay",
+        "hook_ssm_write": "hook_beta",
     }
 
     property_aliases = {

--- a/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
@@ -39,6 +39,10 @@ class SSM2MixerBridge(GeneralizedComponent):
         "hook_in_proj": "in_proj.hook_out",
         "hook_conv": "conv1d.hook_out",
         "hook_inner_norm": "inner_norm.hook_out",
+        # Canonical SSM vocabulary (additive). Mamba-2 fuses B/C/dt into the
+        # in_proj/conv1d outputs, so only the mixer output has a granular hook;
+        # B/C/dt/decay/state are reconstructed via compute_effective_attention /
+        # compute_ssm_state rather than exposed as separate HookPoints.
         "hook_ssm_out": "hook_out",
     }
 

--- a/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
@@ -100,14 +100,28 @@ class SSM2MixerBridge(GeneralizedComponent):
             )
 
         cfg = self.config
-        num_heads: int = cfg.n_heads
-        head_dim: int = cfg.d_head
-        intermediate_size: int = getattr(cfg, "intermediate_size", num_heads * head_dim)
-        state_size: int = getattr(cfg, "state_size", 128)
-        n_groups: int = getattr(cfg, "n_groups", 1)
+        # SSM dims come from the wrapped HF mixer, not cfg: on a hybrid the shared
+        # cfg holds the *attention* dims (cfg.n_heads etc.), while the HF mixer
+        # module always carries the true Mamba dims (matching A_log/dt_bias, which
+        # are already read off the module via __getattr__). cfg is the fallback.
+        oc = self.original_component
+
+        def _mamba_dim(module_attr: str, cfg_attr: str, default: Any) -> Any:
+            if oc is not None:
+                val = getattr(oc, module_attr, None)
+                if val is not None:
+                    return val
+            return getattr(cfg, cfg_attr, default)
+
+        num_heads = int(_mamba_dim("num_heads", "n_heads", 0))
+        intermediate_size = int(
+            _mamba_dim("intermediate_size", "intermediate_size", num_heads * int(cfg.d_head))
+        )
+        state_size = int(_mamba_dim("ssm_state_size", "state_size", 128))
+        n_groups = int(_mamba_dim("n_groups", "n_groups", 1))
 
         # Mirror HF's tuple convention so downstream equality checks stay consistent
-        time_step_limit = getattr(cfg, "time_step_limit", (0.0, float("inf")))
+        time_step_limit = _mamba_dim("time_step_limit", "time_step_limit", (0.0, float("inf")))
         time_step_min = float(time_step_limit[0])
         time_step_max = float(time_step_limit[1])
 

--- a/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
@@ -239,6 +239,9 @@ class SSM2MixerBridge(GeneralizedComponent):
         ``compute_effective_attention``. Read-only: no ``forward()`` re-run.
         Verify with ``y_t = C_t · S_t + D · x_t == inner_norm.hook_in``.
 
+        On padded batches the cached hooks are unmasked, so ``S`` is exact only at
+        non-pad positions; pad-position state is out of contract.
+
         Args:
             cache: ActivationCache from ``run_with_cache`` with this layer's
                 in_proj and conv1d hooks.

--- a/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
@@ -52,9 +52,8 @@ class SSM2MixerBridge(SSMStateHookMixin, GeneralizedComponent):
     }
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)  # SSMStateHookMixin adds hook_ssm_state + eager_scan
-        # Real per-step write term dt·(x⊗B) (input-linear); fires only on the
-        # eager-scan path. hook_ssm_state comes from the mixin.
+        super().__init__(*args, **kwargs)  # mixin adds hook_ssm_state + eager_scan
+        # Real per-step write term dt·(x⊗B); fires only on the eager-scan path.
         self.hook_ssm_write = HookPoint()
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
@@ -124,7 +123,7 @@ class SSM2MixerBridge(SSMStateHookMixin, GeneralizedComponent):
             return states
 
         # 1-2. Projection + conv — reuse the HF submodule bridges (their hooks fire).
-        # HF masks padding both before in_proj and after the conv (before B/C split).
+        # Match HF: mask padding before in_proj and after conv (before B/C split).
         projected = oc.in_proj(_mask_pad(hidden_states))
         d_mlp = (projected.shape[-1] - 2 * intermediate - 2 * n_groups * state - num_heads) // 2
         _, _, gate, hidden_B_C, dt = projected.split(
@@ -154,7 +153,6 @@ class SSM2MixerBridge(SSMStateHookMixin, GeneralizedComponent):
         A = -torch.exp(self.A_log.float())  # [num_heads]
 
         # 3. Eager recurrence with intervention hooks.
-        # write_t[b, t, h, d, n] = dt_t · x_t[d] · B_t[n]
         writes = dt[:, :, :, None, None] * x[:, :, :, :, None] * B[:, :, :, None, :]
         writes = self.hook_ssm_write(writes)  # [batch, seq, heads, head_dim, state]
 
@@ -305,7 +303,6 @@ class SSM2MixerBridge(SSMStateHookMixin, GeneralizedComponent):
         conv1d_out = cache[conv1d_key].float()  # [batch, conv_dim, seq + kernel - 1]
         batch_size, seq_len = in_proj_out.shape[0], in_proj_out.shape[1]
 
-        # dt: last num_heads features of in_proj, post softplus + clamp
         dt = torch.nn.functional.softplus(in_proj_out[..., -num_heads:] + self.dt_bias.float())
         dt = torch.clamp(dt, float(time_step_limit[0]), float(time_step_limit[1]))
 

--- a/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
@@ -162,7 +162,9 @@ class SSM2MixerBridge(GeneralizedComponent):
         writes = dt[:, :, :, None, None] * x[:, :, :, :, None] * B[:, :, :, None, :]
         writes = self.hook_ssm_write(writes)  # [batch, seq, heads, head_dim, state]
 
-        ssm_state = torch.zeros(batch, num_heads, head_dim, state, dtype=torch.float32)
+        ssm_state = torch.zeros(
+            batch, num_heads, head_dim, state, dtype=writes.dtype, device=writes.device
+        )
         states = []
         for t in range(seq_len):
             decay = torch.exp(dt[:, t, :] * A[None, :])  # [batch, heads]

--- a/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
@@ -1,5 +1,5 @@
 """Wrap-don't-reimplement bridge for HF's Mamba2Mixer, plus SSD effective attention."""
-from typing import Any
+from typing import Any, NamedTuple, Optional
 
 import torch
 
@@ -7,6 +7,16 @@ from transformer_lens.ActivationCache import ActivationCache
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
+
+
+class _SSDTerms(NamedTuple):
+    """SSD intermediates reconstructed from cached Mamba-2 hooks (HF discretization)."""
+
+    dt: torch.Tensor  # [batch, seq, num_heads]
+    L: torch.Tensor  # [batch, num_heads, seq, seq] causal decay (upper triangle zero)
+    x: torch.Tensor  # [batch, seq, num_heads, head_dim] SSM input per head
+    B: torch.Tensor  # [batch, seq, num_heads, state] (group-expanded)
+    C: torch.Tensor  # [batch, seq, num_heads, state] (group-expanded)
 
 
 class SSM2MixerBridge(GeneralizedComponent):
@@ -87,6 +97,66 @@ class SSM2MixerBridge(GeneralizedComponent):
 
         Cost is O(batch · num_heads · seq_len²); use on short sequences (≤2k).
         """
+        terms = self._ssd_terms(cache, layer_idx)
+
+        # CB[b, h, i, j] = <C[b, i, h], B[b, j, h]>
+        CB = torch.einsum("bihs,bjhs->bhij", terms.C, terms.B)
+        M = terms.L * CB  # [batch, num_heads, seq, seq]
+
+        if include_dt_scaling:
+            # Multiply column j by dt[j, h] to absorb the B discretization
+            M = M * terms.dt.permute(0, 2, 1)[:, :, None, :]
+
+        return M
+
+    def compute_ssm_state(
+        self,
+        cache: ActivationCache,
+        layer_idx: int,
+        time_step: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Reconstruct the recurrent SSM state ``S`` from cached hook values.
+
+        Mamba-2's recurrence is ``S_t = dA_t · S_{t-1} + dt_t · (x_t ⊗ B_t)`` with
+        ``dA_t[h] = exp(dt_t[h] · A[h])``, so post-hoc::
+
+            S_t[h, p, n] = sum_{j<=t} L[t, j] · dt_j[h] · x_j[h, p] · B_j[h, n]
+
+        where ``L`` is the same causal decay matrix used by
+        ``compute_effective_attention``. Read-only: no ``forward()`` re-run.
+        Verify with ``y_t = C_t · S_t + D · x_t == inner_norm.hook_in``.
+
+        Args:
+            cache: ActivationCache from ``run_with_cache`` with this layer's
+                in_proj and conv1d hooks.
+            layer_idx: Block index for this mixer.
+            time_step: If given, return only ``S`` at that position
+                (``[batch, num_heads, head_dim, state]``); avoids materializing
+                the full tensor. None returns every step.
+
+        Returns:
+            ``[batch, num_heads, seq, head_dim, state]`` for all steps, or
+            ``[batch, num_heads, head_dim, state]`` for a single ``time_step``.
+
+        Memory is O(batch · num_heads · seq · head_dim · state) for the full
+        tensor; pass ``time_step`` (or short sequences) when that is too large.
+        """
+        terms = self._ssd_terms(cache, layer_idx)
+        dtx = terms.dt[..., None] * terms.x  # [batch, seq, num_heads, head_dim]
+        if time_step is not None:
+            # S_t = sum_{j<=t} L[t, j] · (dt_j x_j) ⊗ B_j
+            return torch.einsum("bhj,bjhp,bjhn->bhpn", terms.L[:, :, time_step, :], dtx, terms.B)
+        return torch.einsum("bhtj,bjhp,bjhn->bhtpn", terms.L, dtx, terms.B)
+
+    def _ssd_terms(self, cache: ActivationCache, layer_idx: int) -> _SSDTerms:
+        """Reconstruct the shared SSD intermediates (dt, decay L, per-head x/B/C).
+
+        Mirrors HF Mamba2Mixer's discretization from the cached in_proj/conv1d
+        outputs. Dims come from the wrapped HF mixer, not cfg: on a hybrid the
+        shared cfg holds the *attention* dims (cfg.n_heads etc.), while the HF
+        mixer always carries the true Mamba dims (as do A_log/dt_bias, already
+        read off the module via __getattr__). cfg is the fallback.
+        """
         if self.config is None:
             raise RuntimeError("SSM2MixerBridge.config must be set")
 
@@ -94,16 +164,11 @@ class SSM2MixerBridge(GeneralizedComponent):
         conv1d_key = f"blocks.{layer_idx}.mixer.conv1d.hook_out"
         if in_proj_key not in cache or conv1d_key not in cache:
             raise RuntimeError(
-                f"compute_effective_attention needs {in_proj_key!r} and "
-                f"{conv1d_key!r} in cache. Run `run_with_cache()` on the bridge "
-                "before calling this method."
+                f"SSD reconstruction needs {in_proj_key!r} and {conv1d_key!r} in "
+                "cache. Run `run_with_cache()` on the bridge before calling this."
             )
 
         cfg = self.config
-        # SSM dims come from the wrapped HF mixer, not cfg: on a hybrid the shared
-        # cfg holds the *attention* dims (cfg.n_heads etc.), while the HF mixer
-        # module always carries the true Mamba dims (matching A_log/dt_bias, which
-        # are already read off the module via __getattr__). cfg is the fallback.
         oc = self.original_component
 
         def _mamba_dim(module_attr: str, cfg_attr: str, default: Any) -> Any:
@@ -114,70 +179,45 @@ class SSM2MixerBridge(GeneralizedComponent):
             return getattr(cfg, cfg_attr, default)
 
         num_heads = int(_mamba_dim("num_heads", "n_heads", 0))
+        head_dim = int(_mamba_dim("head_dim", "d_head", 0))
         intermediate_size = int(
-            _mamba_dim("intermediate_size", "intermediate_size", num_heads * int(cfg.d_head))
+            _mamba_dim("intermediate_size", "intermediate_size", num_heads * head_dim)
         )
         state_size = int(_mamba_dim("ssm_state_size", "state_size", 128))
         n_groups = int(_mamba_dim("n_groups", "n_groups", 1))
-
-        # Mirror HF's tuple convention so downstream equality checks stay consistent
         time_step_limit = _mamba_dim("time_step_limit", "time_step_limit", (0.0, float("inf")))
-        time_step_min = float(time_step_limit[0])
-        time_step_max = float(time_step_limit[1])
 
-        in_proj_out = cache[in_proj_key]  # [batch, seq, proj_size]
-        conv1d_out = cache[conv1d_key]  # [batch, conv_dim, seq + conv_kernel - 1]
+        in_proj_out = cache[in_proj_key].float()  # [batch, seq, proj_size]
+        conv1d_out = cache[conv1d_key].float()  # [batch, conv_dim, seq + kernel - 1]
         batch_size, seq_len = in_proj_out.shape[0], in_proj_out.shape[1]
 
-        # Match HF's SSM numerical precision
-        in_proj_out_f = in_proj_out.float()
-        conv1d_out_f = conv1d_out.float()
+        # dt: last num_heads features of in_proj, post softplus + clamp
+        dt = torch.nn.functional.softplus(in_proj_out[..., -num_heads:] + self.dt_bias.float())
+        dt = torch.clamp(dt, float(time_step_limit[0]), float(time_step_limit[1]))
 
-        # dt is the last num_heads features of in_proj output, post softplus+clamp
-        dt_raw = in_proj_out_f[..., -num_heads:]
-        dt_bias = self.dt_bias.float()
-        dt = torch.nn.functional.softplus(dt_raw + dt_bias)
-        dt = torch.clamp(dt, time_step_min, time_step_max)  # [batch, seq, num_heads]
-
-        # B, C come from the conv1d output after trimming to seq_len and applying SiLU
-        conv_trimmed = conv1d_out_f[..., :seq_len]
-        conv_activated = torch.nn.functional.silu(conv_trimmed).transpose(1, 2)
-        split_sizes = [intermediate_size, n_groups * state_size, n_groups * state_size]
-        _hidden_x, B_flat, C_flat = conv_activated.split(split_sizes, dim=-1)
-        B = B_flat.view(batch_size, seq_len, n_groups, state_size)
-        C = C_flat.view(batch_size, seq_len, n_groups, state_size)
-
-        # GQA-style: each of n_groups B/C pairs is replicated to cover n_heads // n_groups heads
+        # x, B, C from conv1d output (trim to seq, SiLU, channel-last split)
+        conv_activated = torch.nn.functional.silu(conv1d_out[..., :seq_len]).transpose(1, 2)
+        x_flat, B_flat, C_flat = conv_activated.split(
+            [intermediate_size, n_groups * state_size, n_groups * state_size], dim=-1
+        )
+        x = x_flat.view(batch_size, seq_len, num_heads, head_dim)
+        # GQA-style: each of n_groups B/C pairs covers n_heads // n_groups heads
         heads_per_group = num_heads // n_groups
-        B_h = B.repeat_interleave(heads_per_group, dim=2)
-        C_h = C.repeat_interleave(heads_per_group, dim=2)
+        B = B_flat.view(batch_size, seq_len, n_groups, state_size).repeat_interleave(
+            heads_per_group, dim=2
+        )
+        C = C_flat.view(batch_size, seq_len, n_groups, state_size).repeat_interleave(
+            heads_per_group, dim=2
+        )
 
+        # L[i, j] = exp(sum_{k=j+1}^{i} A[h] · dt[k, h]) for i >= j, else 0.
+        # exp(cumsum[i] - cumsum[j]); cumsum[j] includes dt[j], so the sum is k>j.
         A = -torch.exp(self.A_log.float())  # [num_heads]
-
-        # L[i, j] = exp(sum_{k=j+1}^{i} A[h] * dt[k, h]) for i >= j, else 0
-        # Computed as exp(cumsum[i] - cumsum[j]) since cumsum[j] includes dt[j],
-        # so the remaining sum runs from k=j+1 to k=i.
-        log_a = dt * A[None, None, :]
-        cumsum_log_a = torch.cumsum(log_a, dim=1)
-        cs = cumsum_log_a.permute(0, 2, 1)  # [batch, num_heads, seq]
+        cs = torch.cumsum(dt * A[None, None, :], dim=1).permute(0, 2, 1)  # [batch, num_heads, seq]
         L_log = cs[:, :, :, None] - cs[:, :, None, :]
         causal_mask = torch.tril(
             torch.ones(seq_len, seq_len, dtype=torch.bool, device=L_log.device)
         )
-        L = torch.where(
-            causal_mask[None, None, :, :],
-            torch.exp(L_log),
-            torch.zeros_like(L_log),
-        )
+        L = torch.where(causal_mask[None, None], torch.exp(L_log), torch.zeros_like(L_log))
 
-        # CB[b, h, i, j] = <C[b, i, h], B[b, j, h]>
-        CB = torch.einsum("bihs,bjhs->bhij", C_h, B_h)
-
-        M = L * CB  # [batch, num_heads, seq, seq]
-
-        if include_dt_scaling:
-            # Multiply column j by dt[j, h] to absorb the B discretization
-            dt_col = dt.permute(0, 2, 1)[:, :, None, :]
-            M = M * dt_col
-
-        return M
+        return _SSDTerms(dt=dt, L=L, x=x, B=B, C=C)

--- a/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
@@ -8,6 +8,9 @@ from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
+from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
+    SSMStateHookMixin,
+)
 
 
 class _SSDTerms(NamedTuple):
@@ -20,7 +23,7 @@ class _SSDTerms(NamedTuple):
     C: torch.Tensor  # [batch, seq, num_heads, state] (group-expanded)
 
 
-class SSM2MixerBridge(GeneralizedComponent):
+class SSM2MixerBridge(SSMStateHookMixin, GeneralizedComponent):
     """Opaque wrapper around Mamba-2's Mamba2Mixer.
 
     Structural differences from Mamba-1:
@@ -48,18 +51,11 @@ class SSM2MixerBridge(GeneralizedComponent):
         "hook_ssm_out": "hook_out",
     }
 
-    # Opt-in slow path: when True (and not generating), forward() runs an eager
-    # Python scan instead of HF's fused kernel, firing hook_ssm_write /
-    # hook_ssm_state so they can be intervened on. Default False — the standard
-    # run_with_cache path is untouched. See _eager_scan_forward.
-    eager_scan: bool = False
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        # Per-step write term (dt·x⊗B) and recurrent-state trajectory. Only fire
-        # on the eager-scan path; intervening on them re-runs the recurrence.
+        super().__init__(*args, **kwargs)  # SSMStateHookMixin adds hook_ssm_state + eager_scan
+        # Real per-step write term dt·(x⊗B) (input-linear); fires only on the
+        # eager-scan path. hook_ssm_state comes from the mixin.
         self.hook_ssm_write = HookPoint()
-        self.hook_ssm_state = HookPoint()
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         """Hook the input, run HF torch_forward (or the eager scan), hook the output."""

--- a/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm2_mixer.py
@@ -4,6 +4,7 @@ from typing import Any, NamedTuple, Optional
 import torch
 
 from transformer_lens.ActivationCache import ActivationCache
+from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
@@ -40,27 +41,48 @@ class SSM2MixerBridge(GeneralizedComponent):
         "hook_conv": "conv1d.hook_out",
         "hook_inner_norm": "inner_norm.hook_out",
         # Canonical SSM vocabulary (additive). Mamba-2 fuses B/C/dt into the
-        # in_proj/conv1d outputs, so only the mixer output has a granular hook;
-        # B/C/dt/decay/state are reconstructed via compute_effective_attention /
-        # compute_ssm_state rather than exposed as separate HookPoints.
+        # in_proj/conv1d outputs, so only the mixer output has a granular hook by
+        # default; B/C/dt/decay are reconstructed via compute_effective_attention /
+        # compute_ssm_state. hook_ssm_write / hook_ssm_state are real HookPoints
+        # that fire only on the opt-in eager-scan intervention path.
         "hook_ssm_out": "hook_out",
     }
 
+    # Opt-in slow path: when True (and not generating), forward() runs an eager
+    # Python scan instead of HF's fused kernel, firing hook_ssm_write /
+    # hook_ssm_state so they can be intervened on. Default False — the standard
+    # run_with_cache path is untouched. See _eager_scan_forward.
+    eager_scan: bool = False
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Per-step write term (dt·x⊗B) and recurrent-state trajectory. Only fire
+        # on the eager-scan path; intervening on them re-runs the recurrence.
+        self.hook_ssm_write = HookPoint()
+        self.hook_ssm_state = HookPoint()
+
     def forward(self, *args: Any, **kwargs: Any) -> Any:
-        """Hook the input, delegate to HF torch_forward, hook the output."""
+        """Hook the input, run HF torch_forward (or the eager scan), hook the output."""
         if self.original_component is None:
             raise RuntimeError(
                 f"Original component not set for {self.name}. "
                 "Call set_original_component() first."
             )
 
+        hidden_states: Optional[torch.Tensor] = None
         if len(args) > 0 and isinstance(args[0], torch.Tensor):
-            hooked = self.hook_in(args[0])
-            args = (hooked,) + args[1:]
+            hidden_states = self.hook_in(args[0])
+            args = (hidden_states,) + args[1:]
         elif "hidden_states" in kwargs and isinstance(kwargs["hidden_states"], torch.Tensor):
-            kwargs["hidden_states"] = self.hook_in(kwargs["hidden_states"])
+            hidden_states = self.hook_in(kwargs["hidden_states"])
+            kwargs["hidden_states"] = hidden_states
 
-        output = self.original_component(*args, **kwargs)
+        # Eager-scan slow path: opt-in flag, prefill only (no cache_params). Keyed
+        # on explicit state, never on hook-registry introspection.
+        if self.eager_scan and hidden_states is not None and kwargs.get("cache_params") is None:
+            output: Any = self._eager_scan_forward(hidden_states, kwargs.get("attention_mask"))
+        else:
+            output = self.original_component(*args, **kwargs)
 
         if isinstance(output, tuple) and len(output) > 0:
             first = output[0]
@@ -70,6 +92,93 @@ class SSM2MixerBridge(GeneralizedComponent):
         if isinstance(output, torch.Tensor):
             return self.hook_out(output)
         return output
+
+    def _eager_scan_forward(
+        self, hidden_states: torch.Tensor, attention_mask: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        """Reimplement the Mamba-2 mixer prefill forward with an eager Python scan.
+
+        Reuses HF's in_proj / conv1d / inner-norm / out_proj submodules (so their
+        hooks still fire) and reimplements ONLY the SSD recurrence::
+
+            write_t = dt_t · (x_t ⊗ B_t)            -> hook_ssm_write [b, seq, h, d, n]
+            S_t     = exp(dt_t·A) · S_{t-1} + write_t
+            S       = stack_t S_t                    -> hook_ssm_state [b, seq, h, d, n]
+            y_t     = C_t · S_t                       (recomputed from the hooked state)
+
+        Intervening on hook_ssm_write re-runs the recurrence (the change propagates
+        to every later state); hook_ssm_state is the post-scan trajectory, so a
+        patch there changes only the same-position output y_t = C_t·S_t, not the
+        forward recurrence — patch hook_ssm_write for a propagating state edit.
+
+        Kernel-divergence caveat: this eager scan reproduces HF's fused chunk scan
+        only to floating-point tolerance (≈1e-6 fp32), never bit-for-bit, on any
+        family. It is O(seq) Python and materializes an O(b·seq·h·d·n) write/state
+        tensor — orders of magnitude slower/heavier than the kernel. Prefill only.
+        """
+        oc: Any = self.original_component
+        batch, seq_len, _ = hidden_states.shape
+        intermediate, num_heads, head_dim = oc.intermediate_size, oc.num_heads, oc.head_dim
+        n_groups, state = oc.n_groups, oc.ssm_state_size
+
+        def _mask_pad(states: torch.Tensor) -> torch.Tensor:
+            # Mirror HF apply_mask_to_padding_states (no-op for batch 1 / unpadded).
+            if attention_mask is not None and attention_mask.shape[1] > 1 and batch > 1:
+                return (states * attention_mask[:, :, None]).to(states.dtype)
+            return states
+
+        # 1-2. Projection + conv — reuse the HF submodule bridges (their hooks fire).
+        # HF masks padding both before in_proj and after the conv (before B/C split).
+        projected = oc.in_proj(_mask_pad(hidden_states))
+        d_mlp = (projected.shape[-1] - 2 * intermediate - 2 * n_groups * state - num_heads) // 2
+        _, _, gate, hidden_B_C, dt = projected.split(
+            [d_mlp, d_mlp, intermediate, oc.conv_dim, num_heads], dim=-1
+        )
+        hidden_B_C = oc.act(oc.conv1d(hidden_B_C.transpose(1, 2))[..., :seq_len].transpose(1, 2))
+        hidden_B_C = _mask_pad(hidden_B_C)
+        x_flat, B_flat, C_flat = hidden_B_C.split(
+            [intermediate, n_groups * state, n_groups * state], dim=-1
+        )
+
+        x = x_flat.reshape(batch, seq_len, num_heads, head_dim).float()
+        heads_per_group = num_heads // n_groups
+        B = (
+            B_flat.reshape(batch, seq_len, n_groups, state)
+            .repeat_interleave(heads_per_group, dim=2)
+            .float()
+        )
+        C = (
+            C_flat.reshape(batch, seq_len, n_groups, state)
+            .repeat_interleave(heads_per_group, dim=2)
+            .float()
+        )
+
+        dt = torch.nn.functional.softplus(dt.float() + self.dt_bias.float())
+        dt = torch.clamp(dt, float(oc.time_step_limit[0]), float(oc.time_step_limit[1]))
+        A = -torch.exp(self.A_log.float())  # [num_heads]
+
+        # 3. Eager recurrence with intervention hooks.
+        # write_t[b, t, h, d, n] = dt_t · x_t[d] · B_t[n]
+        writes = dt[:, :, :, None, None] * x[:, :, :, :, None] * B[:, :, :, None, :]
+        writes = self.hook_ssm_write(writes)  # [batch, seq, heads, head_dim, state]
+
+        ssm_state = torch.zeros(batch, num_heads, head_dim, state, dtype=torch.float32)
+        states = []
+        for t in range(seq_len):
+            decay = torch.exp(dt[:, t, :] * A[None, :])  # [batch, heads]
+            ssm_state = decay[:, :, None, None] * ssm_state + writes[:, t]
+            states.append(ssm_state)
+        state_traj = torch.stack(states, dim=1)  # [batch, seq, heads, head_dim, state]
+        state_traj = self.hook_ssm_state(state_traj)
+
+        y = torch.einsum("bthn,bthdn->bthd", C, state_traj)
+        y = y + self.D.float()[None, None, :, None] * x
+        y = y.reshape(batch, seq_len, intermediate)
+
+        # 4. Gated norm + output projection — reuse the HF submodule bridges.
+        scan_output = oc.norm(y.to(hidden_states.dtype), gate)
+        contextualized: torch.Tensor = oc.out_proj(scan_output)
+        return contextualized
 
     def compute_effective_attention(
         self,

--- a/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
@@ -4,8 +4,12 @@ from typing import Any, NamedTuple, Optional
 import torch
 
 from transformer_lens.ActivationCache import ActivationCache
+from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
+)
+from transformer_lens.model_bridge.generalized_components.ssm_protocol import (
+    SSMStateHookMixin,
 )
 
 
@@ -18,7 +22,7 @@ class _S6Terms(NamedTuple):
     C: torch.Tensor  # [batch, seq, state] (shared across channels)
 
 
-class SSMMixerBridge(GeneralizedComponent):
+class SSMMixerBridge(SSMStateHookMixin, GeneralizedComponent):
     """Opaque wrapper around Mamba-1's MambaMixer.
 
     Submodules (in_proj, conv1d, x_proj, dt_proj, out_proj) are swapped into
@@ -41,22 +45,34 @@ class SSMMixerBridge(GeneralizedComponent):
         "hook_ssm_dt": "dt_proj.hook_out",
     }
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)  # SSMStateHookMixin adds hook_ssm_state + eager_scan
+        # Real per-step write term dt·x·B (input-linear). Per-channel (no head_dim):
+        # [batch, channels, seq, state]. hook_ssm_state comes from the mixin.
+        self.hook_ssm_write = HookPoint()
+
     def forward(self, *args: Any, **kwargs: Any) -> Any:
-        """Hook the input, delegate to HF slow_forward, hook the output."""
+        """Hook the input, run HF slow_forward (or the eager scan), hook the output."""
         if self.original_component is None:
             raise RuntimeError(
                 f"Original component not set for {self.name}. "
                 "Call set_original_component() first."
             )
 
-        # Hook the hidden_states input (positional or keyword)
+        hidden_states: Optional[torch.Tensor] = None
         if len(args) > 0 and isinstance(args[0], torch.Tensor):
-            hooked = self.hook_in(args[0])
-            args = (hooked,) + args[1:]
+            hidden_states = self.hook_in(args[0])
+            args = (hidden_states,) + args[1:]
         elif "hidden_states" in kwargs and isinstance(kwargs["hidden_states"], torch.Tensor):
-            kwargs["hidden_states"] = self.hook_in(kwargs["hidden_states"])
+            hidden_states = self.hook_in(kwargs["hidden_states"])
+            kwargs["hidden_states"] = hidden_states
 
-        output = self.original_component(*args, **kwargs)
+        # Eager-scan slow path: opt-in, prefill only (no cache_params). Keyed on
+        # explicit state, never on hook-registry introspection.
+        if self.eager_scan and hidden_states is not None and kwargs.get("cache_params") is None:
+            output: Any = self._eager_scan_forward(hidden_states, kwargs.get("attention_mask"))
+        else:
+            output = self.original_component(*args, **kwargs)
 
         # Hook the primary output tensor, preserving tuple structure
         if isinstance(output, tuple) and len(output) > 0:
@@ -67,6 +83,76 @@ class SSMMixerBridge(GeneralizedComponent):
         if isinstance(output, torch.Tensor):
             return self.hook_out(output)
         return output
+
+    def _eager_scan_forward(
+        self, hidden_states: torch.Tensor, attention_mask: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        """Reimplement the Mamba-1 mixer prefill forward with an eager Python S6 scan.
+
+        Reuses HF's in_proj / conv1d / x_proj / dt_proj / out_proj submodules (so
+        their hooks still fire) and reimplements ONLY the S6 recurrence::
+
+            write_t[c, s] = dt_t[c] · x_t[c] · B_t[s]        -> hook_ssm_write [b, c, seq, s]
+            S_t[c, s]     = exp(A[c,s]·dt_t[c]) · S_{t-1} + write_t
+            S             = stack_t S_t                       -> hook_ssm_state [b, c, seq, s]
+            y_t[c]        = sum_s C_t[s] · S_t[c, s] + D[c] · x_t[c]
+
+        Intervening on hook_ssm_write re-runs the recurrence (propagates to later
+        states); hook_ssm_state is the post-scan trajectory, so a patch there
+        changes only the same-position output y_t = C_t·S_t — patch hook_ssm_write
+        for a propagating state edit.
+
+        Kernel-divergence caveat: reproduces HF's scan only to fp tolerance
+        (≈1e-6 fp32), never bit-for-bit. O(seq) Python; materializes an
+        O(b·channels·seq·state) write/state tensor. Prefill only.
+        """
+        oc: Any = self.original_component
+        batch, seq_len, _ = hidden_states.shape
+        d_inner = oc.intermediate_size
+        state = oc.ssm_state_size
+        dt_rank = oc.time_step_rank
+
+        def _mask_cf(states: torch.Tensor) -> torch.Tensor:
+            # Channel-first padding mask, mirroring HF (no-op for batch 1 / unpadded).
+            if attention_mask is not None and attention_mask.shape[1] > 1 and batch > 1:
+                return states * attention_mask.unsqueeze(1).to(states.dtype)
+            return states
+
+        # 1-2. in_proj + gate split, conv — reuse the HF submodule bridges (hooks fire).
+        # HF masks padding on the channel-first x both before and after the conv.
+        projected = oc.in_proj(hidden_states).transpose(1, 2)  # [b, 2*d_inner, seq]
+        x_raw, gate = projected.chunk(2, dim=1)  # [b, d_inner, seq]
+        x = oc.act(oc.conv1d(_mask_cf(x_raw))[..., :seq_len])  # [b, d_inner, seq]
+        x = _mask_cf(x)
+
+        # 3. x_proj -> dt low-rank / B / C ; dt_proj -> dt (softplus, channel-first).
+        ssm_params = oc.x_proj(x.transpose(1, 2))  # [b, seq, dt_rank + 2*state]
+        time_step, B, C = ssm_params.split([dt_rank, state, state], dim=-1)  # B, C: [b, seq, state]
+        dt = torch.nn.functional.softplus(oc.dt_proj(time_step)).transpose(1, 2).float()
+        A = -torch.exp(self.A_log.float())  # [d_inner, state]
+        x_f, B_f, C_f = x.float(), B.float(), C.float()
+
+        # 4. Eager recurrence with intervention hooks.
+        # write_t[b, c, t, s] = dt_t[c] · x_t[c] · B_t[s]
+        writes = (dt * x_f)[:, :, :, None] * B_f[:, None, :, :]  # [b, d_inner, seq, state]
+        writes = self.hook_ssm_write(writes)
+
+        ssm_state = torch.zeros(batch, d_inner, state, dtype=writes.dtype, device=writes.device)
+        states = []
+        for t in range(seq_len):
+            decay = torch.exp(A[None] * dt[:, :, t, None])  # [batch, d_inner, state]
+            ssm_state = decay * ssm_state + writes[:, :, t]
+            states.append(ssm_state)
+        state_traj = torch.stack(states, dim=2)  # [batch, d_inner, seq, state]
+        state_traj = self.hook_ssm_state(state_traj)
+
+        y = torch.einsum("bcts,bts->bct", state_traj, C_f)  # [batch, d_inner, seq]
+        y = y + self.D.float()[None, :, None] * x_f
+        scan_output = y * torch.nn.functional.silu(gate.float())
+
+        # 5. Output projection — reuse the HF submodule bridge.
+        contextualized: torch.Tensor = oc.out_proj(scan_output.transpose(1, 2).to(hidden_states.dtype))
+        return contextualized
 
     def compute_effective_attention(
         self,

--- a/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
@@ -143,6 +143,9 @@ class SSMMixerBridge(GeneralizedComponent):
         (``SiLU(conv1d.hook_out)``). Read-only: no ``forward()`` re-run. Verify
         with ``y_t[c] = sum_s C_t[s]·S_t[c,s] + D[c]·x_t[c]``.
 
+        On padded batches the cached hooks are unmasked, so ``S`` is exact only at
+        non-pad positions; pad-position state is out of contract.
+
         Args:
             cache: ActivationCache from ``run_with_cache`` with this layer's
                 x_proj, dt_proj, and conv1d hooks.
@@ -155,8 +158,9 @@ class SSMMixerBridge(GeneralizedComponent):
             ``[batch, channels, state]`` for a single ``time_step``.
 
         Peak memory is O(batch · channels · state · seq²) — the per-(channel,
-        state) decay tensor (as in ``compute_effective_attention``); use on short
-        sequences (or pass ``time_step``).
+        state) decay tensor, built in full by ``_s6_terms`` regardless of
+        ``time_step`` (which bounds only the returned tensor, not this peak); use
+        on short sequences.
         """
         conv_key = f"blocks.{layer_idx}.mixer.conv1d.hook_out"
         if conv_key not in cache:

--- a/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
@@ -1,5 +1,5 @@
 """Wrap-don't-reimplement bridge for HF's MambaMixer (Mamba-1), plus S6 effective attention."""
-from typing import Any
+from typing import Any, NamedTuple, Optional
 
 import torch
 
@@ -7,6 +7,15 @@ from transformer_lens.ActivationCache import ActivationCache
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
+
+
+class _S6Terms(NamedTuple):
+    """S6 intermediates reconstructed from cached Mamba-1 hooks (per-channel)."""
+
+    dt: torch.Tensor  # [batch, channels, seq]
+    decay: torch.Tensor  # [batch, channels, state, i, j] causal (upper triangle zero)
+    B: torch.Tensor  # [batch, seq, state] (shared across channels)
+    C: torch.Tensor  # [batch, seq, state] (shared across channels)
 
 
 class SSMMixerBridge(GeneralizedComponent):
@@ -102,6 +111,77 @@ class SSMMixerBridge(GeneralizedComponent):
         per-(channel, state) decay tensor — even for the summed default; use on
         short sequences.
         """
+        t = self._s6_terms(cache, layer_idx)
+
+        # M_coord[c, s, i, j] = C[i, s] · decay[c, s, i, j] · B[j, s]
+        C_col = t.C.permute(0, 2, 1)[:, None, :, :, None]  # [batch, 1, state, i, 1]
+        B_col = t.B.permute(0, 2, 1)[:, None, :, None, :]  # [batch, 1, state, 1, j]
+        M_coord = C_col * t.decay * B_col  # [batch, channels, state, i, j]
+
+        if include_dt_scaling:
+            M_coord = M_coord * t.dt[:, :, None, None, :]  # × dt[c, j]
+
+        if per_state_coord:
+            return M_coord
+        return M_coord.sum(dim=2)  # [batch, channels, seq, seq]
+
+    def compute_ssm_state(
+        self,
+        cache: ActivationCache,
+        layer_idx: int,
+        time_step: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Reconstruct Mamba-1's recurrent state ``S`` from cached hook values.
+
+        S6 recurrence ``h_t[c,s] = exp(A[c,s]·dt_t[c])·h_{t-1}[c,s] + dt_t[c]·x_t[c]·B_t[s]``
+        unrolls to::
+
+            S_t[c, s] = sum_{j<=t} decay[c, s, t, j] · dt_j[c] · x_j[c] · B_j[s]
+
+        with the same per-(channel, state) ``decay`` used by
+        ``compute_effective_attention``. ``x`` is the post-conv SiLU input
+        (``SiLU(conv1d.hook_out)``). Read-only: no ``forward()`` re-run. Verify
+        with ``y_t[c] = sum_s C_t[s]·S_t[c,s] + D[c]·x_t[c]``.
+
+        Args:
+            cache: ActivationCache from ``run_with_cache`` with this layer's
+                x_proj, dt_proj, and conv1d hooks.
+            layer_idx: Block index for this mixer.
+            time_step: If given, return only ``S`` at that position
+                (``[batch, channels, state]``); None returns every step.
+
+        Returns:
+            ``[batch, channels, seq, state]`` for all steps, or
+            ``[batch, channels, state]`` for a single ``time_step``.
+
+        Peak memory is O(batch · channels · state · seq²) — the per-(channel,
+        state) decay tensor (as in ``compute_effective_attention``); use on short
+        sequences (or pass ``time_step``).
+        """
+        conv_key = f"blocks.{layer_idx}.mixer.conv1d.hook_out"
+        if conv_key not in cache:
+            raise RuntimeError(
+                f"compute_ssm_state needs {conv_key!r} in cache. Run "
+                "`run_with_cache()` on the bridge before calling this method."
+            )
+        t = self._s6_terms(cache, layer_idx)
+        seq_len = t.dt.shape[-1]
+        # x = SiLU(conv output), the SSM scan input; channel-first [batch, channels, seq].
+        x = torch.nn.functional.silu(cache[conv_key].float()[..., :seq_len])
+        dtx = t.dt * x  # dt_j[c]·x_j[c], [batch, channels, seq]
+        # S_t[c, s] = sum_{j<=t} decay[c, s, t, j] · dtx[c, j] · B_j[s]
+        if time_step is not None:
+            return torch.einsum("bcsj,bcj,bjs->bcs", t.decay[:, :, :, time_step, :], dtx, t.B)
+        return torch.einsum("bcsij,bcj,bjs->bcis", t.decay, dtx, t.B)
+
+    def _s6_terms(self, cache: ActivationCache, layer_idx: int) -> _S6Terms:
+        """Reconstruct the shared S6 intermediates (dt, per-(channel,state) decay, B, C).
+
+        Reused by ``compute_effective_attention`` and ``compute_ssm_state``. Reads
+        B/C from ``x_proj.hook_out`` (shared across channels), dt from
+        ``dt_proj.hook_out`` (softplus), and A via ``__getattr__``. Dims come from
+        the wrapped HF mixer, cfg is the fallback (mirrors the Mamba-2 bridge).
+        """
         if self.config is None:
             raise RuntimeError("SSMMixerBridge.config must be set")
 
@@ -110,8 +190,8 @@ class SSMMixerBridge(GeneralizedComponent):
         for key in (x_proj_key, dt_proj_key):
             if key not in cache:
                 raise RuntimeError(
-                    f"compute_effective_attention needs {key!r} in cache. Run "
-                    "`run_with_cache()` on the bridge before calling this method."
+                    f"S6 reconstruction needs {key!r} in cache. Run "
+                    "`run_with_cache()` on the bridge before calling this."
                 )
 
         cfg = self.config
@@ -128,7 +208,7 @@ class SSMMixerBridge(GeneralizedComponent):
         dt_rank = int(_mamba_dim("time_step_rank", "time_step_rank", 0))
 
         x_proj_out = cache[x_proj_key].float()  # [batch, seq, dt_rank + 2*state]
-        dt_proj_out = cache[dt_proj_key].float()  # [batch, seq, intermediate_size]
+        dt_proj_out = cache[dt_proj_key].float()  # [batch, seq, channels]
         seq_len = dt_proj_out.shape[1]
 
         # B, C from x_proj output (shared across channels); first dt_rank cols are dt low-rank.
@@ -138,8 +218,7 @@ class SSMMixerBridge(GeneralizedComponent):
         dt = torch.nn.functional.softplus(dt_proj_out).transpose(1, 2)  # [batch, channels, seq]
         A = -torch.exp(self.A_log.float())  # [channels, state]
 
-        # Per-(channel, state) causal decay:
-        # decay[c, n, i, j] = exp(A[c,n] · (cumdt[c,i] - cumdt[c,j])) for i >= j, else 0.
+        # decay[c, s, i, j] = exp(A[c,s]·(cumdt[c,i]-cumdt[c,j])) for i >= j, else 0.
         cumdt = torch.cumsum(dt, dim=-1)  # [batch, channels, seq]
         dcs = cumdt[:, :, :, None] - cumdt[:, :, None, :]  # [batch, channels, i, j]
         decay_exp = (
@@ -153,15 +232,4 @@ class SSMMixerBridge(GeneralizedComponent):
             torch.exp(decay_exp),
             torch.zeros_like(decay_exp),
         )
-
-        # M_coord[c, n, i, j] = C[i, n] · decay · B[j, n]
-        C_col = C.permute(0, 2, 1)[:, None, :, :, None]  # [batch, 1, state, i, 1]
-        B_col = B.permute(0, 2, 1)[:, None, :, None, :]  # [batch, 1, state, 1, j]
-        M_coord = C_col * decay * B_col  # [batch, channels, state, i, j]
-
-        if include_dt_scaling:
-            M_coord = M_coord * dt[:, :, None, None, :]  # × dt[c, j]
-
-        if per_state_coord:
-            return M_coord
-        return M_coord.sum(dim=2)  # [batch, channels, seq, seq]
+        return _S6Terms(dt=dt, decay=decay, B=B, C=C)

--- a/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
@@ -1,8 +1,9 @@
-"""Wrap-don't-reimplement bridge for HF's MambaMixer (Mamba-1)."""
+"""Wrap-don't-reimplement bridge for HF's MambaMixer (Mamba-1), plus S6 effective attention."""
 from typing import Any
 
 import torch
 
+from transformer_lens.ActivationCache import ActivationCache
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
@@ -54,3 +55,110 @@ class SSMMixerBridge(GeneralizedComponent):
         if isinstance(output, torch.Tensor):
             return self.hook_out(output)
         return output
+
+    def compute_effective_attention(
+        self,
+        cache: ActivationCache,
+        layer_idx: int,
+        include_dt_scaling: bool = False,
+        per_state_coord: bool = False,
+    ) -> torch.Tensor:
+        """Materialize Mamba-1's per-channel effective attention from cached hooks.
+
+        Mamba-1's S6 selective scan is equivalent to causal attention with a
+        per-channel, per-state-coordinate learned decay — see "The Hidden
+        Attention of Mamba" (Ali et al., ACL 2025). Unlike Mamba-2 there is no
+        head grouping: each of the ``intermediate_size`` channels has its own
+        ``A`` row, so the "head" axis here is the channel axis::
+
+            M[c, i, j] = sum_n C[i, n] · prod_{k=j+1..i} exp(A[c,n]·dt[c,k]) · B[j, n]
+
+        Reads B/C from ``x_proj.hook_out`` and dt from ``dt_proj.hook_out``
+        (dt = softplus of that output); A from the module via ``__getattr__``.
+        Read-only: no ``forward()`` re-run.
+
+        Args:
+            cache: ActivationCache from ``run_with_cache`` with this layer's
+                x_proj and dt_proj hooks.
+            layer_idx: Block index for this mixer.
+            include_dt_scaling: False (default) returns the attention-like form;
+                True multiplies column j by dt[c, j], giving the reconstruction
+                form satisfying ``y[c,i] = sum_j M[c,i,j]·x[c,j] + D[c]·x[c,i]``
+                (x is the post-conv SiLU input; y the pre-gate scan output).
+            per_state_coord: False (default) sums over the state coordinate and
+                returns ``[batch, channels, seq, seq]``. True returns the
+                unsummed ``[batch, channels, state, seq, seq]`` tensor (the
+                paper's D·N matrices) — OFF by default.
+
+        Returns:
+            ``[batch, intermediate_size, seq, seq]``, or
+            ``[batch, intermediate_size, state_size, seq, seq]`` when
+            ``per_state_coord`` is True.
+
+        Peak memory is O(batch · intermediate_size · state_size · seq²) — the
+        per-(channel, state) decay tensor — even for the summed default; use on
+        short sequences.
+        """
+        if self.config is None:
+            raise RuntimeError("SSMMixerBridge.config must be set")
+
+        x_proj_key = f"blocks.{layer_idx}.mixer.x_proj.hook_out"
+        dt_proj_key = f"blocks.{layer_idx}.mixer.dt_proj.hook_out"
+        for key in (x_proj_key, dt_proj_key):
+            if key not in cache:
+                raise RuntimeError(
+                    f"compute_effective_attention needs {key!r} in cache. Run "
+                    "`run_with_cache()` on the bridge before calling this method."
+                )
+
+        cfg = self.config
+        oc = self.original_component
+
+        def _mamba_dim(module_attr: str, cfg_attr: str, default: Any) -> Any:
+            if oc is not None:
+                val = getattr(oc, module_attr, None)
+                if val is not None:
+                    return val
+            return getattr(cfg, cfg_attr, default)
+
+        state_size = int(_mamba_dim("ssm_state_size", "state_size", 16))
+        dt_rank = int(_mamba_dim("time_step_rank", "time_step_rank", 0))
+
+        x_proj_out = cache[x_proj_key].float()  # [batch, seq, dt_rank + 2*state]
+        dt_proj_out = cache[dt_proj_key].float()  # [batch, seq, intermediate_size]
+        seq_len = dt_proj_out.shape[1]
+
+        # B, C from x_proj output (shared across channels); first dt_rank cols are dt low-rank.
+        _time_step, B, C = x_proj_out.split([dt_rank, state_size, state_size], dim=-1)
+
+        # Per-channel dt = softplus(dt_proj output), channel-first.
+        dt = torch.nn.functional.softplus(dt_proj_out).transpose(1, 2)  # [batch, channels, seq]
+        A = -torch.exp(self.A_log.float())  # [channels, state]
+
+        # Per-(channel, state) causal decay:
+        # decay[c, n, i, j] = exp(A[c,n] · (cumdt[c,i] - cumdt[c,j])) for i >= j, else 0.
+        cumdt = torch.cumsum(dt, dim=-1)  # [batch, channels, seq]
+        dcs = cumdt[:, :, :, None] - cumdt[:, :, None, :]  # [batch, channels, i, j]
+        decay_exp = (
+            A[None, :, :, None, None] * dcs[:, :, None, :, :]
+        )  # [batch, channels, state, i, j]
+        causal_mask = torch.tril(
+            torch.ones(seq_len, seq_len, dtype=torch.bool, device=decay_exp.device)
+        )
+        decay = torch.where(
+            causal_mask[None, None, None, :, :],
+            torch.exp(decay_exp),
+            torch.zeros_like(decay_exp),
+        )
+
+        # M_coord[c, n, i, j] = C[i, n] · decay · B[j, n]
+        C_col = C.permute(0, 2, 1)[:, None, :, :, None]  # [batch, 1, state, i, 1]
+        B_col = B.permute(0, 2, 1)[:, None, :, None, :]  # [batch, 1, state, 1, j]
+        M_coord = C_col * decay * B_col  # [batch, channels, state, i, j]
+
+        if include_dt_scaling:
+            M_coord = M_coord * dt[:, :, None, None, :]  # × dt[c, j]
+
+        if per_state_coord:
+            return M_coord
+        return M_coord.sum(dim=2)  # [batch, channels, seq, seq]

--- a/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
@@ -27,6 +27,9 @@ class SSMMixerBridge(GeneralizedComponent):
         "hook_x_proj": "x_proj.hook_out",
         "hook_dt_proj": "dt_proj.hook_out",
         "hook_ssm_out": "hook_out",
+        # Canonical SSM vocabulary (additive): Mamba-1 exposes the discrete time
+        # step via dt_proj. B/C are bundled in x_proj (not separately hooked).
+        "hook_ssm_dt": "dt_proj.hook_out",
     }
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:

--- a/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
@@ -257,8 +257,9 @@ class SSMMixerBridge(SSMStateHookMixin, GeneralizedComponent):
             )
         t = self._s6_terms(cache, layer_idx)
         seq_len = t.dt.shape[-1]
-        # x = SiLU(conv output), the SSM scan input; channel-first [batch, channels, seq].
-        x = torch.nn.functional.silu(cache[conv_key].float()[..., :seq_len])
+        oc: Any = self.original_component
+        # x = act(conv output), the SSM scan input; channel-first [batch, channels, seq].
+        x = oc.act(cache[conv_key].float()[..., :seq_len])
         dtx = t.dt * x  # dt_j[c]·x_j[c], [batch, channels, seq]
         # S_t[c, s] = sum_{j<=t} decay[c, s, t, j] · dtx[c, j] · B_j[s]
         if time_step is not None:

--- a/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
@@ -46,9 +46,8 @@ class SSMMixerBridge(SSMStateHookMixin, GeneralizedComponent):
     }
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)  # SSMStateHookMixin adds hook_ssm_state + eager_scan
-        # Real per-step write term dt·x·B (input-linear). Per-channel (no head_dim):
-        # [batch, channels, seq, state]. hook_ssm_state comes from the mixin.
+        super().__init__(*args, **kwargs)  # mixin adds hook_ssm_state + eager_scan
+        # Real per-step write term dt·x·B, per-channel [batch, channels, seq, state].
         self.hook_ssm_write = HookPoint()
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
@@ -113,8 +112,9 @@ class SSMMixerBridge(SSMStateHookMixin, GeneralizedComponent):
         dt_rank = oc.time_step_rank
 
         def _mask_cf(states: torch.Tensor) -> torch.Tensor:
-            # Channel-first padding mask, mirroring HF (no-op for batch 1 / unpadded).
-            if attention_mask is not None and attention_mask.shape[1] > 1 and batch > 1:
+            # HF MambaMixer masks whenever attention_mask is present (no batch guard,
+            # unlike Mamba-2), so match that — batch-1 padded inputs included.
+            if attention_mask is not None:
                 return states * attention_mask.unsqueeze(1).to(states.dtype)
             return states
 
@@ -133,7 +133,6 @@ class SSMMixerBridge(SSMStateHookMixin, GeneralizedComponent):
         x_f, B_f, C_f = x.float(), B.float(), C.float()
 
         # 4. Eager recurrence with intervention hooks.
-        # write_t[b, c, t, s] = dt_t[c] · x_t[c] · B_t[s]
         writes = (dt * x_f)[:, :, :, None] * B_f[:, None, :, :]  # [b, d_inner, seq, state]
         writes = self.hook_ssm_write(writes)
 
@@ -148,7 +147,7 @@ class SSMMixerBridge(SSMStateHookMixin, GeneralizedComponent):
 
         y = torch.einsum("bcts,bts->bct", state_traj, C_f)  # [batch, d_inner, seq]
         y = y + self.D.float()[None, :, None] * x_f
-        scan_output = y * torch.nn.functional.silu(gate.float())
+        scan_output = y * oc.act(gate.float())  # HF gates with self.act, not hardcoded silu
 
         # 5. Output projection — reuse the HF submodule bridge.
         contextualized: torch.Tensor = oc.out_proj(
@@ -306,7 +305,6 @@ class SSMMixerBridge(SSMStateHookMixin, GeneralizedComponent):
         # B, C from x_proj output (shared across channels); first dt_rank cols are dt low-rank.
         _time_step, B, C = x_proj_out.split([dt_rank, state_size, state_size], dim=-1)
 
-        # Per-channel dt = softplus(dt_proj output), channel-first.
         dt = torch.nn.functional.softplus(dt_proj_out).transpose(1, 2)  # [batch, channels, seq]
         A = -torch.exp(self.A_log.float())  # [channels, state]
 

--- a/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_mixer.py
@@ -151,7 +151,9 @@ class SSMMixerBridge(SSMStateHookMixin, GeneralizedComponent):
         scan_output = y * torch.nn.functional.silu(gate.float())
 
         # 5. Output projection — reuse the HF submodule bridge.
-        contextualized: torch.Tensor = oc.out_proj(scan_output.transpose(1, 2).to(hidden_states.dtype))
+        contextualized: torch.Tensor = oc.out_proj(
+            scan_output.transpose(1, 2).to(hidden_states.dtype)
+        )
         return contextualized
 
     def compute_effective_attention(

--- a/transformer_lens/model_bridge/generalized_components/ssm_protocol.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_protocol.py
@@ -1,0 +1,68 @@
+"""Family-agnostic discovery for SSM / recurrent-mixer effective attention.
+
+Defines the structural contract (``SSMMixerProtocol``) that ``SSM2MixerBridge``
+(Mamba-2), ``SSMMixerBridge`` (Mamba-1), and ``GatedDeltaNetBridge`` all satisfy,
+plus a lookup that finds a block's SSM mixer regardless of which variant slot it
+occupies (``.mixer`` for Mamba, ``.linear_attn`` for gated-delta-net). A Protocol
+(not a base class) keeps each family's own hook set — only the discovery surface
+is shared.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
+
+import torch
+import torch.nn as nn
+
+from transformer_lens.model_bridge.generalized_components.block import (
+    VARIANT_SUBMODULE_NAMES,
+)
+
+if TYPE_CHECKING:
+    from transformer_lens.ActivationCache import ActivationCache
+
+
+@runtime_checkable
+class SSMMixerProtocol(Protocol):
+    """An SSM/recurrent mixer that can materialize an effective-attention matrix.
+
+    Only ``compute_effective_attention(cache, layer_idx)`` is required; families
+    add their own optional keyword options (e.g. ``include_dt_scaling``,
+    ``per_state_coord``) which callers discover by signature introspection.
+    """
+
+    def compute_effective_attention(self, cache: "ActivationCache", layer_idx: int) -> torch.Tensor:
+        ...
+
+
+_PASSTHROUGH_CHILDREN = frozenset({"hook_in", "hook_out", "_original_component"})
+
+
+def _is_realized_ssm_mixer(mixer: object) -> bool:
+    """True unless ``mixer`` is a no-op passthrough wrapper.
+
+    A hybrid like NemotronH wires a single ``SSM2MixerBridge`` ``.mixer`` slot on
+    *every* layer; on attention / MLP / MoE layers its optional projection
+    submodules are skipped, leaving only the universal ``hook_in`` / ``hook_out``.
+    A realized mixer always has something more — projection submodules (Mamba-1/2)
+    or interior hooks like ``hook_q`` / ``hook_log_decay`` (gated-delta-net). This
+    structural check needs no ``cfg.layers_block_type``.
+    """
+    return any(name not in _PASSTHROUGH_CHILDREN for name in getattr(mixer, "_modules", {}))
+
+
+def find_ssm_mixer(block: nn.Module) -> Optional[SSMMixerProtocol]:
+    """Return the block's SSM mixer submodule, or None if it has none.
+
+    Scans the layer-type variant slots (``.mixer`` / ``.linear_attn`` / ``.mamba``
+    / ``.ssm``) and returns the first that conforms to ``SSMMixerProtocol`` and is
+    a realized SSM mixer (not a passthrough wrapper). An attention layer (only
+    ``.attn``), or a hybrid's passthrough ``.mixer`` on a non-SSM layer, returns
+    None.
+    """
+    modules = getattr(block, "_modules", {})
+    for name in VARIANT_SUBMODULE_NAMES:
+        sub = modules.get(name)
+        if isinstance(sub, SSMMixerProtocol) and _is_realized_ssm_mixer(sub):
+            return sub
+    return None

--- a/transformer_lens/model_bridge/generalized_components/ssm_protocol.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_protocol.py
@@ -1,19 +1,22 @@
-"""Family-agnostic discovery for SSM / recurrent-mixer effective attention.
+"""Family-agnostic discovery + shared state-mutation surface for SSM/recurrent mixers.
 
 Defines the structural contract (``SSMMixerProtocol``) that ``SSM2MixerBridge``
 (Mamba-2), ``SSMMixerBridge`` (Mamba-1), and ``GatedDeltaNetBridge`` all satisfy,
 plus a lookup that finds a block's SSM mixer regardless of which variant slot it
 occupies (``.mixer`` for Mamba, ``.linear_attn`` for gated-delta-net). A Protocol
 (not a base class) keeps each family's own hook set — only the discovery surface
-is shared.
+is shared. ``SSMStateHookMixin`` is the one place the canonical eager-scan
+intervention hooks (``hook_ssm_state`` + the ``eager_scan`` opt-in) are defined, so
+the three families share a single definition rather than repeating it ad hoc.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
 
 import torch
 import torch.nn as nn
 
+from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge.generalized_components.block import (
     VARIANT_SUBMODULE_NAMES,
 )
@@ -33,6 +36,41 @@ class SSMMixerProtocol(Protocol):
 
     def compute_effective_attention(self, cache: "ActivationCache", layer_idx: int) -> torch.Tensor:
         ...
+
+
+class SSMStateHookMixin:
+    """Canonical cross-family state-mutation hook surface for SSM/recurrent mixers.
+
+    The single definition point for the eager-scan intervention vocabulary, so
+    interp tools address the same quantities by the same name across Mamba-1
+    (``SSMMixerBridge``), Mamba-2 (``SSM2MixerBridge``) and gated-delta-net
+    (``GatedDeltaNetBridge``):
+
+    - ``hook_ssm_state`` — post-scan recurrent-state trajectory ``S_t`` (created
+      here for every family). Patching it changes only the same-position readout
+      (``y_t = C_t·S_t`` or ``S_t^T q_t``), not the forward recurrence.
+    - ``hook_ssm_write`` — per-step write influence. A *real* HookPoint for the
+      input-linear families (Mamba-1/2: ``dt·(x⊗B)``, added by the subclass); an
+      *alias* onto the write-strength gate for the state-dependent delta rule
+      (gated-delta-net → ``hook_beta``). Patching it re-runs the recurrence, so the
+      edit propagates to every later state.
+
+    ``eager_scan`` (opt-in, prefill only): when True, ``forward`` runs a readable
+    Python scan instead of HF's fused kernel so these hooks fire and can be
+    intervened on. Default False leaves the standard cached path bit-for-bit
+    untouched. Keyed only on explicit state (``cache_params is None``), never on
+    hook-registry introspection.
+
+    Mixed in *before* ``GeneralizedComponent`` so its cooperative ``__init__``
+    reaches the component base; the state hook is registered after the base sets up
+    ``nn.Module`` internals.
+    """
+
+    eager_scan: bool = False
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.hook_ssm_state = HookPoint()
 
 
 # Children present on *every* SSM2MixerBridge regardless of whether it wraps a

--- a/transformer_lens/model_bridge/generalized_components/ssm_protocol.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_protocol.py
@@ -39,31 +39,19 @@ class SSMMixerProtocol(Protocol):
 
 
 class SSMStateHookMixin:
-    """Canonical cross-family state-mutation hook surface for SSM/recurrent mixers.
+    """Canonical state-mutation hooks shared by the SSM/recurrent mixers.
 
-    The single definition point for the eager-scan intervention vocabulary, so
-    interp tools address the same quantities by the same name across Mamba-1
-    (``SSMMixerBridge``), Mamba-2 (``SSM2MixerBridge``) and gated-delta-net
-    (``GatedDeltaNetBridge``):
+    One definition point so Mamba-1/Mamba-2/gated-delta-net expose the same names:
 
-    - ``hook_ssm_state`` — post-scan recurrent-state trajectory ``S_t`` (created
-      here for every family). Patching it changes only the same-position readout
-      (``y_t = C_t·S_t`` or ``S_t^T q_t``), not the forward recurrence.
-    - ``hook_ssm_write`` — per-step write influence. A *real* HookPoint for the
-      input-linear families (Mamba-1/2: ``dt·(x⊗B)``, added by the subclass); an
-      *alias* onto the write-strength gate for the state-dependent delta rule
-      (gated-delta-net → ``hook_beta``). Patching it re-runs the recurrence, so the
-      edit propagates to every later state.
+    - ``hook_ssm_state`` — post-scan state trajectory ``S_t`` (created here for all);
+      patching it changes only the same-position readout, not the recurrence.
+    - ``hook_ssm_write`` — per-step write influence: a real HookPoint for the input-
+      linear families (Mamba-1/2 ``dt·(x⊗B)``, added by the subclass), an alias onto
+      ``hook_beta`` for the state-dependent delta rule; patching it re-runs the scan.
 
-    ``eager_scan`` (opt-in, prefill only): when True, ``forward`` runs a readable
-    Python scan instead of HF's fused kernel so these hooks fire and can be
-    intervened on. Default False leaves the standard cached path bit-for-bit
-    untouched. Keyed only on explicit state (``cache_params is None``), never on
-    hook-registry introspection.
-
-    Mixed in *before* ``GeneralizedComponent`` so its cooperative ``__init__``
-    reaches the component base; the state hook is registered after the base sets up
-    ``nn.Module`` internals.
+    ``eager_scan`` (opt-in, prefill only) swaps HF's fused kernel for a Python scan so
+    these hooks fire; default False leaves the cached path bit-for-bit untouched. Must
+    precede ``GeneralizedComponent`` in the bases so ``super().__init__`` reaches it.
     """
 
     eager_scan: bool = False

--- a/transformer_lens/model_bridge/generalized_components/ssm_protocol.py
+++ b/transformer_lens/model_bridge/generalized_components/ssm_protocol.py
@@ -35,7 +35,12 @@ class SSMMixerProtocol(Protocol):
         ...
 
 
-_PASSTHROUGH_CHILDREN = frozenset({"hook_in", "hook_out", "_original_component"})
+# Children present on *every* SSM2MixerBridge regardless of whether it wraps a
+# real Mamba layer — universal I/O hooks, the wrapped module, and the eager-scan
+# analysis hooks. None of these signal that the mixer is realized.
+_PASSTHROUGH_CHILDREN = frozenset(
+    {"hook_in", "hook_out", "_original_component", "hook_ssm_write", "hook_ssm_state"}
+)
 
 
 def _is_realized_ssm_mixer(mixer: object) -> bool:
@@ -43,10 +48,10 @@ def _is_realized_ssm_mixer(mixer: object) -> bool:
 
     A hybrid like NemotronH wires a single ``SSM2MixerBridge`` ``.mixer`` slot on
     *every* layer; on attention / MLP / MoE layers its optional projection
-    submodules are skipped, leaving only the universal ``hook_in`` / ``hook_out``.
-    A realized mixer always has something more — projection submodules (Mamba-1/2)
-    or interior hooks like ``hook_q`` / ``hook_log_decay`` (gated-delta-net). This
-    structural check needs no ``cfg.layers_block_type``.
+    submodules are skipped, leaving only the universal hooks. A realized mixer
+    always has something more — projection submodules (Mamba-1/2) or interior
+    hooks like ``hook_q`` / ``hook_log_decay`` (gated-delta-net). This structural
+    check needs no ``cfg.layers_block_type``.
     """
     return any(name not in _PASSTHROUGH_CHILDREN for name in getattr(mixer, "_modules", {}))
 

--- a/transformer_lens/model_bridge/supported_architectures/granite_moe_hybrid.py
+++ b/transformer_lens/model_bridge/supported_architectures/granite_moe_hybrid.py
@@ -5,7 +5,10 @@ a few are standard attention (determined by config.layer_types). Every layer
 has a shared MLP and optional sparse MoE.
 
 Both attention and Mamba are mapped as optional — each present only on its
-respective layer type. Mamba hooks expose in_proj, conv1d, and inner_norm.
+respective layer type. The Mamba mixer is wired under the canonical ``.mixer``
+slot (HF path is ``.mamba``) so SSM analyses (compute_effective_attention)
+reach it the same way as on NemotronH / Mamba-2. Mamba hooks expose in_proj,
+conv1d, and inner_norm (the gated two-input MambaRMSNormGated).
 """
 
 from typing import Any
@@ -14,6 +17,7 @@ from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapt
 from transformer_lens.model_bridge.generalized_components import (
     BlockBridge,
     EmbeddingBridge,
+    GatedRMSNormBridge,
     LinearBridge,
     MLPBridge,
     MoEBridge,
@@ -47,10 +51,24 @@ class GraniteMoeHybridArchitectureAdapter(GraniteArchitectureAdapter):
 
         self.supports_fold_ln = False
         self.weight_processing_conversions = {}
+
+        # Expose the per-layer mixer-type list uniformly as cfg.layers_block_type
+        # (HF stores it as `layer_types`; passthrough copies that name). Matches
+        # NemotronH so analysis tools can inspect which layers are Mamba.
+        layers_block_type = (
+            getattr(cfg, "layers_block_type", None) or getattr(cfg, "layer_types", None) or []
+        )
+        setattr(self.cfg, "layers_block_type", list(layers_block_type))
+
         self.component_mapping = self._build_component_mapping()
 
     def _build_mamba_bridge(self) -> SSM2MixerBridge:
-        """Mamba-2 mixer bridge with in_proj, conv1d, inner_norm hooks."""
+        """Mamba-2 mixer bridge with in_proj, conv1d, inner_norm hooks.
+
+        ``name="mamba"`` is the HF submodule path; the bridge exposes it under the
+        canonical ``.mixer`` dict key (see ``_build_component_mapping``). inner_norm
+        is the gated two-input MambaRMSNormGated, so it wraps GatedRMSNormBridge.
+        """
         return SSM2MixerBridge(
             name="mamba",
             config=self.cfg,
@@ -58,7 +76,7 @@ class GraniteMoeHybridArchitectureAdapter(GraniteArchitectureAdapter):
             submodules={
                 "in_proj": LinearBridge(name="in_proj"),
                 "conv1d": DepthwiseConv1DBridge(name="conv1d"),
-                "inner_norm": LinearBridge(name="norm"),
+                "inner_norm": GatedRMSNormBridge(name="norm"),
             },
         )
 
@@ -67,7 +85,7 @@ class GraniteMoeHybridArchitectureAdapter(GraniteArchitectureAdapter):
             "ln1": RMSNormalizationBridge(name="input_layernorm", config=self.cfg),
             "ln2": RMSNormalizationBridge(name="post_attention_layernorm", config=self.cfg),
             "attn": self._build_attention_bridge(optional=True),
-            "mamba": self._build_mamba_bridge(),
+            "mixer": self._build_mamba_bridge(),
             "shared_mlp": MLPBridge(
                 name="shared_mlp",
                 config=self.cfg,

--- a/transformer_lens/model_bridge/supported_architectures/granite_moe_hybrid.py
+++ b/transformer_lens/model_bridge/supported_architectures/granite_moe_hybrid.py
@@ -41,6 +41,9 @@ class GraniteMoeHybridArchitectureAdapter(GraniteArchitectureAdapter):
     universal. Inherits Granite config and attention bridge construction.
     """
 
+    # Explicit for parity with the Mamba/NemotronH siblings.
+    applicable_phases: list[int] = [1, 2, 3, 4]
+
     def __init__(self, cfg: Any) -> None:
         ArchitectureAdapter.__init__(self, cfg)
         self._setup_common_config(cfg)
@@ -52,9 +55,8 @@ class GraniteMoeHybridArchitectureAdapter(GraniteArchitectureAdapter):
         self.supports_fold_ln = False
         self.weight_processing_conversions = {}
 
-        # Expose the per-layer mixer-type list uniformly as cfg.layers_block_type
-        # (HF stores it as `layer_types`; passthrough copies that name). Matches
-        # NemotronH so analysis tools can inspect which layers are Mamba.
+        # Normalize the per-layer mixer-type list as cfg.layers_block_type (HF names
+        # it `layer_types`) so analysis tools can find the Mamba layers, as on NemotronH.
         layers_block_type = (
             getattr(cfg, "layers_block_type", None) or getattr(cfg, "layer_types", None) or []
         )

--- a/transformer_lens/model_bridge/supported_architectures/mamba.py
+++ b/transformer_lens/model_bridge/supported_architectures/mamba.py
@@ -23,11 +23,9 @@ class MambaArchitectureAdapter(ArchitectureAdapter):
     ``_HF_PASSTHROUGH_ATTRS`` in sources/transformers.py.
     """
 
-    # Phases 1-3 are transformer-shaped (component/weight comparison) and don't
-    # fit SSMs; component-level coverage lives in integration tests:
-    # tests/integration/model_bridge/test_mamba_adapter.py. Phase 4 (generation
-    # + text-quality) needs no component comparison, so it applies.
-    applicable_phases: list[int] = [4]
+    # White-box forward: P1 is exact vs raw HF (mixer delegates to HF); P2/P3 skip
+    # without a HookedTransformer; P4 is generation.
+    applicable_phases: list[int] = [1, 2, 3, 4]
 
     def __init__(self, cfg: Any) -> None:
         super().__init__(cfg)

--- a/transformer_lens/model_bridge/supported_architectures/mamba2.py
+++ b/transformer_lens/model_bridge/supported_architectures/mamba2.py
@@ -1,5 +1,6 @@
 """Architecture adapter for HF's Mamba2ForCausalLM, plus the effective attention helper."""
-from typing import Any, Callable, Dict, Optional, Union
+import warnings
+from typing import Any, Dict, Optional, Union
 
 import torch
 
@@ -116,95 +117,20 @@ def compute_effective_attention(
     layer: Optional[int] = None,
     include_dt_scaling: bool = False,
 ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
-    """Compute Mamba-2 effective attention M = L ⊙ (C B^T) for one or all layers.
+    """Mamba-2 effective attention for one or all layers.
 
-    Wraps ``SSM2MixerBridge.compute_effective_attention`` so callers don't have
-    to repeat the layer index, and resolves SSM layers across all families
-    (full Mamba-2 and hybrids like NemotronH / GraniteMoeHybrid) when ``layer``
-    is None. Non-SSM layers (attention / MLP / MoE) are skipped structurally.
-
-    Args:
-        bridge: A loaded ``TransformerBridge`` whose SSM layers use ``.mixer``.
-        cache: ActivationCache from ``run_with_cache`` with in_proj and conv1d
-            hooks populated for every SSM layer.
-        layer: Specific block index, or None for every SSM layer.
-        include_dt_scaling: See ``SSM2MixerBridge.compute_effective_attention``.
-
-    Returns:
-        For a single ``layer``: ``[batch, num_heads, seq, seq]``.
-        For ``layer=None``: a stacked ``[n_layers, batch, num_heads, seq, seq]``
-        tensor when *every* block is an SSM layer (full Mamba-2), otherwise a
-        ``{layer_idx: [batch, num_heads, seq, seq]}`` dict over the SSM layers
-        (heterogeneous hybrids).
-
-    Raises:
-        TypeError: If the requested ``layer`` has no ``SSM2MixerBridge`` mixer.
-        RuntimeError: If ``layer=None`` finds no cached SSM mixer layers.
-
-    Example::
-
-        from transformer_lens.model_bridge.supported_architectures.mamba2 import (
-            compute_effective_attention,
-        )
-
-        M5 = compute_effective_attention(bridge, cache, layer=5)
-        M_all = compute_effective_attention(bridge, cache)
+    .. deprecated::
+        Use the family-agnostic ``cache.compute_ssm_effective_attention(layer=...)``
+        instead. This thin wrapper delegates to it and ignores ``bridge`` (the
+        cache already knows its model).
     """
-    if layer is not None:
-        mixer = getattr(bridge.blocks[layer], "mixer", None)
-        if not isinstance(mixer, SSM2MixerBridge):
-            raise TypeError(
-                f"Layer {layer} has no SSM2MixerBridge mixer (got "
-                f"{type(mixer).__name__}); compute_effective_attention requires "
-                "a Mamba-2 / SSM layer."
-            )
-        return mixer.compute_effective_attention(
-            cache, layer_idx=layer, include_dt_scaling=include_dt_scaling
-        )
-
-    return _over_ssm_layers(
-        bridge,
-        cache,
-        lambda mixer, idx: mixer.compute_effective_attention(
-            cache, layer_idx=idx, include_dt_scaling=include_dt_scaling
-        ),
+    warnings.warn(
+        "mamba2.compute_effective_attention is deprecated; use "
+        "cache.compute_ssm_effective_attention(layer=..., include_dt_scaling=...).",
+        DeprecationWarning,
+        stacklevel=2,
     )
-
-
-def _over_ssm_layers(
-    bridge: TransformerBridge,
-    cache: ActivationCache,
-    fn: Callable[[SSM2MixerBridge, int], torch.Tensor],
-) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
-    """Apply ``fn(mixer, layer_idx)`` over every SSM mixer layer, stack or dict.
-
-    Enumerates SSM mixer layers structurally (``blocks_with`` checks ``_modules``,
-    so attention layers without a ``.mixer`` slot are skipped). On a hybrid where
-    every block carries a passthrough ``.mixer`` (NemotronH), the cached-hook
-    check filters out the non-Mamba mixers. Returns a stacked tensor (dim 0 =
-    layer) when *every* block is an SSM layer, else a ``{layer_idx: result}`` dict.
-    """
-    results: Dict[int, torch.Tensor] = {}
-    for layer_idx, block in bridge.blocks_with("mixer"):
-        mixer = block.mixer
-        if not isinstance(mixer, SSM2MixerBridge):
-            continue
-        in_proj_key = f"blocks.{layer_idx}.mixer.in_proj.hook_out"
-        conv1d_key = f"blocks.{layer_idx}.mixer.conv1d.hook_out"
-        if in_proj_key not in cache or conv1d_key not in cache:
-            continue
-        results[layer_idx] = fn(mixer, layer_idx)
-
-    if not results:
-        raise RuntimeError(
-            "No SSM mixer layers with cached in_proj/conv1d hooks were found. "
-            "Run `run_with_cache()` on a Mamba-2 / SSM bridge first."
-        )
-
-    n_blocks = len(bridge.blocks)
-    if len(results) == n_blocks and list(results) == list(range(n_blocks)):
-        return torch.stack([results[i] for i in range(n_blocks)], dim=0)
-    return results
+    return cache.compute_ssm_effective_attention(layer=layer, include_dt_scaling=include_dt_scaling)
 
 
 def compute_ssm_state(
@@ -213,39 +139,16 @@ def compute_ssm_state(
     layer: Optional[int] = None,
     time_step: Optional[int] = None,
 ) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
-    """Reconstruct the recurrent SSM state ``S`` for one or all SSM layers.
+    """Reconstruct the recurrent SSM state ``S`` for one or all Mamba-2 layers.
 
-    Thin wrapper over ``SSM2MixerBridge.compute_ssm_state`` mirroring
-    ``compute_effective_attention``; also reachable as ``cache.compute_ssm_state``.
-    See ``SSM2MixerBridge.compute_ssm_state`` for the reconstruction and shapes.
-
-    Args:
-        bridge: A loaded ``TransformerBridge`` whose SSM layers use ``.mixer``.
-        cache: ActivationCache from ``run_with_cache`` with in_proj/conv1d hooks.
-        layer: Specific block index, or None for every SSM layer.
-        time_step: Optional single position (memory-bounded); None for all steps.
-
-    Returns:
-        For a single ``layer``: the per-layer state tensor.
-        For ``layer=None``: a stacked tensor (dim 0 = layer) when every block is
-        an SSM layer, else a ``{layer_idx: state}`` dict over the SSM layers.
-
-    Raises:
-        TypeError: If the requested ``layer`` has no ``SSM2MixerBridge`` mixer.
-        RuntimeError: If ``layer=None`` finds no cached SSM mixer layers.
+    .. deprecated::
+        Use ``cache.compute_ssm_state(layer=..., time_step=...)`` instead. This
+        thin wrapper delegates to it and ignores ``bridge``.
     """
-    if layer is not None:
-        mixer = getattr(bridge.blocks[layer], "mixer", None)
-        if not isinstance(mixer, SSM2MixerBridge):
-            raise TypeError(
-                f"Layer {layer} has no SSM2MixerBridge mixer (got "
-                f"{type(mixer).__name__}); compute_ssm_state requires a Mamba-2 / "
-                "SSM layer."
-            )
-        return mixer.compute_ssm_state(cache, layer_idx=layer, time_step=time_step)
-
-    return _over_ssm_layers(
-        bridge,
-        cache,
-        lambda mixer, idx: mixer.compute_ssm_state(cache, layer_idx=idx, time_step=time_step),
+    warnings.warn(
+        "mamba2.compute_ssm_state is deprecated; use "
+        "cache.compute_ssm_state(layer=..., time_step=...).",
+        DeprecationWarning,
+        stacklevel=2,
     )
+    return cache.compute_ssm_state(layer=layer, time_step=time_step)

--- a/transformer_lens/model_bridge/supported_architectures/mamba2.py
+++ b/transformer_lens/model_bridge/supported_architectures/mamba2.py
@@ -1,5 +1,5 @@
 """Architecture adapter for HF's Mamba2ForCausalLM, plus the effective attention helper."""
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 
@@ -162,10 +162,28 @@ def compute_effective_attention(
             cache, layer_idx=layer, include_dt_scaling=include_dt_scaling
         )
 
-    # All-layers: enumerate SSM mixer layers structurally (blocks_with checks
-    # _modules, so attention layers without a `.mixer` slot are skipped). On a
-    # hybrid where every block carries a passthrough `.mixer` (NemotronH), the
-    # cached-hook check below filters out the non-Mamba mixers.
+    return _over_ssm_layers(
+        bridge,
+        cache,
+        lambda mixer, idx: mixer.compute_effective_attention(
+            cache, layer_idx=idx, include_dt_scaling=include_dt_scaling
+        ),
+    )
+
+
+def _over_ssm_layers(
+    bridge: TransformerBridge,
+    cache: ActivationCache,
+    fn: Callable[[SSM2MixerBridge, int], torch.Tensor],
+) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
+    """Apply ``fn(mixer, layer_idx)`` over every SSM mixer layer, stack or dict.
+
+    Enumerates SSM mixer layers structurally (``blocks_with`` checks ``_modules``,
+    so attention layers without a ``.mixer`` slot are skipped). On a hybrid where
+    every block carries a passthrough ``.mixer`` (NemotronH), the cached-hook
+    check filters out the non-Mamba mixers. Returns a stacked tensor (dim 0 =
+    layer) when *every* block is an SSM layer, else a ``{layer_idx: result}`` dict.
+    """
     results: Dict[int, torch.Tensor] = {}
     for layer_idx, block in bridge.blocks_with("mixer"):
         mixer = block.mixer
@@ -175,18 +193,59 @@ def compute_effective_attention(
         conv1d_key = f"blocks.{layer_idx}.mixer.conv1d.hook_out"
         if in_proj_key not in cache or conv1d_key not in cache:
             continue
-        results[layer_idx] = mixer.compute_effective_attention(
-            cache, layer_idx=layer_idx, include_dt_scaling=include_dt_scaling
-        )
+        results[layer_idx] = fn(mixer, layer_idx)
 
     if not results:
         raise RuntimeError(
-            "compute_effective_attention found no SSM mixer layers with cached "
-            "in_proj/conv1d hooks. Run `run_with_cache()` on a Mamba-2 / SSM "
-            "bridge first."
+            "No SSM mixer layers with cached in_proj/conv1d hooks were found. "
+            "Run `run_with_cache()` on a Mamba-2 / SSM bridge first."
         )
 
     n_blocks = len(bridge.blocks)
     if len(results) == n_blocks and list(results) == list(range(n_blocks)):
         return torch.stack([results[i] for i in range(n_blocks)], dim=0)
     return results
+
+
+def compute_ssm_state(
+    bridge: TransformerBridge,
+    cache: ActivationCache,
+    layer: Optional[int] = None,
+    time_step: Optional[int] = None,
+) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
+    """Reconstruct the recurrent SSM state ``S`` for one or all SSM layers.
+
+    Thin wrapper over ``SSM2MixerBridge.compute_ssm_state`` mirroring
+    ``compute_effective_attention``; also reachable as ``cache.compute_ssm_state``.
+    See ``SSM2MixerBridge.compute_ssm_state`` for the reconstruction and shapes.
+
+    Args:
+        bridge: A loaded ``TransformerBridge`` whose SSM layers use ``.mixer``.
+        cache: ActivationCache from ``run_with_cache`` with in_proj/conv1d hooks.
+        layer: Specific block index, or None for every SSM layer.
+        time_step: Optional single position (memory-bounded); None for all steps.
+
+    Returns:
+        For a single ``layer``: the per-layer state tensor.
+        For ``layer=None``: a stacked tensor (dim 0 = layer) when every block is
+        an SSM layer, else a ``{layer_idx: state}`` dict over the SSM layers.
+
+    Raises:
+        TypeError: If the requested ``layer`` has no ``SSM2MixerBridge`` mixer.
+        RuntimeError: If ``layer=None`` finds no cached SSM mixer layers.
+    """
+    if layer is not None:
+        mixer = getattr(bridge.blocks[layer], "mixer", None)
+        if not isinstance(mixer, SSM2MixerBridge):
+            raise TypeError(
+                f"Layer {layer} has no SSM2MixerBridge mixer (got "
+                f"{type(mixer).__name__}); compute_ssm_state requires a Mamba-2 / "
+                "SSM layer."
+            )
+        return mixer.compute_ssm_state(cache, layer_idx=layer, time_step=time_step)
+
+    return _over_ssm_layers(
+        bridge,
+        cache,
+        lambda mixer, idx: mixer.compute_ssm_state(cache, layer_idx=idx, time_step=time_step),
+    )

--- a/transformer_lens/model_bridge/supported_architectures/mamba2.py
+++ b/transformer_lens/model_bridge/supported_architectures/mamba2.py
@@ -1,5 +1,5 @@
 """Architecture adapter for HF's Mamba2ForCausalLM, plus the effective attention helper."""
-from typing import Any, Optional
+from typing import Any, Dict, Optional, Union
 
 import torch
 
@@ -115,26 +115,31 @@ def compute_effective_attention(
     cache: ActivationCache,
     layer: Optional[int] = None,
     include_dt_scaling: bool = False,
-) -> torch.Tensor:
+) -> Union[torch.Tensor, Dict[int, torch.Tensor]]:
     """Compute Mamba-2 effective attention M = L ⊙ (C B^T) for one or all layers.
 
     Wraps ``SSM2MixerBridge.compute_effective_attention`` so callers don't have
-    to repeat the layer index, and adds all-layers stacking when ``layer`` is
-    None.
+    to repeat the layer index, and resolves SSM layers across all families
+    (full Mamba-2 and hybrids like NemotronH / GraniteMoeHybrid) when ``layer``
+    is None. Non-SSM layers (attention / MLP / MoE) are skipped structurally.
 
     Args:
-        bridge: A loaded Mamba-2 ``TransformerBridge``.
+        bridge: A loaded ``TransformerBridge`` whose SSM layers use ``.mixer``.
         cache: ActivationCache from ``run_with_cache`` with in_proj and conv1d
-            hooks populated for every requested layer.
-        layer: Specific block index, or None for all layers stacked.
+            hooks populated for every SSM layer.
+        layer: Specific block index, or None for every SSM layer.
         include_dt_scaling: See ``SSM2MixerBridge.compute_effective_attention``.
 
     Returns:
-        Shape ``[batch, num_heads, seq, seq]`` for a single layer, or
-        ``[n_layers, batch, num_heads, seq, seq]`` when layer is None.
+        For a single ``layer``: ``[batch, num_heads, seq, seq]``.
+        For ``layer=None``: a stacked ``[n_layers, batch, num_heads, seq, seq]``
+        tensor when *every* block is an SSM layer (full Mamba-2), otherwise a
+        ``{layer_idx: [batch, num_heads, seq, seq]}`` dict over the SSM layers
+        (heterogeneous hybrids).
 
     Raises:
-        TypeError: If any targeted block's mixer isn't an ``SSM2MixerBridge``.
+        TypeError: If the requested ``layer`` has no ``SSM2MixerBridge`` mixer.
+        RuntimeError: If ``layer=None`` finds no cached SSM mixer layers.
 
     Example::
 
@@ -146,29 +151,42 @@ def compute_effective_attention(
         M_all = compute_effective_attention(bridge, cache)
     """
     if layer is not None:
-        mixer = bridge.blocks[layer].mixer
+        mixer = getattr(bridge.blocks[layer], "mixer", None)
         if not isinstance(mixer, SSM2MixerBridge):
             raise TypeError(
-                f"Layer {layer} mixer is {type(mixer).__name__}, not "
-                "SSM2MixerBridge. compute_effective_attention requires a "
-                "Mamba-2 bridge."
+                f"Layer {layer} has no SSM2MixerBridge mixer (got "
+                f"{type(mixer).__name__}); compute_effective_attention requires "
+                "a Mamba-2 / SSM layer."
             )
         return mixer.compute_effective_attention(
             cache, layer_idx=layer, include_dt_scaling=include_dt_scaling
         )
 
-    matrices = []
-    for layer_idx, block in enumerate(bridge.blocks):
+    # All-layers: enumerate SSM mixer layers structurally (blocks_with checks
+    # _modules, so attention layers without a `.mixer` slot are skipped). On a
+    # hybrid where every block carries a passthrough `.mixer` (NemotronH), the
+    # cached-hook check below filters out the non-Mamba mixers.
+    results: Dict[int, torch.Tensor] = {}
+    for layer_idx, block in bridge.blocks_with("mixer"):
         mixer = block.mixer
         if not isinstance(mixer, SSM2MixerBridge):
-            raise TypeError(
-                f"Layer {layer_idx} mixer is {type(mixer).__name__}, not "
-                "SSM2MixerBridge. compute_effective_attention requires a "
-                "Mamba-2 bridge."
-            )
-        matrices.append(
-            mixer.compute_effective_attention(
-                cache, layer_idx=layer_idx, include_dt_scaling=include_dt_scaling
-            )
+            continue
+        in_proj_key = f"blocks.{layer_idx}.mixer.in_proj.hook_out"
+        conv1d_key = f"blocks.{layer_idx}.mixer.conv1d.hook_out"
+        if in_proj_key not in cache or conv1d_key not in cache:
+            continue
+        results[layer_idx] = mixer.compute_effective_attention(
+            cache, layer_idx=layer_idx, include_dt_scaling=include_dt_scaling
         )
-    return torch.stack(matrices, dim=0)
+
+    if not results:
+        raise RuntimeError(
+            "compute_effective_attention found no SSM mixer layers with cached "
+            "in_proj/conv1d hooks. Run `run_with_cache()` on a Mamba-2 / SSM "
+            "bridge first."
+        )
+
+    n_blocks = len(bridge.blocks)
+    if len(results) == n_blocks and list(results) == list(range(n_blocks)):
+        return torch.stack([results[i] for i in range(n_blocks)], dim=0)
+    return results

--- a/transformer_lens/model_bridge/supported_architectures/mamba2.py
+++ b/transformer_lens/model_bridge/supported_architectures/mamba2.py
@@ -29,11 +29,9 @@ class Mamba2ArchitectureAdapter(ArchitectureAdapter):
     loop with Mamba-1.
     """
 
-    # Phases 1-3 are transformer-shaped (component/weight comparison) and don't
-    # fit SSMs; component-level coverage lives in integration tests:
-    # tests/integration/model_bridge/test_mamba2_adapter.py. Phase 4 (generation
-    # + text-quality) needs no component comparison, so it applies.
-    applicable_phases: list[int] = [4]
+    # White-box forward: P1 is exact vs raw HF (mixer delegates to HF); P2/P3 skip
+    # without a HookedTransformer; P4 is generation.
+    applicable_phases: list[int] = [1, 2, 3, 4]
 
     def __init__(self, cfg: Any) -> None:
         super().__init__(cfg)

--- a/transformer_lens/model_bridge/supported_architectures/nemotron_h.py
+++ b/transformer_lens/model_bridge/supported_architectures/nemotron_h.py
@@ -1,6 +1,6 @@
 """Nemotron-H hybrid Mamba2-Transformer architecture adapter.
 
-Supports NemotronHForCausalLM (nvidia/Nemotron-H-8B-Base, Nemotron-H-47B-A13B).
+Supports NemotronHForCausalLM (e.g. nvidia/NVIDIA-Nemotron-Nano-9B-v2, Nemotron-3 series).
 
 Architecture overview:
 - Heterogeneous layers defined by ``config.layers_block_type`` — each element is

--- a/transformer_lens/model_bridge/supported_architectures/nemotron_h.py
+++ b/transformer_lens/model_bridge/supported_architectures/nemotron_h.py
@@ -90,9 +90,12 @@ class NemotronHArchitectureAdapter(ArchitectureAdapter):
         self.cfg.is_stateful = True
 
         # Expose the heterogeneous layer-type list so tests and analysis tools
-        # can inspect which layers are which without loading a full HF model.
-        layers_block_type = getattr(cfg, "layers_block_type", [])
-        setattr(self.cfg, "layers_block_type", layers_block_type)
+        # can inspect which layers are which without loading a full HF model. The
+        # passthrough copies HF's `layer_types`; fall back to it (matches Granite).
+        layers_block_type = (
+            getattr(cfg, "layers_block_type", None) or getattr(cfg, "layer_types", None) or []
+        )
+        setattr(self.cfg, "layers_block_type", list(layers_block_type))
 
         # Mamba-2 dimensional config (mirrors Mamba2ArchitectureAdapter).
         mamba_num_heads = getattr(cfg, "mamba_num_heads", 128)

--- a/transformer_lens/model_bridge/supported_architectures/nemotron_h.py
+++ b/transformer_lens/model_bridge/supported_architectures/nemotron_h.py
@@ -26,9 +26,8 @@ Key adapter decisions:
   Mamba-specific inner submodules (in_proj, conv1d, inner_norm, out_proj) are
   declared ``optional=True`` so setup skips them gracefully on non-Mamba layers.
 - MLP layers use ``relu2`` activation (not SwiGLU); ``gated_mlp = False``.
-- ``applicable_phases = []``: ``verify_models`` is transformer-shaped and would
-  require a dedicated refactor to cover SSM hybrids. Coverage lives in the
-  integration test instead.
+- ``applicable_phases = [1, 2, 3, 4]``: P1 is exact vs raw HF (passthrough mixers);
+  P2/P3 skip without a HookedTransformer; P4 is generation.
 """
 
 from typing import Any
@@ -69,9 +68,9 @@ class NemotronHArchitectureAdapter(ArchitectureAdapter):
     is determined by ``config.layers_block_type[layer_idx]``.
     """
 
-    # verify_models is transformer-shaped and requires a dedicated refactor to
-    # cover SSM hybrids. Integration tests cover forward-pass correctness instead.
-    applicable_phases: list[int] = []
+    # White-box forward: P1 is exact vs raw HF (passthrough mixers); P2/P3 skip
+    # without a HookedTransformer; P4 is generation.
+    applicable_phases: list[int] = [1, 2, 3, 4]
 
     def __init__(self, cfg: Any) -> None:
         super().__init__(cfg)
@@ -89,9 +88,8 @@ class NemotronHArchitectureAdapter(ArchitectureAdapter):
         # Mamba layers require per-step SSM state; generation is stateful.
         self.cfg.is_stateful = True
 
-        # Expose the heterogeneous layer-type list so tests and analysis tools
-        # can inspect which layers are which without loading a full HF model. The
-        # passthrough copies HF's `layer_types`; fall back to it (matches Granite).
+        # Normalize the per-layer type list as cfg.layers_block_type (HF names it
+        # `layer_types`) so analysis tools can find the Mamba layers, as on Granite.
         layers_block_type = (
             getattr(cfg, "layers_block_type", None) or getattr(cfg, "layer_types", None) or []
         )

--- a/transformer_lens/tools/model_registry/AGENTS.md
+++ b/transformer_lens/tools/model_registry/AGENTS.md
@@ -116,6 +116,8 @@ Never edit manually.
 | 7 | Multimodal (vision/text alignment) — only Llava / Gemma3-multimodal |
 | 8 | Audio — only Hubert |
 
+SSM / recurrent families and the hybrids (Mamba-1/2, gated-delta-net, NemotronH, GraniteMoeHybrid, Qwen3.5/Qwen3-Next) declare `applicable_phases = [1, 2, 3, 4]` — all four apply. P2/P3 run but skip their HookedTransformer-comparison sub-tests (SSMs have no HT), which is scored as a pass.
+
 ### Phase-score thresholds
 
 `verify_models` enforces hard pass/fail at the thresholds in `_MIN_PHASE_SCORES` ([`verify_models.py:508`](verify_models.py)). Below threshold OR a required-test failure → `STATUS_FAILED`. The contract:

--- a/transformer_lens/tools/model_registry/data/architecture_gaps.json
+++ b/transformer_lens/tools/model_registry/data/architecture_gaps.json
@@ -1,33 +1,14 @@
 {
-  "generated_at": "2026-06-25",
+  "generated_at": "2026-07-01",
   "scan_info": {
-    "total_scanned": 5949,
+    "total_scanned": 5855,
     "task_filter": "text-generation",
     "min_downloads": 500,
-    "scan_duration_seconds": 8.1
+    "scan_duration_seconds": 7.0
   },
-  "total_unsupported_architectures": 507,
-  "total_unsupported_models": 3862,
+  "total_unsupported_architectures": 514,
+  "total_unsupported_models": 4737,
   "gaps": [
-    {
-      "architecture_id": "NemotronHForCausalLM",
-      "total_models": 153,
-      "total_downloads": 16859572,
-      "min_param_count": 4226684,
-      "sample_models": [
-        "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
-        "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-        "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
-        "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
-        "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Japanese",
-        "trl-internal-testing/tiny-NemotronHForCausalLM-nano",
-        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
-        "trl-internal-testing/tiny-NemotronHForCausalLM-ultra",
-        "trl-internal-testing/tiny-NemotronHForCausalLM-super",
-        "nvidia/Nemotron-Cascade-2-30B-A3B"
-      ],
-      "relevancy_score": 99.7
-    },
     {
       "architecture_id": "MarianMTModel",
       "total_models": 154,
@@ -48,9 +29,28 @@
       "relevancy_score": 98.6
     },
     {
+      "architecture_id": "Qwen3_5MoeForConditionalGeneration",
+      "total_models": 144,
+      "total_downloads": 1125570,
+      "min_param_count": 664944,
+      "sample_models": [
+        "cyankiwi/Nex-N2-mini-AWQ-INT4",
+        "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
+        "genevera/Qwen3.6-35B-A3B-Abliterated-Heretic-AWQ-4bit",
+        "nex-agi/Nex-N2-mini",
+        "Momix-44/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
+        "nex-agi/Nex-N2-Pro",
+        "atbender/Qwen3.6-VL-REAP-26B-A3B-W4A16",
+        "happypatrick/Qwen3.5-397B-A17B-heretic-int4-AutoRound",
+        "bullerwins/Nex-N2-Pro-4bit-W4A16",
+        "YuYu1015/Huihui-Qwen3.6-35B-A3B-abliterated-int4-AutoRound"
+      ],
+      "relevancy_score": 91.4
+    },
+    {
       "architecture_id": "Lfm2ForCausalLM",
-      "total_models": 95,
-      "total_downloads": 1537174,
+      "total_models": 133,
+      "total_downloads": 2121790,
       "min_param_count": 4321856,
       "sample_models": [
         "LiquidAI/LFM2.5-1.2B-Instruct",
@@ -64,50 +64,12 @@
         "LiquidAI/LFM2.5-1.2B-JP-202606",
         "LiquidAI/LFM2-2.6B"
       ],
-      "relevancy_score": 77.7
-    },
-    {
-      "architecture_id": "Qwen3_5MoeForConditionalGeneration",
-      "total_models": 100,
-      "total_downloads": 622389,
-      "min_param_count": 1034089088,
-      "sample_models": [
-        "cyankiwi/Nex-N2-mini-AWQ-INT4",
-        "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
-        "genevera/Qwen3.6-35B-A3B-Abliterated-Heretic-AWQ-4bit",
-        "nex-agi/Nex-N2-mini",
-        "Momix-44/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
-        "nex-agi/Nex-N2-Pro",
-        "atbender/Qwen3.6-VL-REAP-26B-A3B-W4A16",
-        "happypatrick/Qwen3.5-397B-A17B-heretic-int4-AutoRound",
-        "bullerwins/Nex-N2-Pro-4bit-W4A16",
-        "YuYu1015/Huihui-Qwen3.6-35B-A3B-abliterated-int4-AutoRound"
-      ],
-      "relevancy_score": 73.3
-    },
-    {
-      "architecture_id": "DeepseekV4ForCausalLM",
-      "total_models": 52,
-      "total_downloads": 13485551,
-      "min_param_count": 110369621,
-      "sample_models": [
-        "deepseek-ai/DeepSeek-V4-Pro",
-        "deepseek-ai/DeepSeek-V4-Flash",
-        "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
-        "dealignai/DeepSeek-V4-Flash-JANG-CRACK",
-        "shuidian/DeepSeek-V4-Flash-JANG-CRACK",
-        "HuggingFaceTB/nanowhale-100m",
-        "BennyGM/DeepSeek-V4-Pro-bf16",
-        "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
-        "Intel/DeepSeek-V4-Pro-W4A16-AutoRound",
-        "JANGQ-AI/DeepSeek-V4-Flash-JANGTQ2"
-      ],
-      "relevancy_score": 69.7
+      "relevancy_score": 89.5
     },
     {
       "architecture_id": "DFlashDraftModel",
-      "total_models": 64,
-      "total_downloads": 1200690,
+      "total_models": 88,
+      "total_downloads": 1674736,
       "min_param_count": 385906176,
       "sample_models": [
         "z-lab/Qwen3-8B-DFlash-b16",
@@ -121,12 +83,31 @@
         "z-lab/gpt-oss-20b-DFlash",
         "z-lab/Qwen3.5-35B-A3B-DFlash"
       ],
-      "relevancy_score": 68.1
+      "relevancy_score": 75.9
+    },
+    {
+      "architecture_id": "DeepseekV4ForCausalLM",
+      "total_models": 70,
+      "total_downloads": 16637388,
+      "min_param_count": 110369621,
+      "sample_models": [
+        "deepseek-ai/DeepSeek-V4-Pro",
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
+        "dealignai/DeepSeek-V4-Flash-JANG-CRACK",
+        "shuidian/DeepSeek-V4-Flash-JANG-CRACK",
+        "HuggingFaceTB/nanowhale-100m",
+        "BennyGM/DeepSeek-V4-Pro-bf16",
+        "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
+        "Intel/DeepSeek-V4-Pro-W4A16-AutoRound",
+        "JANGQ-AI/DeepSeek-V4-Flash-JANGTQ2"
+      ],
+      "relevancy_score": 75.5
     },
     {
       "architecture_id": "MiniCPMForCausalLM",
-      "total_models": 57,
-      "total_downloads": 646259,
+      "total_models": 71,
+      "total_downloads": 927705,
       "min_param_count": 433873920,
       "sample_models": [
         "openbmb/MiniCPM-2B-sft-bf16",
@@ -140,88 +121,12 @@
         "openbmb/BitCPM-CANN-0.5B-unquantized",
         "openbmb/MiniCPM-S-1B-sft"
       ],
-      "relevancy_score": 64.8
-    },
-    {
-      "architecture_id": "T5WithLMHeadModel",
-      "total_models": 42,
-      "total_downloads": 1032735,
-      "min_param_count": 222903936,
-      "sample_models": [
-        "google-t5/t5-3b",
-        "google-t5/t5-11b",
-        "unicamp-dl/ptt5-base-portuguese-vocab",
-        "Rostlab/prot_t5_xl_bfd",
-        "SEBIS/legal_t5_small_summ_en",
-        "SEBIS/legal_t5_small_summ_it",
-        "unicamp-dl/ptt5-small-portuguese-vocab",
-        "SEBIS/legal_t5_small_summ_fr",
-        "unicamp-dl/ptt5-large-portuguese-vocab",
-        "gagan3012/k2t"
-      ],
-      "relevancy_score": 61.4
-    },
-    {
-      "architecture_id": "Glm4MoeLiteForCausalLM",
-      "total_models": 27,
-      "total_downloads": 7000683,
-      "min_param_count": 5768240,
-      "sample_models": [
-        "zai-org/GLM-4.7-Flash",
-        "unsloth/GLM-4.7-Flash",
-        "cyankiwi/GLM-4.7-Flash-AWQ-4bit",
-        "QuantTrio/GLM-4.7-Flash-AWQ",
-        "Ex0bit/GLM-4.7-Flash-PRISM",
-        "huihui-ai/Huihui-GLM-4.7-Flash-abliterated",
-        "cyankiwi/GLM-4.7-Flash-REAP-23B-A3B-AWQ-4bit",
-        "Olafangensan/GLM-4.7-Flash-heretic",
-        "cyankiwi/GLM-4.7-Flash-AWQ-8bit",
-        "tiny-random/glm-4.7-flash"
-      ],
-      "relevancy_score": 61.0
-    },
-    {
-      "architecture_id": "QWenLMHeadModel",
-      "total_models": 53,
-      "total_downloads": 1173335,
-      "min_param_count": 1836828672,
-      "sample_models": [
-        "Qwen/Qwen-VL",
-        "cckevinn/SeeClick",
-        "Qwen/Qwen-VL-Chat",
-        "Qwen/Qwen-7B-Chat",
-        "Qwen/Qwen-7B",
-        "TheBloke/Qwen-7B-Chat-AWQ",
-        "Qwen/Qwen-Audio-Chat",
-        "Qwen/Qwen-14B",
-        "Qwen/Qwen-14B-Chat",
-        "Qwen/Qwen-1_8B"
-      ],
-      "relevancy_score": 60.9
-    },
-    {
-      "architecture_id": "ParlerTTSForConditionalGeneration",
-      "total_models": 33,
-      "total_downloads": 2560642,
-      "min_param_count": 647027186,
-      "sample_models": [
-        "ai4bharat/indic-parler-tts",
-        "parler-tts/parler-tts-mini-v1",
-        "parler-tts/parler-tts-large-v1",
-        "parler-tts/parler_tts_mini_v0.1",
-        "parler-tts/parler-tts-mini-multilingual-v1.1",
-        "parler-tts/parler-tts-mini-v1.1",
-        "ai4bharat/indic-parler-tts-pretrained",
-        "parler-tts/parler-tts-mini-expresso",
-        "atlithor/EmotiveIcelandic",
-        "2121-8/japanese-parler-tts-mini"
-      ],
-      "relevancy_score": 60.7
+      "relevancy_score": 69.7
     },
     {
       "architecture_id": "MiniMaxM2ForCausalLM",
-      "total_models": 76,
-      "total_downloads": 10035611,
+      "total_models": 99,
+      "total_downloads": 12619591,
       "min_param_count": 15303312058,
       "sample_models": [
         "MiniMaxAI/MiniMax-M2.7",
@@ -235,12 +140,50 @@
         "QuantTrio/MiniMax-M2.7-AWQ",
         "JANGQ-AI/MiniMax-M2.7-JANGTQ"
       ],
-      "relevancy_score": 60.1
+      "relevancy_score": 67.3
+    },
+    {
+      "architecture_id": "QWenLMHeadModel",
+      "total_models": 69,
+      "total_downloads": 1488558,
+      "min_param_count": 1836828672,
+      "sample_models": [
+        "Qwen/Qwen-VL",
+        "cckevinn/SeeClick",
+        "Qwen/Qwen-VL-Chat",
+        "Qwen/Qwen-7B-Chat",
+        "Qwen/Qwen-7B",
+        "TheBloke/Qwen-7B-Chat-AWQ",
+        "Qwen/Qwen-Audio-Chat",
+        "Qwen/Qwen-14B",
+        "Qwen/Qwen-14B-Chat",
+        "Qwen/Qwen-1_8B"
+      ],
+      "relevancy_score": 66.1
+    },
+    {
+      "architecture_id": "T5WithLMHeadModel",
+      "total_models": 56,
+      "total_downloads": 1336656,
+      "min_param_count": 222903936,
+      "sample_models": [
+        "google-t5/t5-3b",
+        "google-t5/t5-11b",
+        "unicamp-dl/ptt5-base-portuguese-vocab",
+        "Rostlab/prot_t5_xl_bfd",
+        "SEBIS/legal_t5_small_summ_en",
+        "SEBIS/legal_t5_small_summ_it",
+        "unicamp-dl/ptt5-small-portuguese-vocab",
+        "SEBIS/legal_t5_small_summ_fr",
+        "unicamp-dl/ptt5-large-portuguese-vocab",
+        "gagan3012/k2t"
+      ],
+      "relevancy_score": 66.1
     },
     {
       "architecture_id": "FalconH1ForCausalLM",
-      "total_models": 42,
-      "total_downloads": 550692,
+      "total_models": 55,
+      "total_downloads": 736957,
       "min_param_count": 91131072,
       "sample_models": [
         "tiiuae/Falcon-H1-0.5B-Base",
@@ -254,12 +197,50 @@
         "tiiuae/Falcon-H1-34B-Instruct",
         "tiiuae/Falcon-H1-34B-Base"
       ],
-      "relevancy_score": 60.1
+      "relevancy_score": 64.5
+    },
+    {
+      "architecture_id": "Glm4MoeLiteForCausalLM",
+      "total_models": 35,
+      "total_downloads": 9799340,
+      "min_param_count": 5768240,
+      "sample_models": [
+        "zai-org/GLM-4.7-Flash",
+        "unsloth/GLM-4.7-Flash",
+        "cyankiwi/GLM-4.7-Flash-AWQ-4bit",
+        "QuantTrio/GLM-4.7-Flash-AWQ",
+        "Ex0bit/GLM-4.7-Flash-PRISM",
+        "huihui-ai/Huihui-GLM-4.7-Flash-abliterated",
+        "cyankiwi/GLM-4.7-Flash-REAP-23B-A3B-AWQ-4bit",
+        "Olafangensan/GLM-4.7-Flash-heretic",
+        "cyankiwi/GLM-4.7-Flash-AWQ-8bit",
+        "tiny-random/glm-4.7-flash"
+      ],
+      "relevancy_score": 64.1
+    },
+    {
+      "architecture_id": "ParlerTTSForConditionalGeneration",
+      "total_models": 42,
+      "total_downloads": 3355473,
+      "min_param_count": 647027186,
+      "sample_models": [
+        "ai4bharat/indic-parler-tts",
+        "parler-tts/parler-tts-mini-v1",
+        "parler-tts/parler-tts-large-v1",
+        "parler-tts/parler_tts_mini_v0.1",
+        "parler-tts/parler-tts-mini-multilingual-v1.1",
+        "parler-tts/parler-tts-mini-v1.1",
+        "ai4bharat/indic-parler-tts-pretrained",
+        "parler-tts/parler-tts-mini-expresso",
+        "atlithor/EmotiveIcelandic",
+        "2121-8/japanese-parler-tts-mini"
+      ],
+      "relevancy_score": 63.9
     },
     {
       "architecture_id": "Gemma4AssistantForCausalLM",
-      "total_models": 24,
-      "total_downloads": 3638749,
+      "total_models": 33,
+      "total_downloads": 5152069,
       "min_param_count": 77993476,
       "sample_models": [
         "google/gemma-4-31B-it-assistant",
@@ -270,33 +251,15 @@
         "google/gemma-4-E4B-it-qat-q4_0-unquantized-assistant",
         "google/gemma-4-26B-A4B-it-qat-q4_0-unquantized-assistant",
         "guardiangate1775/gemma-4-26B-A4B-it-assistant-4bit",
-        "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant"
+        "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant",
+        "kunhunjon/gemma-4-26B-A4B-it-qat-assistant-w4a16-ct"
       ],
-      "relevancy_score": 58.8
-    },
-    {
-      "architecture_id": "HunYuanDenseV1ForCausalLM",
-      "total_models": 41,
-      "total_downloads": 333772,
-      "min_param_count": 539010048,
-      "sample_models": [
-        "tencent/Hy-MT2-1.8B",
-        "tencent/Hunyuan-7B-Instruct",
-        "tencent/Hy-MT2-7B",
-        "tencent/HY-MT1.5-1.8B",
-        "tencent/Hunyuan-MT-7B",
-        "shawnw3i/Hy-MT2-1.8B-AWQ",
-        "tencent/HY-MT1.5-7B",
-        "huihui-ai/Huihui-HY-MT1.5-7B-abliterated",
-        "tencent/Hunyuan-MT-Chimera-7B",
-        "tencent/HY-MT1.5-1.8B-GPTQ-Int4"
-      ],
-      "relevancy_score": 58.7
+      "relevancy_score": 62.2
     },
     {
       "architecture_id": "ExaoneForCausalLM",
-      "total_models": 30,
-      "total_downloads": 1208776,
+      "total_models": 40,
+      "total_downloads": 1649174,
       "min_param_count": 236983296,
       "sample_models": [
         "LGAI-EXAONE/EXAONE-3.5-32B-Instruct-AWQ",
@@ -310,12 +273,64 @@
         "hyper-accel/tiny-random-exaone",
         "LGAI-EXAONE/EXAONE-Deep-2.4B"
       ],
-      "relevancy_score": 58.2
+      "relevancy_score": 61.8
+    },
+    {
+      "architecture_id": "Cohere2ForCausalLM",
+      "total_models": 36,
+      "total_downloads": 1515892,
+      "min_param_count": 2099096,
+      "sample_models": [
+        "trl-internal-testing/tiny-Cohere2ForCausalLM",
+        "CohereLabs/c4ai-command-r7b-12-2024",
+        "CohereLabs/tiny-aya-base",
+        "CohereLabs/tiny-aya-global",
+        "CohereLabs/c4ai-command-a-03-2025",
+        "CohereLabs/c4ai-command-r7b-arabic-02-2025",
+        "CohereLabs/command-a-reasoning-08-2025",
+        "CohereLabs/tiny-aya-earth",
+        "CohereLabs/tiny-aya-water"
+      ],
+      "relevancy_score": 60.5
+    },
+    {
+      "architecture_id": "Phi3VForCausalLM",
+      "total_models": 17,
+      "total_downloads": 9004672,
+      "min_param_count": 304612720,
+      "sample_models": [
+        "microsoft/Phi-3.5-vision-instruct",
+        "TIGER-Lab/VLM2Vec-Full",
+        "microsoft/Phi-3-vision-128k-instruct",
+        "failspy/Phi-3-vision-128k-instruct-abliterated-alpha",
+        "Desm0nt/Phi-3-HornyVision-128k-instruct",
+        "yujiepan/phi-3-vision-tiny-random"
+      ],
+      "relevancy_score": 58.7
+    },
+    {
+      "architecture_id": "YatGPTForCausalLM",
+      "total_models": 52,
+      "total_downloads": 53290,
+      "min_param_count": 261096362,
+      "sample_models": [
+        "mlnomad/yatnmn-softplus-sb-ca-d12-chinchilla-261M-seed2-pytorch",
+        "mlnomad/yatnmn-softplus-sb-ca-d12-chinchilla-261M-seed1-pytorch",
+        "mlnomad/yatnmn-softplus-ca-d12-chinchilla-261M-seed2-pytorch",
+        "mlnomad/yatnmn-softplus-ca-d12-chinchilla-261M-seed1-pytorch",
+        "mlnomad/yatnmn-softplus-d12-chinchilla-261M-seed2-pytorch",
+        "mlnomad/yatnmn-softplus-sb-d12-chinchilla-261M-seed1-pytorch",
+        "mlnomad/yatnmn-softplus-sb-d12-chinchilla-261M-seed2-pytorch",
+        "mlnomad/yatnmn-softplus-d12-chinchilla-261M-seed1-pytorch",
+        "mlnomad/yatnmn-softplus-d22-chinchilla-1B-pytorch",
+        "mlnomad/yatnmn-softplus-sb-ca-d12-chinchilla-261M-pytorch"
+      ],
+      "relevancy_score": 58.1
     },
     {
       "architecture_id": "M2M100ForConditionalGeneration",
-      "total_models": 22,
-      "total_downloads": 2549811,
+      "total_models": 24,
+      "total_downloads": 2552801,
       "min_param_count": 332735488,
       "sample_models": [
         "AbteeXAILab/lumynax-translate-nllb-200-3b",
@@ -329,51 +344,97 @@
         "stas/tiny-m2m_100",
         "Xenova/nllb-200-distilled-600M"
       ],
-      "relevancy_score": 57.5
+      "relevancy_score": 58.1
     },
     {
-      "architecture_id": "Phi3VForCausalLM",
-      "total_models": 14,
-      "total_downloads": 6908063,
-      "min_param_count": 304612720,
+      "architecture_id": "LlamaForCausalLMEagle3",
+      "total_models": 35,
+      "total_downloads": 301662,
+      "min_param_count": 215481600,
       "sample_models": [
-        "microsoft/Phi-3.5-vision-instruct",
-        "TIGER-Lab/VLM2Vec-Full",
-        "microsoft/Phi-3-vision-128k-instruct",
-        "failspy/Phi-3-vision-128k-instruct-abliterated-alpha",
-        "Desm0nt/Phi-3-HornyVision-128k-instruct",
-        "yujiepan/phi-3-vision-tiny-random"
+        "lightseekorg/kimi-k2.6-eagle3",
+        "nvidia/gpt-oss-120b-Eagle3-long-context",
+        "nvidia/gpt-oss-120b-Eagle3-v3",
+        "Inferact/MiniMax-M3-EAGLE3",
+        "taobao-mnn/Qwen3-VL-8B-Instruct-Eagle3",
+        "nvidia/gpt-oss-120b-Eagle3-short-context",
+        "thoughtworks/MiniMax-M2.5-Eagle3",
+        "nvidia/gpt-oss-120b-Eagle3-throughput",
+        "nvidia/Qwen3-235B-A22B-Eagle3"
       ],
-      "relevancy_score": 57.2
-    },
-    {
-      "architecture_id": "Cohere2ForCausalLM",
-      "total_models": 27,
-      "total_downloads": 1085565,
-      "min_param_count": 2099096,
-      "sample_models": [
-        "trl-internal-testing/tiny-Cohere2ForCausalLM",
-        "CohereLabs/c4ai-command-r7b-12-2024",
-        "CohereLabs/tiny-aya-base",
-        "CohereLabs/tiny-aya-global",
-        "CohereLabs/c4ai-command-a-03-2025",
-        "CohereLabs/c4ai-command-r7b-arabic-02-2025",
-        "CohereLabs/command-a-reasoning-08-2025",
-        "CohereLabs/tiny-aya-earth",
-        "CohereLabs/tiny-aya-water"
-      ],
-      "relevancy_score": 57.1
+      "relevancy_score": 56.8
     },
     {
       "architecture_id": "H2OVLChatModel",
-      "total_models": 6,
-      "total_downloads": 6524500,
+      "total_models": 8,
+      "total_downloads": 8853218,
       "min_param_count": 826295808,
       "sample_models": [
         "h2oai/h2ovl-mississippi-800m",
         "h2oai/h2ovl-mississippi-2b"
       ],
-      "relevancy_score": 54.8
+      "relevancy_score": 56.0
+    },
+    {
+      "architecture_id": "FalconMambaForCausalLM",
+      "total_models": 19,
+      "total_downloads": 1583076,
+      "min_param_count": 525400,
+      "sample_models": [
+        "tiiuae/falcon-mamba-7b",
+        "tiiuae/falcon-mamba-tiny-dev",
+        "trl-internal-testing/tiny-FalconMambaForCausalLM",
+        "tiiuae/falcon-mamba-7b-instruct",
+        "tiiuae/Falcon3-Mamba-7B-Instruct"
+      ],
+      "relevancy_score": 55.6
+    },
+    {
+      "architecture_id": "BambaForCausalLM",
+      "total_models": 12,
+      "total_downloads": 2698061,
+      "min_param_count": 33110760,
+      "sample_models": [
+        "hmellor/tiny-random-BambaForCausalLM",
+        "ibm-ai-platform/Bamba-9B-v1",
+        "ibm-ai-platform/Bamba-9B-v2"
+      ],
+      "relevancy_score": 54.7
+    },
+    {
+      "architecture_id": "LightOnOCRForConditionalGeneration",
+      "total_models": 28,
+      "total_downloads": 1835166,
+      "min_param_count": 1005647872,
+      "sample_models": [
+        "lightonai/LightOnOCR-2-1B",
+        "lightonai/LightOnOCR-1B-1025",
+        "lightonai/LightOnOCR-2-1B-bbox-soup",
+        "lightonai/LightOnOCR-2-1B-base",
+        "lightonai/LightOnOCR-2-1B-bbox",
+        "lightonai/LightOnOCR-2-1B-ocr-soup",
+        "lightonai/LightOnOCR-2-1B-bbox-base"
+      ],
+      "relevancy_score": 54.5
+    },
+    {
+      "architecture_id": "LlavaLlamaForCausalLM",
+      "total_models": 55,
+      "total_downloads": 1690361,
+      "min_param_count": 7062902784,
+      "sample_models": [
+        "liuhaotian/llava-v1.5-7b",
+        "ChantalPellegrini/RaDialog-interactive-radiology-report-generation",
+        "liuhaotian/llava-v1.6-vicuna-7b",
+        "liuhaotian/llava-v1.5-13b",
+        "liuhaotian/llava-v1.6-vicuna-13b",
+        "wisdomik/Quilt-Llava-v1.5-7b",
+        "lmms-lab/llama3-llava-next-8b",
+        "Vishal24/llava_1.5_image_classification_v3",
+        "ManishThota/Ollama_Video_llama_7B",
+        "etri-vilab/Ko-LLaVA-13b"
+      ],
+      "relevancy_score": 54.3
     },
     {
       "architecture_id": "MBartForConditionalGeneration",
@@ -395,88 +456,9 @@
       "relevancy_score": 54.2
     },
     {
-      "architecture_id": "YatGPTForCausalLM",
-      "total_models": 39,
-      "total_downloads": 45146,
-      "min_param_count": 261096362,
-      "sample_models": [
-        "mlnomad/yatnmn-softplus-sb-ca-d12-chinchilla-261M-seed2-pytorch",
-        "mlnomad/yatnmn-softplus-sb-ca-d12-chinchilla-261M-seed1-pytorch",
-        "mlnomad/yatnmn-softplus-ca-d12-chinchilla-261M-seed2-pytorch",
-        "mlnomad/yatnmn-softplus-ca-d12-chinchilla-261M-seed1-pytorch",
-        "mlnomad/yatnmn-softplus-d12-chinchilla-261M-seed2-pytorch",
-        "mlnomad/yatnmn-softplus-sb-d12-chinchilla-261M-seed1-pytorch",
-        "mlnomad/yatnmn-softplus-sb-d12-chinchilla-261M-seed2-pytorch",
-        "mlnomad/yatnmn-softplus-d12-chinchilla-261M-seed1-pytorch",
-        "mlnomad/yatnmn-softplus-d22-chinchilla-1B-pytorch",
-        "mlnomad/yatnmn-softplus-sb-ca-d12-chinchilla-261M-pytorch"
-      ],
-      "relevancy_score": 53.9
-    },
-    {
-      "architecture_id": "LlamaForCausalLMEagle3",
-      "total_models": 26,
-      "total_downloads": 236284,
-      "min_param_count": 215481600,
-      "sample_models": [
-        "lightseekorg/kimi-k2.6-eagle3",
-        "nvidia/gpt-oss-120b-Eagle3-long-context",
-        "nvidia/gpt-oss-120b-Eagle3-v3",
-        "Inferact/MiniMax-M3-EAGLE3",
-        "taobao-mnn/Qwen3-VL-8B-Instruct-Eagle3",
-        "nvidia/gpt-oss-120b-Eagle3-short-context",
-        "thoughtworks/MiniMax-M2.5-Eagle3",
-        "nvidia/gpt-oss-120b-Eagle3-throughput",
-        "nvidia/Qwen3-235B-A22B-Eagle3"
-      ],
-      "relevancy_score": 53.6
-    },
-    {
-      "architecture_id": "FalconMambaForCausalLM",
-      "total_models": 14,
-      "total_downloads": 1162249,
-      "min_param_count": 525400,
-      "sample_models": [
-        "tiiuae/falcon-mamba-7b",
-        "tiiuae/falcon-mamba-tiny-dev",
-        "trl-internal-testing/tiny-FalconMambaForCausalLM",
-        "tiiuae/falcon-mamba-7b-instruct",
-        "tiiuae/Falcon3-Mamba-7B-Instruct"
-      ],
-      "relevancy_score": 53.5
-    },
-    {
-      "architecture_id": "BambaForCausalLM",
-      "total_models": 9,
-      "total_downloads": 2166327,
-      "min_param_count": 33110760,
-      "sample_models": [
-        "hmellor/tiny-random-BambaForCausalLM",
-        "ibm-ai-platform/Bamba-9B-v1",
-        "ibm-ai-platform/Bamba-9B-v2"
-      ],
-      "relevancy_score": 53.3
-    },
-    {
-      "architecture_id": "LightOnOCRForConditionalGeneration",
-      "total_models": 21,
-      "total_downloads": 1407880,
-      "min_param_count": 1005647872,
-      "sample_models": [
-        "lightonai/LightOnOCR-2-1B",
-        "lightonai/LightOnOCR-1B-1025",
-        "lightonai/LightOnOCR-2-1B-bbox-soup",
-        "lightonai/LightOnOCR-2-1B-base",
-        "lightonai/LightOnOCR-2-1B-bbox",
-        "lightonai/LightOnOCR-2-1B-ocr-soup",
-        "lightonai/LightOnOCR-2-1B-bbox-base"
-      ],
-      "relevancy_score": 51.9
-    },
-    {
       "architecture_id": "JambaForCausalLM",
-      "total_models": 21,
-      "total_downloads": 128306,
+      "total_models": 28,
+      "total_downloads": 179399,
       "min_param_count": 127679344,
       "sample_models": [
         "ai21labs/AI21-Jamba-Mini-1.5",
@@ -487,12 +469,31 @@
         "ai21labs/AI21-Jamba-Reasoning-3B",
         "ai21labs/AI21-Jamba2-3B"
       ],
-      "relevancy_score": 50.9
+      "relevancy_score": 53.6
+    },
+    {
+      "architecture_id": "MultiScaleForCausalLM",
+      "total_models": 101,
+      "total_downloads": 71026,
+      "min_param_count": null,
+      "sample_models": [
+        "KoinicLabs/AXL-Translate",
+        "KoinicLabs/AXL-Chat-10M",
+        "KoinicLabs/AXL-Secure-Lion",
+        "KoinicLabs/AXL-Code-1B",
+        "KoinicLabs/AXL-Secure-10M",
+        "KoinicLabs/AXL-Comment-5M",
+        "KoinicLabs/AXL-Vision-0.8M",
+        "KoinicLabs/AXL-Vision-v2",
+        "KoinicLabs/AXL-Chat-Pro",
+        "KoinicLabs/AXL-Refactor-Lion"
+      ],
+      "relevancy_score": 53.0
     },
     {
       "architecture_id": "Eagle3Speculator",
-      "total_models": 15,
-      "total_downloads": 296816,
+      "total_models": 20,
+      "total_downloads": 409203,
       "min_param_count": 950186496,
       "sample_models": [
         "RedHatAI/Qwen3-8B-speculator.eagle3",
@@ -501,49 +502,12 @@
         "RedHatAI/Qwen3-32B-speculator.eagle3",
         "RedHatAI/Qwen3-14B-speculator.eagle3"
       ],
-      "relevancy_score": 50.9
-    },
-    {
-      "architecture_id": "LlavaQwenForCausalLM",
-      "total_models": 12,
-      "total_downloads": 350696,
-      "min_param_count": 893618208,
-      "sample_models": [
-        "lmms-lab/llava-onevision-qwen2-7b-ov",
-        "lmms-lab/LLaVA-Video-7B-Qwen2",
-        "lmms-lab/llava-onevision-qwen2-0.5b-ov",
-        "lmms-lab/LongVA-7B"
-      ],
-      "relevancy_score": 50.4
-    },
-    {
-      "architecture_id": "HfMoondream",
-      "total_models": 6,
-      "total_downloads": 5626256,
-      "min_param_count": 1927237104,
-      "sample_models": [
-        "vikhyatk/moondream2",
-        "moondream/moondream3-preview"
-      ],
-      "relevancy_score": 50.4
-    },
-    {
-      "architecture_id": "ArceeForCausalLM",
-      "total_models": 12,
-      "total_downloads": 314521,
-      "min_param_count": 4129088,
-      "sample_models": [
-        "optimum-intel-internal-testing/tiny-random-ArceeForCausalLM",
-        "arcee-ai/AFM-4.5B-Base",
-        "onnx-internal-testing/tiny-random-ArceeForCausalLM",
-        "arcee-ai/AFM-4.5B"
-      ],
-      "relevancy_score": 50.1
+      "relevancy_score": 53.0
     },
     {
       "architecture_id": "Ovis",
-      "total_models": 18,
-      "total_downloads": 875971,
+      "total_models": 24,
+      "total_downloads": 1176708,
       "min_param_count": 1267417974,
       "sample_models": [
         "AIDC-AI/Ovis2-1B",
@@ -551,9 +515,112 @@
         "AIDC-AI/Ovis1.6-Gemma2-9B",
         "AIDC-AI/Ovis2-4B",
         "AIDC-AI/Ovis2-8B",
-        "AIDC-AI/Ovis2-34B"
+        "AIDC-AI/Ovis2-34B",
+        "ATH-MaaS/Ovis2-1B",
+        "ATH-MaaS/Ovis1.6-Llama3.2-3B",
+        "ATH-MaaS/Ovis1.6-Gemma2-9B",
+        "ATH-MaaS/Ovis2-4B"
       ],
-      "relevancy_score": 50.0
+      "relevancy_score": 52.4
+    },
+    {
+      "architecture_id": "LlavaQwenForCausalLM",
+      "total_models": 16,
+      "total_downloads": 514384,
+      "min_param_count": 893618208,
+      "sample_models": [
+        "lmms-lab/llava-onevision-qwen2-7b-ov",
+        "lmms-lab/LLaVA-Video-7B-Qwen2",
+        "lmms-lab/llava-onevision-qwen2-0.5b-ov",
+        "lmms-lab/LongVA-7B"
+      ],
+      "relevancy_score": 52.4
+    },
+    {
+      "architecture_id": "Qwen2MoeForCausalLM",
+      "total_models": 24,
+      "total_downloads": 1075803,
+      "min_param_count": 1763452928,
+      "sample_models": [
+        "Qwen/Qwen1.5-MoE-A2.7B",
+        "Qwen/Qwen1.5-MoE-A2.7B-Chat",
+        "Qwen/Qwen2-57B-A14B-Instruct",
+        "Qwen/Qwen2-57B-A14B",
+        "Qwen/Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4",
+        "hyper-accel/ci-random-qwen2-moe-a3b"
+      ],
+      "relevancy_score": 52.2
+    },
+    {
+      "architecture_id": "ArceeForCausalLM",
+      "total_models": 16,
+      "total_downloads": 442598,
+      "min_param_count": 4129088,
+      "sample_models": [
+        "optimum-intel-internal-testing/tiny-random-ArceeForCausalLM",
+        "arcee-ai/AFM-4.5B-Base",
+        "onnx-internal-testing/tiny-random-ArceeForCausalLM",
+        "arcee-ai/AFM-4.5B"
+      ],
+      "relevancy_score": 52.0
+    },
+    {
+      "architecture_id": "HfMoondream",
+      "total_models": 8,
+      "total_downloads": 7491036,
+      "min_param_count": 1927237104,
+      "sample_models": [
+        "vikhyatk/moondream2",
+        "moondream/moondream3-preview"
+      ],
+      "relevancy_score": 51.7
+    },
+    {
+      "architecture_id": "NemotronLabsDiffusionModel",
+      "total_models": 24,
+      "total_downloads": 3704132,
+      "min_param_count": 3831659520,
+      "sample_models": [
+        "nvidia/Nemotron-Labs-Diffusion-8B-Base",
+        "nvidia/Nemotron-Labs-Diffusion-3B-Base",
+        "nvidia/Nemotron-Labs-Diffusion-8B",
+        "nvidia/Nemotron-Labs-Diffusion-3B",
+        "nvidia/Nemotron-Labs-Diffusion-14B-Base",
+        "nvidia/Nemotron-Labs-Diffusion-14B"
+      ],
+      "relevancy_score": 50.9
+    },
+    {
+      "architecture_id": "HunYuanVLForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 1140251,
+      "min_param_count": 996208112,
+      "sample_models": [
+        "tencent/HunyuanOCR"
+      ],
+      "relevancy_score": 50.5
+    },
+    {
+      "architecture_id": "Gemma4UnifiedAssistantForCausalLM",
+      "total_models": 12,
+      "total_downloads": 299496,
+      "min_param_count": 422856964,
+      "sample_models": [
+        "google/gemma-4-12B-it-assistant",
+        "google/gemma-4-12B-it-qat-q4_0-unquantized-assistant",
+        "kunhunjon/gemma-4-12B-it-qat-assistant-w4a16-ct"
+      ],
+      "relevancy_score": 50.1
+    },
+    {
+      "architecture_id": "OpenAIGPTLMHeadModel",
+      "total_models": 4,
+      "total_downloads": 945634,
+      "min_param_count": 119680512,
+      "sample_models": [
+        "openai-community/openai-gpt"
+      ],
+      "relevancy_score": 50.1
     },
     {
       "architecture_id": "PegasusForConditionalGeneration",
@@ -574,58 +641,183 @@
       "relevancy_score": 50.0
     },
     {
-      "architecture_id": "Qwen2MoeForCausalLM",
-      "total_models": 18,
-      "total_downloads": 790323,
-      "min_param_count": 1763452928,
+      "architecture_id": "Step3p7ForConditionalGeneration",
+      "total_models": 21,
+      "total_downloads": 546253,
+      "min_param_count": 2956129024,
       "sample_models": [
-        "Qwen/Qwen1.5-MoE-A2.7B",
-        "Qwen/Qwen1.5-MoE-A2.7B-Chat",
-        "Qwen/Qwen2-57B-A14B-Instruct",
-        "Qwen/Qwen2-57B-A14B",
-        "Qwen/Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4",
-        "hyper-accel/ci-random-qwen2-moe-a3b"
+        "stepfun-ai/Step-3.7-Flash",
+        "cyankiwi/Step-3.7-Flash-AWQ-INT4",
+        "Hikari07jp/Step-3.7-Flash-MTP-draft",
+        "0xSero/Step-3.7-Flash-173B",
+        "0xSero/Step-3.7-Flash-148B",
+        "nameistoken/Step-3.7-Flash-Quark-W4A16"
       ],
-      "relevancy_score": 49.8
+      "relevancy_score": 49.9
     },
     {
-      "architecture_id": "HunYuanVLForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 865778,
-      "min_param_count": 996208112,
+      "architecture_id": "SeedOssForCausalLM",
+      "total_models": 15,
+      "total_downloads": 187264,
+      "min_param_count": 2497064,
       "sample_models": [
-        "tencent/HunyuanOCR"
+        "ByteDance-Seed/Seed-OSS-36B-Instruct",
+        "cyankiwi/Hermes-4.3-36B-AWQ-4bit",
+        "ByteDance-Seed/Seed-OSS-36B-Base",
+        "tiny-random/seed-oss"
+      ],
+      "relevancy_score": 49.9
+    },
+    {
+      "architecture_id": "NemotronForCausalLM",
+      "total_models": 23,
+      "total_downloads": 54883,
+      "min_param_count": 2150720,
+      "sample_models": [
+        "badaoui/tiny-random-NemotronForCausalLM",
+        "mgoin/Nemotron-4-340B-Instruct-hf",
+        "mgoin/nemotron-3-8b-chat-4k-sft-hf",
+        "thhaus/nemotron3-8b",
+        "domyn/Domyn-Small-v1.0",
+        "OpenLLM-France/Luciole-1B-Base"
+      ],
+      "relevancy_score": 49.7
+    },
+    {
+      "architecture_id": "Idefics3ForConditionalGeneration",
+      "total_models": 8,
+      "total_downloads": 443613,
+      "min_param_count": 257517120,
+      "sample_models": [
+        "ibm-granite/granite-docling-258M",
+        "docling-project/ScreenVLM"
+      ],
+      "relevancy_score": 49.7
+    },
+    {
+      "architecture_id": "RITAModelForCausalLM",
+      "total_models": 16,
+      "total_downloads": 137323,
+      "min_param_count": 85096320,
+      "sample_models": [
+        "lightonai/RITA_s",
+        "lightonai/RITA_m",
+        "lightonai/RITA_l",
+        "lightonai/RITA_xl"
       ],
       "relevancy_score": 49.6
     },
     {
-      "architecture_id": "LlavaLlamaForCausalLM",
-      "total_models": 40,
-      "total_downloads": 1414584,
-      "min_param_count": 7062902784,
+      "architecture_id": "Zamba2ForCausalLM",
+      "total_models": 12,
+      "total_downloads": 1547927,
+      "min_param_count": 1215064704,
       "sample_models": [
-        "liuhaotian/llava-v1.5-7b",
-        "ChantalPellegrini/RaDialog-interactive-radiology-report-generation",
-        "liuhaotian/llava-v1.6-vicuna-7b",
-        "liuhaotian/llava-v1.5-13b",
-        "liuhaotian/llava-v1.6-vicuna-13b",
-        "wisdomik/Quilt-Llava-v1.5-7b",
-        "lmms-lab/llama3-llava-next-8b",
-        "Vishal24/llava_1.5_image_classification_v3",
-        "ManishThota/Ollama_Video_llama_7B",
-        "etri-vilab/Ko-LLaVA-13b"
+        "Zyphra/Zamba2-1.2B-instruct",
+        "Zyphra/Zamba2-7B-Instruct",
+        "Zyphra/Zamba2-2.7B"
       ],
       "relevancy_score": 49.5
     },
     {
-      "architecture_id": "OpenAIGPTLMHeadModel",
-      "total_models": 3,
-      "total_downloads": 705713,
-      "min_param_count": 119680512,
+      "architecture_id": "LlavaQwen2ForCausalLM",
+      "total_models": 20,
+      "total_downloads": 71317,
+      "min_param_count": 758833760,
       "sample_models": [
-        "openai-community/openai-gpt"
+        "qnguyen3/nanoLLaVA",
+        "apple/FastVLM-0.5B",
+        "apple/FastVLM-1.5B",
+        "FreedomIntelligence/HuatuoGPT-Vision-7B",
+        "apple/FastVLM-7B"
+      ],
+      "relevancy_score": 49.4
+    },
+    {
+      "architecture_id": "RWKV7ForCausalLM",
+      "total_models": 21,
+      "total_downloads": 59885,
+      "min_param_count": 27388416,
+      "sample_models": [
+        "yashmahe2018/vanilla-skip-rwkv7-strict-small-babylm2026",
+        "fla-hub/rwkv7-0.4B-g1",
+        "RWKV/RWKV7-Goose-World2.9-0.4B-HF",
+        "yashmahe2018/rwkv7-halfclm-strict-small",
+        "RWKV/RWKV7-Goose-World3-1.5B-HF",
+        "fla-hub/rwkv7-1.5B-world"
+      ],
+      "relevancy_score": 49.3
+    },
+    {
+      "architecture_id": "HyenaDNAForCausalLM",
+      "total_models": 20,
+      "total_downloads": 69068,
+      "min_param_count": 450712,
+      "sample_models": [
+        "LongSafari/hyenadna-small-32k-seqlen-hf",
+        "LongSafari/hyenadna-tiny-1k-seqlen-hf",
+        "LongSafari/hyenadna-medium-160k-seqlen-hf",
+        "LongSafari/hyenadna-large-1m-seqlen-hf",
+        "LongSafari/hyenadna-tiny-1k-seqlen-d256-hf",
+        "LongSafari/hyenadna-tiny-16k-seqlen-d128-hf"
+      ],
+      "relevancy_score": 49.3
+    },
+    {
+      "architecture_id": "DotsOCRForCausalLM",
+      "total_models": 19,
+      "total_downloads": 3591921,
+      "min_param_count": 3039179264,
+      "sample_models": [
+        "rednote-hilab/dots.mocr",
+        "rednote-hilab/dots.ocr",
+        "rednote-hilab/dots.mocr-svg",
+        "kristaller486/dots.ocr-1.5",
+        "davanstrien/dots.ocr-1.5"
+      ],
+      "relevancy_score": 49.3
+    },
+    {
+      "architecture_id": "ProGen2ForPreTraining",
+      "total_models": 28,
+      "total_downloads": 21321,
+      "min_param_count": 151158821,
+      "sample_models": [
+        "multimolecule/progen2-small",
+        "multimolecule/progen2-medium",
+        "multimolecule/progen2-base",
+        "multimolecule/progen2-xlarge",
+        "multimolecule/progen2-large",
+        "multimolecule/progen2-oas",
+        "multimolecule/progen2-bfd90"
       ],
       "relevancy_score": 49.2
+    },
+    {
+      "architecture_id": "DynColMaskMoELLaVAQwen2ForCausalLM",
+      "total_models": 28,
+      "total_downloads": 20383,
+      "min_param_count": 936779392,
+      "sample_models": [
+        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r128_20260422_053621",
+        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r64_20260422_030205",
+        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r32_20260422_002811",
+        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r4_20260421_191943",
+        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r8_20260421_215406",
+        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r16_20260420_180515",
+        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r16_20260418_062801"
+      ],
+      "relevancy_score": 49.1
+    },
+    {
+      "architecture_id": "SundialForPrediction",
+      "total_models": 4,
+      "total_downloads": 591580,
+      "min_param_count": 128329680,
+      "sample_models": [
+        "thuml/sundial-base-128m"
+      ],
+      "relevancy_score": 49.1
     },
     {
       "architecture_id": "Qwen2AudioForConditionalGeneration",
@@ -637,85 +829,45 @@
         "Qwen/Qwen2-Audio-7B",
         "trl-internal-testing/tiny-Qwen2AudioForConditionalGeneration"
       ],
+      "relevancy_score": 49.0
+    },
+    {
+      "architecture_id": "DeciLMForCausalLM",
+      "total_models": 32,
+      "total_downloads": 3300370,
+      "min_param_count": 7043551232,
+      "sample_models": [
+        "nvidia/Llama-3_3-Nemotron-Super-49B-v1_5",
+        "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
+        "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
+        "nvidia/Llama-3_1-Nemotron-51B-Instruct",
+        "Deci/DeciLM-7B-instruct",
+        "nvidia/Llama-3_1-Nemotron-Ultra-253B-CPT-v1",
+        "etsien/Llama-3_3-Nemotron-Super-49B-v1_5-GPTQ-w4a8",
+        "NewstaR/Porpoise-6b-instruct",
+        "Danielbrdz/Barcenas-6b",
+        "NewstaR/StableGalen-6b"
+      ],
       "relevancy_score": 48.9
     },
     {
-      "architecture_id": "Idefics3ForConditionalGeneration",
-      "total_models": 6,
-      "total_downloads": 349241,
-      "min_param_count": 257517120,
+      "architecture_id": "OuroForCausalLM",
+      "total_models": 20,
+      "total_downloads": 389795,
+      "min_param_count": 1434652673,
       "sample_models": [
-        "ibm-granite/granite-docling-258M",
-        "docling-project/ScreenVLM"
+        "ByteDance/Ouro-1.4B",
+        "ByteDance/Ouro-2.6B-Thinking",
+        "ByteDance/Ouro-1.4B-Thinking",
+        "ByteDance/Ouro-2.6B",
+        "KristianS7/Ouro-1.4B"
       ],
-      "relevancy_score": 48.6
-    },
-    {
-      "architecture_id": "NemotronLabsDiffusionModel",
-      "total_models": 18,
-      "total_downloads": 2679242,
-      "min_param_count": 3831659520,
-      "sample_models": [
-        "nvidia/Nemotron-Labs-Diffusion-8B-Base",
-        "nvidia/Nemotron-Labs-Diffusion-3B-Base",
-        "nvidia/Nemotron-Labs-Diffusion-8B",
-        "nvidia/Nemotron-Labs-Diffusion-3B",
-        "nvidia/Nemotron-Labs-Diffusion-14B-Base",
-        "nvidia/Nemotron-Labs-Diffusion-14B"
-      ],
-      "relevancy_score": 48.4
-    },
-    {
-      "architecture_id": "Gemma4UnifiedAssistantForCausalLM",
-      "total_models": 9,
-      "total_downloads": 192274,
-      "min_param_count": 422856964,
-      "sample_models": [
-        "google/gemma-4-12B-it-assistant",
-        "google/gemma-4-12B-it-qat-q4_0-unquantized-assistant",
-        "kunhunjon/gemma-4-12B-it-qat-assistant-w4a16-ct"
-      ],
-      "relevancy_score": 48.2
-    },
-    {
-      "architecture_id": "SundialForPrediction",
-      "total_models": 3,
-      "total_downloads": 443278,
-      "min_param_count": 128329680,
-      "sample_models": [
-        "thuml/sundial-base-128m"
-      ],
-      "relevancy_score": 48.2
-    },
-    {
-      "architecture_id": "SeedOssForCausalLM",
-      "total_models": 11,
-      "total_downloads": 136998,
-      "min_param_count": 2497064,
-      "sample_models": [
-        "ByteDance-Seed/Seed-OSS-36B-Instruct",
-        "cyankiwi/Hermes-4.3-36B-AWQ-4bit",
-        "ByteDance-Seed/Seed-OSS-36B-Base",
-        "tiny-random/seed-oss"
-      ],
-      "relevancy_score": 48.1
-    },
-    {
-      "architecture_id": "Zamba2ForCausalLM",
-      "total_models": 9,
-      "total_downloads": 1142055,
-      "min_param_count": 1215064704,
-      "sample_models": [
-        "Zyphra/Zamba2-1.2B-instruct",
-        "Zyphra/Zamba2-7B-Instruct",
-        "Zyphra/Zamba2-2.7B"
-      ],
-      "relevancy_score": 48.0
+      "relevancy_score": 48.9
     },
     {
       "architecture_id": "BloomModel",
-      "total_models": 15,
-      "total_downloads": 70491,
+      "total_models": 17,
+      "total_downloads": 88286,
       "min_param_count": 16156544,
       "sample_models": [
         "bigscience/bigscience-small-testing",
@@ -726,25 +878,52 @@
         "TurkuNLP/gpt3-finnish-13B",
         "BelleGroup/BELLE-7B-2M"
       ],
-      "relevancy_score": 47.9
+      "relevancy_score": 48.9
     },
     {
-      "architecture_id": "RITAModelForCausalLM",
-      "total_models": 12,
-      "total_downloads": 100793,
-      "min_param_count": 85096320,
+      "architecture_id": "ProGenForCausalLM",
+      "total_models": 16,
+      "total_downloads": 89065,
+      "min_param_count": 151148576,
       "sample_models": [
-        "lightonai/RITA_s",
-        "lightonai/RITA_m",
-        "lightonai/RITA_l",
-        "lightonai/RITA_xl"
+        "hugohrban/progen2-small",
+        "hugohrban/progen2-large",
+        "hugohrban/progen2-base",
+        "hugohrban/progen2-medium"
       ],
-      "relevancy_score": 47.7
+      "relevancy_score": 48.7
+    },
+    {
+      "architecture_id": "BertLMHeadModel",
+      "total_models": 24,
+      "total_downloads": 28854,
+      "min_param_count": 184474880,
+      "sample_models": [
+        "sagawa/molscaletransfer-chemlm-0.06m",
+        "sagawa/molscaletransfer-chemlm-0.83m",
+        "sagawa/molscaletransfer-chemlm-2.30m",
+        "ielab/TILDE",
+        "dicta-il/BEREL_3.0",
+        "ENM/scibert_scivocab_cased-new-finetuned-leukaemia"
+      ],
+      "relevancy_score": 48.6
+    },
+    {
+      "architecture_id": "Eagle3DraftModel",
+      "total_models": 12,
+      "total_downloads": 139472,
+      "min_param_count": 522152832,
+      "sample_models": [
+        "RedHatAI/gpt-oss-20b-speculator.eagle3",
+        "RedHatAI/gpt-oss-120b-speculator.eagle3",
+        "RedHatAI/Qwen3-30B-A3B-Instruct-2507-speculator.eagle3"
+      ],
+      "relevancy_score": 48.4
     },
     {
       "architecture_id": "NandiForCausalLM",
-      "total_models": 14,
-      "total_downloads": 69602,
+      "total_models": 16,
+      "total_downloads": 71927,
       "min_param_count": 153412928,
       "sample_models": [
         "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -754,116 +933,69 @@
         "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
         "FrontiersMind/Nandi-Mini-150M-Instruct"
       ],
-      "relevancy_score": 47.5
-    },
-    {
-      "architecture_id": "Step3p7ForConditionalGeneration",
-      "total_models": 15,
-      "total_downloads": 382404,
-      "min_param_count": 2956129024,
-      "sample_models": [
-        "stepfun-ai/Step-3.7-Flash",
-        "cyankiwi/Step-3.7-Flash-AWQ-INT4",
-        "Hikari07jp/Step-3.7-Flash-MTP-draft",
-        "0xSero/Step-3.7-Flash-173B",
-        "0xSero/Step-3.7-Flash-148B"
-      ],
-      "relevancy_score": 47.4
-    },
-    {
-      "architecture_id": "NemotronForCausalLM",
-      "total_models": 17,
-      "total_downloads": 40787,
-      "min_param_count": 2150720,
-      "sample_models": [
-        "badaoui/tiny-random-NemotronForCausalLM",
-        "mgoin/Nemotron-4-340B-Instruct-hf",
-        "mgoin/nemotron-3-8b-chat-4k-sft-hf",
-        "thhaus/nemotron3-8b",
-        "domyn/Domyn-Small-v1.0",
-        "OpenLLM-France/Luciole-1B-Base"
-      ],
-      "relevancy_score": 47.3
-    },
-    {
-      "architecture_id": "LlavaQwen2ForCausalLM",
-      "total_models": 15,
-      "total_downloads": 53603,
-      "min_param_count": 758833760,
-      "sample_models": [
-        "qnguyen3/nanoLLaVA",
-        "apple/FastVLM-0.5B",
-        "apple/FastVLM-1.5B",
-        "FreedomIntelligence/HuatuoGPT-Vision-7B",
-        "apple/FastVLM-7B"
-      ],
-      "relevancy_score": 47.3
-    },
-    {
-      "architecture_id": "HyenaDNAForCausalLM",
-      "total_models": 15,
-      "total_downloads": 52395,
-      "min_param_count": 450712,
-      "sample_models": [
-        "LongSafari/hyenadna-small-32k-seqlen-hf",
-        "LongSafari/hyenadna-tiny-1k-seqlen-hf",
-        "LongSafari/hyenadna-medium-160k-seqlen-hf",
-        "LongSafari/hyenadna-large-1m-seqlen-hf",
-        "LongSafari/hyenadna-tiny-1k-seqlen-d256-hf",
-        "LongSafari/hyenadna-tiny-16k-seqlen-d128-hf"
-      ],
-      "relevancy_score": 47.2
-    },
-    {
-      "architecture_id": "DotsOCRForCausalLM",
-      "total_models": 14,
-      "total_downloads": 2702911,
-      "min_param_count": 3039179264,
-      "sample_models": [
-        "rednote-hilab/dots.mocr",
-        "rednote-hilab/dots.ocr",
-        "rednote-hilab/dots.mocr-svg",
-        "kristaller486/dots.ocr-1.5",
-        "davanstrien/dots.ocr-1.5"
-      ],
-      "relevancy_score": 47.2
+      "relevancy_score": 48.2
     },
     {
       "architecture_id": "OrionForCausalLM",
-      "total_models": 9,
-      "total_downloads": 108635,
+      "total_models": 11,
+      "total_downloads": 144746,
       "min_param_count": 93459456,
       "sample_models": [
         "OrionStarAI/Orion-14B-Chat",
         "OrionStarAI/Orion-14B-Base",
         "hyper-accel/tiny-random-orion"
       ],
-      "relevancy_score": 47.0
+      "relevancy_score": 48.2
     },
     {
-      "architecture_id": "ProGenForCausalLM",
-      "total_models": 12,
-      "total_downloads": 67740,
-      "min_param_count": 151148576,
+      "architecture_id": "Eagle3DeepseekV2ForCausalLM",
+      "total_models": 16,
+      "total_downloads": 459368,
+      "min_param_count": 1841199104,
       "sample_models": [
-        "hugohrban/progen2-small",
-        "hugohrban/progen2-large",
-        "hugohrban/progen2-base",
-        "hugohrban/progen2-medium"
+        "lightseekorg/kimi-k2.6-eagle3-mla",
+        "lightseekorg/kimi-k2.5-eagle3-mla",
+        "nvidia/Kimi-K2.5-Thinking-Eagle3",
+        "nvidia/Kimi-K2.6-Eagle3"
       ],
-      "relevancy_score": 46.9
+      "relevancy_score": 48.1
     },
     {
-      "architecture_id": "Eagle3DraftModel",
+      "architecture_id": "PinyinCodeForCausalLM",
+      "total_models": 16,
+      "total_downloads": 55710,
+      "min_param_count": 33674240,
+      "sample_models": [
+        "CPSPX/babylm-zho-pinyin-code-33M",
+        "timorobrecht/full_chinese_gpu3.1",
+        "CPSPX/babylm-zho-pinyin-code-97M",
+        "timorobrecht/full_chinese_gpu3.2-dpo"
+      ],
+      "relevancy_score": 47.7
+    },
+    {
+      "architecture_id": "VibeVoiceForConditionalGeneration",
       "total_models": 9,
-      "total_downloads": 102420,
-      "min_param_count": 522152832,
+      "total_downloads": 969463,
+      "min_param_count": 2704021985,
       "sample_models": [
-        "RedHatAI/gpt-oss-20b-speculator.eagle3",
-        "RedHatAI/gpt-oss-120b-speculator.eagle3",
-        "RedHatAI/Qwen3-30B-A3B-Instruct-2507-speculator.eagle3"
+        "microsoft/VibeVoice-1.5B",
+        "vibevoice/VibeVoice-1.5B",
+        "bezzam/VibeVoice-1.5B-hf"
       ],
-      "relevancy_score": 46.9
+      "relevancy_score": 47.6
+    },
+    {
+      "architecture_id": "Fgclip2Model",
+      "total_models": 12,
+      "total_downloads": 76451,
+      "min_param_count": 383803394,
+      "sample_models": [
+        "qihoo360/fg-clip2-base",
+        "qihoo360/fg-clip2-so400m",
+        "qihoo360/fg-clip2-large"
+      ],
+      "relevancy_score": 47.2
     },
     {
       "architecture_id": "EncoderDecoderModel",
@@ -880,81 +1012,49 @@
       "relevancy_score": 46.9
     },
     {
-      "architecture_id": "OuroForCausalLM",
-      "total_models": 15,
-      "total_downloads": 288169,
-      "min_param_count": 1434652673,
+      "architecture_id": "Ernie4_5ForCausalLM",
+      "total_models": 8,
+      "total_downloads": 109570,
+      "min_param_count": 360748032,
       "sample_models": [
-        "ByteDance/Ouro-1.4B",
-        "ByteDance/Ouro-2.6B-Thinking",
-        "ByteDance/Ouro-1.4B-Thinking",
-        "ByteDance/Ouro-2.6B",
-        "KristianS7/Ouro-1.4B"
+        "baidu/ERNIE-4.5-0.3B-PT",
+        "baidu/ERNIE-4.5-0.3B-Base-PT"
       ],
       "relevancy_score": 46.8
     },
     {
-      "architecture_id": "DeciLMForCausalLM",
-      "total_models": 26,
-      "total_downloads": 2687705,
-      "min_param_count": 7043551232,
+      "architecture_id": "RemoteForCausalLM",
+      "total_models": 4,
+      "total_downloads": 184810,
+      "min_param_count": 2054056,
       "sample_models": [
-        "nvidia/Llama-3_3-Nemotron-Super-49B-v1_5",
-        "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
-        "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
-        "nvidia/Llama-3_1-Nemotron-51B-Instruct",
-        "Deci/DeciLM-7B-instruct",
-        "nvidia/Llama-3_1-Nemotron-Ultra-253B-CPT-v1",
-        "etsien/Llama-3_3-Nemotron-Super-49B-v1_5-GPTQ-w4a8",
-        "NewstaR/Porpoise-6b-instruct",
-        "Danielbrdz/Barcenas-6b",
-        "NewstaR/StableGalen-6b"
+        "trl-internal-testing/tiny-RemoteForCausalLM"
       ],
       "relevancy_score": 46.7
     },
     {
-      "architecture_id": "RWKV7ForCausalLM",
-      "total_models": 15,
-      "total_downloads": 40337,
-      "min_param_count": 27388416,
+      "architecture_id": "GlmForCausalLM",
+      "total_models": 20,
+      "total_downloads": 125616,
+      "min_param_count": 1593427968,
       "sample_models": [
-        "yashmahe2018/vanilla-skip-rwkv7-strict-small-babylm2026",
-        "fla-hub/rwkv7-0.4B-g1",
-        "RWKV/RWKV7-Goose-World2.9-0.4B-HF",
-        "yashmahe2018/rwkv7-halfclm-strict-small",
-        "RWKV/RWKV7-Goose-World3-1.5B-HF"
-      ],
-      "relevancy_score": 46.7
-    },
-    {
-      "architecture_id": "DynColMaskMoELLaVAQwen2ForCausalLM",
-      "total_models": 21,
-      "total_downloads": 16575,
-      "min_param_count": 936779392,
-      "sample_models": [
-        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r128_20260422_053621",
-        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r64_20260422_030205",
-        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r32_20260422_002811",
-        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r4_20260421_191943",
-        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r8_20260421_215406",
-        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r16_20260420_180515",
-        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-col-mask-moe-sparse-4e-2k-sp0.9-r16_20260418_062801"
+        "zai-org/glm-4-9b-chat-hf",
+        "zai-org/glm-4-9b-hf",
+        "zai-org/glm-edge-4b-chat",
+        "zai-org/glm-edge-1.5b-chat",
+        "zai-org/glm-4-9b-chat-1m-hf"
       ],
       "relevancy_score": 46.6
     },
     {
-      "architecture_id": "ProGen2ForPreTraining",
-      "total_models": 21,
-      "total_downloads": 16220,
-      "min_param_count": 151158821,
+      "architecture_id": "_A2DQwen3LMHeadModel",
+      "total_models": 11,
+      "total_downloads": 62966,
+      "min_param_count": 596049920,
       "sample_models": [
-        "multimolecule/progen2-small",
-        "multimolecule/progen2-medium",
-        "multimolecule/progen2-base",
-        "multimolecule/progen2-xlarge",
-        "multimolecule/progen2-large",
-        "multimolecule/progen2-oas",
-        "multimolecule/progen2-bfd90"
+        "divelab/OPDLM-0.6B",
+        "divelab/OPDLM-4B",
+        "divelab/OPDLM-MATH-4B"
       ],
       "relevancy_score": 46.5
     },
@@ -974,32 +1074,43 @@
       "relevancy_score": 46.5
     },
     {
-      "architecture_id": "BertLMHeadModel",
-      "total_models": 18,
-      "total_downloads": 23524,
-      "min_param_count": 184474880,
+      "architecture_id": "IlamaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 1126605,
+      "min_param_count": 1235814400,
       "sample_models": [
-        "sagawa/molscaletransfer-chemlm-0.06m",
-        "sagawa/molscaletransfer-chemlm-0.83m",
-        "sagawa/molscaletransfer-chemlm-2.30m",
-        "ielab/TILDE",
-        "dicta-il/BEREL_3.0",
-        "ENM/scibert_scivocab_cased-new-finetuned-leukaemia"
+        "hmellor/Ilama-3.2-1B"
+      ],
+      "relevancy_score": 46.5
+    },
+    {
+      "architecture_id": "Starcoder2ForCausalLM",
+      "total_models": 21,
+      "total_downloads": 675003,
+      "min_param_count": 3030371328,
+      "sample_models": [
+        "bigcode/starcoder2-3b",
+        "bigcode/starcoder2-7b",
+        "bigcode/starcoder2-15b",
+        "bigcode/starcoder2-15b-instruct-v0.1",
+        "Johnblick187/starcoder2-15b",
+        "TechxGenus/starcoder2-7b-GPTQ"
       ],
       "relevancy_score": 46.4
     },
     {
-      "architecture_id": "Eagle3DeepseekV2ForCausalLM",
-      "total_models": 12,
-      "total_downloads": 349120,
-      "min_param_count": 1841199104,
+      "architecture_id": "VisionEncoderDecoderModel",
+      "total_models": 17,
+      "total_downloads": 25186,
+      "min_param_count": 239195904,
       "sample_models": [
-        "lightseekorg/kimi-k2.6-eagle3-mla",
-        "lightseekorg/kimi-k2.5-eagle3-mla",
-        "nvidia/Kimi-K2.5-Thinking-Eagle3",
-        "nvidia/Kimi-K2.6-Eagle3"
+        "AbteeXAILab/lumynax-ocr-trocr-large-printed",
+        "AbteeXAILab/lumynax-doc-nougat-base",
+        "AbteeXAILab/lumynax-ocr-trocr-large-handwritten",
+        "AbteeXAILab/lumynax-doc-donut-base",
+        "Molkaatb/ChestX"
       ],
-      "relevancy_score": 46.4
+      "relevancy_score": 46.3
     },
     {
       "architecture_id": "FSMTForConditionalGeneration",
@@ -1016,49 +1127,104 @@
       "relevancy_score": 46.3
     },
     {
-      "architecture_id": "VibeVoiceForConditionalGeneration",
-      "total_models": 6,
-      "total_downloads": 721604,
-      "min_param_count": 2704021985,
+      "architecture_id": "SDARForCausalLM",
+      "total_models": 21,
+      "total_downloads": 89602,
+      "min_param_count": 2031739904,
       "sample_models": [
-        "microsoft/VibeVoice-1.5B",
-        "vibevoice/VibeVoice-1.5B"
+        "JetLM/SDAR-8B-Chat",
+        "JetLM/SDAR-1.7B-Chat",
+        "JetLM/SDAR-8B-Chat-b32",
+        "yifanyu/I-DLM-8B",
+        "JetLM/SDAR-1.7B-Chat-b32",
+        "JetLM/SDAR-8B-Chat-b64"
       ],
       "relevancy_score": 46.1
     },
     {
-      "architecture_id": "Fgclip2Model",
-      "total_models": 9,
-      "total_downloads": 59355,
-      "min_param_count": 383803394,
+      "architecture_id": "Qwen3_5MoeForCausalLM",
+      "total_models": 37,
+      "total_downloads": 58152,
+      "min_param_count": 5642996864,
       "sample_models": [
-        "qihoo360/fg-clip2-base",
-        "qihoo360/fg-clip2-so400m",
-        "qihoo360/fg-clip2-large"
+        "dawncr0w/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-text-oQ4",
+        "samuelfaj/Qwen3.6-35B-A3B-NSC-ACE-SABER-8bit-MTPLX-Optimized-Speed",
+        "FINAL-Bench/Darwin-36B-Opus",
+        "0xSero/Qwen3.6-28B",
+        "samuelfaj/Qwen3.6-35B-A3B-NSC-ACE-SABER-4bit-MTPLX-Optimized-Speed",
+        "dawncr0w/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-text-oQ8",
+        "dawncr0w/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-text-oQ6",
+        "samuelfaj/Qwen3.6-35B-A3B-NSC-ACE-SABER-6bit-MTPLX-Optimized-Speed",
+        "88plug/Qwen3.6-35B-A3B-W8A16",
+        "jenerallee78/Qwen3.6-35B-A3B-Abliterix-EGA-abliterated"
+      ],
+      "relevancy_score": 45.9
+    },
+    {
+      "architecture_id": "OLMoForCausalLM",
+      "total_models": 23,
+      "total_downloads": 58646,
+      "min_param_count": 1176764416,
+      "sample_models": [
+        "allenai/OLMo-1B",
+        "allenai/OLMo-7B",
+        "allenai/OLMo-7B-Instruct",
+        "allenai/MolmoE-1B-0924",
+        "Nhoodie/omni-dna-ici-dc",
+        "allenai/OLMo-7B-Twin-2T"
+      ],
+      "relevancy_score": 45.8
+    },
+    {
+      "architecture_id": "CambrianQwenForCausalLM",
+      "total_models": 11,
+      "total_downloads": 46529,
+      "min_param_count": 893618208,
+      "sample_models": [
+        "nyu-visionx/Scale-RAE-Qwen1.5B_DiT2.4B",
+        "nyu-visionx/Cambrian-S-7B",
+        "nyu-visionx/Cambrian-S-0.5B"
+      ],
+      "relevancy_score": 45.8
+    },
+    {
+      "architecture_id": "OpenMythosForCausalLM",
+      "total_models": 4,
+      "total_downloads": 112460,
+      "min_param_count": 95907328,
+      "sample_models": [
+        "maidacundo/open-mythos-140m"
       ],
       "relevancy_score": 45.7
     },
     {
-      "architecture_id": "PinyinCodeForCausalLM",
-      "total_models": 12,
-      "total_downloads": 35066,
-      "min_param_count": 33674240,
+      "architecture_id": "BitNetForCausalLM",
+      "total_models": 8,
+      "total_downloads": 62121,
+      "min_param_count": 849787090,
       "sample_models": [
-        "CPSPX/babylm-zho-pinyin-code-33M",
-        "timorobrecht/full_chinese_gpu3.1",
-        "CPSPX/babylm-zho-pinyin-code-97M",
-        "timorobrecht/full_chinese_gpu3.2-dpo"
+        "microsoft/bitnet-b1.58-2B-4T",
+        "microsoft/bitnet-b1.58-2B-4T-bf16"
       ],
-      "relevancy_score": 45.5
+      "relevancy_score": 45.6
     },
     {
-      "architecture_id": "Ernie4_5ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 81731,
-      "min_param_count": 360748032,
+      "architecture_id": "Kanana2VecModel",
+      "total_models": 4,
+      "total_downloads": 738086,
+      "min_param_count": 2086979328,
       "sample_models": [
-        "baidu/ERNIE-4.5-0.3B-PT",
-        "baidu/ERNIE-4.5-0.3B-Base-PT"
+        "kakaocorp/kanana-nano-2.1b-embedding"
+      ],
+      "relevancy_score": 45.6
+    },
+    {
+      "architecture_id": "Llama4ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 105554,
+      "min_param_count": 3269144,
+      "sample_models": [
+        "trl-internal-testing/tiny-Llama4ForCausalLM"
       ],
       "relevancy_score": 45.5
     },
@@ -1075,22 +1241,50 @@
       "relevancy_score": 45.5
     },
     {
-      "architecture_id": "IlamaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 817683,
-      "min_param_count": 1235814400,
+      "architecture_id": "Exaone4ForCausalLM",
+      "total_models": 12,
+      "total_downloads": 220238,
+      "min_param_count": 1279391488,
       "sample_models": [
-        "hmellor/Ilama-3.2-1B"
+        "LGAI-EXAONE/EXAONE-4.0-32B",
+        "LGAI-EXAONE/EXAONE-4.0-1.2B",
+        "LGAI-EXAONE/EXAONE-4.0.1-32B"
       ],
-      "relevancy_score": 45.5
+      "relevancy_score": 45.4
     },
     {
-      "architecture_id": "OpenMythosForCausalLM",
-      "total_models": 3,
-      "total_downloads": 100124,
-      "min_param_count": 95907328,
+      "architecture_id": "AfmoeForCausalLM",
+      "total_models": 24,
+      "total_downloads": 237334,
+      "min_param_count": 6120003328,
       "sample_models": [
-        "maidacundo/open-mythos-140m"
+        "arcee-ai/Trinity-Nano-Preview",
+        "arcee-ai/Trinity-Mini",
+        "arcee-ai/Trinity-Large-Thinking",
+        "arcee-ai/Trinity-Nano-Base",
+        "dphn/Dolphin-X1-Trinity-Nano",
+        "arcee-ai/Trinity-Large-Preview"
+      ],
+      "relevancy_score": 45.1
+    },
+    {
+      "architecture_id": "HrmTextForCausalLM",
+      "total_models": 8,
+      "total_downloads": 334920,
+      "min_param_count": 1182795264,
+      "sample_models": [
+        "sapientinc/HRM-Text-1B",
+        "LLM-OS-Models/KoHRM-Text-1.4B"
+      ],
+      "relevancy_score": 45.1
+    },
+    {
+      "architecture_id": "FGCLIPModel",
+      "total_models": 4,
+      "total_downloads": 85495,
+      "min_param_count": 150136832,
+      "sample_models": [
+        "qihoo360/fg-clip-base"
       ],
       "relevancy_score": 45.1
     },
@@ -1106,142 +1300,63 @@
       "relevancy_score": 45.1
     },
     {
-      "architecture_id": "MultiScaleForCausalLM",
-      "total_models": 75,
-      "total_downloads": 55644,
-      "min_param_count": null,
+      "architecture_id": "HyenaDnaForCausalLM",
+      "total_models": 16,
+      "total_downloads": 15469,
+      "min_param_count": 436352,
       "sample_models": [
-        "KoinicLabs/AXL-Translate",
-        "KoinicLabs/AXL-Chat-10M",
-        "KoinicLabs/AXL-Secure-Lion",
-        "KoinicLabs/AXL-Code-1B",
-        "KoinicLabs/AXL-Secure-10M",
-        "KoinicLabs/AXL-Comment-5M",
-        "KoinicLabs/AXL-Vision-0.8M",
-        "KoinicLabs/AXL-Vision-v2",
-        "KoinicLabs/AXL-Chat-Pro",
-        "KoinicLabs/AXL-Refactor-Lion"
+        "multimolecule/hyenadna-tiny",
+        "multimolecule/hyenadna-small",
+        "multimolecule/hyenadna-large",
+        "multimolecule/hyenadna-medium"
+      ],
+      "relevancy_score": 45.0
+    },
+    {
+      "architecture_id": "Phi4MMForCausalLM",
+      "total_models": 8,
+      "total_downloads": 2008006,
+      "min_param_count": 5574460384,
+      "sample_models": [
+        "microsoft/Phi-4-multimodal-instruct",
+        "Lexius/Phi-4-multimodal-instruct"
       ],
       "relevancy_score": 44.9
     },
     {
-      "architecture_id": "VisionEncoderDecoderModel",
-      "total_models": 13,
-      "total_downloads": 21676,
-      "min_param_count": 239195904,
+      "architecture_id": "TTTForCausalLM",
+      "total_models": 12,
+      "total_downloads": 20408,
+      "min_param_count": 733608192,
       "sample_models": [
-        "AbteeXAILab/lumynax-ocr-trocr-large-printed",
-        "AbteeXAILab/lumynax-doc-nougat-base",
-        "AbteeXAILab/lumynax-ocr-trocr-large-handwritten",
-        "AbteeXAILab/lumynax-doc-donut-base",
-        "Molkaatb/ChestX"
-      ],
-      "relevancy_score": 44.8
-    },
-    {
-      "architecture_id": "RemoteForCausalLM",
-      "total_models": 3,
-      "total_downloads": 88262,
-      "min_param_count": 2054056,
-      "sample_models": [
-        "trl-internal-testing/tiny-RemoteForCausalLM"
-      ],
-      "relevancy_score": 44.8
-    },
-    {
-      "architecture_id": "Llama4ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 81342,
-      "min_param_count": 3269144,
-      "sample_models": [
-        "trl-internal-testing/tiny-Llama4ForCausalLM"
-      ],
-      "relevancy_score": 44.7
-    },
-    {
-      "architecture_id": "Kanana2VecModel",
-      "total_models": 3,
-      "total_downloads": 565953,
-      "min_param_count": 2086979328,
-      "sample_models": [
-        "kakaocorp/kanana-nano-2.1b-embedding"
-      ],
-      "relevancy_score": 44.7
-    },
-    {
-      "architecture_id": "_A2DQwen3LMHeadModel",
-      "total_models": 8,
-      "total_downloads": 38664,
-      "min_param_count": 596049920,
-      "sample_models": [
-        "divelab/OPDLM-0.6B",
-        "divelab/OPDLM-4B",
-        "divelab/OPDLM-MATH-4B"
-      ],
-      "relevancy_score": 44.6
-    },
-    {
-      "architecture_id": "GlmForCausalLM",
-      "total_models": 15,
-      "total_downloads": 93391,
-      "min_param_count": 1593427968,
-      "sample_models": [
-        "zai-org/glm-4-9b-chat-hf",
-        "zai-org/glm-4-9b-hf",
-        "zai-org/glm-edge-4b-chat",
-        "zai-org/glm-edge-1.5b-chat",
-        "zai-org/glm-4-9b-chat-1m-hf"
-      ],
-      "relevancy_score": 44.5
-    },
-    {
-      "architecture_id": "BitNetForCausalLM",
-      "total_models": 6,
-      "total_downloads": 47719,
-      "min_param_count": 849787090,
-      "sample_models": [
-        "microsoft/bitnet-b1.58-2B-4T",
-        "microsoft/bitnet-b1.58-2B-4T-bf16"
+        "RetentionLabs/TTT-Linear-760M-Base-Pile-8k",
+        "RetentionLabs/TTT-Linear-1.3B-Base-Pile-8k",
+        "RetentionLabs/TTT-MLP-760M-Base-Pile-8k"
       ],
       "relevancy_score": 44.4
     },
     {
-      "architecture_id": "Starcoder2ForCausalLM",
+      "architecture_id": "DbrxForCausalLM",
+      "total_models": 4,
+      "total_downloads": 58347,
+      "min_param_count": 4876152,
+      "sample_models": [
+        "trl-internal-testing/tiny-DbrxForCausalLM"
+      ],
+      "relevancy_score": 44.3
+    },
+    {
+      "architecture_id": "Ernie4_5_MoeForCausalLM",
       "total_models": 16,
-      "total_downloads": 496456,
-      "min_param_count": 3030371328,
+      "total_downloads": 432589,
+      "min_param_count": 4532627992,
       "sample_models": [
-        "bigcode/starcoder2-3b",
-        "bigcode/starcoder2-7b",
-        "bigcode/starcoder2-15b",
-        "bigcode/starcoder2-15b-instruct-v0.1",
-        "Johnblick187/starcoder2-15b",
-        "TechxGenus/starcoder2-7b-GPTQ"
+        "baidu/ERNIE-4.5-21B-A3B-PT",
+        "cyankiwi/ERNIE-4.5-21B-A3B-Thinking-AWQ-4bit",
+        "baidu/ERNIE-4.5-21B-A3B-Thinking",
+        "baidu/ERNIE-4.5-300B-A47B-PT"
       ],
-      "relevancy_score": 44.3
-    },
-    {
-      "architecture_id": "CambrianQwenForCausalLM",
-      "total_models": 9,
-      "total_downloads": 29882,
-      "min_param_count": 893618208,
-      "sample_models": [
-        "nyu-visionx/Scale-RAE-Qwen1.5B_DiT2.4B",
-        "nyu-visionx/Cambrian-S-7B",
-        "nyu-visionx/Cambrian-S-0.5B"
-      ],
-      "relevancy_score": 44.3
-    },
-    {
-      "architecture_id": "HrmTextForCausalLM",
-      "total_models": 6,
-      "total_downloads": 297201,
-      "min_param_count": 1182795264,
-      "sample_models": [
-        "sapientinc/HRM-Text-1B",
-        "LLM-OS-Models/KoHRM-Text-1.4B"
-      ],
-      "relevancy_score": 44.3
+      "relevancy_score": 44.0
     },
     {
       "architecture_id": "LongT5ForConditionalGeneration",
@@ -1257,31 +1372,55 @@
       "relevancy_score": 44.0
     },
     {
-      "architecture_id": "SDARForCausalLM",
+      "architecture_id": "LLaDAModelLM",
       "total_models": 16,
-      "total_downloads": 63830,
-      "min_param_count": 2031739904,
+      "total_downloads": 2710535,
+      "min_param_count": 8015581184,
       "sample_models": [
-        "JetLM/SDAR-8B-Chat",
-        "JetLM/SDAR-1.7B-Chat",
-        "JetLM/SDAR-8B-Chat-b32",
-        "yifanyu/I-DLM-8B",
-        "JetLM/SDAR-1.7B-Chat-b32",
-        "JetLM/SDAR-8B-Chat-b64"
+        "GSAI-ML/LLaDA-8B-Instruct",
+        "GSAI-ML/LLaDA-1.5",
+        "GSAI-ML/LLaDA-8B-Base",
+        "Zigeng/dParallel-LLaDA-8B-instruct"
       ],
       "relevancy_score": 43.9
     },
     {
-      "architecture_id": "Exaone4ForCausalLM",
-      "total_models": 9,
-      "total_downloads": 163194,
-      "min_param_count": 1279391488,
+      "architecture_id": "GPT",
+      "total_models": 12,
+      "total_downloads": 15138,
+      "min_param_count": 14259072,
       "sample_models": [
-        "LGAI-EXAONE/EXAONE-4.0-32B",
-        "LGAI-EXAONE/EXAONE-4.0-1.2B",
-        "LGAI-EXAONE/EXAONE-4.0.1-32B"
+        "younissk/nanoBeard-sloop-14M",
+        "Imperius/mini-tron-50",
+        "ncncomplete/nanogpt-tinystories"
       ],
-      "relevancy_score": 43.9
+      "relevancy_score": 43.8
+    },
+    {
+      "architecture_id": "Florence2ForConditionalGeneration",
+      "total_models": 11,
+      "total_downloads": 16883,
+      "min_param_count": 3549945,
+      "sample_models": [
+        "onnx-community/Florence-2-base-ft",
+        "onnx-community/Florence-2-large-ft",
+        "Xenova/tiny-random-Florence2ForConditionalGeneration"
+      ],
+      "relevancy_score": 43.7
+    },
+    {
+      "architecture_id": "MiMoForCausalLM",
+      "total_models": 19,
+      "total_downloads": 1586785,
+      "min_param_count": 7833409536,
+      "sample_models": [
+        "XiaomiMiMo/MiMo-7B-Base",
+        "XiaomiMiMo/MiMo-7B-RL",
+        "XiaomiMiMo/MiMo-7B-SFT",
+        "XiaomiMiMo/MiMo-7B-RL-Zero",
+        "XiaomiMiMo/MiMo-7B-RL-0530"
+      ],
+      "relevancy_score": 43.6
     },
     {
       "architecture_id": "PldrllmForCausalLM",
@@ -1298,25 +1437,37 @@
       "relevancy_score": 43.6
     },
     {
-      "architecture_id": "Phi4MMForCausalLM",
-      "total_models": 6,
-      "total_downloads": 1478049,
-      "min_param_count": 5574460384,
+      "architecture_id": "Plamo2ForCausalLM",
+      "total_models": 8,
+      "total_downloads": 161318,
+      "min_param_count": 1291441920,
       "sample_models": [
-        "microsoft/Phi-4-multimodal-instruct",
-        "Lexius/Phi-4-multimodal-instruct"
+        "pfnet/plamo-2-1b",
+        "pfnet/plamo-2-translate"
       ],
       "relevancy_score": 43.6
     },
     {
-      "architecture_id": "FGCLIPModel",
-      "total_models": 3,
-      "total_downloads": 49451,
-      "min_param_count": 150136832,
+      "architecture_id": "GeluGPTForCausalLM",
+      "total_models": 12,
+      "total_downloads": 12434,
+      "min_param_count": 261096338,
       "sample_models": [
-        "qihoo360/fg-clip-base"
+        "mlnomad/gelu-d12-chinchilla-261M-seed2-pytorch",
+        "mlnomad/gelu-d12-chinchilla-261M-seed1-pytorch",
+        "mlnomad/gelu-d12-chinchilla-261M-pytorch"
       ],
-      "relevancy_score": 43.6
+      "relevancy_score": 43.4
+    },
+    {
+      "architecture_id": "BD3LM",
+      "total_models": 4,
+      "total_downloads": 39185,
+      "min_param_count": 169627250,
+      "sample_models": [
+        "kuleshov-group/bd3lm-owt-block_size4"
+      ],
+      "relevancy_score": 43.4
     },
     {
       "architecture_id": "T5Gemma2ForConditionalGeneration",
@@ -1331,27 +1482,31 @@
       "relevancy_score": 43.4
     },
     {
-      "architecture_id": "HyenaDnaForCausalLM",
-      "total_models": 12,
-      "total_downloads": 12116,
-      "min_param_count": 436352,
+      "architecture_id": "AraGPT2LMHeadModel",
+      "total_models": 11,
+      "total_downloads": 13612,
+      "min_param_count": 829369856,
       "sample_models": [
-        "multimolecule/hyenadna-tiny",
-        "multimolecule/hyenadna-small",
-        "multimolecule/hyenadna-large",
-        "multimolecule/hyenadna-medium"
+        "aubmindlab/aragpt2-mega",
+        "aubmindlab/aragpt2-large",
+        "QCRI/Fanar-2-Diwan"
       ],
       "relevancy_score": 43.3
     },
     {
-      "architecture_id": "DbrxForCausalLM",
-      "total_models": 3,
-      "total_downloads": 43099,
-      "min_param_count": 4876152,
+      "architecture_id": "Glm4ForCausalLM",
+      "total_models": 23,
+      "total_downloads": 765649,
+      "min_param_count": 9400279040,
       "sample_models": [
-        "trl-internal-testing/tiny-DbrxForCausalLM"
+        "mratsim/GLM-4-32B-0414.w4a16-gptq",
+        "zai-org/GLM-4-9B-0414",
+        "zai-org/GLM-4-32B-0414",
+        "zai-org/GLM-Z1-9B-0414",
+        "zai-org/GLM-Z1-32B-0414",
+        "unsloth/GLM-4-9B-0414-unsloth-bnb-4bit"
       ],
-      "relevancy_score": 43.3
+      "relevancy_score": 43.2
     },
     {
       "architecture_id": "LEDForConditionalGeneration",
@@ -1369,136 +1524,135 @@
       "relevancy_score": 43.2
     },
     {
-      "architecture_id": "TTTForCausalLM",
-      "total_models": 9,
-      "total_downloads": 15207,
-      "min_param_count": 733608192,
+      "architecture_id": "Mistral3ForConditionalGeneration",
+      "total_models": 28,
+      "total_downloads": 51371,
+      "min_param_count": 3849090048,
       "sample_models": [
-        "RetentionLabs/TTT-Linear-760M-Base-Pile-8k",
-        "RetentionLabs/TTT-Linear-1.3B-Base-Pile-8k",
-        "RetentionLabs/TTT-MLP-760M-Base-Pile-8k"
+        "ArmGPT/ArmenianGPT-1.0-3B",
+        "Surpem/Supertron2-24B",
+        "rdtand/Mistral-Medium-3.5-128B-PrismaQuant-4.75-vllm",
+        "JANGQ-AI/Mistral-Small-4-119B-A6B-JANG_2L",
+        "dgomes03/Ministral-3-14B-Instruct-2512-mixed-6-4-bit",
+        "aitf-komdigi/KomdigiITS-8B-DFK-TextClassification",
+        "TyKaoz/Mistral-Small-3.2-24B-Instruct-2506-4bit",
+        "squ11z1/LeChatonFat"
+      ],
+      "relevancy_score": 43.0
+    },
+    {
+      "architecture_id": "A2DQwen3LMHeadModel",
+      "total_models": 8,
+      "total_downloads": 18129,
+      "min_param_count": 751632384,
+      "sample_models": [
+        "dllm-hub/Qwen3-0.6B-diffusion-bd3lm-v0.1",
+        "dllm-hub/Qwen3-0.6B-diffusion-mdlm-v0.1"
+      ],
+      "relevancy_score": 43.0
+    },
+    {
+      "architecture_id": "GLAForCausalLM",
+      "total_models": 10,
+      "total_downloads": 13317,
+      "min_param_count": 341707776,
+      "sample_models": [
+        "fla-hub/gla-1.3B-100B",
+        "fla-hub/gla-340M-15B",
+        "fla-hub/gla-2.7B-100B"
       ],
       "relevancy_score": 42.9
     },
     {
-      "architecture_id": "AfmoeForCausalLM",
-      "total_models": 18,
-      "total_downloads": 175629,
-      "min_param_count": 6120003328,
+      "architecture_id": "HGRNBitForCausalLM",
+      "total_models": 8,
+      "total_downloads": 17154,
+      "min_param_count": 374108160,
       "sample_models": [
-        "arcee-ai/Trinity-Nano-Preview",
-        "arcee-ai/Trinity-Mini",
-        "arcee-ai/Trinity-Large-Thinking",
-        "arcee-ai/Trinity-Nano-Base",
-        "dphn/Dolphin-X1-Trinity-Nano",
-        "arcee-ai/Trinity-Large-Preview"
+        "ridger/MMfreeLM-370M",
+        "ridger/MMfreeLM-2.7B"
       ],
-      "relevancy_score": 42.7
+      "relevancy_score": 42.9
     },
     {
-      "architecture_id": "Qwen3_5MoeForCausalLM",
-      "total_models": 28,
-      "total_downloads": 42695,
-      "min_param_count": 5642996864,
+      "architecture_id": "Ovis2_5",
+      "total_models": 8,
+      "total_downloads": 118188,
+      "min_param_count": 2570429672,
       "sample_models": [
-        "dawncr0w/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-text-oQ4",
-        "samuelfaj/Qwen3.6-35B-A3B-NSC-ACE-SABER-8bit-MTPLX-Optimized-Speed",
-        "FINAL-Bench/Darwin-36B-Opus",
-        "0xSero/Qwen3.6-28B",
-        "samuelfaj/Qwen3.6-35B-A3B-NSC-ACE-SABER-4bit-MTPLX-Optimized-Speed",
-        "dawncr0w/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-text-oQ8",
-        "dawncr0w/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-text-oQ6",
-        "samuelfaj/Qwen3.6-35B-A3B-NSC-ACE-SABER-6bit-MTPLX-Optimized-Speed",
-        "88plug/Qwen3.6-35B-A3B-W8A16",
-        "jenerallee78/Qwen3.6-35B-A3B-Abliterix-EGA-abliterated"
+        "AIDC-AI/Ovis2.5-9B",
+        "AIDC-AI/Ovis2.5-2B",
+        "ATH-MaaS/Ovis2.5-9B",
+        "ATH-MaaS/Ovis2.5-2B"
       ],
-      "relevancy_score": 42.6
+      "relevancy_score": 42.9
     },
     {
-      "architecture_id": "OLMoForCausalLM",
-      "total_models": 18,
-      "total_downloads": 24900,
-      "min_param_count": 1176764416,
+      "architecture_id": "Plamo3ForCausalLM",
+      "total_models": 7,
+      "total_downloads": 136743,
+      "min_param_count": 2603344384,
       "sample_models": [
-        "allenai/OLMo-1B",
-        "allenai/OLMo-7B",
-        "allenai/OLMo-7B-Instruct",
-        "allenai/MolmoE-1B-0924",
-        "Nhoodie/omni-dna-ici-dc",
-        "allenai/OLMo-7B-Twin-2T"
+        "pfnet/plamo-3-nict-2b-base",
+        "pfnet/plamo-3-nict-8b-base"
       ],
-      "relevancy_score": 42.6
+      "relevancy_score": 42.9
     },
     {
-      "architecture_id": "GPT",
-      "total_models": 9,
-      "total_downloads": 13079,
-      "min_param_count": 14259072,
+      "architecture_id": "Qwen3AttnResForCausalLM",
+      "total_models": 12,
+      "total_downloads": 9743,
+      "min_param_count": 115578880,
       "sample_models": [
-        "younissk/nanoBeard-sloop-14M",
-        "Imperius/mini-tron-50",
-        "ncncomplete/nanogpt-tinystories"
+        "Ethangou/attention-residuals-100M-full",
+        "Ethangou/attention-residuals-0.6B-block",
+        "Ethangou/attention-residuals-100M-block"
+      ],
+      "relevancy_score": 42.8
+    },
+    {
+      "architecture_id": "ColMaskMoELLaVAQwen2ForCausalLM",
+      "total_models": 12,
+      "total_downloads": 8536,
+      "min_param_count": 935673472,
+      "sample_models": [
+        "KKHYA/llavaqwen2.5-0.5b-finetune-col-mask-moe-sparse-4e-2k-sp0.9_20260418_062427",
+        "KKHYA/llavaqwen2.5-0.5b-finetune-col-mask-moe-sparse-4e-2k-sp0.9_20260418_062617",
+        "KKHYA/llavaqwen2.5-0.5b-finetune-col-mask-moe-sparse-4e-2k-sp0.7_20260416_182923"
       ],
       "relevancy_score": 42.6
     },
     {
-      "architecture_id": "BD3LM",
-      "total_models": 3,
-      "total_downloads": 29349,
-      "min_param_count": 169627250,
+      "architecture_id": "MarlinForConditionalGeneration",
+      "total_models": 8,
+      "total_downloads": 97867,
+      "min_param_count": 2213241664,
       "sample_models": [
-        "kuleshov-group/bd3lm-owt-block_size4"
+        "NemoStation/Marlin-2B",
+        "lunahr/Marlin-2B-ungated"
       ],
       "relevancy_score": 42.5
     },
     {
-      "architecture_id": "AraGPT2LMHeadModel",
-      "total_models": 9,
-      "total_downloads": 11813,
-      "min_param_count": 829369856,
+      "architecture_id": "HybridEchoForCausalLM",
+      "total_models": 5,
+      "total_downloads": 21539,
+      "min_param_count": 672190080,
       "sample_models": [
-        "aubmindlab/aragpt2-mega",
-        "aubmindlab/aragpt2-large",
-        "QCRI/Fanar-2-Diwan"
+        "mrs83/Kurtis-EON1-Hybrid-0.7B-v0.1.1",
+        "mrs83/Kurtis-EON1-Hybrid-2B-v0.1.2"
       ],
-      "relevancy_score": 42.4
+      "relevancy_score": 42.5
     },
     {
-      "architecture_id": "Plamo2ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 120185,
-      "min_param_count": 1291441920,
+      "architecture_id": "FalconOCRForCausalLM",
+      "total_models": 4,
+      "total_downloads": 23305,
+      "min_param_count": 269944416,
       "sample_models": [
-        "pfnet/plamo-2-1b",
-        "pfnet/plamo-2-translate"
+        "tiiuae/Falcon-OCR"
       ],
-      "relevancy_score": 42.4
-    },
-    {
-      "architecture_id": "LLaDAModelLM",
-      "total_models": 12,
-      "total_downloads": 2132115,
-      "min_param_count": 8015581184,
-      "sample_models": [
-        "GSAI-ML/LLaDA-8B-Instruct",
-        "GSAI-ML/LLaDA-1.5",
-        "GSAI-ML/LLaDA-8B-Base",
-        "Zigeng/dParallel-LLaDA-8B-instruct"
-      ],
-      "relevancy_score": 42.2
-    },
-    {
-      "architecture_id": "Ernie4_5_MoeForCausalLM",
-      "total_models": 12,
-      "total_downloads": 326101,
-      "min_param_count": 4532627992,
-      "sample_models": [
-        "baidu/ERNIE-4.5-21B-A3B-PT",
-        "cyankiwi/ERNIE-4.5-21B-A3B-Thinking-AWQ-4bit",
-        "baidu/ERNIE-4.5-21B-A3B-Thinking",
-        "baidu/ERNIE-4.5-300B-A47B-PT"
-      ],
-      "relevancy_score": 42.2
+      "relevancy_score": 42.3
     },
     {
       "architecture_id": "Qwen3ASRForConditionalGeneration",
@@ -1511,203 +1665,123 @@
         "NbAiLab/nb-asr-beta-qwen06b-lunde05",
         "bezzam/Qwen3-ASR-0.6B-hf"
       ],
-      "relevancy_score": 42.1
-    },
-    {
-      "architecture_id": "GeluGPTForCausalLM",
-      "total_models": 9,
-      "total_downloads": 10541,
-      "min_param_count": 261096338,
-      "sample_models": [
-        "mlnomad/gelu-d12-chinchilla-261M-seed2-pytorch",
-        "mlnomad/gelu-d12-chinchilla-261M-seed1-pytorch",
-        "mlnomad/gelu-d12-chinchilla-261M-pytorch"
-      ],
-      "relevancy_score": 42.1
-    },
-    {
-      "architecture_id": "HybridEchoForCausalLM",
-      "total_models": 4,
-      "total_downloads": 20829,
-      "min_param_count": 672190080,
-      "sample_models": [
-        "mrs83/Kurtis-EON1-Hybrid-0.7B-v0.1.1",
-        "mrs83/Kurtis-EON1-Hybrid-2B-v0.1.2"
-      ],
-      "relevancy_score": 42.1
-    },
-    {
-      "architecture_id": "Plamo3ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 102937,
-      "min_param_count": 2603344384,
-      "sample_models": [
-        "pfnet/plamo-3-nict-2b-base",
-        "pfnet/plamo-3-nict-8b-base"
-      ],
-      "relevancy_score": 42.0
-    },
-    {
-      "architecture_id": "A2DQwen3LMHeadModel",
-      "total_models": 6,
-      "total_downloads": 14767,
-      "min_param_count": 751632384,
-      "sample_models": [
-        "dllm-hub/Qwen3-0.6B-diffusion-bd3lm-v0.1",
-        "dllm-hub/Qwen3-0.6B-diffusion-mdlm-v0.1"
-      ],
-      "relevancy_score": 41.9
-    },
-    {
-      "architecture_id": "Ovis2_5",
-      "total_models": 6,
-      "total_downloads": 87234,
-      "min_param_count": 2570429672,
-      "sample_models": [
-        "AIDC-AI/Ovis2.5-9B",
-        "AIDC-AI/Ovis2.5-2B"
-      ],
-      "relevancy_score": 41.7
-    },
-    {
-      "architecture_id": "MiMoForCausalLM",
-      "total_models": 15,
-      "total_downloads": 1061578,
-      "min_param_count": 7833409536,
-      "sample_models": [
-        "XiaomiMiMo/MiMo-7B-Base",
-        "XiaomiMiMo/MiMo-7B-RL",
-        "XiaomiMiMo/MiMo-7B-SFT",
-        "XiaomiMiMo/MiMo-7B-RL-Zero",
-        "XiaomiMiMo/MiMo-7B-RL-0530"
-      ],
-      "relevancy_score": 41.6
-    },
-    {
-      "architecture_id": "Qwen3AttnResForCausalLM",
-      "total_models": 9,
-      "total_downloads": 8065,
-      "min_param_count": 115578880,
-      "sample_models": [
-        "Ethangou/attention-residuals-100M-full",
-        "Ethangou/attention-residuals-0.6B-block",
-        "Ethangou/attention-residuals-100M-block"
-      ],
-      "relevancy_score": 41.6
-    },
-    {
-      "architecture_id": "HGRNBitForCausalLM",
-      "total_models": 6,
-      "total_downloads": 12380,
-      "min_param_count": 374108160,
-      "sample_models": [
-        "ridger/MMfreeLM-370M",
-        "ridger/MMfreeLM-2.7B"
-      ],
-      "relevancy_score": 41.6
-    },
-    {
-      "architecture_id": "FalconOCRForCausalLM",
-      "total_models": 3,
-      "total_downloads": 18108,
-      "min_param_count": 269944416,
-      "sample_models": [
-        "tiiuae/Falcon-OCR"
-      ],
-      "relevancy_score": 41.5
-    },
-    {
-      "architecture_id": "GLAForCausalLM",
-      "total_models": 7,
-      "total_downloads": 9898,
-      "min_param_count": 341707776,
-      "sample_models": [
-        "fla-hub/gla-1.3B-100B",
-        "fla-hub/gla-340M-15B",
-        "fla-hub/gla-2.7B-100B"
-      ],
-      "relevancy_score": 41.4
-    },
-    {
-      "architecture_id": "MarlinForConditionalGeneration",
-      "total_models": 6,
-      "total_downloads": 77941,
-      "min_param_count": 2213241664,
-      "sample_models": [
-        "NemoStation/Marlin-2B",
-        "lunahr/Marlin-2B-ungated"
-      ],
-      "relevancy_score": 41.4
-    },
-    {
-      "architecture_id": "ColMaskMoELLaVAQwen2ForCausalLM",
-      "total_models": 9,
-      "total_downloads": 6908,
-      "min_param_count": 935673472,
-      "sample_models": [
-        "KKHYA/llavaqwen2.5-0.5b-finetune-col-mask-moe-sparse-4e-2k-sp0.9_20260418_062427",
-        "KKHYA/llavaqwen2.5-0.5b-finetune-col-mask-moe-sparse-4e-2k-sp0.9_20260418_062617",
-        "KKHYA/llavaqwen2.5-0.5b-finetune-col-mask-moe-sparse-4e-2k-sp0.7_20260416_182923"
-      ],
-      "relevancy_score": 41.2
+      "relevancy_score": 42.2
     },
     {
       "architecture_id": "axiomForCausalLM",
-      "total_models": 6,
-      "total_downloads": 10221,
+      "total_models": 8,
+      "total_downloads": 12388,
       "min_param_count": 488664064,
       "sample_models": [
         "user-anto/Axiom-Dense-380M-Base",
         "user-anto/Axiom-Dense-380M-Instruct"
       ],
-      "relevancy_score": 41.2
+      "relevancy_score": 42.2
+    },
+    {
+      "architecture_id": "FalconPerceptionForSegmentation",
+      "total_models": 4,
+      "total_downloads": 21975,
+      "min_param_count": 632372288,
+      "sample_models": [
+        "tiiuae/Falcon-Perception"
+      ],
+      "relevancy_score": 42.2
     },
     {
       "architecture_id": "BharatGPTForCausalLM",
-      "total_models": 6,
-      "total_downloads": 10139,
+      "total_models": 8,
+      "total_downloads": 11759,
       "min_param_count": 353748992,
       "sample_models": [
         "Harshhvm/bharat-minigpt-350m-pretrain-3b-tokens",
         "anshullpal/ByteZira-Vaani-350M-pretrain-base-model"
       ],
-      "relevancy_score": 41.2
-    },
-    {
-      "architecture_id": "FalconPerceptionForSegmentation",
-      "total_models": 3,
-      "total_downloads": 16085,
-      "min_param_count": 632372288,
-      "sample_models": [
-        "tiiuae/Falcon-Perception"
-      ],
-      "relevancy_score": 41.2
-    },
-    {
-      "architecture_id": "Glm4ForCausalLM",
-      "total_models": 17,
-      "total_downloads": 576358,
-      "min_param_count": 9400279040,
-      "sample_models": [
-        "mratsim/GLM-4-32B-0414.w4a16-gptq",
-        "zai-org/GLM-4-9B-0414",
-        "zai-org/GLM-4-32B-0414",
-        "zai-org/GLM-Z1-9B-0414",
-        "zai-org/GLM-Z1-32B-0414",
-        "unsloth/GLM-4-9B-0414-unsloth-bnb-4bit"
-      ],
-      "relevancy_score": 40.9
+      "relevancy_score": 42.1
     },
     {
       "architecture_id": "LanceAI",
-      "total_models": 6,
-      "total_downloads": 9030,
+      "total_models": 8,
+      "total_downloads": 10551,
       "min_param_count": 393241088,
       "sample_models": [
         "NeuraCraft/Lance-AI-V2",
         "NeuraCraft/Lance-AI"
       ],
-      "relevancy_score": 40.9
+      "relevancy_score": 41.8
+    },
+    {
+      "architecture_id": "SarvamMoEForCausalLM",
+      "total_models": 11,
+      "total_downloads": 224166,
+      "min_param_count": 6815594732,
+      "sample_models": [
+        "sarvamai/sarvam-30b",
+        "QuantTrio/sarvam-30b-AWQ",
+        "Orange/Sarvam-30b-GPTQ-w8a16"
+      ],
+      "relevancy_score": 41.1
+    },
+    {
+      "architecture_id": "CALIForCausalLM",
+      "total_models": 4,
+      "total_downloads": 13048,
+      "min_param_count": 123782400,
+      "sample_models": [
+        "Sandroeth/cali-0.1B"
+      ],
+      "relevancy_score": 41.1
+    },
+    {
+      "architecture_id": "TransformerForCausalLM",
+      "total_models": 4,
+      "total_downloads": 80752,
+      "min_param_count": 1364297728,
+      "sample_models": [
+        "fla-hub/transformer-1.3B-100B"
+      ],
+      "relevancy_score": 41.0
+    },
+    {
+      "architecture_id": "TinyMindForCausalLM",
+      "total_models": 8,
+      "total_downloads": 6526,
+      "min_param_count": 17731328,
+      "sample_models": [
+        "HenrySentinel/tinyMind-SFT",
+        "HenrySentinel/tinyMind"
+      ],
+      "relevancy_score": 40.8
+    },
+    {
+      "architecture_id": "LayerWiseMiniCPMForCausalLM",
+      "total_models": 4,
+      "total_downloads": 76865,
+      "min_param_count": 2724956928,
+      "sample_models": [
+        "BAAI/bge-reranker-v2-minicpm-layerwise"
+      ],
+      "relevancy_score": 40.8
+    },
+    {
+      "architecture_id": "HCXVisionForCausalLM",
+      "total_models": 4,
+      "total_downloads": 502121,
+      "min_param_count": 3721243520,
+      "sample_models": [
+        "naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B"
+      ],
+      "relevancy_score": 40.8
+    },
+    {
+      "architecture_id": "SpatialLMQwenForCausalLM",
+      "total_models": 4,
+      "total_downloads": 10988,
+      "min_param_count": 603511168,
+      "sample_models": [
+        "manycore-research/SpatialLM1.1-Qwen-0.5B"
+      ],
+      "relevancy_score": 40.8
     },
     {
       "architecture_id": "GlmAsrForConditionalGeneration",
@@ -1736,31 +1810,95 @@
       "relevancy_score": 40.6
     },
     {
-      "architecture_id": "CALIForCausalLM",
-      "total_models": 3,
-      "total_downloads": 11266,
-      "min_param_count": 123782400,
+      "architecture_id": "Moondream",
+      "total_models": 4,
+      "total_downloads": 67776,
+      "min_param_count": 1857482608,
       "sample_models": [
-        "Sandroeth/cali-0.1B"
+        "vikhyatk/moondream1"
+      ],
+      "relevancy_score": 40.6
+    },
+    {
+      "architecture_id": "MobilintQwen3ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 10296,
+      "min_param_count": 388956160,
+      "sample_models": [
+        "mobilint/Qwen3-4B"
+      ],
+      "relevancy_score": 40.6
+    },
+    {
+      "architecture_id": "DeepseekV32ForCausalLM",
+      "total_models": 20,
+      "total_downloads": 13965982,
+      "min_param_count": 685355329792,
+      "sample_models": [
+        "deepseek-ai/DeepSeek-V3.2",
+        "QuantTrio/DeepSeek-V3.2-AWQ",
+        "deepseek-ai/DeepSeek-V3.2-Exp",
+        "deepseek-ai/DeepSeek-V3.2-Speciale",
+        "deepseek-ai/DeepSeek-Math-V2"
       ],
       "relevancy_score": 40.5
     },
     {
-      "architecture_id": "Mistral3ForConditionalGeneration",
-      "total_models": 21,
-      "total_downloads": 39261,
-      "min_param_count": 3849090048,
+      "architecture_id": "TRMTextISMForCausalLM",
+      "total_models": 7,
+      "total_downloads": 6571,
+      "min_param_count": 84312320,
       "sample_models": [
-        "ArmGPT/ArmenianGPT-1.0-3B",
-        "Surpem/Supertron2-24B",
-        "rdtand/Mistral-Medium-3.5-128B-PrismaQuant-4.75-vllm",
-        "JANGQ-AI/Mistral-Small-4-119B-A6B-JANG_2L",
-        "dgomes03/Ministral-3-14B-Instruct-2512-mixed-6-4-bit",
-        "aitf-komdigi/KomdigiITS-8B-DFK-TextClassification",
-        "TyKaoz/Mistral-Small-3.2-24B-Instruct-2506-4bit",
-        "squ11z1/LeChatonFat"
+        "summerMC/TRM-textv3.5",
+        "summerMC/Trm-text-1B"
+      ],
+      "relevancy_score": 40.5
+    },
+    {
+      "architecture_id": "BitnetForCausalLM",
+      "total_models": 5,
+      "total_downloads": 8518,
+      "min_param_count": 728843904,
+      "sample_models": [
+        "1bitLLM/bitnet_b1_58-large",
+        "1bitLLM/bitnet_b1_58-3B"
+      ],
+      "relevancy_score": 40.5
+    },
+    {
+      "architecture_id": "RecurrentGemmaForCausalLM",
+      "total_models": 10,
+      "total_downloads": 26908,
+      "min_param_count": 2682862080,
+      "sample_models": [
+        "google/recurrentgemma-2b",
+        "google/recurrentgemma-2b-it",
+        "google/recurrentgemma-9b-it",
+        "google/recurrentgemma-9b"
       ],
       "relevancy_score": 40.4
+    },
+    {
+      "architecture_id": "DUO",
+      "total_models": 7,
+      "total_downloads": 6049,
+      "min_param_count": 167928865,
+      "sample_models": [
+        "kekchpek/idlm-duo-tynigsm",
+        "s-sahoo/duo"
+      ],
+      "relevancy_score": 40.4
+    },
+    {
+      "architecture_id": "Gemma4ForCausalLM",
+      "total_models": 7,
+      "total_downloads": 5918,
+      "min_param_count": 4496390,
+      "sample_models": [
+        "veyra-ai/Kairo-5M-Gemma4-Base",
+        "zentropi-ai/cope-b-a4b"
+      ],
+      "relevancy_score": 40.3
     },
     {
       "architecture_id": "EchoForCausalLM",
@@ -1773,117 +1911,205 @@
       "relevancy_score": 40.3
     },
     {
-      "architecture_id": "TransformerForCausalLM",
-      "total_models": 3,
-      "total_downloads": 59830,
-      "min_param_count": 1364297728,
+      "architecture_id": "DreamModel",
+      "total_models": 16,
+      "total_downloads": 482825,
+      "min_param_count": 7615616512,
       "sample_models": [
-        "fla-hub/transformer-1.3B-100B"
+        "Dream-org/Dream-v0-Instruct-7B",
+        "Dream-org/Dream-v0-Base-7B",
+        "Dream-org/Dream-Coder-v0-Instruct-7B",
+        "neurovsa/Dream-Coder-v0-Instruct-7B-HM-Model"
+      ],
+      "relevancy_score": 40.2
+    },
+    {
+      "architecture_id": "Qwen3TTSForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 8121,
+      "min_param_count": 914643008,
+      "sample_models": [
+        "g-group-ai-lab/gwen-tts-0.6B"
+      ],
+      "relevancy_score": 40.1
+    },
+    {
+      "architecture_id": "SwarmForCausalLM",
+      "total_models": 4,
+      "total_downloads": 7686,
+      "min_param_count": 52729731,
+      "sample_models": [
+        "reaperdoesntknow/SAGI"
       ],
       "relevancy_score": 40.0
     },
     {
-      "architecture_id": "SarvamMoEForCausalLM",
-      "total_models": 9,
-      "total_downloads": 168805,
-      "min_param_count": 6815594732,
-      "sample_models": [
-        "sarvamai/sarvam-30b",
-        "QuantTrio/sarvam-30b-AWQ",
-        "Orange/Sarvam-30b-GPTQ-w8a16"
-      ],
-      "relevancy_score": 39.9
-    },
-    {
-      "architecture_id": "LayerWiseMiniCPMForCausalLM",
-      "total_models": 3,
-      "total_downloads": 56751,
-      "min_param_count": 2724956928,
-      "sample_models": [
-        "BAAI/bge-reranker-v2-minicpm-layerwise"
-      ],
-      "relevancy_score": 39.9
-    },
-    {
-      "architecture_id": "SpatialLMQwenForCausalLM",
-      "total_models": 3,
-      "total_downloads": 8397,
-      "min_param_count": 603511168,
-      "sample_models": [
-        "manycore-research/SpatialLM1.1-Qwen-0.5B"
-      ],
-      "relevancy_score": 39.9
-    },
-    {
-      "architecture_id": "TinyMindForCausalLM",
-      "total_models": 6,
-      "total_downloads": 5382,
-      "min_param_count": 17731328,
-      "sample_models": [
-        "HenrySentinel/tinyMind-SFT",
-        "HenrySentinel/tinyMind"
-      ],
-      "relevancy_score": 39.8
-    },
-    {
-      "architecture_id": "HCXVisionForCausalLM",
-      "total_models": 3,
-      "total_downloads": 368595,
-      "min_param_count": 3721243520,
-      "sample_models": [
-        "naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B"
-      ],
-      "relevancy_score": 39.8
-    },
-    {
-      "architecture_id": "Gemma4ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 5077,
-      "min_param_count": 4496390,
-      "sample_models": [
-        "veyra-ai/Kairo-5M-Gemma4-Base",
-        "zentropi-ai/cope-b-a4b"
-      ],
-      "relevancy_score": 39.7
-    },
-    {
-      "architecture_id": "BitnetForCausalLM",
+      "architecture_id": "DeepseekVLV2ForCausalLM",
       "total_models": 4,
-      "total_downloads": 6658,
-      "min_param_count": 728843904,
+      "total_downloads": 344873,
+      "min_param_count": 3370501440,
       "sample_models": [
-        "1bitLLM/bitnet_b1_58-large",
-        "1bitLLM/bitnet_b1_58-3B"
+        "Isotr0py/deepseek-vl2-tiny"
+      ],
+      "relevancy_score": 40.0
+    },
+    {
+      "architecture_id": "HiggsMultimodalQwen3ForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 328453,
+      "min_param_count": 4654850537,
+      "sample_models": [
+        "bosonai/higgs-audio-v3-tts-4b",
+        "bosonai/higgs-tts-v3-4b",
+        "bosonai/higgs-tts-3-4b"
+      ],
+      "relevancy_score": 39.9
+    },
+    {
+      "architecture_id": "InductionForCausalLM",
+      "total_models": 3,
+      "total_downloads": 8595,
+      "min_param_count": 12288816,
+      "sample_models": [
+        "Lllllmmmmmm/conv-induction-babylm-strict-small"
+      ],
+      "relevancy_score": 39.9
+    },
+    {
+      "architecture_id": "SquaredReLUQwen3ForCausalLM",
+      "total_models": 6,
+      "total_downloads": 5287,
+      "min_param_count": 524779008,
+      "sample_models": [
+        "Ba2han/qwen3_from_scratch",
+        "Ba2han/sft-test2"
+      ],
+      "relevancy_score": 39.8
+    },
+    {
+      "architecture_id": "HybridMoRMoEForCausalLM",
+      "total_models": 4,
+      "total_downloads": 6963,
+      "min_param_count": 294194343,
+      "sample_models": [
+        "TorchLLM/HybridMoRMoE"
+      ],
+      "relevancy_score": 39.8
+    },
+    {
+      "architecture_id": "VexionLMForCausalLM",
+      "total_models": 4,
+      "total_downloads": 7140,
+      "min_param_count": 317774592,
+      "sample_models": [
+        "DZER-Studios/Vexion-LM"
+      ],
+      "relevancy_score": 39.8
+    },
+    {
+      "architecture_id": "GPTX3ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 6919,
+      "min_param_count": 5158464,
+      "sample_models": [
+        "AxiomicLabs/GPT-S-5M"
+      ],
+      "relevancy_score": 39.8
+    },
+    {
+      "architecture_id": "Llama4ForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 6721,
+      "min_param_count": 6686880,
+      "sample_models": [
+        "yujiepan/llama-4-tiny-random"
       ],
       "relevancy_score": 39.7
     },
     {
-      "architecture_id": "Moondream",
-      "total_models": 3,
-      "total_downloads": 50863,
-      "min_param_count": 1857482608,
+      "architecture_id": "MetisMoRLMHeadModel",
+      "total_models": 4,
+      "total_downloads": 6353,
+      "min_param_count": 503772163,
       "sample_models": [
-        "vikhyatk/moondream1"
-      ],
-      "relevancy_score": 39.7
-    },
-    {
-      "architecture_id": "MobilintQwen3ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 7457,
-      "min_param_count": 388956160,
-      "sample_models": [
-        "mobilint/Qwen3-4B"
+        "Lernex/Metis-1.4-base"
       ],
       "relevancy_score": 39.6
     },
     {
-      "architecture_id": "SwarmForCausalLM",
-      "total_models": 3,
-      "total_downloads": 6458,
-      "min_param_count": 52729731,
+      "architecture_id": "DebertaForSequenceClassification",
+      "total_models": 4,
+      "total_downloads": 6248,
+      "min_param_count": 139199753,
       "sample_models": [
-        "reaperdoesntknow/SAGI"
+        "AbteeXAILab/lumynax-guard-text-moderation"
+      ],
+      "relevancy_score": 39.6
+    },
+    {
+      "architecture_id": "TableTransformerForObjectDetection",
+      "total_models": 4,
+      "total_downloads": 6307,
+      "min_param_count": 28818631,
+      "sample_models": [
+        "AbteeXAILab/lumynax-doc-table-transformer-detection"
+      ],
+      "relevancy_score": 39.6
+    },
+    {
+      "architecture_id": "MellumForCausalLM",
+      "total_models": 20,
+      "total_downloads": 198386,
+      "min_param_count": 12149923072,
+      "sample_models": [
+        "JetBrains/Mellum2-12B-A2.5B-Thinking",
+        "JetBrains/Mellum2-12B-A2.5B-Base",
+        "JetBrains/Mellum2-12B-A2.5B-Instruct",
+        "cyankiwi/Mellum2-12B-A2.5B-Thinking-AWQ-INT4",
+        "JetBrains/Mellum2-12B-A2.5B-Thinking-SFT"
+      ],
+      "relevancy_score": 39.5
+    },
+    {
+      "architecture_id": "Videollama3Qwen2ForCausalLM",
+      "total_models": 8,
+      "total_downloads": 23670,
+      "min_param_count": 1959993584,
+      "sample_models": [
+        "DAMO-NLP-SG/VideoLLaMA3-7B",
+        "DAMO-NLP-SG/VideoLLaMA3-2B"
+      ],
+      "relevancy_score": 39.5
+    },
+    {
+      "architecture_id": "MolformerForCausalLM",
+      "total_models": 5,
+      "total_downloads": 5134,
+      "min_param_count": 46805760,
+      "sample_models": [
+        "ibm-research/GP-MoLFormer-Uniq",
+        "ralyn/NPComposer-v2"
+      ],
+      "relevancy_score": 39.4
+    },
+    {
+      "architecture_id": "DeltaNetForCausalLM",
+      "total_models": 8,
+      "total_downloads": 21528,
+      "min_param_count": 1365677056,
+      "sample_models": [
+        "fla-hub/delta_net-1.3B-8K-100B",
+        "fla-hub/delta_net-1.3B-100B"
+      ],
+      "relevancy_score": 39.3
+    },
+    {
+      "architecture_id": "EnigmaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 5390,
+      "min_param_count": 12882304,
+      "sample_models": [
+        "dr-tkxx/Enigma"
       ],
       "relevancy_score": 39.3
     },
@@ -1898,115 +2124,56 @@
       "relevancy_score": 39.3
     },
     {
-      "architecture_id": "TRMTextISMForCausalLM",
-      "total_models": 5,
-      "total_downloads": 4538,
-      "min_param_count": 84312320,
+      "architecture_id": "GiddForDiffusionLM",
+      "total_models": 8,
+      "total_downloads": 18746,
+      "min_param_count": 2957629440,
       "sample_models": [
-        "summerMC/TRM-textv3.5",
-        "summerMC/Trm-text-1B"
-      ],
-      "relevancy_score": 39.2
-    },
-    {
-      "architecture_id": "SquaredReLUQwen3ForCausalLM",
-      "total_models": 5,
-      "total_downloads": 4681,
-      "min_param_count": 524779008,
-      "sample_models": [
-        "Ba2han/qwen3_from_scratch",
-        "Ba2han/sft-test2"
-      ],
-      "relevancy_score": 39.2
-    },
-    {
-      "architecture_id": "Qwen3TTSForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 6071,
-      "min_param_count": 914643008,
-      "sample_models": [
-        "g-group-ai-lab/gwen-tts-0.6B"
-      ],
-      "relevancy_score": 39.2
-    },
-    {
-      "architecture_id": "VexionLMForCausalLM",
-      "total_models": 3,
-      "total_downloads": 6165,
-      "min_param_count": 317774592,
-      "sample_models": [
-        "DZER-Studios/Vexion-LM"
-      ],
-      "relevancy_score": 39.2
-    },
-    {
-      "architecture_id": "Llama4ForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 5918,
-      "min_param_count": 6686880,
-      "sample_models": [
-        "yujiepan/llama-4-tiny-random"
-      ],
-      "relevancy_score": 39.1
-    },
-    {
-      "architecture_id": "MetisMoRLMHeadModel",
-      "total_models": 3,
-      "total_downloads": 5691,
-      "min_param_count": 503772163,
-      "sample_models": [
-        "Lernex/Metis-1.4-base"
-      ],
-      "relevancy_score": 39.1
-    },
-    {
-      "architecture_id": "HybridMoRMoEForCausalLM",
-      "total_models": 3,
-      "total_downloads": 5751,
-      "min_param_count": 294194343,
-      "sample_models": [
-        "TorchLLM/HybridMoRMoE"
-      ],
-      "relevancy_score": 39.1
-    },
-    {
-      "architecture_id": "DeepseekVLV2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 252416,
-      "min_param_count": 3370501440,
-      "sample_models": [
-        "Isotr0py/deepseek-vl2-tiny"
+        "dvruette/gidd-unif-10b",
+        "dvruette/gidd-unif-3b"
       ],
       "relevancy_score": 39.0
     },
     {
-      "architecture_id": "TableTransformerForObjectDetection",
-      "total_models": 3,
-      "total_downloads": 5425,
-      "min_param_count": 28818631,
+      "architecture_id": "VrityaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4713,
+      "min_param_count": 163000320,
       "sample_models": [
-        "AbteeXAILab/lumynax-doc-table-transformer-detection"
+        "curious-techie/Vritya-Tiny-163M-HF"
       ],
       "relevancy_score": 39.0
     },
     {
-      "architecture_id": "DUO",
-      "total_models": 5,
-      "total_downloads": 4073,
-      "min_param_count": 167928865,
+      "architecture_id": "NamerModel",
+      "total_models": 4,
+      "total_downloads": 4847,
+      "min_param_count": 883369,
       "sample_models": [
-        "kekchpek/idlm-duo-tynigsm",
-        "s-sahoo/duo"
+        "edwinhere/namer"
       ],
-      "relevancy_score": 38.9
+      "relevancy_score": 39.0
     },
     {
-      "architecture_id": "DebertaForSequenceClassification",
-      "total_models": 3,
-      "total_downloads": 5374,
-      "min_param_count": 139199753,
+      "architecture_id": "SmallLLMForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4874,
+      "min_param_count": 123920640,
       "sample_models": [
-        "AbteeXAILab/lumynax-guard-text-moderation"
+        "snehangshu511/tinystories-gpt2-124M-scratch"
+      ],
+      "relevancy_score": 39.0
+    },
+    {
+      "architecture_id": "OlmoHybridForCausalLM",
+      "total_models": 16,
+      "total_downloads": 256449,
+      "min_param_count": 7430870688,
+      "sample_models": [
+        "allenai/Olmo-Hybrid-7B",
+        "allenai/Olmo-Hybrid-Instruct-SFT-7B",
+        "allenai/Olmo-Hybrid-Think-SFT-7B",
+        "allenai/Olmo-Hybrid-Instruct-DPO-7B"
       ],
       "relevancy_score": 38.9
     },
@@ -2021,104 +2188,55 @@
       "relevancy_score": 38.9
     },
     {
-      "architecture_id": "GPTX3ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 5251,
-      "min_param_count": 5158464,
+      "architecture_id": "YForCausalLM3",
+      "total_models": 4,
+      "total_downloads": 4241,
+      "min_param_count": 55064320,
       "sample_models": [
-        "AxiomicLabs/GPT-S-5M"
-      ],
-      "relevancy_score": 38.9
-    },
-    {
-      "architecture_id": "HiggsMultimodalQwen3ForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 229970,
-      "min_param_count": 4654850537,
-      "sample_models": [
-        "bosonai/higgs-audio-v3-tts-4b",
-        "bosonai/higgs-tts-v3-4b"
+        "SnifferCaptain/ymodel3-n1"
       ],
       "relevancy_score": 38.8
     },
     {
-      "architecture_id": "InductionForCausalLM",
-      "total_models": 2,
-      "total_downloads": 5588,
-      "min_param_count": 12288816,
+      "architecture_id": "VanFastForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4132,
+      "min_param_count": 376644864,
       "sample_models": [
-        "Lllllmmmmmm/conv-induction-babylm-strict-small"
+        "summerMC/summerV2"
       ],
       "relevancy_score": 38.7
     },
     {
-      "architecture_id": "DreamModel",
-      "total_models": 12,
-      "total_downloads": 402170,
-      "min_param_count": 7615616512,
+      "architecture_id": "Qwen3VLForConditionalGeneration",
+      "total_models": 8,
+      "total_downloads": 97882,
+      "min_param_count": 4437815808,
       "sample_models": [
-        "Dream-org/Dream-v0-Instruct-7B",
-        "Dream-org/Dream-v0-Base-7B",
-        "Dream-org/Dream-Coder-v0-Instruct-7B",
-        "neurovsa/Dream-Coder-v0-Instruct-7B-HM-Model"
-      ],
-      "relevancy_score": 38.6
-    },
-    {
-      "architecture_id": "MolformerForCausalLM",
-      "total_models": 4,
-      "total_downloads": 4018,
-      "min_param_count": 46805760,
-      "sample_models": [
-        "ibm-research/GP-MoLFormer-Uniq",
-        "ralyn/NPComposer-v2"
-      ],
-      "relevancy_score": 38.6
-    },
-    {
-      "architecture_id": "DeepseekV32ForCausalLM",
-      "total_models": 15,
-      "total_downloads": 10970298,
-      "min_param_count": 685355329792,
-      "sample_models": [
-        "deepseek-ai/DeepSeek-V3.2",
-        "QuantTrio/DeepSeek-V3.2-AWQ",
-        "deepseek-ai/DeepSeek-V3.2-Exp",
-        "deepseek-ai/DeepSeek-V3.2-Speciale",
-        "deepseek-ai/DeepSeek-Math-V2"
+        "Goekdeniz-Guelmez/Josiefied-Qwen3-VL-4B-Instruct-abliterated-beta-v1",
+        "DreamFast/Qwen3-VL-8B-Heretic-1.3.0"
       ],
       "relevancy_score": 38.5
     },
     {
-      "architecture_id": "RecurrentGemmaForCausalLM",
-      "total_models": 6,
-      "total_downloads": 18182,
-      "min_param_count": 2682862080,
+      "architecture_id": "LangFlow",
+      "total_models": 4,
+      "total_downloads": 3759,
+      "min_param_count": 170805361,
       "sample_models": [
-        "google/recurrentgemma-2b",
-        "google/recurrentgemma-2b-it"
+        "Continuous-Rivals-Discrete/langflow-owt"
       ],
-      "relevancy_score": 38.4
+      "relevancy_score": 38.5
     },
     {
-      "architecture_id": "NamerModel",
-      "total_models": 3,
-      "total_downloads": 4181,
-      "min_param_count": 883369,
+      "architecture_id": "MobileLLMP1ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 24933,
+      "min_param_count": 1084453120,
       "sample_models": [
-        "edwinhere/namer"
+        "facebook/MobileLLM-Pro-base"
       ],
-      "relevancy_score": 38.4
-    },
-    {
-      "architecture_id": "SmallLLMForCausalLM",
-      "total_models": 3,
-      "total_downloads": 4191,
-      "min_param_count": 123920640,
-      "sample_models": [
-        "snehangshu511/tinystories-gpt2-124M-scratch"
-      ],
-      "relevancy_score": 38.4
+      "relevancy_score": 38.5
     },
     {
       "architecture_id": "YasinForCausalLM",
@@ -2131,44 +2249,42 @@
       "relevancy_score": 38.4
     },
     {
-      "architecture_id": "VrityaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 4040,
-      "min_param_count": 163000320,
+      "architecture_id": "SLM",
+      "total_models": 4,
+      "total_downloads": 3445,
+      "min_param_count": 50550784,
       "sample_models": [
-        "curious-techie/Vritya-Tiny-163M-HF"
+        "aman0419/Vitallm-50M"
       ],
       "relevancy_score": 38.3
     },
     {
-      "architecture_id": "EnigmaForCausalLM",
+      "architecture_id": "HanziForCausalLM",
       "total_models": 3,
-      "total_downloads": 3955,
-      "min_param_count": 12882304,
+      "total_downloads": 3868,
+      "min_param_count": 123535318,
       "sample_models": [
-        "dr-tkxx/Enigma"
+        "EjZhou/chinese-babylm-2026-hanzi-a3large"
       ],
       "relevancy_score": 38.3
     },
     {
-      "architecture_id": "GiddForDiffusionLM",
-      "total_models": 6,
-      "total_downloads": 16470,
-      "min_param_count": 2957629440,
+      "architecture_id": "GoatVVVForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3270,
+      "min_param_count": 88867190,
       "sample_models": [
-        "dvruette/gidd-unif-10b",
-        "dvruette/gidd-unif-3b"
+        "mlnomad/goat-vvv-d12-fineweb-5x-pytorch"
       ],
       "relevancy_score": 38.2
     },
     {
-      "architecture_id": "Videollama3Qwen2ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 16994,
-      "min_param_count": 1959993584,
+      "architecture_id": "RecursiveLanguageModel",
+      "total_models": 4,
+      "total_downloads": 3340,
+      "min_param_count": 198464806,
       "sample_models": [
-        "DAMO-NLP-SG/VideoLLaMA3-7B",
-        "DAMO-NLP-SG/VideoLLaMA3-2B"
+        "Girinath11/recursive-language-model-198m"
       ],
       "relevancy_score": 38.2
     },
@@ -2183,15 +2299,90 @@
       "relevancy_score": 38.2
     },
     {
-      "architecture_id": "DeltaNetForCausalLM",
-      "total_models": 6,
-      "total_downloads": 15753,
-      "min_param_count": 1365677056,
+      "architecture_id": "LLaDA2MoeModelLM",
+      "total_models": 16,
+      "total_downloads": 1180876,
+      "min_param_count": 16255643392,
       "sample_models": [
-        "fla-hub/delta_net-1.3B-8K-100B",
-        "fla-hub/delta_net-1.3B-100B"
+        "inclusionAI/LLaDA2.0-mini",
+        "inclusionAI/LLaDA2.1-flash",
+        "inclusionAI/LLaDA2.1-mini",
+        "inclusionAI/LLaDA2.0-mini-preview"
       ],
       "relevancy_score": 38.1
+    },
+    {
+      "architecture_id": "AV2TextForConditionalGeneration",
+      "total_models": 5,
+      "total_downloads": 2738,
+      "min_param_count": 480465000,
+      "sample_models": [
+        "nguyenvulebinh/AV-HuBERT-MuAViC-en",
+        "nguyenvulebinh/AV-HuBERT"
+      ],
+      "relevancy_score": 38.1
+    },
+    {
+      "architecture_id": "KimiLinearForCausalLM",
+      "total_models": 12,
+      "total_downloads": 294022,
+      "min_param_count": 9373302656,
+      "sample_models": [
+        "moonshotai/Kimi-Linear-48B-A3B-Instruct",
+        "moonshotai/Kimi-Linear-48B-A3B-Base",
+        "cyankiwi/Kimi-Linear-48B-A3B-Instruct-AWQ-4bit"
+      ],
+      "relevancy_score": 38.0
+    },
+    {
+      "architecture_id": "Rwkv7ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2912,
+      "min_param_count": 34158592,
+      "sample_models": [
+        "admijgjtjtjtjjg/dfdfdf"
+      ],
+      "relevancy_score": 38.0
+    },
+    {
+      "architecture_id": "TachBitModel",
+      "total_models": 4,
+      "total_downloads": 2919,
+      "min_param_count": 284873472,
+      "sample_models": [
+        "tachyonx-ai/TachBit-285"
+      ],
+      "relevancy_score": 38.0
+    },
+    {
+      "architecture_id": "DogeForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2966,
+      "min_param_count": 13118728,
+      "sample_models": [
+        "SmallDoge/Doge-20M"
+      ],
+      "relevancy_score": 38.0
+    },
+    {
+      "architecture_id": "SmoothieModel",
+      "total_models": 4,
+      "total_downloads": 2939,
+      "min_param_count": 155829504,
+      "sample_models": [
+        "yasserrmd/smoothie-diffusion-qqp"
+      ],
+      "relevancy_score": 38.0
+    },
+    {
+      "architecture_id": "ARAr381MForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2927,
+      "min_param_count": 381480960,
+      "sample_models": [
+        "AraFus/AraFusion-AR-381M-v2"
+      ],
+      "relevancy_score": 38.0
     },
     {
       "architecture_id": "GPTX2ForCausalLM",
@@ -2205,112 +2396,175 @@
       "relevancy_score": 38.0
     },
     {
-      "architecture_id": "VanFastForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3511,
-      "min_param_count": 376644864,
+      "architecture_id": "YoutuVLForConditionalGeneration",
+      "total_models": 8,
+      "total_downloads": 11019,
+      "min_param_count": 2515984240,
       "sample_models": [
-        "summerMC/summerV2"
-      ],
-      "relevancy_score": 38.0
-    },
-    {
-      "architecture_id": "YForCausalLM3",
-      "total_models": 3,
-      "total_downloads": 3339,
-      "min_param_count": 55064320,
-      "sample_models": [
-        "SnifferCaptain/ymodel3-n1"
+        "tencent/Youtu-Parsing",
+        "tencent/Youtu-VL-4B-Instruct"
       ],
       "relevancy_score": 37.9
     },
     {
-      "architecture_id": "Qwen3VLForConditionalGeneration",
-      "total_models": 6,
-      "total_downloads": 93689,
-      "min_param_count": 4437815808,
+      "architecture_id": "HierColMaskMoELLaVAQwen2ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2840,
+      "min_param_count": 935731840,
       "sample_models": [
-        "Goekdeniz-Guelmez/Josiefied-Qwen3-VL-4B-Instruct-abliterated-beta-v1",
-        "DreamFast/Qwen3-VL-8B-Heretic-1.3.0"
+        "KKHYA/llavaqwen2.5-0.5b-finetune-hier-col-mask-moe-sparse-4e-2k-sp0.9_20260418_063208"
+      ],
+      "relevancy_score": 37.9
+    },
+    {
+      "architecture_id": "LatentMoELLaVAQwen2ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2776,
+      "min_param_count": 935673472,
+      "sample_models": [
+        "KKHYA/llavaqwen2.5-0.5b-finetune-latent-sparse-moe-4e-1k_20260413_214436"
+      ],
+      "relevancy_score": 37.9
+    },
+    {
+      "architecture_id": "RubiRLM",
+      "total_models": 4,
+      "total_downloads": 2794,
+      "min_param_count": 988446027,
+      "sample_models": [
+        "DevHunterAI/RubiRLM-1B-Base"
+      ],
+      "relevancy_score": 37.9
+    },
+    {
+      "architecture_id": "KaniTTS2ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2871,
+      "min_param_count": 369977088,
+      "sample_models": [
+        "nineninesix/kani-tts-2-en"
+      ],
+      "relevancy_score": 37.9
+    },
+    {
+      "architecture_id": "DynHierColMaskMoELLaVAQwen2ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2822,
+      "min_param_count": 940155520,
+      "sample_models": [
+        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-hier-col-mask-moe-sparse-4e-2k-sp0.9-r16_20260418_063238"
+      ],
+      "relevancy_score": 37.9
+    },
+    {
+      "architecture_id": "GlubLM",
+      "total_models": 4,
+      "total_downloads": 2855,
+      "min_param_count": 36055680,
+      "sample_models": [
+        "DenSec02/glublm-36m"
+      ],
+      "relevancy_score": 37.9
+    },
+    {
+      "architecture_id": "HCXVisionV2ForCausalLM",
+      "total_models": 7,
+      "total_downloads": 526296,
+      "min_param_count": 10741664520,
+      "sample_models": [
+        "naver-hyperclovax/HyperCLOVAX-SEED-Think-32B",
+        "naver-hyperclovax/HyperCLOVAX-SEED-Omni-8B"
       ],
       "relevancy_score": 37.8
     },
     {
-      "architecture_id": "RecursiveLanguageModel",
-      "total_models": 3,
-      "total_downloads": 2711,
-      "min_param_count": 198464806,
+      "architecture_id": "MiniMindForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2684,
+      "min_param_count": 63912192,
       "sample_models": [
-        "Girinath11/recursive-language-model-198m"
+        "chujiamo/baiheng_0405"
       ],
-      "relevancy_score": 37.5
+      "relevancy_score": 37.8
     },
     {
-      "architecture_id": "GoatVVVForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2705,
-      "min_param_count": 88867190,
+      "architecture_id": "KsByteForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2677,
+      "min_param_count": 15837440,
       "sample_models": [
-        "mlnomad/goat-vvv-d12-fineweb-5x-pytorch"
+        "Omarrran/ks-byte-lm-spacebyte-transformers"
       ],
-      "relevancy_score": 37.5
+      "relevancy_score": 37.8
     },
     {
-      "architecture_id": "MobileLLMP1ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 18420,
-      "min_param_count": 1084453120,
+      "architecture_id": "HeliumForCausalLM",
+      "total_models": 4,
+      "total_downloads": 18326,
+      "min_param_count": 2172643840,
       "sample_models": [
-        "facebook/MobileLLM-Pro-base"
+        "kyutai/helium-1-preview-2b"
       ],
-      "relevancy_score": 37.5
+      "relevancy_score": 37.8
     },
     {
-      "architecture_id": "SLM",
-      "total_models": 3,
-      "total_downloads": 2764,
-      "min_param_count": 50550784,
+      "architecture_id": "HFHealthSLM",
+      "total_models": 4,
+      "total_downloads": 2731,
+      "min_param_count": 23468288,
       "sample_models": [
-        "aman0419/Vitallm-50M"
+        "rohansingh2612/healthslm"
       ],
-      "relevancy_score": 37.5
+      "relevancy_score": 37.8
     },
     {
-      "architecture_id": "LangFlow",
-      "total_models": 3,
-      "total_downloads": 2688,
-      "min_param_count": 170805361,
+      "architecture_id": "FusionInDecoderForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 2759,
+      "min_param_count": 247577856,
       "sample_models": [
-        "Continuous-Rivals-Discrete/langflow-owt"
+        "Intel/fid_flan_t5_base_nq"
       ],
-      "relevancy_score": 37.5
+      "relevancy_score": 37.8
     },
     {
-      "architecture_id": "MellumForCausalLM",
-      "total_models": 15,
-      "total_downloads": 139432,
-      "min_param_count": 12149923072,
+      "architecture_id": "HybridQwen3ForCausalLM",
+      "total_models": 14,
+      "total_downloads": 181379,
+      "min_param_count": 8495712960,
       "sample_models": [
-        "JetBrains/Mellum2-12B-A2.5B-Thinking",
-        "JetBrains/Mellum2-12B-A2.5B-Base",
-        "JetBrains/Mellum2-12B-A2.5B-Instruct",
-        "cyankiwi/Mellum2-12B-A2.5B-Thinking-AWQ-INT4",
-        "JetBrains/Mellum2-12B-A2.5B-Thinking-SFT"
+        "amazon/GKA-primed-HQwen3-32B-Instruct",
+        "amazon/GKA-primed-HQwen3-8B-Reasoner",
+        "amazon/GKA-primed-HQwen3-32B-Reasoner",
+        "amazon/GDN-primed-HQwen3-8B-Instruct",
+        "amazon/BMOJOF-primed-HQwen3-8B-Instruct",
+        "amazon/Mamba2-primed-HQwen3-8B-Instruct"
       ],
-      "relevancy_score": 37.3
+      "relevancy_score": 37.6
     },
     {
-      "architecture_id": "OlmoHybridForCausalLM",
-      "total_models": 12,
-      "total_downloads": 209003,
-      "min_param_count": 7430870688,
+      "architecture_id": "MoshiForConditionalGeneration",
+      "total_models": 6,
+      "total_downloads": 558308,
+      "min_param_count": 7783880545,
       "sample_models": [
-        "allenai/Olmo-Hybrid-7B",
-        "allenai/Olmo-Hybrid-Instruct-SFT-7B",
-        "allenai/Olmo-Hybrid-Think-SFT-7B",
-        "allenai/Olmo-Hybrid-Instruct-DPO-7B"
+        "kmhf/hf-moshiko",
+        "kmhf/hf-moshika"
       ],
-      "relevancy_score": 37.3
+      "relevancy_score": 37.6
+    },
+    {
+      "architecture_id": "Qwen3VLMoeForConditionalGeneration",
+      "total_models": 16,
+      "total_downloads": 5664951,
+      "min_param_count": 31070754032,
+      "sample_models": [
+        "QuantTrio/Qwen3-VL-30B-A3B-Instruct-AWQ",
+        "QuantTrio/Qwen3-VL-30B-A3B-Thinking-AWQ",
+        "QuantTrio/Qwen3-VL-235B-A22B-Instruct-AWQ",
+        "QuantTrio/Qwen3-VL-235B-A22B-Thinking-AWQ"
+      ],
+      "relevancy_score": 37.4
     },
     {
       "architecture_id": "OpensciForCausalLM",
@@ -2321,6 +2575,45 @@
         "open-sci/open-sci-ref-v0.02-1.7b-fineweb-edu-1.4t-1T-4096-rope_theta-100k",
         "open-sci/open-sci-ref-v0.02-1.7b-dclm-1T-4096-rope_theta-100k",
         "open-sci/open-sci-ref-v0.02-1.7b-nemotron-hq-1T-4096-rope_theta-100k"
+      ],
+      "relevancy_score": 37.4
+    },
+    {
+      "architecture_id": "SpikeWhaleLM",
+      "total_models": 3,
+      "total_downloads": 2534,
+      "min_param_count": 97272836,
+      "sample_models": [
+        "Quazim0t0/Escarda-86M-Base"
+      ],
+      "relevancy_score": 37.4
+    },
+    {
+      "architecture_id": "RWForCausalLM",
+      "total_models": 16,
+      "total_downloads": 17669,
+      "min_param_count": 6854619456,
+      "sample_models": [
+        "h2oai/h2ogpt-gm-oasst1-en-2048-falcon-7b-v2",
+        "explosion-testing/refined-web-model-test",
+        "lightonai/alfred-40b-1023",
+        "projecte-aina/aguila-7b",
+        "h2oai/h2ogpt-gm-oasst1-en-2048-falcon-7b-v3",
+        "OpenAssistant/falcon-40b-sft-top1-560",
+        "nomic-ai/gpt4all-falcon",
+        "QuixiAI/WizardLM-Uncensored-Falcon-40b"
+      ],
+      "relevancy_score": 37.3
+    },
+    {
+      "architecture_id": "GraniteSwitchForCausalLM",
+      "total_models": 12,
+      "total_downloads": 32079,
+      "min_param_count": 4149977600,
+      "sample_models": [
+        "ibm-granite/granite-switch-4.1-3b-preview",
+        "ibm-granite/granite-switch-4.1-8b-preview",
+        "ibm-granite/granite-switch-4.1-30b-preview"
       ],
       "relevancy_score": 37.3
     },
@@ -2338,73 +2631,42 @@
       "relevancy_score": 37.3
     },
     {
-      "architecture_id": "AV2TextForConditionalGeneration",
-      "total_models": 4,
-      "total_downloads": 2174,
-      "min_param_count": 480465000,
+      "architecture_id": "Veyra2ApricotForCausalLM",
+      "total_models": 3,
+      "total_downloads": 2442,
+      "min_param_count": 49303040,
       "sample_models": [
-        "nguyenvulebinh/AV-HuBERT-MuAViC-en",
-        "nguyenvulebinh/AV-HuBERT"
+        "veyra-ai/Veyra2-Apricot-50M-Base"
       ],
       "relevancy_score": 37.3
     },
     {
-      "architecture_id": "TachBitModel",
-      "total_models": 3,
-      "total_downloads": 2371,
-      "min_param_count": 284873472,
+      "architecture_id": "TarsierForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 598918,
+      "min_param_count": 7063427072,
       "sample_models": [
-        "tachyonx-ai/TachBit-285"
+        "omni-research/Tarsier-7b"
       ],
       "relevancy_score": 37.2
     },
     {
-      "architecture_id": "GlubLM",
-      "total_models": 3,
-      "total_downloads": 2308,
-      "min_param_count": 36055680,
+      "architecture_id": "CostWiseGemmaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 614564,
+      "min_param_count": 9241831424,
       "sample_models": [
-        "DenSec02/glublm-36m"
+        "BAAI/bge-reranker-v2.5-gemma2-lightweight"
       ],
       "relevancy_score": 37.2
     },
     {
-      "architecture_id": "Rwkv7ForCausalLM",
+      "architecture_id": "MobilintLlamaForCausalLM",
       "total_models": 3,
-      "total_downloads": 2321,
-      "min_param_count": 34158592,
+      "total_downloads": 2353,
+      "min_param_count": 262668288,
       "sample_models": [
-        "admijgjtjtjtjjg/dfdfdf"
-      ],
-      "relevancy_score": 37.2
-    },
-    {
-      "architecture_id": "HierColMaskMoELLaVAQwen2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2300,
-      "min_param_count": 935731840,
-      "sample_models": [
-        "KKHYA/llavaqwen2.5-0.5b-finetune-hier-col-mask-moe-sparse-4e-2k-sp0.9_20260418_063208"
-      ],
-      "relevancy_score": 37.2
-    },
-    {
-      "architecture_id": "ARAr381MForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2373,
-      "min_param_count": 381480960,
-      "sample_models": [
-        "AraFus/AraFusion-AR-381M-v2"
-      ],
-      "relevancy_score": 37.2
-    },
-    {
-      "architecture_id": "DogeForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2291,
-      "min_param_count": 13118728,
-      "sample_models": [
-        "SmallDoge/Doge-20M"
+        "mobilint/Llama-3.2-1B-Instruct"
       ],
       "relevancy_score": 37.2
     },
@@ -2420,103 +2682,85 @@
       "relevancy_score": 37.2
     },
     {
-      "architecture_id": "RubiRLM",
-      "total_models": 3,
-      "total_downloads": 2245,
-      "min_param_count": 988446027,
+      "architecture_id": "VaultGemmaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 13207,
+      "min_param_count": 1038741120,
       "sample_models": [
-        "DevHunterAI/RubiRLM-1B-Base"
+        "google/vaultgemma-1b"
       ],
       "relevancy_score": 37.1
     },
     {
-      "architecture_id": "LatentMoELLaVAQwen2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2239,
-      "min_param_count": 935673472,
+      "architecture_id": "Rwkv5ForCausalLM",
+      "total_models": 8,
+      "total_downloads": 7077,
+      "min_param_count": 1577754624,
       "sample_models": [
-        "KKHYA/llavaqwen2.5-0.5b-finetune-latent-sparse-moe-4e-1k_20260413_214436"
-      ],
-      "relevancy_score": 37.1
-    },
-    {
-      "architecture_id": "HFHealthSLM",
-      "total_models": 3,
-      "total_downloads": 2192,
-      "min_param_count": 23468288,
-      "sample_models": [
-        "rohansingh2612/healthslm"
-      ],
-      "relevancy_score": 37.1
-    },
-    {
-      "architecture_id": "DynHierColMaskMoELLaVAQwen2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2285,
-      "min_param_count": 940155520,
-      "sample_models": [
-        "KKHYA/llavaqwen2.5-0.5b-finetune-dyn-hier-col-mask-moe-sparse-4e-2k-sp0.9-r16_20260418_063238"
-      ],
-      "relevancy_score": 37.1
-    },
-    {
-      "architecture_id": "KaniTTS2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2170,
-      "min_param_count": 369977088,
-      "sample_models": [
-        "nineninesix/kani-tts-2-en"
+        "RWKV/rwkv-5-world-1b5",
+        "RWKV/rwkv-5-world-3b"
       ],
       "relevancy_score": 37.0
     },
     {
-      "architecture_id": "FusionInDecoderForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 2174,
-      "min_param_count": 247577856,
+      "architecture_id": "BolmoForCausalLM",
+      "total_models": 4,
+      "total_downloads": 12333,
+      "min_param_count": 1468911776,
       "sample_models": [
-        "Intel/fid_flan_t5_base_nq"
+        "allenai/Bolmo-1B"
       ],
       "relevancy_score": 37.0
     },
     {
-      "architecture_id": "MiniMindForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2146,
-      "min_param_count": 63912192,
+      "architecture_id": "OrthrusLM",
+      "total_models": 8,
+      "total_downloads": 6914,
+      "min_param_count": 2072903680,
       "sample_models": [
-        "chujiamo/baiheng_0405"
-      ],
-      "relevancy_score": 37.0
-    },
-    {
-      "architecture_id": "SmoothieModel",
-      "total_models": 3,
-      "total_downloads": 2157,
-      "min_param_count": 155829504,
-      "sample_models": [
-        "yasserrmd/smoothie-diffusion-qqp"
-      ],
-      "relevancy_score": 37.0
-    },
-    {
-      "architecture_id": "KsByteForCausalLM",
-      "total_models": 3,
-      "total_downloads": 1999,
-      "min_param_count": 15837440,
-      "sample_models": [
-        "Omarrran/ks-byte-lm-spacebyte-transformers"
+        "chiennv/Orthrus-Qwen3-8B",
+        "chiennv/Orthrus-Qwen3-1.7B"
       ],
       "relevancy_score": 36.9
     },
     {
-      "architecture_id": "HCXVisionV2ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 388666,
-      "min_param_count": 10741664520,
+      "architecture_id": "FunAsrNanoForConditionalGeneration",
+      "total_models": 3,
+      "total_downloads": 1983,
+      "min_param_count": 985374304,
       "sample_models": [
-        "naver-hyperclovax/HyperCLOVAX-SEED-Think-32B",
-        "naver-hyperclovax/HyperCLOVAX-SEED-Omni-8B"
+        "FunAudioLLM/Fun-ASR-Nano-2512-hf"
+      ],
+      "relevancy_score": 36.9
+    },
+    {
+      "architecture_id": "SLMForCausalLM",
+      "total_models": 3,
+      "total_downloads": 1998,
+      "min_param_count": 12065792,
+      "sample_models": [
+        "liodon-ai/slm-10m"
+      ],
+      "relevancy_score": 36.9
+    },
+    {
+      "architecture_id": "EshmunForCausalLM",
+      "total_models": 3,
+      "total_downloads": 2033,
+      "min_param_count": 341319680,
+      "sample_models": [
+        "khairi/Eshmun-0.3B-CPT"
+      ],
+      "relevancy_score": 36.9
+    },
+    {
+      "architecture_id": "YoutuForCausalLM",
+      "total_models": 5,
+      "total_downloads": 9684,
+      "min_param_count": 1961560064,
+      "sample_models": [
+        "tencent/Youtu-LLM-2B-Base",
+        "tencent/Youtu-LLM-2B"
       ],
       "relevancy_score": 36.8
     },
@@ -2531,23 +2775,13 @@
       "relevancy_score": 36.8
     },
     {
-      "architecture_id": "HanziForCausalLM",
-      "total_models": 2,
-      "total_downloads": 2234,
-      "min_param_count": 123535318,
-      "sample_models": [
-        "EjZhou/chinese-babylm-2026-hanzi-a3large"
-      ],
-      "relevancy_score": 36.8
-    },
-    {
-      "architecture_id": "MoshiForConditionalGeneration",
+      "architecture_id": "NanoChatForCausalLM",
       "total_models": 5,
-      "total_downloads": 425200,
-      "min_param_count": 7783880545,
+      "total_downloads": 9328,
+      "min_param_count": 2217082880,
       "sample_models": [
-        "kmhf/hf-moshiko",
-        "kmhf/hf-moshika"
+        "l0ulan/chinese-babylm-nanochat-d22-step10000",
+        "Twobombs/nanochat-d34-sft-hf"
       ],
       "relevancy_score": 36.7
     },
@@ -2562,25 +2796,36 @@
       "relevancy_score": 36.7
     },
     {
-      "architecture_id": "YoutuVLForConditionalGeneration",
-      "total_models": 6,
-      "total_downloads": 7973,
-      "min_param_count": 2515984240,
+      "architecture_id": "MolmoForCausalLM",
+      "total_models": 15,
+      "total_downloads": 99586,
+      "min_param_count": 7665032192,
       "sample_models": [
-        "tencent/Youtu-Parsing",
-        "tencent/Youtu-VL-4B-Instruct"
+        "allenai/Molmo-7B-D-0924",
+        "allenai/Molmo-72B-0924",
+        "allenai/Molmo-7B-O-0924",
+        "cyan2k/molmo-7B-O-bnb-4bit"
       ],
       "relevancy_score": 36.6
     },
     {
-      "architecture_id": "KimiLinearForCausalLM",
-      "total_models": 9,
-      "total_downloads": 221546,
-      "min_param_count": 9373302656,
+      "architecture_id": "QuarkForCausalLM",
+      "total_models": 3,
+      "total_downloads": 1746,
+      "min_param_count": 302080768,
       "sample_models": [
-        "moonshotai/Kimi-Linear-48B-A3B-Instruct",
-        "moonshotai/Kimi-Linear-48B-A3B-Base",
-        "cyankiwi/Kimi-Linear-48B-A3B-Instruct-AWQ-4bit"
+        "ThingAI/Quark-270m-Base"
+      ],
+      "relevancy_score": 36.6
+    },
+    {
+      "architecture_id": "GTLMForCausalLM",
+      "total_models": 8,
+      "total_downloads": 5514,
+      "min_param_count": 2095989760,
+      "sample_models": [
+        "Madras1/GTLM-1-2B-A350M",
+        "Madras1/GTLM-1-2B-A350M-fp16"
       ],
       "relevancy_score": 36.5
     },
@@ -2595,254 +2840,137 @@
       "relevancy_score": 36.5
     },
     {
-      "architecture_id": "RWForCausalLM",
-      "total_models": 14,
-      "total_downloads": 15266,
-      "min_param_count": 6854619456,
+      "architecture_id": "XLNetLMHeadModel",
+      "total_models": 24,
+      "total_downloads": 1171367,
+      "min_param_count": null,
       "sample_models": [
-        "h2oai/h2ogpt-gm-oasst1-en-2048-falcon-7b-v2",
-        "explosion-testing/refined-web-model-test",
-        "lightonai/alfred-40b-1023",
-        "projecte-aina/aguila-7b",
-        "h2oai/h2ogpt-gm-oasst1-en-2048-falcon-7b-v3",
-        "OpenAssistant/falcon-40b-sft-top1-560",
-        "nomic-ai/gpt4all-falcon",
-        "QuixiAI/WizardLM-Uncensored-Falcon-40b"
+        "xlnet/xlnet-base-cased",
+        "xlnet/xlnet-large-cased",
+        "hfl/chinese-xlnet-base",
+        "sshleifer/tiny-xlnet-base-cased",
+        "textattack/xlnet-base-cased-imdb",
+        "textattack/xlnet-base-cased-CoLA"
       ],
       "relevancy_score": 36.4
     },
     {
-      "architecture_id": "LLaDA2MoeModelLM",
-      "total_models": 12,
-      "total_downloads": 922374,
-      "min_param_count": 16255643392,
+      "architecture_id": "HawkForCausalLM",
+      "total_models": 1,
+      "total_downloads": 1834,
+      "min_param_count": 115270528,
       "sample_models": [
-        "inclusionAI/LLaDA2.0-mini",
-        "inclusionAI/LLaDA2.1-flash",
-        "inclusionAI/LLaDA2.1-mini",
-        "inclusionAI/LLaDA2.0-mini-preview"
-      ],
-      "relevancy_score": 36.4
-    },
-    {
-      "architecture_id": "HeliumForCausalLM",
-      "total_models": 3,
-      "total_downloads": 10984,
-      "min_param_count": 2172643840,
-      "sample_models": [
-        "kyutai/helium-1-preview-2b"
-      ],
-      "relevancy_score": 36.4
-    },
-    {
-      "architecture_id": "CostWiseGemmaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 457708,
-      "min_param_count": 9241831424,
-      "sample_models": [
-        "BAAI/bge-reranker-v2.5-gemma2-lightweight"
-      ],
-      "relevancy_score": 36.3
-    },
-    {
-      "architecture_id": "BolmoForCausalLM",
-      "total_models": 3,
-      "total_downloads": 9669,
-      "min_param_count": 1468911776,
-      "sample_models": [
-        "allenai/Bolmo-1B"
-      ],
-      "relevancy_score": 36.2
-    },
-    {
-      "architecture_id": "VaultGemmaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 9832,
-      "min_param_count": 1038741120,
-      "sample_models": [
-        "google/vaultgemma-1b"
-      ],
-      "relevancy_score": 36.2
-    },
-    {
-      "architecture_id": "TarsierForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 439836,
-      "min_param_count": 7063427072,
-      "sample_models": [
-        "omni-research/Tarsier-7b"
-      ],
-      "relevancy_score": 36.2
-    },
-    {
-      "architecture_id": "MobilintLlamaForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1688,
-      "min_param_count": 262668288,
-      "sample_models": [
-        "mobilint/Llama-3.2-1B-Instruct"
-      ],
-      "relevancy_score": 36.2
-    },
-    {
-      "architecture_id": "Veyra2ApricotForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1620,
-      "min_param_count": 49303040,
-      "sample_models": [
-        "veyra-ai/Veyra2-Apricot-50M-Base"
+        "NeTS-lab/babylm26_multiling_hawk_MoP16K_baseline"
       ],
       "relevancy_score": 36.1
-    },
-    {
-      "architecture_id": "SpikeWhaleLM",
-      "total_models": 2,
-      "total_downloads": 1614,
-      "min_param_count": 97272836,
-      "sample_models": [
-        "Quazim0t0/Escarda-86M-Base"
-      ],
-      "relevancy_score": 36.1
-    },
-    {
-      "architecture_id": "GraniteSwitchForCausalLM",
-      "total_models": 9,
-      "total_downloads": 25905,
-      "min_param_count": 4149977600,
-      "sample_models": [
-        "ibm-granite/granite-switch-4.1-3b-preview",
-        "ibm-granite/granite-switch-4.1-8b-preview",
-        "ibm-granite/granite-switch-4.1-30b-preview"
-      ],
-      "relevancy_score": 36.0
-    },
-    {
-      "architecture_id": "Rwkv5ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 5719,
-      "min_param_count": 1577754624,
-      "sample_models": [
-        "RWKV/rwkv-5-world-1b5",
-        "RWKV/rwkv-5-world-3b"
-      ],
-      "relevancy_score": 36.0
-    },
-    {
-      "architecture_id": "OrthrusLM",
-      "total_models": 6,
-      "total_downloads": 5429,
-      "min_param_count": 2072903680,
-      "sample_models": [
-        "chiennv/Orthrus-Qwen3-8B",
-        "chiennv/Orthrus-Qwen3-1.7B"
-      ],
-      "relevancy_score": 35.8
-    },
-    {
-      "architecture_id": "YoutuForCausalLM",
-      "total_models": 4,
-      "total_downloads": 7062,
-      "min_param_count": 1961560064,
-      "sample_models": [
-        "tencent/Youtu-LLM-2B-Base",
-        "tencent/Youtu-LLM-2B"
-      ],
-      "relevancy_score": 35.8
-    },
-    {
-      "architecture_id": "EshmunForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1338,
-      "min_param_count": 341319680,
-      "sample_models": [
-        "khairi/Eshmun-0.3B-CPT"
-      ],
-      "relevancy_score": 35.7
-    },
-    {
-      "architecture_id": "FunAsrNanoForConditionalGeneration",
-      "total_models": 2,
-      "total_downloads": 1296,
-      "min_param_count": 985374304,
-      "sample_models": [
-        "FunAudioLLM/Fun-ASR-Nano-2512-hf"
-      ],
-      "relevancy_score": 35.7
-    },
-    {
-      "architecture_id": "SLMForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1314,
-      "min_param_count": 12065792,
-      "sample_models": [
-        "liodon-ai/slm-10m"
-      ],
-      "relevancy_score": 35.7
-    },
-    {
-      "architecture_id": "Qwen3VLMoeForConditionalGeneration",
-      "total_models": 12,
-      "total_downloads": 4212596,
-      "min_param_count": 31070754032,
-      "sample_models": [
-        "QuantTrio/Qwen3-VL-30B-A3B-Instruct-AWQ",
-        "QuantTrio/Qwen3-VL-30B-A3B-Thinking-AWQ",
-        "QuantTrio/Qwen3-VL-235B-A22B-Instruct-AWQ",
-        "QuantTrio/Qwen3-VL-235B-A22B-Thinking-AWQ"
-      ],
-      "relevancy_score": 35.6
-    },
-    {
-      "architecture_id": "NanoChatForCausalLM",
-      "total_models": 4,
-      "total_downloads": 6271,
-      "min_param_count": 2217082880,
-      "sample_models": [
-        "l0ulan/chinese-babylm-nanochat-d22-step10000",
-        "Twobombs/nanochat-d34-sft-hf"
-      ],
-      "relevancy_score": 35.6
-    },
-    {
-      "architecture_id": "HybridQwen3ForCausalLM",
-      "total_models": 9,
-      "total_downloads": 132477,
-      "min_param_count": 8500245504,
-      "sample_models": [
-        "amazon/GKA-primed-HQwen3-32B-Instruct",
-        "amazon/GKA-primed-HQwen3-8B-Reasoner",
-        "amazon/GKA-primed-HQwen3-32B-Reasoner"
-      ],
-      "relevancy_score": 35.4
-    },
-    {
-      "architecture_id": "GTLMForCausalLM",
-      "total_models": 6,
-      "total_downloads": 4417,
-      "min_param_count": 2095989760,
-      "sample_models": [
-        "Madras1/GTLM-1-2B-A350M",
-        "Madras1/GTLM-1-2B-A350M-fp16"
-      ],
-      "relevancy_score": 35.4
-    },
-    {
-      "architecture_id": "QuarkForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1158,
-      "min_param_count": 302080768,
-      "sample_models": [
-        "ThingAI/Quark-270m-Base"
-      ],
-      "relevancy_score": 35.4
     },
     {
       "architecture_id": "HulumedQwen3ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 42626,
+      "total_models": 4,
+      "total_downloads": 48149,
       "min_param_count": 4833079536,
       "sample_models": [
         "ZJU-AI4H/Hulu-Med-4B"
+      ],
+      "relevancy_score": 35.9
+    },
+    {
+      "architecture_id": "SMBUnstructuredForCausalLM",
+      "total_models": 4,
+      "total_downloads": 6954,
+      "min_param_count": 1720060928,
+      "sample_models": [
+        "standardmodelbio/SMB-v1_Qwen3-1.7b_multi-objective"
+      ],
+      "relevancy_score": 35.8
+    },
+    {
+      "architecture_id": "FlexOlmoForCausalLM",
+      "total_models": 12,
+      "total_downloads": 95858,
+      "min_param_count": 11627401216,
+      "sample_models": [
+        "allenai/Flex-reddit-2x7B-1T",
+        "allenai/FlexOlmo-7x7B-1T",
+        "shanearora/Flex-reddit-2x7B-1T"
+      ],
+      "relevancy_score": 35.7
+    },
+    {
+      "architecture_id": "InternLM3ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 296531,
+      "min_param_count": 8804241408,
+      "sample_models": [
+        "internlm/internlm3-8b-instruct"
+      ],
+      "relevancy_score": 35.7
+    },
+    {
+      "architecture_id": "RavenForCausalLM",
+      "total_models": 4,
+      "total_downloads": 45315,
+      "min_param_count": 3911400096,
+      "sample_models": [
+        "tomg-group-umd/huginn-0125"
+      ],
+      "relevancy_score": 35.7
+    },
+    {
+      "architecture_id": "LlavaMistralForCausalLM",
+      "total_models": 8,
+      "total_downloads": 166198,
+      "min_param_count": 7566219264,
+      "sample_models": [
+        "liuhaotian/llava-v1.6-mistral-7b",
+        "microsoft/llava-med-v1.5-mistral-7b"
+      ],
+      "relevancy_score": 35.6
+    },
+    {
+      "architecture_id": "ArkasrForConditionalGeneration",
+      "total_models": 5,
+      "total_downloads": 5424,
+      "min_param_count": 1299463168,
+      "sample_models": [
+        "AutoArk-AI/ARK-ASR-0.6B",
+        "AutoArk-AI/ARK-ASR-3B"
+      ],
+      "relevancy_score": 35.6
+    },
+    {
+      "architecture_id": "RwkvForCausalLM",
+      "total_models": 17,
+      "total_downloads": 42973,
+      "min_param_count": 7518044160,
+      "sample_models": [
+        "RWKV/v5-Eagle-7B-HF",
+        "RWKV/rwkv-4-169m-pile",
+        "RWKV/v5-EagleX-v2-7B-HF",
+        "RWKV/rwkv-4-430m-pile",
+        "RWKV/rwkv-raven-1b5",
+        "RWKV/rwkv-raven-14b",
+        "recursal/EagleX_1-7T_HF"
+      ],
+      "relevancy_score": 35.4
+    },
+    {
+      "architecture_id": "IsaacForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 5445,
+      "min_param_count": 2567073008,
+      "sample_models": [
+        "PerceptronAI/Isaac-0.1"
+      ],
+      "relevancy_score": 35.3
+    },
+    {
+      "architecture_id": "NanochatForCausalLM",
+      "total_models": 2,
+      "total_downloads": 1067,
+      "min_param_count": 524288824,
+      "sample_models": [
+        "himalaya-ai/himalayagpt-0.5b-it"
       ],
       "relevancy_score": 35.3
     },
@@ -2857,12 +2985,46 @@
       "relevancy_score": 35.3
     },
     {
-      "architecture_id": "RavenForCausalLM",
-      "total_models": 3,
-      "total_downloads": 38693,
-      "min_param_count": 3911400096,
+      "architecture_id": "LLaMAForCausalLM",
+      "total_models": 7,
+      "total_downloads": 23207,
+      "min_param_count": 6738425856,
       "sample_models": [
-        "tomg-group-umd/huginn-0125"
+        "maicomputer/alpaca-13b",
+        "AdaptLLM/finance-LLM"
+      ],
+      "relevancy_score": 35.2
+    },
+    {
+      "architecture_id": "IQuestCoderForCausalLM",
+      "total_models": 8,
+      "total_downloads": 130381,
+      "min_param_count": 7612810240,
+      "sample_models": [
+        "IQuestLab/IQuest-Coder-V1-40B-Instruct",
+        "IQuestLab/IQuest-Coder-V1-7B-Instruct",
+        "IQuestLab/IQuest-Coder-V1-14B-Base"
+      ],
+      "relevancy_score": 35.1
+    },
+    {
+      "architecture_id": "Sarashina2VisionForCausalLM",
+      "total_models": 8,
+      "total_downloads": 19340,
+      "min_param_count": 3801475696,
+      "sample_models": [
+        "sbintuitions/sarashina2.2-vision-3b",
+        "sbintuitions/sarashina2.2-ocr"
+      ],
+      "relevancy_score": 35.1
+    },
+    {
+      "architecture_id": "JinaVLMForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 4948,
+      "min_param_count": 2481403760,
+      "sample_models": [
+        "jinaai/jina-vlm"
       ],
       "relevancy_score": 35.1
     },
@@ -2877,37 +3039,89 @@
       "relevancy_score": 35.1
     },
     {
-      "architecture_id": "MolmoForCausalLM",
-      "total_models": 12,
-      "total_downloads": 71197,
-      "min_param_count": 7665032192,
+      "architecture_id": "NeoLLMForCausalLM",
+      "total_models": 1,
+      "total_downloads": 1137,
+      "min_param_count": 117311018,
       "sample_models": [
-        "allenai/Molmo-7B-D-0924",
-        "allenai/Molmo-72B-0924",
-        "allenai/Molmo-7B-O-0924",
-        "cyan2k/molmo-7B-O-bnb-4bit"
+        "KitsuVp/NeoLLM"
+      ],
+      "relevancy_score": 35.1
+    },
+    {
+      "architecture_id": "PenguinVLQwen3ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4881,
+      "min_param_count": 2167941120,
+      "sample_models": [
+        "tencent/Penguin-VL-2B"
       ],
       "relevancy_score": 35.0
     },
     {
-      "architecture_id": "SMBUnstructuredForCausalLM",
-      "total_models": 3,
-      "total_downloads": 5288,
-      "min_param_count": 1720060928,
+      "architecture_id": "CheXagentForCausalLM",
+      "total_models": 4,
+      "total_downloads": 31982,
+      "min_param_count": 3140746752,
       "sample_models": [
-        "standardmodelbio/SMB-v1_Qwen3-1.7b_multi-objective"
+        "StanfordAIMI/CheXagent-2-3b"
       ],
-      "relevancy_score": 34.9
+      "relevancy_score": 35.0
     },
     {
-      "architecture_id": "InternLM3ForCausalLM",
+      "architecture_id": "BarbetForCausalLM",
       "total_models": 3,
-      "total_downloads": 217423,
-      "min_param_count": 8804241408,
+      "total_downloads": 5615,
+      "min_param_count": 1088124920,
       "sample_models": [
-        "internlm/internlm3-8b-instruct"
+        "OpenFormosa/barbet-1b-base"
       ],
-      "relevancy_score": 34.7
+      "relevancy_score": 35.0
+    },
+    {
+      "architecture_id": "JAISLMHeadModel",
+      "total_models": 15,
+      "total_downloads": 41502,
+      "min_param_count": 13462730280,
+      "sample_models": [
+        "inceptionai/jais-13b-chat",
+        "inceptionai/jais-13b",
+        "inceptionai/jais-family-13b-chat",
+        "inceptionai/jais-30b-chat-v3",
+        "inceptionai/jais-30b-v3"
+      ],
+      "relevancy_score": 34.8
+    },
+    {
+      "architecture_id": "Jais2ForCausalLM",
+      "total_models": 8,
+      "total_downloads": 110000,
+      "min_param_count": 8090401280,
+      "sample_models": [
+        "inceptionai/Jais-2-8B-Chat",
+        "inceptionai/Jais-2-70B-Chat"
+      ],
+      "relevancy_score": 34.8
+    },
+    {
+      "architecture_id": "Maira2ForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 28821,
+      "min_param_count": 6880185600,
+      "sample_models": [
+        "microsoft/maira-2"
+      ],
+      "relevancy_score": 34.8
+    },
+    {
+      "architecture_id": "XCurOSForCausalLM",
+      "total_models": 4,
+      "total_downloads": 198170,
+      "min_param_count": 7615616512,
+      "sample_models": [
+        "XCurOS/XCurOS0.1-8B-Instruct"
+      ],
+      "relevancy_score": 34.8
     },
     {
       "architecture_id": "MusicFlamingoForConditionalGeneration",
@@ -2921,75 +3135,35 @@
         "nvidia/audio-flamingo-next-captioner-hf",
         "nvidia/music-flamingo-think-2601-hf"
       ],
+      "relevancy_score": 34.7
+    },
+    {
+      "architecture_id": "GritLM",
+      "total_models": 4,
+      "total_downloads": 181545,
+      "min_param_count": 7241732096,
+      "sample_models": [
+        "parasail-ai/GritLM-7B-vllm"
+      ],
+      "relevancy_score": 34.7
+    },
+    {
+      "architecture_id": "PanguEmbeddedForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4014,
+      "min_param_count": 1391497728,
+      "sample_models": [
+        "FreedomIntelligence/openPangu-Embedded-1B"
+      ],
       "relevancy_score": 34.6
     },
     {
-      "architecture_id": "LlavaMistralForCausalLM",
-      "total_models": 6,
-      "total_downloads": 128525,
-      "min_param_count": 7566219264,
+      "architecture_id": "ParamBharatGenForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3232,
+      "min_param_count": 2860693504,
       "sample_models": [
-        "liuhaotian/llava-v1.6-mistral-7b",
-        "microsoft/llava-med-v1.5-mistral-7b"
-      ],
-      "relevancy_score": 34.5
-    },
-    {
-      "architecture_id": "LLaMAForCausalLM",
-      "total_models": 6,
-      "total_downloads": 17984,
-      "min_param_count": 6738425856,
-      "sample_models": [
-        "maicomputer/alpaca-13b",
-        "AdaptLLM/finance-LLM"
-      ],
-      "relevancy_score": 34.4
-    },
-    {
-      "architecture_id": "PenguinVLQwen3ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 4239,
-      "min_param_count": 2167941120,
-      "sample_models": [
-        "tencent/Penguin-VL-2B"
-      ],
-      "relevancy_score": 34.4
-    },
-    {
-      "architecture_id": "RwkvForCausalLM",
-      "total_models": 15,
-      "total_downloads": 33087,
-      "min_param_count": 7518044160,
-      "sample_models": [
-        "RWKV/v5-Eagle-7B-HF",
-        "RWKV/rwkv-4-169m-pile",
-        "RWKV/v5-EagleX-v2-7B-HF",
-        "RWKV/rwkv-4-430m-pile",
-        "RWKV/rwkv-raven-1b5",
-        "RWKV/rwkv-raven-14b",
-        "recursal/EagleX_1-7T_HF"
-      ],
-      "relevancy_score": 34.3
-    },
-    {
-      "architecture_id": "IQuestCoderForCausalLM",
-      "total_models": 7,
-      "total_downloads": 98324,
-      "min_param_count": 7612810240,
-      "sample_models": [
-        "IQuestLab/IQuest-Coder-V1-40B-Instruct",
-        "IQuestLab/IQuest-Coder-V1-7B-Instruct",
-        "IQuestLab/IQuest-Coder-V1-14B-Base"
-      ],
-      "relevancy_score": 34.2
-    },
-    {
-      "architecture_id": "IsaacForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 3780,
-      "min_param_count": 2567073008,
-      "sample_models": [
-        "PerceptronAI/Isaac-0.1"
+        "bharatgenai/Param-1-2.9B-Instruct"
       ],
       "relevancy_score": 34.2
     },
@@ -3005,47 +3179,19 @@
       "relevancy_score": 34.2
     },
     {
-      "architecture_id": "FlexOlmoForCausalLM",
-      "total_models": 9,
-      "total_downloads": 71629,
-      "min_param_count": 11627401216,
+      "architecture_id": "MiMoV2ForCausalLM",
+      "total_models": 22,
+      "total_downloads": 512881,
+      "min_param_count": 52930771392,
       "sample_models": [
-        "allenai/Flex-reddit-2x7B-1T",
-        "allenai/FlexOlmo-7x7B-1T",
-        "shanearora/Flex-reddit-2x7B-1T"
+        "XiaomiMiMo/MiMo-V2.5-Pro",
+        "XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash",
+        "spectator2026/MiMo-V2.5-AWQ-int4",
+        "kernelpool/MiMo-V2.5-Pro-6bit",
+        "XiaomiMiMo/MiMo-V2.5-Pro-Base",
+        "nwzjk/MiMo-V2.5-AWQ-int4"
       ],
       "relevancy_score": 34.1
-    },
-    {
-      "architecture_id": "JinaVLMForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 3610,
-      "min_param_count": 2481403760,
-      "sample_models": [
-        "jinaai/jina-vlm"
-      ],
-      "relevancy_score": 34.1
-    },
-    {
-      "architecture_id": "Sarashina2VisionForCausalLM",
-      "total_models": 6,
-      "total_downloads": 15158,
-      "min_param_count": 3801475696,
-      "sample_models": [
-        "sbintuitions/sarashina2.2-vision-3b",
-        "sbintuitions/sarashina2.2-ocr"
-      ],
-      "relevancy_score": 34.0
-    },
-    {
-      "architecture_id": "CheXagentForCausalLM",
-      "total_models": 3,
-      "total_downloads": 23029,
-      "min_param_count": 3140746752,
-      "sample_models": [
-        "StanfordAIMI/CheXagent-2-3b"
-      ],
-      "relevancy_score": 34.0
     },
     {
       "architecture_id": "EveMoEForCausalLM",
@@ -3058,22 +3204,46 @@
       "relevancy_score": 34.0
     },
     {
-      "architecture_id": "XCurOSForCausalLM",
-      "total_models": 3,
-      "total_downloads": 145740,
-      "min_param_count": 7615616512,
+      "architecture_id": "LagunaForCausalLM",
+      "total_models": 18,
+      "total_downloads": 801545,
+      "min_param_count": 33442617088,
       "sample_models": [
-        "XCurOS/XCurOS0.1-8B-Instruct"
+        "poolside/Laguna-XS.2",
+        "cyankiwi/Laguna-XS.2-AWQ-INT4",
+        "poolside/Laguna-XS.2-INT4",
+        "poolside/Laguna-M.1",
+        "poolside/Laguna-M.1-base"
       ],
       "relevancy_score": 33.9
     },
     {
-      "architecture_id": "BarbetForCausalLM",
-      "total_models": 2,
-      "total_downloads": 3702,
-      "min_param_count": 1088124920,
+      "architecture_id": "MaskMoELLaVAQwen2ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2805,
+      "min_param_count": 1563012736,
       "sample_models": [
-        "OpenFormosa/barbet-1b-base"
+        "KKHYA/llavaqwen2.5-0.5b-finetune-mask-moe-sparse-4e-2k-sp0.9_20260416_183544"
+      ],
+      "relevancy_score": 33.9
+    },
+    {
+      "architecture_id": "CacaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2820,
+      "min_param_count": 1000020992,
+      "sample_models": [
+        "Lyon28/caca-1B-untrained"
+      ],
+      "relevancy_score": 33.9
+    },
+    {
+      "architecture_id": "Papagan",
+      "total_models": 4,
+      "total_downloads": 2780,
+      "min_param_count": 1298763264,
+      "sample_models": [
+        "SutskeverFanBoy/papagan_1.3b"
       ],
       "relevancy_score": 33.9
     },
@@ -3088,47 +3258,34 @@
       "relevancy_score": 33.9
     },
     {
-      "architecture_id": "XLNetLMHeadModel",
-      "total_models": 18,
-      "total_downloads": 799167,
-      "min_param_count": null,
+      "architecture_id": "Phi3SmallForCausalLM",
+      "total_models": 8,
+      "total_downloads": 70709,
+      "min_param_count": 7392272384,
       "sample_models": [
-        "xlnet/xlnet-base-cased",
-        "xlnet/xlnet-large-cased",
-        "hfl/chinese-xlnet-base",
-        "sshleifer/tiny-xlnet-base-cased",
-        "textattack/xlnet-base-cased-imdb",
-        "textattack/xlnet-base-cased-CoLA"
+        "microsoft/Phi-3-small-8k-instruct",
+        "microsoft/Phi-3-small-128k-instruct"
       ],
       "relevancy_score": 33.8
     },
     {
-      "architecture_id": "ArkasrForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 3070,
-      "min_param_count": 1299463168,
+      "architecture_id": "InternS1ForConditionalGeneration",
+      "total_models": 8,
+      "total_downloads": 70025,
+      "min_param_count": 8538804224,
       "sample_models": [
-        "AutoArk-AI/ARK-ASR-0.6B"
+        "internlm/Intern-S1",
+        "internlm/Intern-S1-mini"
       ],
       "relevancy_score": 33.8
     },
     {
-      "architecture_id": "Maira2ForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 21321,
-      "min_param_count": 6880185600,
+      "architecture_id": "MoELLaVAQwen2ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2662,
+      "min_param_count": 1406119552,
       "sample_models": [
-        "microsoft/maira-2"
-      ],
-      "relevancy_score": 33.8
-    },
-    {
-      "architecture_id": "PanguEmbeddedForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3099,
-      "min_param_count": 1391497728,
-      "sample_models": [
-        "FreedomIntelligence/openPangu-Embedded-1B"
+        "KKHYA/llavaqwen2.5-0.5b-finetune-moe-4e-2k_20260331_194516"
       ],
       "relevancy_score": 33.8
     },
@@ -3143,12 +3300,12 @@
       "relevancy_score": 33.8
     },
     {
-      "architecture_id": "GritLM",
-      "total_models": 3,
-      "total_downloads": 135264,
-      "min_param_count": 7241732096,
+      "architecture_id": "MotifForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2574,
+      "min_param_count": 2597218432,
       "sample_models": [
-        "parasail-ai/GritLM-7B-vllm"
+        "Motif-Technologies/Motif-2.6B"
       ],
       "relevancy_score": 33.7
     },
@@ -3163,13 +3320,25 @@
       "relevancy_score": 33.7
     },
     {
-      "architecture_id": "Jais2ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 82006,
-      "min_param_count": 8090401280,
+      "architecture_id": "IdeficsForVisionText2Text",
+      "total_models": 12,
+      "total_downloads": 35400,
+      "min_param_count": 8929682192,
       "sample_models": [
-        "inceptionai/Jais-2-8B-Chat",
-        "inceptionai/Jais-2-70B-Chat"
+        "HuggingFaceM4/idefics-80b-instruct",
+        "HuggingFaceM4/idefics-9b",
+        "HuggingFaceM4/idefics-9b-instruct"
+      ],
+      "relevancy_score": 33.6
+    },
+    {
+      "architecture_id": "ChatGLMModel",
+      "total_models": 8,
+      "total_downloads": 64320,
+      "min_param_count": 9399951392,
+      "sample_models": [
+        "zai-org/glm-4-9b",
+        "zai-org/codegeex4-all-9b"
       ],
       "relevancy_score": 33.6
     },
@@ -3185,6 +3354,16 @@
       "relevancy_score": 33.6
     },
     {
+      "architecture_id": "SMTModelForCausalLM",
+      "total_models": 1,
+      "total_downloads": 569,
+      "min_param_count": 16126425,
+      "sample_models": [
+        "JuanCarlosMartinezSevilla/jazzmus-model"
+      ],
+      "relevancy_score": 33.6
+    },
+    {
       "architecture_id": "XLMRobertaForCausalLM",
       "total_models": 1,
       "total_downloads": 562,
@@ -3195,12 +3374,22 @@
       "relevancy_score": 33.6
     },
     {
-      "architecture_id": "NanochatForCausalLM",
-      "total_models": 1,
-      "total_downloads": 531,
-      "min_param_count": 524288824,
+      "architecture_id": "QuasarForCausalLM",
+      "total_models": 4,
+      "total_downloads": 106104,
+      "min_param_count": 8602037248,
       "sample_models": [
-        "himalaya-ai/himalayagpt-0.5b-it"
+        "silx-ai/Quasar-10B"
+      ],
+      "relevancy_score": 33.5
+    },
+    {
+      "architecture_id": "TinyQwen3NoveltyForCausalLM",
+      "total_models": 1,
+      "total_downloads": 533,
+      "min_param_count": 8131968,
+      "sample_models": [
+        "User01110/tinyLM-8M-exp"
       ],
       "relevancy_score": 33.5
     },
@@ -3225,16 +3414,6 @@
       "relevancy_score": 33.4
     },
     {
-      "architecture_id": "ParamBharatGenForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2386,
-      "min_param_count": 2860693504,
-      "sample_models": [
-        "bharatgenai/Param-1-2.9B-Instruct"
-      ],
-      "relevancy_score": 33.2
-    },
-    {
       "architecture_id": "SpatialLMLlamaForCausalLM",
       "total_models": 3,
       "total_downloads": 2291,
@@ -3245,55 +3424,14 @@
       "relevancy_score": 33.2
     },
     {
-      "architecture_id": "CacaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2269,
-      "min_param_count": 1000020992,
+      "architecture_id": "BailingMoeV2ForCausalLM",
+      "total_models": 12,
+      "total_downloads": 167726,
+      "min_param_count": 16255643392,
       "sample_models": [
-        "Lyon28/caca-1B-untrained"
-      ],
-      "relevancy_score": 33.1
-    },
-    {
-      "architecture_id": "MaskMoELLaVAQwen2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2265,
-      "min_param_count": 1563012736,
-      "sample_models": [
-        "KKHYA/llavaqwen2.5-0.5b-finetune-mask-moe-sparse-4e-2k-sp0.9_20260416_183544"
-      ],
-      "relevancy_score": 33.1
-    },
-    {
-      "architecture_id": "Papagan",
-      "total_models": 3,
-      "total_downloads": 2226,
-      "min_param_count": 1298763264,
-      "sample_models": [
-        "SutskeverFanBoy/papagan_1.3b"
-      ],
-      "relevancy_score": 33.1
-    },
-    {
-      "architecture_id": "MoELLaVAQwen2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2133,
-      "min_param_count": 1406119552,
-      "sample_models": [
-        "KKHYA/llavaqwen2.5-0.5b-finetune-moe-4e-2k_20260331_194516"
-      ],
-      "relevancy_score": 33.0
-    },
-    {
-      "architecture_id": "JAISLMHeadModel",
-      "total_models": 10,
-      "total_downloads": 33463,
-      "min_param_count": 13462730280,
-      "sample_models": [
-        "inceptionai/jais-13b-chat",
-        "inceptionai/jais-13b",
-        "inceptionai/jais-family-13b-chat",
-        "inceptionai/jais-30b-chat-v3"
+        "inclusionAI/Ling-mini-2.0",
+        "inclusionAI/Ling-1T",
+        "inclusionAI/Ling-flash-2.0"
       ],
       "relevancy_score": 32.8
     },
@@ -3308,55 +3446,60 @@
       "relevancy_score": 32.8
     },
     {
-      "architecture_id": "MotifForCausalLM",
-      "total_models": 3,
-      "total_downloads": 1926,
-      "min_param_count": 2597218432,
+      "architecture_id": "EmoForCausalLM",
+      "total_models": 5,
+      "total_downloads": 9203,
+      "min_param_count": 3901818880,
       "sample_models": [
-        "Motif-Technologies/Motif-2.6B"
+        "allenai/Emo_1b14b_1T",
+        "allenai/StdMoE_1b4b_130B"
       ],
-      "relevancy_score": 32.8
+      "relevancy_score": 32.7
     },
     {
-      "architecture_id": "InternS1ForConditionalGeneration",
-      "total_models": 6,
-      "total_downloads": 52526,
-      "min_param_count": 8538804224,
+      "architecture_id": "AprielForCausalLM",
+      "total_models": 4,
+      "total_downloads": 10691,
+      "min_param_count": 4832071680,
       "sample_models": [
-        "internlm/Intern-S1",
-        "internlm/Intern-S1-mini"
+        "ServiceNow-AI/Apriel-5B-Instruct"
       ],
-      "relevancy_score": 32.6
+      "relevancy_score": 32.7
     },
     {
-      "architecture_id": "Phi3SmallForCausalLM",
-      "total_models": 6,
-      "total_downloads": 50758,
-      "min_param_count": 7392272384,
+      "architecture_id": "HulumedQwen2ForCausalLM",
+      "total_models": 7,
+      "total_downloads": 43346,
+      "min_param_count": 8044744944,
       "sample_models": [
-        "microsoft/Phi-3-small-8k-instruct",
-        "microsoft/Phi-3-small-128k-instruct"
-      ],
-      "relevancy_score": 32.5
-    },
-    {
-      "architecture_id": "QuasarForCausalLM",
-      "total_models": 3,
-      "total_downloads": 75373,
-      "min_param_count": 8602037248,
-      "sample_models": [
-        "silx-ai/Quasar-10B"
+        "ZJU-AI4H/Hulu-Med-7B",
+        "ZJU-AI4H/Hulu-Med-32B"
       ],
       "relevancy_score": 32.5
     },
     {
-      "architecture_id": "ChatGLMModel",
-      "total_models": 6,
-      "total_downloads": 48349,
-      "min_param_count": 9399951392,
+      "architecture_id": "Rwkv6ForCausalLM",
+      "total_models": 15,
+      "total_downloads": 13615,
+      "min_param_count": 7635746816,
       "sample_models": [
-        "zai-org/glm-4-9b",
-        "zai-org/codegeex4-all-9b"
+        "RWKV/rwkv-6-world-3b",
+        "RWKV/rwkv-6-world-1b6",
+        "RWKV/v6-Finch-1B6-HF",
+        "RWKV/v6-Finch-14B-HF",
+        "RWKV/v6-Finch-7B-HF"
+      ],
+      "relevancy_score": 32.4
+    },
+    {
+      "architecture_id": "BailingMoeForCausalLM",
+      "total_models": 10,
+      "total_downloads": 179673,
+      "min_param_count": 16801974272,
+      "sample_models": [
+        "inclusionAI/Ling-lite-1.5",
+        "inclusionAI/Ling-lite",
+        "inclusionAI/Ling-plus"
       ],
       "relevancy_score": 32.4
     },
@@ -3372,64 +3515,49 @@
       "relevancy_score": 32.4
     },
     {
-      "architecture_id": "LagunaForCausalLM",
-      "total_models": 13,
-      "total_downloads": 705719,
-      "min_param_count": 33442617088,
+      "architecture_id": "InternLMForCausalLM",
+      "total_models": 20,
+      "total_downloads": 280342,
+      "min_param_count": null,
       "sample_models": [
-        "poolside/Laguna-XS.2",
-        "cyankiwi/Laguna-XS.2-AWQ-INT4",
-        "poolside/Laguna-XS.2-INT4",
-        "poolside/Laguna-M.1",
-        "poolside/Laguna-M.1-base"
+        "internlm/internlm-chat-7b",
+        "internlm/internlm-7b",
+        "internlm/internlm-20b",
+        "TongjiFinLab/CFGPT1-pt-7B",
+        "internlm/internlm-chat-20b",
+        "internlm/Agent-FLAN-7b"
+      ],
+      "relevancy_score": 32.2
+    },
+    {
+      "architecture_id": "PITForCausalLM",
+      "total_models": 5,
+      "total_downloads": 6859,
+      "min_param_count": 4232577024,
+      "sample_models": [
+        "NurErtug/pit-finance-grpo-merged",
+        "Dapinsky/PIT-4B-FT-202212-math-reasoning-dpo"
       ],
       "relevancy_score": 32.1
     },
     {
-      "architecture_id": "IdeficsForVisionText2Text",
-      "total_models": 9,
-      "total_downloads": 24198,
-      "min_param_count": 8929682192,
+      "architecture_id": "DeepseekForCausalLM",
+      "total_models": 8,
+      "total_downloads": 192858,
+      "min_param_count": 16375728128,
       "sample_models": [
-        "HuggingFaceM4/idefics-80b-instruct",
-        "HuggingFaceM4/idefics-9b",
-        "HuggingFaceM4/idefics-9b-instruct"
+        "deepseek-ai/deepseek-moe-16b-base",
+        "deepseek-ai/deepseek-moe-16b-chat"
       ],
-      "relevancy_score": 31.9
+      "relevancy_score": 32.0
     },
     {
-      "architecture_id": "EmoForCausalLM",
+      "architecture_id": "HunyuanImage3ForCausalMM",
       "total_models": 4,
-      "total_downloads": 7549,
-      "min_param_count": 3901818880,
+      "total_downloads": 2091307,
+      "min_param_count": 83009199459,
       "sample_models": [
-        "allenai/Emo_1b14b_1T",
-        "allenai/StdMoE_1b4b_130B"
-      ],
-      "relevancy_score": 31.9
-    },
-    {
-      "architecture_id": "MiMoV2ForCausalLM",
-      "total_models": 17,
-      "total_downloads": 354391,
-      "min_param_count": 52930771392,
-      "sample_models": [
-        "XiaomiMiMo/MiMo-V2.5-Pro",
-        "XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash",
-        "spectator2026/MiMo-V2.5-AWQ-int4",
-        "kernelpool/MiMo-V2.5-Pro-6bit",
-        "XiaomiMiMo/MiMo-V2.5-Pro-Base",
-        "nwzjk/MiMo-V2.5-AWQ-int4"
-      ],
-      "relevancy_score": 31.8
-    },
-    {
-      "architecture_id": "AprielForCausalLM",
-      "total_models": 3,
-      "total_downloads": 8042,
-      "min_param_count": 4832071680,
-      "sample_models": [
-        "ServiceNow-AI/Apriel-5B-Instruct"
+        "tencent/HunyuanImage-3.0"
       ],
       "relevancy_score": 31.8
     },
@@ -3445,40 +3573,14 @@
       "relevancy_score": 31.7
     },
     {
-      "architecture_id": "HulumedQwen2ForCausalLM",
-      "total_models": 5,
-      "total_downloads": 35622,
-      "min_param_count": 8044744944,
-      "sample_models": [
-        "ZJU-AI4H/Hulu-Med-7B",
-        "ZJU-AI4H/Hulu-Med-32B"
-      ],
-      "relevancy_score": 31.5
-    },
-    {
-      "architecture_id": "PITForCausalLM",
+      "architecture_id": "StepAudio2ForCausalLM",
       "total_models": 4,
-      "total_downloads": 6019,
-      "min_param_count": 4232577024,
+      "total_downloads": 42507,
+      "min_param_count": 8315179264,
       "sample_models": [
-        "NurErtug/pit-finance-grpo-merged",
-        "Dapinsky/PIT-4B-FT-202212-math-reasoning-dpo"
+        "stepfun-ai/Step-Audio-2-mini"
       ],
-      "relevancy_score": 31.5
-    },
-    {
-      "architecture_id": "Rwkv6ForCausalLM",
-      "total_models": 13,
-      "total_downloads": 11376,
-      "min_param_count": 7635746816,
-      "sample_models": [
-        "RWKV/rwkv-6-world-3b",
-        "RWKV/rwkv-6-world-1b6",
-        "RWKV/v6-Finch-1B6-HF",
-        "RWKV/v6-Finch-14B-HF",
-        "RWKV/v6-Finch-7B-HF"
-      ],
-      "relevancy_score": 31.4
+      "relevancy_score": 31.6
     },
     {
       "architecture_id": "GPTSanJapaneseForConditionalGeneration",
@@ -3491,106 +3593,206 @@
       "relevancy_score": 31.4
     },
     {
-      "architecture_id": "BailingMoeV2ForCausalLM",
-      "total_models": 9,
-      "total_downloads": 126010,
-      "min_param_count": 16255643392,
-      "sample_models": [
-        "inclusionAI/Ling-mini-2.0",
-        "inclusionAI/Ling-1T",
-        "inclusionAI/Ling-flash-2.0"
-      ],
-      "relevancy_score": 31.3
-    },
-    {
-      "architecture_id": "HunyuanImage3ForCausalMM",
-      "total_models": 3,
-      "total_downloads": 1789960,
-      "min_param_count": 83009199459,
-      "sample_models": [
-        "tencent/HunyuanImage-3.0"
-      ],
-      "relevancy_score": 31.2
-    },
-    {
-      "architecture_id": "BailingMoeForCausalLM",
-      "total_models": 7,
-      "total_downloads": 133908,
-      "min_param_count": 16801974272,
-      "sample_models": [
-        "inclusionAI/Ling-lite-1.5",
-        "inclusionAI/Ling-lite",
-        "inclusionAI/Ling-plus"
-      ],
-      "relevancy_score": 30.9
-    },
-    {
-      "architecture_id": "DeepseekForCausalLM",
-      "total_models": 6,
-      "total_downloads": 143523,
-      "min_param_count": 16375728128,
-      "sample_models": [
-        "deepseek-ai/deepseek-moe-16b-base",
-        "deepseek-ai/deepseek-moe-16b-chat"
-      ],
-      "relevancy_score": 30.7
-    },
-    {
-      "architecture_id": "InternLMForCausalLM",
-      "total_models": 16,
-      "total_downloads": 221634,
-      "min_param_count": null,
-      "sample_models": [
-        "internlm/internlm-chat-7b",
-        "internlm/internlm-7b",
-        "internlm/internlm-20b",
-        "TongjiFinLab/CFGPT1-pt-7B",
-        "internlm/internlm-chat-20b",
-        "internlm/Agent-FLAN-7b"
-      ],
-      "relevancy_score": 30.6
-    },
-    {
       "architecture_id": "CXRMate2ForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 4254,
+      "total_models": 4,
+      "total_downloads": 5501,
       "min_param_count": 3322260224,
       "sample_models": [
         "aehrc/cxrmate-2"
       ],
-      "relevancy_score": 30.5
-    },
-    {
-      "architecture_id": "StepAudio2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 27607,
-      "min_param_count": 8315179264,
-      "sample_models": [
-        "stepfun-ai/Step-Audio-2-mini"
-      ],
-      "relevancy_score": 30.4
+      "relevancy_score": 31.3
     },
     {
       "architecture_id": "BioGptForCausalLM",
-      "total_models": 9,
-      "total_downloads": 446425,
+      "total_models": 11,
+      "total_downloads": 587762,
       "min_param_count": null,
       "sample_models": [
         "microsoft/biogpt",
         "microsoft/BioGPT-Large",
         "microsoft/BioGPT-Large-PubMedQA"
       ],
-      "relevancy_score": 30.0
+      "relevancy_score": 31.2
     },
     {
       "architecture_id": "DyninOmniForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 22512,
+      "total_models": 4,
+      "total_downloads": 28962,
       "min_param_count": 8116244480,
       "sample_models": [
         "snu-aidas/Dynin-Omni"
       ],
-      "relevancy_score": 30.0
+      "relevancy_score": 30.8
+    },
+    {
+      "architecture_id": "CogVLMVideoForCausalLM",
+      "total_models": 8,
+      "total_downloads": 15909,
+      "min_param_count": 12507532544,
+      "sample_models": [
+        "zai-org/VisionReward-Video",
+        "zai-org/cogvlm2-llama3-caption"
+      ],
+      "relevancy_score": 30.7
+    },
+    {
+      "architecture_id": "GPTBERTForCausalLM",
+      "total_models": 32,
+      "total_downloads": 24615,
+      "min_param_count": null,
+      "sample_models": [
+        "BabyLM-community/GPT-BERT-baseline-babylm-eng-nld-zho-equal",
+        "BabyLM-community/GPT-BERT-baseline-babylm-Strict",
+        "BabyLM-community/GPT-BERT-baseline-babylm-eng-nld-equal",
+        "BabyLM-community/GPT-BERT-baseline-babylm-zho",
+        "BabyLM-community/GPT-BERT-baseline-babylm-nld",
+        "BabyLM-community/GPT-BERT-baseline-babylm-Strict-Small",
+        "BabyLM-community/GPT-BERT-baseline-babylm-zho-nld-equal",
+        "BabyLM-community/GPT-BERT-baseline-babylm-eng-zho-equal"
+      ],
+      "relevancy_score": 30.6
+    },
+    {
+      "architecture_id": "Phi4FlashForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3949,
+      "min_param_count": 3852562944,
+      "sample_models": [
+        "microsoft/Phi-4-mini-flash-reasoning"
+      ],
+      "relevancy_score": 30.6
+    },
+    {
+      "architecture_id": "LamedPhi3ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3814,
+      "min_param_count": 4049101904,
+      "sample_models": [
+        "GoodBaiBai88/M3D-LaMed-Phi-3-4B"
+      ],
+      "relevancy_score": 30.5
+    },
+    {
+      "architecture_id": "InstellaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3834,
+      "min_param_count": 3112675840,
+      "sample_models": [
+        "amd/Instella-3B-Instruct"
+      ],
+      "relevancy_score": 30.5
+    },
+    {
+      "architecture_id": "StepVLForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 24891,
+      "min_param_count": 10171750144,
+      "sample_models": [
+        "QuantTrio/Step3-VL-10B-AWQ"
+      ],
+      "relevancy_score": 30.5
+    },
+    {
+      "architecture_id": "SolarForCausalLM",
+      "total_models": 4,
+      "total_downloads": 165696,
+      "min_param_count": 22140032000,
+      "sample_models": [
+        "upstage/solar-pro-preview-instruct"
+      ],
+      "relevancy_score": 30.5
+    },
+    {
+      "architecture_id": "InternS1ProForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 1068937,
+      "min_param_count": null,
+      "sample_models": [
+        "internlm/Intern-S1-Pro"
+      ],
+      "relevancy_score": 30.4
+    },
+    {
+      "architecture_id": "Emu3ForCausalLM",
+      "total_models": 8,
+      "total_downloads": 13179,
+      "min_param_count": 8492011520,
+      "sample_models": [
+        "BAAI/Emu3-Gen",
+        "BAAI/Emu3.5-Image"
+      ],
+      "relevancy_score": 30.3
+    },
+    {
+      "architecture_id": "Param2MoEForCausalLM",
+      "total_models": 4,
+      "total_downloads": 151661,
+      "min_param_count": 17151140480,
+      "sample_models": [
+        "bharatgenai/Param2-17B-A2.4B-Thinking"
+      ],
+      "relevancy_score": 30.3
+    },
+    {
+      "architecture_id": "BunnyPhiForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3342,
+      "min_param_count": 3182254624,
+      "sample_models": [
+        "BAAI/Bunny-v1_0-3B"
+      ],
+      "relevancy_score": 30.3
+    },
+    {
+      "architecture_id": "LibraLlamaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3408,
+      "min_param_count": 6800327990,
+      "sample_models": [
+        "X-iZhang/libra-v1.0-7b"
+      ],
+      "relevancy_score": 30.3
+    },
+    {
+      "architecture_id": "MoELLaVAQwen3ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3283,
+      "min_param_count": 3927104512,
+      "sample_models": [
+        "KKHYA/llavaqwen3-1.7b-finetune-moe-4e-2k_20260427_233320"
+      ],
+      "relevancy_score": 30.2
+    },
+    {
+      "architecture_id": "ReformerModelWithLMHead",
+      "total_models": 8,
+      "total_downloads": 539392,
+      "min_param_count": null,
+      "sample_models": [
+        "google/reformer-crime-and-punishment",
+        "google/reformer-enwik8"
+      ],
+      "relevancy_score": 30.1
+    },
+    {
+      "architecture_id": "MiniCPMSALAForCausalLM",
+      "total_models": 4,
+      "total_downloads": 20389,
+      "min_param_count": 9477203968,
+      "sample_models": [
+        "openbmb/MiniCPM-SALA"
+      ],
+      "relevancy_score": 30.1
+    },
+    {
+      "architecture_id": "Step3p5ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 937972,
+      "min_param_count": 199384301376,
+      "sample_models": [
+        "stepfun-ai/Step-3.5-Flash"
+      ],
+      "relevancy_score": 30.1
     },
     {
       "architecture_id": "AeroForConditionalGeneration",
@@ -3603,44 +3805,79 @@
       "relevancy_score": 30.0
     },
     {
-      "architecture_id": "StepVLForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 20795,
-      "min_param_count": 10171750144,
+      "architecture_id": "VeridianForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2841,
+      "min_param_count": 3938699264,
       "sample_models": [
-        "QuantTrio/Step3-VL-10B-AWQ"
+        "MagistrTheOne/veridian-beta"
+      ],
+      "relevancy_score": 29.9
+    },
+    {
+      "architecture_id": "LaneformerForCausalLM",
+      "total_models": 1,
+      "total_downloads": 640,
+      "min_param_count": 2320069632,
+      "sample_models": [
+        "kogai/laneformer-2b-it"
+      ],
+      "relevancy_score": 29.9
+    },
+    {
+      "architecture_id": "BailingMoeV2_5ForCausalLM",
+      "total_models": 15,
+      "total_downloads": 171333,
+      "min_param_count": 107494409216,
+      "sample_models": [
+        "inclusionAI/Ring-2.5-1T",
+        "inclusionAI/Ling-2.6-flash",
+        "inclusionAI/Ring-2.6-1T",
+        "inclusionAI/Ling-2.6-1T"
       ],
       "relevancy_score": 29.8
     },
     {
-      "architecture_id": "InstellaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2918,
-      "min_param_count": 3112675840,
+      "architecture_id": "KORMoForCausalLM",
+      "total_models": 8,
+      "total_downloads": 10312,
+      "min_param_count": 10756624384,
       "sample_models": [
-        "amd/Instella-3B-Instruct"
+        "KORMo-Team/KORMo-10B-base",
+        "KORMo-Team/KORMo-10B-sft"
       ],
-      "relevancy_score": 29.7
+      "relevancy_score": 29.8
     },
     {
-      "architecture_id": "Phi4FlashForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3027,
-      "min_param_count": 3852562944,
+      "architecture_id": "Videollama2MistralForCausalLM",
+      "total_models": 6,
+      "total_downloads": 13576,
+      "min_param_count": 8034428160,
       "sample_models": [
-        "microsoft/Phi-4-mini-flash-reasoning"
+        "DAMO-NLP-SG/VideoLLaMA2-7B-16F",
+        "DAMO-NLP-SG/VideoLLaMA2-7B"
       ],
-      "relevancy_score": 29.7
+      "relevancy_score": 29.8
     },
     {
-      "architecture_id": "LamedPhi3ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2877,
-      "min_param_count": 4049101904,
+      "architecture_id": "SmartCoderMoEForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2749,
+      "min_param_count": 4717965312,
       "sample_models": [
-        "GoodBaiBai88/M3D-LaMed-Phi-3-4B"
+        "Johnblick187/SmartCoderMoE"
       ],
-      "relevancy_score": 29.6
+      "relevancy_score": 29.8
+    },
+    {
+      "architecture_id": "TalkieForCausalLM",
+      "total_models": 4,
+      "total_downloads": 16874,
+      "min_param_count": 13280257721,
+      "sample_models": [
+        "lewtun/talkie-1930-13b-it-hf"
+      ],
+      "relevancy_score": 29.7
     },
     {
       "architecture_id": "TrainableM2MForConditionalGeneration",
@@ -3650,150 +3887,81 @@
       "sample_models": [
         "Sunbird/translate-nllb-1.3b-salt"
       ],
+      "relevancy_score": 29.7
+    },
+    {
+      "architecture_id": "GENERatorForCausalLM",
+      "total_models": 1,
+      "total_downloads": 565,
+      "min_param_count": 1162061824,
+      "sample_models": [
+        "GenerTeam/GENERator-v2-prokaryote-1.2b-base"
+      ],
       "relevancy_score": 29.6
     },
     {
-      "architecture_id": "CogVLMVideoForCausalLM",
-      "total_models": 6,
-      "total_downloads": 11923,
-      "min_param_count": 12507532544,
+      "architecture_id": "HYV3ForCausalLM",
+      "total_models": 8,
+      "total_downloads": 367813,
+      "min_param_count": 30064725888,
       "sample_models": [
-        "zai-org/VisionReward-Video",
-        "zai-org/cogvlm2-llama3-caption"
-      ],
-      "relevancy_score": 29.5
-    },
-    {
-      "architecture_id": "MoELLaVAQwen3ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2725,
-      "min_param_count": 3927104512,
-      "sample_models": [
-        "KKHYA/llavaqwen3-1.7b-finetune-moe-4e-2k_20260427_233320"
-      ],
-      "relevancy_score": 29.5
-    },
-    {
-      "architecture_id": "SolarForCausalLM",
-      "total_models": 3,
-      "total_downloads": 123183,
-      "min_param_count": 22140032000,
-      "sample_models": [
-        "upstage/solar-pro-preview-instruct"
-      ],
-      "relevancy_score": 29.5
-    },
-    {
-      "architecture_id": "InternS1ProForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 784387,
-      "min_param_count": null,
-      "sample_models": [
-        "internlm/Intern-S1-Pro"
-      ],
-      "relevancy_score": 29.4
-    },
-    {
-      "architecture_id": "Param2MoEForCausalLM",
-      "total_models": 3,
-      "total_downloads": 113565,
-      "min_param_count": 17151140480,
-      "sample_models": [
-        "bharatgenai/Param2-17B-A2.4B-Thinking"
-      ],
-      "relevancy_score": 29.4
-    },
-    {
-      "architecture_id": "BunnyPhiForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2559,
-      "min_param_count": 3182254624,
-      "sample_models": [
-        "BAAI/Bunny-v1_0-3B"
-      ],
-      "relevancy_score": 29.4
-    },
-    {
-      "architecture_id": "LibraLlamaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2562,
-      "min_param_count": 6800327990,
-      "sample_models": [
-        "X-iZhang/libra-v1.0-7b"
-      ],
-      "relevancy_score": 29.4
-    },
-    {
-      "architecture_id": "Step3p5ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 737498,
-      "min_param_count": 199384301376,
-      "sample_models": [
-        "stepfun-ai/Step-3.5-Flash"
+        "tencent/Hy3-preview",
+        "tencent/Hy-MT2-30B-A3B"
       ],
       "relevancy_score": 29.3
     },
     {
-      "architecture_id": "VeridianForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2295,
-      "min_param_count": 3938699264,
+      "architecture_id": "Step3VLForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 623319,
+      "min_param_count": 320969912832,
       "sample_models": [
-        "MagistrTheOne/veridian-beta"
+        "stepfun-ai/step3"
       ],
-      "relevancy_score": 29.2
+      "relevancy_score": 29.3
     },
     {
-      "architecture_id": "MiniCPMSALAForCausalLM",
-      "total_models": 3,
-      "total_downloads": 15650,
-      "min_param_count": 9477203968,
-      "sample_models": [
-        "openbmb/MiniCPM-SALA"
-      ],
-      "relevancy_score": 29.2
-    },
-    {
-      "architecture_id": "Emu3ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 9683,
-      "min_param_count": 8492011520,
-      "sample_models": [
-        "BAAI/Emu3-Gen",
-        "BAAI/Emu3.5-Image"
-      ],
-      "relevancy_score": 29.1
-    },
-    {
-      "architecture_id": "ReformerModelWithLMHead",
-      "total_models": 6,
-      "total_downloads": 413979,
+      "architecture_id": "LlavaLlamaModel",
+      "total_models": 15,
+      "total_downloads": 118909,
       "min_param_count": null,
       "sample_models": [
-        "google/reformer-crime-and-punishment",
-        "google/reformer-enwik8"
+        "Efficient-Large-Model/NVILA-Lite-8B",
+        "Efficient-Large-Model/VILA1.5-3b",
+        "Efficient-Large-Model/NVILA-8B",
+        "Efficient-Large-Model/Llama-3-VILA1.5-8B"
       ],
       "relevancy_score": 29.0
     },
     {
-      "architecture_id": "SmartCoderMoEForCausalLM",
+      "architecture_id": "TinyLlavaForConditionalGeneration",
       "total_models": 3,
-      "total_downloads": 2180,
-      "min_param_count": 4717965312,
+      "total_downloads": 1986,
+      "min_param_count": 3217417280,
       "sample_models": [
-        "Johnblick187/SmartCoderMoE"
+        "tinyllava/TinyLLaVA-Phi-2-SigLIP-3.1B"
       ],
-      "relevancy_score": 29.0
+      "relevancy_score": 28.9
     },
     {
-      "architecture_id": "TalkieForCausalLM",
-      "total_models": 3,
-      "total_downloads": 13136,
-      "min_param_count": 13280257721,
+      "architecture_id": "JetMoEForCausalLM",
+      "total_models": 4,
+      "total_downloads": 11363,
+      "min_param_count": 8522237952,
       "sample_models": [
-        "lewtun/talkie-1930-13b-it-hf"
+        "jetmoe/jetmoe-8b"
       ],
       "relevancy_score": 28.8
+    },
+    {
+      "architecture_id": "GPTNeoXJapaneseForCausalLM",
+      "total_models": 4,
+      "total_downloads": 469476,
+      "min_param_count": null,
+      "sample_models": [
+        "abeja/gpt-neox-japanese-2.7b"
+      ],
+      "relevancy_score": 28.7
     },
     {
       "architecture_id": "EvafrillMoForCausalLM",
@@ -3806,253 +3974,268 @@
       "relevancy_score": 28.6
     },
     {
-      "architecture_id": "KORMoForCausalLM",
-      "total_models": 6,
-      "total_downloads": 7588,
-      "min_param_count": 10756624384,
-      "sample_models": [
-        "KORMo-Team/KORMo-10B-base",
-        "KORMo-Team/KORMo-10B-sft"
-      ],
-      "relevancy_score": 28.5
-    },
-    {
-      "architecture_id": "BailingMoeV2_5ForCausalLM",
-      "total_models": 12,
-      "total_downloads": 131773,
-      "min_param_count": 107494409216,
-      "sample_models": [
-        "inclusionAI/Ring-2.5-1T",
-        "inclusionAI/Ling-2.6-flash",
-        "inclusionAI/Ring-2.6-1T",
-        "inclusionAI/Ling-2.6-1T"
-      ],
-      "relevancy_score": 28.3
-    },
-    {
-      "architecture_id": "Step3VLForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 459458,
-      "min_param_count": 320969912832,
-      "sample_models": [
-        "stepfun-ai/step3"
-      ],
-      "relevancy_score": 28.3
-    },
-    {
-      "architecture_id": "HYV3ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 271805,
-      "min_param_count": 30064725888,
-      "sample_models": [
-        "tencent/Hy3-preview",
-        "tencent/Hy-MT2-30B-A3B"
-      ],
-      "relevancy_score": 28.1
-    },
-    {
-      "architecture_id": "JetMoEForCausalLM",
-      "total_models": 3,
-      "total_downloads": 8333,
-      "min_param_count": 8522237952,
-      "sample_models": [
-        "jetmoe/jetmoe-8b"
-      ],
-      "relevancy_score": 27.9
-    },
-    {
-      "architecture_id": "GPTBERTForCausalLM",
-      "total_models": 24,
-      "total_downloads": 19723,
-      "min_param_count": null,
-      "sample_models": [
-        "BabyLM-community/GPT-BERT-baseline-babylm-eng-nld-zho-equal",
-        "BabyLM-community/GPT-BERT-baseline-babylm-Strict",
-        "BabyLM-community/GPT-BERT-baseline-babylm-eng-nld-equal",
-        "BabyLM-community/GPT-BERT-baseline-babylm-zho",
-        "BabyLM-community/GPT-BERT-baseline-babylm-nld",
-        "BabyLM-community/GPT-BERT-baseline-babylm-Strict-Small",
-        "BabyLM-community/GPT-BERT-baseline-babylm-zho-nld-equal",
-        "BabyLM-community/GPT-BERT-baseline-babylm-eng-zho-equal"
-      ],
-      "relevancy_score": 27.8
-    },
-    {
-      "architecture_id": "GPTNeoXJapaneseForCausalLM",
-      "total_models": 3,
-      "total_downloads": 356913,
-      "min_param_count": null,
-      "sample_models": [
-        "abeja/gpt-neox-japanese-2.7b"
-      ],
-      "relevancy_score": 27.8
-    },
-    {
-      "architecture_id": "HyperCLOVAXForCausalLM",
-      "total_models": 3,
-      "total_downloads": 52416,
-      "min_param_count": 14748112896,
-      "sample_models": [
-        "naver-hyperclovax/HyperCLOVAX-SEED-Think-14B"
-      ],
-      "relevancy_score": 27.7
-    },
-    {
-      "architecture_id": "LlavaLlamaModel",
-      "total_models": 12,
-      "total_downloads": 93982,
-      "min_param_count": null,
-      "sample_models": [
-        "Efficient-Large-Model/NVILA-Lite-8B",
-        "Efficient-Large-Model/VILA1.5-3b",
-        "Efficient-Large-Model/NVILA-8B",
-        "Efficient-Large-Model/Llama-3-VILA1.5-8B"
-      ],
-      "relevancy_score": 27.6
-    },
-    {
-      "architecture_id": "TinyLlavaForConditionalGeneration",
-      "total_models": 2,
-      "total_downloads": 1264,
-      "min_param_count": 3217417280,
-      "sample_models": [
-        "tinyllava/TinyLLaVA-Phi-2-SigLIP-3.1B"
-      ],
-      "relevancy_score": 27.6
-    },
-    {
-      "architecture_id": "Videollama2MistralForCausalLM",
-      "total_models": 4,
-      "total_downloads": 5610,
-      "min_param_count": 8034428160,
-      "sample_models": [
-        "DAMO-NLP-SG/VideoLLaMA2-7B-16F",
-        "DAMO-NLP-SG/VideoLLaMA2-7B"
-      ],
-      "relevancy_score": 27.3
-    },
-    {
-      "architecture_id": "MiMoV2ASRForCausalLM",
-      "total_models": 3,
-      "total_downloads": 6322,
-      "min_param_count": 7622619136,
-      "sample_models": [
-        "XiaomiMiMo/MiMo-V2.5-ASR"
-      ],
-      "relevancy_score": 27.3
-    },
-    {
       "architecture_id": "DeepseekOCR2ForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1114,
+      "total_models": 3,
+      "total_downloads": 1688,
       "min_param_count": 3389119360,
       "sample_models": [
         "bartsolutions/DeepSeek-OCR-2-GPTQ-INT8"
       ],
-      "relevancy_score": 27.3
+      "relevancy_score": 28.5
+    },
+    {
+      "architecture_id": "ChatGLMForConditionalGeneration",
+      "total_models": 6,
+      "total_downloads": 6869,
+      "min_param_count": 9399951392,
+      "sample_models": [
+        "qiuhuachuan/MeChat",
+        "IAAR-Shanghai/xVerify-9B-C",
+        "zai-org/LongWriter-glm4-9b"
+      ],
+      "relevancy_score": 28.4
+    },
+    {
+      "architecture_id": "HyperCLOVAXForCausalLM",
+      "total_models": 4,
+      "total_downloads": 61687,
+      "min_param_count": 14748112896,
+      "sample_models": [
+        "naver-hyperclovax/HyperCLOVAX-SEED-Think-14B"
+      ],
+      "relevancy_score": 28.4
+    },
+    {
+      "architecture_id": "MiMoV2ASRForCausalLM",
+      "total_models": 4,
+      "total_downloads": 8837,
+      "min_param_count": 7622619136,
+      "sample_models": [
+        "XiaomiMiMo/MiMo-V2.5-ASR"
+      ],
+      "relevancy_score": 28.3
     },
     {
       "architecture_id": "MiniMaxM1ForCausalLM",
-      "total_models": 6,
-      "total_downloads": 162568,
+      "total_models": 8,
+      "total_downloads": 210297,
       "min_param_count": 456089655296,
       "sample_models": [
         "MiniMaxAI/MiniMax-M1-40k",
         "MiniMaxAI/MiniMax-M1-80k"
       ],
-      "relevancy_score": 27.0
+      "relevancy_score": 28.1
     },
     {
-      "architecture_id": "LongcatFlashForCausalLM",
-      "total_models": 3,
-      "total_downloads": 231734,
-      "min_param_count": 561862880256,
+      "architecture_id": "Cohere2MoeForCausalLM",
+      "total_models": 10,
+      "total_downloads": 134015,
+      "min_param_count": 30484303872,
       "sample_models": [
-        "meituan-longcat/LongCat-Flash-Chat"
+        "CohereLabs/North-Mini-Code-1.0",
+        "CohereLabs/North-Mini-Code-1.0-w4a16",
+        "cyankiwi/North-Mini-Code-1.0-AWQ-INT4"
       ],
-      "relevancy_score": 26.9
-    },
-    {
-      "architecture_id": "LLaDAMoEModel",
-      "total_models": 3,
-      "total_downloads": 4948,
-      "min_param_count": 7356880896,
-      "sample_models": [
-        "inclusionAI/LLaDA-MoE-7B-A1B-Base"
-      ],
-      "relevancy_score": 26.8
-    },
-    {
-      "architecture_id": "ChatGLMForConditionalGeneration",
-      "total_models": 4,
-      "total_downloads": 4171,
-      "min_param_count": 9399951392,
-      "sample_models": [
-        "qiuhuachuan/MeChat",
-        "IAAR-Shanghai/xVerify-9B-C"
-      ],
-      "relevancy_score": 26.7
-    },
-    {
-      "architecture_id": "Glm4vForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 4685,
-      "min_param_count": 10357264896,
-      "sample_models": [
-        "QuantTrio/GLM-4.1V-9B-Thinking-AWQ"
-      ],
-      "relevancy_score": 26.7
+      "relevancy_score": 27.8
     },
     {
       "architecture_id": "CogVLMForCausalLM",
-      "total_models": 6,
-      "total_downloads": 20167,
+      "total_models": 8,
+      "total_downloads": 26881,
       "min_param_count": 17639687424,
       "sample_models": [
         "zai-org/cogvlm2-llama3-chat-19B",
         "zai-org/cogvlm-chat-hf"
       ],
-      "relevancy_score": 26.6
+      "relevancy_score": 27.8
+    },
+    {
+      "architecture_id": "LongcatFlashForCausalLM",
+      "total_models": 4,
+      "total_downloads": 310177,
+      "min_param_count": 561862880256,
+      "sample_models": [
+        "meituan-longcat/LongCat-Flash-Chat"
+      ],
+      "relevancy_score": 27.8
+    },
+    {
+      "architecture_id": "Glm4vForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 6291,
+      "min_param_count": 10357264896,
+      "sample_models": [
+        "QuantTrio/GLM-4.1V-9B-Thinking-AWQ"
+      ],
+      "relevancy_score": 27.6
     },
     {
       "architecture_id": "MiMoV2FlashForCausalLM",
-      "total_models": 3,
-      "total_downloads": 206430,
+      "total_models": 4,
+      "total_downloads": 271233,
       "min_param_count": 309785318400,
       "sample_models": [
         "XiaomiMiMo/MiMo-V2-Flash"
       ],
-      "relevancy_score": 26.6
+      "relevancy_score": 27.5
     },
     {
-      "architecture_id": "ChameleonXLLMXForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 4313,
-      "min_param_count": 7013158912,
+      "architecture_id": "LLaDAMoEModel",
+      "total_models": 4,
+      "total_downloads": 6101,
+      "min_param_count": 7356880896,
       "sample_models": [
-        "Alpha-VLLM/Lumina-mGPT-7B-768"
+        "inclusionAI/LLaDA-MoE-7B-A1B-Base"
       ],
-      "relevancy_score": 26.5
+      "relevancy_score": 27.5
     },
     {
-      "architecture_id": "PhariaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 4378,
-      "min_param_count": 7041544704,
+      "architecture_id": "DiffusionGemmaForBlockDiffusion",
+      "total_models": 8,
+      "total_downloads": 21747,
+      "min_param_count": 25823778864,
       "sample_models": [
-        "Aleph-Alpha/Pharia-1-LLM-7B-control-hf"
+        "aidendle94/diffusiongemma-26B-A4B-it-INT8-dynamic",
+        "edwixx/diffusiongemma-26B-A4B-it-HERETIC-Uncensored"
       ],
-      "relevancy_score": 26.5
+      "relevancy_score": 27.4
     },
     {
       "architecture_id": "ARCHunyuanVideoForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 4380,
+      "total_models": 4,
+      "total_downloads": 5858,
       "min_param_count": 8635301872,
       "sample_models": [
         "TencentARC/ARC-Hunyuan-Video-7B"
       ],
-      "relevancy_score": 26.5
+      "relevancy_score": 27.4
+    },
+    {
+      "architecture_id": "PhariaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 5660,
+      "min_param_count": 7041544704,
+      "sample_models": [
+        "Aleph-Alpha/Pharia-1-LLM-7B-control-hf"
+      ],
+      "relevancy_score": 27.4
+    },
+    {
+      "architecture_id": "MiniMaxM3SparseForConditionalGeneration",
+      "total_models": 12,
+      "total_downloads": 12139,
+      "min_param_count": 24949042838,
+      "sample_models": [
+        "JANGQ-AI/MiniMax-M3-REAP40-JANG_2L",
+        "JANGQ-AI/MiniMax-M3-Medium-JANG_2L",
+        "aquaman164/MiniMax-M3-AutoRound-3.2bit-longctx",
+        "JANGQ-AI/MiniMax-M3-REAP32-Coder",
+        "OsaurusAI/MiniMax-M3-Coder-Small",
+        "JANGQ-AI/MiniMax-M3-REAP22-Coder"
+      ],
+      "relevancy_score": 27.3
+    },
+    {
+      "architecture_id": "Videollama2Qwen2ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 5445,
+      "min_param_count": 8527095391,
+      "sample_models": [
+        "DAMO-NLP-SG/VideoLLaMA2.1-7B-AV"
+      ],
+      "relevancy_score": 27.3
+    },
+    {
+      "architecture_id": "ChameleonXLLMXForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 5605,
+      "min_param_count": 7013158912,
+      "sample_models": [
+        "Alpha-VLLM/Lumina-mGPT-7B-768"
+      ],
+      "relevancy_score": 27.3
+    },
+    {
+      "architecture_id": "MiniCPM3ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 224278,
+      "min_param_count": null,
+      "sample_models": [
+        "openbmb/MiniCPM3-4B"
+      ],
+      "relevancy_score": 27.1
+    },
+    {
+      "architecture_id": "ExaoneMoEForCausalLM",
+      "total_models": 4,
+      "total_downloads": 209414,
+      "min_param_count": 237099669632,
+      "sample_models": [
+        "LGAI-EXAONE/K-EXAONE-236B-A23B"
+      ],
+      "relevancy_score": 27.0
+    },
+    {
+      "architecture_id": "CheXagentForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 4538,
+      "min_param_count": 8362401664,
+      "sample_models": [
+        "StanfordAIMI/CheXagent-8b"
+      ],
+      "relevancy_score": 26.9
+    },
+    {
+      "architecture_id": "LizzyForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4522,
+      "min_param_count": 7298011136,
+      "sample_models": [
+        "flwrlabs/Lizzy-7B"
+      ],
+      "relevancy_score": 26.9
+    },
+    {
+      "architecture_id": "Zaya1VLForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 4620,
+      "min_param_count": 9722232312,
+      "sample_models": [
+        "Zyphra/ZAYA1-VL-8B"
+      ],
+      "relevancy_score": 26.9
+    },
+    {
+      "architecture_id": "AquilaForCausalLM",
+      "total_models": 7,
+      "total_downloads": 126351,
+      "min_param_count": null,
+      "sample_models": [
+        "BAAI/AquilaChat2-7B",
+        "BAAI/AquilaChat2-34B-16K",
+        "BAAI/AquilaChat2-70B-Expr"
+      ],
+      "relevancy_score": 26.8
+    },
+    {
+      "architecture_id": "HunYuanMoEV1ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 196796,
+      "min_param_count": 80393183232,
+      "sample_models": [
+        "tencent/Hunyuan-A13B-Instruct"
+      ],
+      "relevancy_score": 26.8
+    },
+    {
+      "architecture_id": "ZambaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3926,
+      "min_param_count": 7232490496,
+      "sample_models": [
+        "Zyphra/Zamba-7B-v1"
+      ],
+      "relevancy_score": 26.6
     },
     {
       "architecture_id": "Ministral3ForCausalLM",
@@ -4065,107 +4248,111 @@
       "relevancy_score": 26.5
     },
     {
-      "architecture_id": "Videollama2Qwen2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 4048,
-      "min_param_count": 8527095391,
-      "sample_models": [
-        "DAMO-NLP-SG/VideoLLaMA2.1-7B-AV"
-      ],
-      "relevancy_score": 26.3
-    },
-    {
-      "architecture_id": "Zaya1VLForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 4034,
-      "min_param_count": 9722232312,
-      "sample_models": [
-        "Zyphra/ZAYA1-VL-8B"
-      ],
-      "relevancy_score": 26.3
-    },
-    {
-      "architecture_id": "LizzyForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3956,
-      "min_param_count": 7298011136,
-      "sample_models": [
-        "flwrlabs/Lizzy-7B"
-      ],
-      "relevancy_score": 26.3
-    },
-    {
-      "architecture_id": "DiffusionGemmaForBlockDiffusion",
-      "total_models": 6,
-      "total_downloads": 15675,
-      "min_param_count": 25823778864,
-      "sample_models": [
-        "aidendle94/diffusiongemma-26B-A4B-it-INT8-dynamic",
-        "edwixx/diffusiongemma-26B-A4B-it-HERETIC-Uncensored"
-      ],
-      "relevancy_score": 26.1
-    },
-    {
-      "architecture_id": "ExaoneMoEForCausalLM",
-      "total_models": 3,
-      "total_downloads": 157963,
-      "min_param_count": 237099669632,
-      "sample_models": [
-        "LGAI-EXAONE/K-EXAONE-236B-A23B"
-      ],
-      "relevancy_score": 26.1
-    },
-    {
-      "architecture_id": "Cohere2MoeForCausalLM",
-      "total_models": 7,
-      "total_downloads": 87977,
-      "min_param_count": 30484303872,
-      "sample_models": [
-        "CohereLabs/North-Mini-Code-1.0",
-        "CohereLabs/North-Mini-Code-1.0-w4a16",
-        "cyankiwi/North-Mini-Code-1.0-AWQ-INT4"
-      ],
-      "relevancy_score": 26.0
-    },
-    {
-      "architecture_id": "MiniCPM3ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 151062,
+      "architecture_id": "MoAMetricLM",
+      "total_models": 16,
+      "total_downloads": 30359,
       "min_param_count": null,
       "sample_models": [
-        "openbmb/MiniCPM3-4B"
+        "reaperdoesntknow/MoA-400M",
+        "reaperdoesntknow/MoA-150M",
+        "reaperdoesntknow/MoA-155M",
+        "reaperdoesntknow/MoA-100M"
       ],
-      "relevancy_score": 26.0
+      "relevancy_score": 26.4
     },
     {
-      "architecture_id": "CheXagentForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 3440,
-      "min_param_count": 8362401664,
-      "sample_models": [
-        "StanfordAIMI/CheXagent-8b"
-      ],
-      "relevancy_score": 26.0
-    },
-    {
-      "architecture_id": "AquilaForCausalLM",
-      "total_models": 6,
-      "total_downloads": 96975,
+      "architecture_id": "Neutrino",
+      "total_models": 4,
+      "total_downloads": 161901,
       "min_param_count": null,
       "sample_models": [
-        "BAAI/AquilaChat2-7B",
-        "BAAI/AquilaChat2-34B-16K",
-        "BAAI/AquilaChat2-70B-Expr"
+        "neuralcrew/neutrino-instruct"
+      ],
+      "relevancy_score": 26.4
+    },
+    {
+      "architecture_id": "Grok1ModelForCausalLM",
+      "total_models": 4,
+      "total_downloads": 162804,
+      "min_param_count": null,
+      "sample_models": [
+        "hpcai-tech/grok-1"
+      ],
+      "relevancy_score": 26.4
+    },
+    {
+      "architecture_id": "VRT_Qwen2VLForConditionalGeneration",
+      "total_models": 3,
+      "total_downloads": 4189,
+      "min_param_count": 8317087232,
+      "sample_models": [
+        "rp-yu/Qwen2-VL-7b-VPT-CLIP"
+      ],
+      "relevancy_score": 26.4
+    },
+    {
+      "architecture_id": "KimiK25ForConditionalGeneration",
+      "total_models": 19,
+      "total_downloads": 18969,
+      "min_param_count": 38802485184,
+      "sample_models": [
+        "JANGQ-AI/Kimi-K2.6-Small-JANGTQ",
+        "bearzi/Kimi-K2.7-Code-JANGTQ_K",
+        "freakyskittle/kimi-k2.75-code",
+        "JANGQ-AI/Kimi-K2.6-Med-JANGTQ",
+        "sombra-x/Kimi-K2.6-REAP-Solidity",
+        "Ex0bit/Kimi-K2.5-PRISM-REAP-530B-A32B"
+      ],
+      "relevancy_score": 26.3
+    },
+    {
+      "architecture_id": "PersimmonForCausalLM",
+      "total_models": 8,
+      "total_downloads": 89060,
+      "min_param_count": null,
+      "sample_models": [
+        "adept/persimmon-8b-chat",
+        "adept/persimmon-8b-base"
+      ],
+      "relevancy_score": 26.3
+    },
+    {
+      "architecture_id": "SarvamMLAForCausalLM",
+      "total_models": 4,
+      "total_downloads": 147076,
+      "min_param_count": 106031767424,
+      "sample_models": [
+        "sarvamai/sarvam-105b"
+      ],
+      "relevancy_score": 26.2
+    },
+    {
+      "architecture_id": "IQuestLoopCoderForCausalLM",
+      "total_models": 4,
+      "total_downloads": 129387,
+      "min_param_count": 39794696320,
+      "sample_models": [
+        "IQuestLab/IQuest-Coder-V1-40B-Loop-Instruct"
       ],
       "relevancy_score": 25.9
     },
     {
-      "architecture_id": "HunYuanMoEV1ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 146663,
-      "min_param_count": 80393183232,
+      "architecture_id": "AXK1ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 125199,
+      "min_param_count": 518983059456,
       "sample_models": [
-        "tencent/Hunyuan-A13B-Instruct"
+        "skt/A.X-K1"
+      ],
+      "relevancy_score": 25.9
+    },
+    {
+      "architecture_id": "ArcticForCausalLM",
+      "total_models": 4,
+      "total_downloads": 129341,
+      "min_param_count": 478584608768,
+      "sample_models": [
+        "Snowflake/snowflake-arctic-instruct"
       ],
       "relevancy_score": 25.9
     },
@@ -4180,35 +4367,99 @@
         "google/umt5-small",
         "google/umt5-xl"
       ],
+      "relevancy_score": 25.9
+    },
+    {
+      "architecture_id": "KugelAudioForConditionalGeneration",
+      "total_models": 3,
+      "total_downloads": 3188,
+      "min_param_count": 9343355361,
+      "sample_models": [
+        "Roland-JAAI/klonaudio"
+      ],
+      "relevancy_score": 25.9
+    },
+    {
+      "architecture_id": "AX4VLForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 2737,
+      "min_param_count": 7689660144,
+      "sample_models": [
+        "skt/A.X-4.0-VL-Light"
+      ],
       "relevancy_score": 25.8
     },
     {
-      "architecture_id": "ZambaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2980,
-      "min_param_count": 7232490496,
-      "sample_models": [
-        "Zyphra/Zamba-7B-v1"
-      ],
-      "relevancy_score": 25.7
-    },
-    {
-      "architecture_id": "Grok1ModelForCausalLM",
-      "total_models": 3,
-      "total_downloads": 123910,
+      "architecture_id": "CLIPT5ForConditionalGeneration",
+      "total_models": 8,
+      "total_downloads": 62316,
       "min_param_count": null,
       "sample_models": [
-        "hpcai-tech/grok-1"
+        "zhiqiulin/clip-flant5-xxl",
+        "zhiqiulin/clip-flant5-xl"
+      ],
+      "relevancy_score": 25.6
+    },
+    {
+      "architecture_id": "CambrianLlamaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2430,
+      "min_param_count": 8333022208,
+      "sample_models": [
+        "nyu-visionx/cambrian-8b"
+      ],
+      "relevancy_score": 25.6
+    },
+    {
+      "architecture_id": "IQuestPLTCoderForCausalLM",
+      "total_models": 3,
+      "total_downloads": 2881,
+      "min_param_count": 7615749680,
+      "sample_models": [
+        "Multilingual-Multimodal-NLP/LoopCoder-V2"
+      ],
+      "relevancy_score": 25.6
+    },
+    {
+      "architecture_id": "MiniMaxForCausalLM",
+      "total_models": 4,
+      "total_downloads": 106865,
+      "min_param_count": 456089655296,
+      "sample_models": [
+        "MiniMaxAI/MiniMax-Text-01-hf"
       ],
       "relevancy_score": 25.5
     },
     {
-      "architecture_id": "Neutrino",
-      "total_models": 3,
-      "total_downloads": 116318,
+      "architecture_id": "OvisU1",
+      "total_models": 1,
+      "total_downloads": 538,
+      "min_param_count": 3644208367,
+      "sample_models": [
+        "ATH-MaaS/Ovis-U1-3B"
+      ],
+      "relevancy_score": 25.5
+    },
+    {
+      "architecture_id": "LamedLlamaForCausalLM",
+      "total_models": 1,
+      "total_downloads": 523,
+      "min_param_count": 6983027792,
+      "sample_models": [
+        "GoodBaiBai88/M3D-LaMed-Llama-2-7B"
+      ],
+      "relevancy_score": 25.5
+    },
+    {
+      "architecture_id": "BlockFFNForCausalLM",
+      "total_models": 16,
+      "total_downloads": 19263,
       "min_param_count": null,
       "sample_models": [
-        "neuralcrew/neutrino-instruct"
+        "SparseLLM/DECO-0.5B",
+        "SparseLLM/DECO-0.1B",
+        "SparseLLM/DECO-0.2B",
+        "SparseLLM/DECO-1.2B"
       ],
       "relevancy_score": 25.4
     },
@@ -4223,26 +4474,6 @@
       "relevancy_score": 25.4
     },
     {
-      "architecture_id": "VRT_Qwen2VLForConditionalGeneration",
-      "total_models": 2,
-      "total_downloads": 2792,
-      "min_param_count": 8317087232,
-      "sample_models": [
-        "rp-yu/Qwen2-VL-7b-VPT-CLIP"
-      ],
-      "relevancy_score": 25.3
-    },
-    {
-      "architecture_id": "SarvamMLAForCausalLM",
-      "total_models": 3,
-      "total_downloads": 105347,
-      "min_param_count": 106031767424,
-      "sample_models": [
-        "sarvamai/sarvam-105b"
-      ],
-      "relevancy_score": 25.2
-    },
-    {
       "architecture_id": "PLBartForConditionalGeneration",
       "total_models": 2,
       "total_downloads": 122903,
@@ -4251,18 +4482,7 @@
         "uclanlp/plbart-base",
         "uclanlp/plbart-java-cs"
       ],
-      "relevancy_score": 25.2
-    },
-    {
-      "architecture_id": "PersimmonForCausalLM",
-      "total_models": 6,
-      "total_downloads": 66659,
-      "min_param_count": null,
-      "sample_models": [
-        "adept/persimmon-8b-chat",
-        "adept/persimmon-8b-base"
-      ],
-      "relevancy_score": 25.1
+      "relevancy_score": 25.3
     },
     {
       "architecture_id": "WeDLMForCausalLM",
@@ -4271,6 +4491,17 @@
       "min_param_count": 8190735360,
       "sample_models": [
         "tencent/WeDLM-8B-Instruct"
+      ],
+      "relevancy_score": 25.1
+    },
+    {
+      "architecture_id": "BlenderbotSmallForConditionalGeneration",
+      "total_models": 2,
+      "total_downloads": 112562,
+      "min_param_count": null,
+      "sample_models": [
+        "facebook/blenderbot_small-90M",
+        "facebook/blenderbot-90M"
       ],
       "relevancy_score": 25.1
     },
@@ -4295,124 +4526,56 @@
       "relevancy_score": 25.0
     },
     {
-      "architecture_id": "AXK1ForCausalLM",
+      "architecture_id": "InternVideo3ForConditionalGeneration",
       "total_models": 3,
-      "total_downloads": 94019,
-      "min_param_count": 518983059456,
+      "total_downloads": 1998,
+      "min_param_count": 9364294384,
       "sample_models": [
-        "skt/A.X-K1"
-      ],
-      "relevancy_score": 25.0
-    },
-    {
-      "architecture_id": "IQuestLoopCoderForCausalLM",
-      "total_models": 3,
-      "total_downloads": 96837,
-      "min_param_count": 39794696320,
-      "sample_models": [
-        "IQuestLab/IQuest-Coder-V1-40B-Loop-Instruct"
-      ],
-      "relevancy_score": 25.0
-    },
-    {
-      "architecture_id": "ArcticForCausalLM",
-      "total_models": 3,
-      "total_downloads": 96604,
-      "min_param_count": 478584608768,
-      "sample_models": [
-        "Snowflake/snowflake-arctic-instruct"
-      ],
-      "relevancy_score": 25.0
-    },
-    {
-      "architecture_id": "AX4VLForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 2174,
-      "min_param_count": 7689660144,
-      "sample_models": [
-        "skt/A.X-4.0-VL-Light"
-      ],
-      "relevancy_score": 25.0
-    },
-    {
-      "architecture_id": "BlenderbotSmallForConditionalGeneration",
-      "total_models": 2,
-      "total_downloads": 112562,
-      "min_param_count": null,
-      "sample_models": [
-        "facebook/blenderbot_small-90M",
-        "facebook/blenderbot-90M"
-      ],
-      "relevancy_score": 25.0
-    },
-    {
-      "architecture_id": "MoAMetricLM",
-      "total_models": 12,
-      "total_downloads": 25598,
-      "min_param_count": null,
-      "sample_models": [
-        "reaperdoesntknow/MoA-400M",
-        "reaperdoesntknow/MoA-150M",
-        "reaperdoesntknow/MoA-155M",
-        "reaperdoesntknow/MoA-100M"
+        "yanziang/InternVideo3-8B-Instruct"
       ],
       "relevancy_score": 24.9
     },
     {
-      "architecture_id": "CambrianLlamaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 1916,
-      "min_param_count": 8333022208,
-      "sample_models": [
-        "nyu-visionx/cambrian-8b"
-      ],
-      "relevancy_score": 24.8
-    },
-    {
-      "architecture_id": "CLIPT5ForConditionalGeneration",
-      "total_models": 6,
-      "total_downloads": 55162,
+      "architecture_id": "MossForCausalLM",
+      "total_models": 12,
+      "total_downloads": 23596,
       "min_param_count": null,
       "sample_models": [
-        "zhiqiulin/clip-flant5-xxl",
-        "zhiqiulin/clip-flant5-xl"
+        "OpenMOSS-Team/moss-moon-003-sft",
+        "OpenMOSS-Team/moss-moon-003-base",
+        "OpenMOSS-Team/moss-moon-003-sft-plugin"
       ],
       "relevancy_score": 24.7
     },
     {
-      "architecture_id": "MiniMaxForCausalLM",
+      "architecture_id": "Dots1ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 72708,
+      "min_param_count": 142774381696,
+      "sample_models": [
+        "rednote-hilab/dots.llm1.inst"
+      ],
+      "relevancy_score": 24.7
+    },
+    {
+      "architecture_id": "VARGPTQwen2VLForConditionalGeneration",
       "total_models": 3,
-      "total_downloads": 82647,
-      "min_param_count": 456089655296,
+      "total_downloads": 1880,
+      "min_param_count": 10948528387,
       "sample_models": [
-        "MiniMaxAI/MiniMax-Text-01-hf"
+        "VARGPT-family/VARGPT-v1.1"
       ],
       "relevancy_score": 24.7
     },
     {
-      "architecture_id": "KugelAudioForConditionalGeneration",
-      "total_models": 2,
-      "total_downloads": 2096,
-      "min_param_count": 9343355361,
+      "architecture_id": "MinistralForCausalLM",
+      "total_models": 3,
+      "total_downloads": 1875,
+      "min_param_count": 8237443260,
       "sample_models": [
-        "Roland-JAAI/klonaudio"
+        "nassimjp/Ministral-8B-Instruct-2410-4bit"
       ],
       "relevancy_score": 24.7
-    },
-    {
-      "architecture_id": "KimiK25ForConditionalGeneration",
-      "total_models": 15,
-      "total_downloads": 14482,
-      "min_param_count": 38802485184,
-      "sample_models": [
-        "JANGQ-AI/Kimi-K2.6-Small-JANGTQ",
-        "bearzi/Kimi-K2.7-Code-JANGTQ_K",
-        "freakyskittle/kimi-k2.75-code",
-        "JANGQ-AI/Kimi-K2.6-Med-JANGTQ",
-        "sombra-x/Kimi-K2.6-REAP-Solidity",
-        "Ex0bit/Kimi-K2.5-PRISM-REAP-530B-A32B"
-      ],
-      "relevancy_score": 24.5
     },
     {
       "architecture_id": "MagmaForCausalLM",
@@ -4425,6 +4588,16 @@
       "relevancy_score": 24.5
     },
     {
+      "architecture_id": "CogAgentForCausalLM",
+      "total_models": 4,
+      "total_downloads": 9499,
+      "min_param_count": 18291854528,
+      "sample_models": [
+        "zai-org/cogagent-vqa-hf"
+      ],
+      "relevancy_score": 24.4
+    },
+    {
       "architecture_id": "InternLM2ForRewardModel",
       "total_models": 1,
       "total_downloads": 94834,
@@ -4435,77 +4608,70 @@
       "relevancy_score": 24.4
     },
     {
-      "architecture_id": "IQuestPLTCoderForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1750,
-      "min_param_count": 7615749680,
+      "architecture_id": "HookedLlamaForCausalLM",
+      "total_models": 3,
+      "total_downloads": 1529,
+      "min_param_count": 8030261248,
       "sample_models": [
-        "Multilingual-Multimodal-NLP/LoopCoder-V2"
+        "FTK11558/Meta-Llama-3-8B-Instruct-DeepRefusal-Broken-APS"
       ],
       "relevancy_score": 24.3
     },
     {
-      "architecture_id": "MiniMaxM3SparseForConditionalGeneration",
+      "architecture_id": "Qwen2TSForCausalLM",
       "total_models": 6,
-      "total_downloads": 6040,
-      "min_param_count": 29658290213,
-      "sample_models": [
-        "JANGQ-AI/MiniMax-M3-REAP40-JANG_2L",
-        "JANGQ-AI/MiniMax-M3-Medium-JANG_2L",
-        "aquaman164/MiniMax-M3-AutoRound-3.2bit-longctx"
-      ],
-      "relevancy_score": 24.1
-    },
-    {
-      "architecture_id": "BlockFFNForCausalLM",
-      "total_models": 12,
-      "total_downloads": 16500,
+      "total_downloads": 38480,
       "min_param_count": null,
       "sample_models": [
-        "SparseLLM/DECO-0.5B",
-        "SparseLLM/DECO-0.1B",
-        "SparseLLM/DECO-0.2B",
-        "SparseLLM/DECO-1.2B"
+        "bytedance-research/ChatTS-14B",
+        "kaluaim/ChatTS-14B-handler"
       ],
-      "relevancy_score": 23.9
+      "relevancy_score": 24.0
     },
     {
-      "architecture_id": "Dots1ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 57077,
-      "min_param_count": 142774381696,
+      "architecture_id": "QovaryxForCausalLM",
+      "total_models": 12,
+      "total_downloads": 15365,
+      "min_param_count": null,
       "sample_models": [
-        "rednote-hilab/dots.llm1.inst"
+        "tjarvis91/qovaryx-1b-scratch-base",
+        "tjarvis91/qovaryx-50m-scratch-base",
+        "tjarvis91/qovaryx-350m-scratch-base"
       ],
-      "relevancy_score": 23.9
+      "relevancy_score": 23.8
     },
     {
-      "architecture_id": "CogAgentForCausalLM",
-      "total_models": 3,
-      "total_downloads": 7578,
-      "min_param_count": 18291854528,
+      "architecture_id": "CpmBeeForCausalLM",
+      "total_models": 15,
+      "total_downloads": 9615,
+      "min_param_count": null,
       "sample_models": [
-        "zai-org/cogagent-vqa-hf"
+        "openbmb/cpm-bee-10b",
+        "openbmb/cpm-bee-1b",
+        "openbmb/cpm-bee-5b",
+        "openbmb/cpm-bee-2b"
       ],
       "relevancy_score": 23.7
     },
     {
-      "architecture_id": "MinistralForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1246,
-      "min_param_count": 8237443260,
+      "architecture_id": "Qwen2_5_VLForConditionalGeneration",
+      "total_models": 12,
+      "total_downloads": 14087,
+      "min_param_count": null,
       "sample_models": [
-        "nassimjp/Ministral-8B-Instruct-2410-4bit"
+        "OmniSVG/OmniSVG1.1_8B",
+        "OmniSVG/OmniSVG",
+        "OmniSVG/OmniSVG1.1_4B"
       ],
       "relevancy_score": 23.6
     },
     {
-      "architecture_id": "VARGPTQwen2VLForConditionalGeneration",
-      "total_models": 2,
-      "total_downloads": 1252,
-      "min_param_count": 10948528387,
+      "architecture_id": "TransfoXLLMHeadModel",
+      "total_models": 4,
+      "total_downloads": 41546,
+      "min_param_count": null,
       "sample_models": [
-        "VARGPT-family/VARGPT-v1.1"
+        "transfo-xl/transfo-xl-wt103"
       ],
       "relevancy_score": 23.6
     },
@@ -4518,253 +4684,233 @@
         "openbmb/NOSA-8B",
         "openbmb/NOSA-1B"
       ],
-      "relevancy_score": 23.5
-    },
-    {
-      "architecture_id": "MossForCausalLM",
-      "total_models": 9,
-      "total_downloads": 19408,
-      "min_param_count": null,
-      "sample_models": [
-        "OpenMOSS-Team/moss-moon-003-sft",
-        "OpenMOSS-Team/moss-moon-003-base",
-        "OpenMOSS-Team/moss-moon-003-sft-plugin"
-      ],
-      "relevancy_score": 23.4
-    },
-    {
-      "architecture_id": "Qwen2TSForCausalLM",
-      "total_models": 4,
-      "total_downloads": 37377,
-      "min_param_count": null,
-      "sample_models": [
-        "bytedance-research/ChatTS-14B",
-        "kaluaim/ChatTS-14B-handler"
-      ],
-      "relevancy_score": 23.3
-    },
-    {
-      "architecture_id": "InternVideo3ForConditionalGeneration",
-      "total_models": 2,
-      "total_downloads": 1088,
-      "min_param_count": 9364294384,
-      "sample_models": [
-        "yanziang/InternVideo3-8B-Instruct"
-      ],
-      "relevancy_score": 23.3
-    },
-    {
-      "architecture_id": "HookedLlamaForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1016,
-      "min_param_count": 8030261248,
-      "sample_models": [
-        "FTK11558/Meta-Llama-3-8B-Instruct-DeepRefusal-Broken-APS"
-      ],
-      "relevancy_score": 23.1
-    },
-    {
-      "architecture_id": "TransfoXLLMHeadModel",
-      "total_models": 3,
-      "total_downloads": 33474,
-      "min_param_count": null,
-      "sample_models": [
-        "transfo-xl/transfo-xl-wt103"
-      ],
-      "relevancy_score": 22.8
-    },
-    {
-      "architecture_id": "QovaryxForCausalLM",
-      "total_models": 9,
-      "total_downloads": 12660,
-      "min_param_count": null,
-      "sample_models": [
-        "tjarvis91/qovaryx-1b-scratch-base",
-        "tjarvis91/qovaryx-50m-scratch-base",
-        "tjarvis91/qovaryx-350m-scratch-base"
-      ],
-      "relevancy_score": 22.5
-    },
-    {
-      "architecture_id": "CpmBeeForCausalLM",
-      "total_models": 12,
-      "total_downloads": 8037,
-      "min_param_count": null,
-      "sample_models": [
-        "openbmb/cpm-bee-10b",
-        "openbmb/cpm-bee-1b",
-        "openbmb/cpm-bee-5b",
-        "openbmb/cpm-bee-2b"
-      ],
-      "relevancy_score": 22.4
-    },
-    {
-      "architecture_id": "GPTRefactForCausalLM",
-      "total_models": 4,
-      "total_downloads": 24366,
-      "min_param_count": null,
-      "sample_models": [
-        "refactai/Refact-1_6B-fim",
-        "refactai/Refact-1_6-base"
-      ],
-      "relevancy_score": 22.4
-    },
-    {
-      "architecture_id": "SentinelBrainForCausalLM",
-      "total_models": 3,
-      "total_downloads": 4068,
-      "min_param_count": 14814654656,
-      "sample_models": [
-        "lablab-ai-amd-developer-hackathon/SentinelBrain-14B-MoE-v0.1"
-      ],
-      "relevancy_score": 22.4
+      "relevancy_score": 23.6
     },
     {
       "architecture_id": "LISAForCausalLM",
-      "total_models": 9,
-      "total_downloads": 11365,
+      "total_models": 11,
+      "total_downloads": 14353,
       "min_param_count": null,
       "sample_models": [
         "xinlai/LISA-7B-v1",
         "xinlai/LISA-13B-llama2-v1",
         "MBZUAI/GLaMM-GranD-Pretrained"
       ],
-      "relevancy_score": 22.3
-    },
-    {
-      "architecture_id": "Qwen2_5_VLForConditionalGeneration",
-      "total_models": 9,
-      "total_downloads": 10897,
-      "min_param_count": null,
-      "sample_models": [
-        "OmniSVG/OmniSVG1.1_8B",
-        "OmniSVG/OmniSVG",
-        "OmniSVG/OmniSVG1.1_4B"
-      ],
-      "relevancy_score": 22.2
-    },
-    {
-      "architecture_id": "Florence2ForConditionalGeneration",
-      "total_models": 8,
-      "total_downloads": 12586,
-      "min_param_count": null,
-      "sample_models": [
-        "onnx-community/Florence-2-base-ft",
-        "onnx-community/Florence-2-large-ft"
-      ],
-      "relevancy_score": 22.2
+      "relevancy_score": 23.4
     },
     {
       "architecture_id": "QuasarLongForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3844,
+      "total_models": 4,
+      "total_downloads": 5749,
       "min_param_count": 16553954240,
       "sample_models": [
         "silx-ai/Quasar-Preview"
       ],
-      "relevancy_score": 22.2
+      "relevancy_score": 23.4
     },
     {
-      "architecture_id": "InternLMXComposer2ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 24081,
+      "architecture_id": "GPTRefactForCausalLM",
+      "total_models": 5,
+      "total_downloads": 32335,
       "min_param_count": null,
       "sample_models": [
-        "internlm/internlm-xcomposer2-7b"
+        "refactai/Refact-1_6B-fim",
+        "refactai/Refact-1_6-base"
       ],
-      "relevancy_score": 22.1
-    },
-    {
-      "architecture_id": "InternLMXComposerForCausalLM",
-      "total_models": 3,
-      "total_downloads": 23774,
-      "min_param_count": null,
-      "sample_models": [
-        "internlm/internlm-xcomposer-7b"
-      ],
-      "relevancy_score": 22.1
-    },
-    {
-      "architecture_id": "GravityMoEForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3430,
-      "min_param_count": 16242181824,
-      "sample_models": [
-        "trillionlabs/Gravity-16B-A3B-Base"
-      ],
-      "relevancy_score": 22.0
+      "relevancy_score": 23.3
     },
     {
       "architecture_id": "StripedHyenaModelForCausalLM",
-      "total_models": 6,
-      "total_downloads": 14327,
+      "total_models": 8,
+      "total_downloads": 18895,
       "min_param_count": null,
       "sample_models": [
         "togethercomputer/evo-1-8k-base",
         "togethercomputer/evo-1-131k-base"
       ],
-      "relevancy_score": 21.9
+      "relevancy_score": 23.1
     },
     {
       "architecture_id": "MobileLlamaForCausalLM",
-      "total_models": 6,
-      "total_downloads": 14642,
+      "total_models": 8,
+      "total_downloads": 19177,
       "min_param_count": null,
       "sample_models": [
         "mtgv/MobileVLM_V2-1.7B",
-        "mtgv/MobileVLM_V2-3B"
+        "mtgv/MobileVLM_V2-3B",
+        "mtgv/MobileVLM_V2-7B"
       ],
-      "relevancy_score": 21.9
+      "relevancy_score": 23.1
     },
     {
       "architecture_id": "Share4VLlamaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 21820,
+      "total_models": 4,
+      "total_downloads": 31252,
       "min_param_count": null,
       "sample_models": [
         "Lin-Chen/ShareGPT4V-7B"
       ],
-      "relevancy_score": 21.9
+      "relevancy_score": 23.0
+    },
+    {
+      "architecture_id": "SentinelBrainForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4725,
+      "min_param_count": 14814654656,
+      "sample_models": [
+        "lablab-ai-amd-developer-hackathon/SentinelBrain-14B-MoE-v0.1"
+      ],
+      "relevancy_score": 23.0
+    },
+    {
+      "architecture_id": "InternLMXComposerForCausalLM",
+      "total_models": 4,
+      "total_downloads": 31328,
+      "min_param_count": null,
+      "sample_models": [
+        "internlm/internlm-xcomposer-7b"
+      ],
+      "relevancy_score": 23.0
+    },
+    {
+      "architecture_id": "InternLMXComposer2ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 31724,
+      "min_param_count": null,
+      "sample_models": [
+        "internlm/internlm-xcomposer2-7b"
+      ],
+      "relevancy_score": 23.0
     },
     {
       "architecture_id": "MiniMindOmni",
-      "total_models": 6,
-      "total_downloads": 13618,
+      "total_models": 8,
+      "total_downloads": 16807,
       "min_param_count": null,
       "sample_models": [
         "jingyaogong/minimind-3o-moe",
         "jingyaogong/minimind-3o"
       ],
-      "relevancy_score": 21.8
+      "relevancy_score": 22.8
+    },
+    {
+      "architecture_id": "GravityMoEForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4324,
+      "min_param_count": 16242181824,
+      "sample_models": [
+        "trillionlabs/Gravity-16B-A3B-Base"
+      ],
+      "relevancy_score": 22.8
+    },
+    {
+      "architecture_id": "AILOForCausalLM",
+      "total_models": 12,
+      "total_downloads": 9147,
+      "min_param_count": null,
+      "sample_models": [
+        "xxrickyxx/Ailo152m-v2",
+        "xxrickyxx/Ailo152m-events-en",
+        "xxrickyxx/Ailo152m-v2-ita"
+      ],
+      "relevancy_score": 22.7
     },
     {
       "architecture_id": "LiquidForCausalLM",
-      "total_models": 6,
-      "total_downloads": 13394,
+      "total_models": 8,
+      "total_downloads": 15778,
       "min_param_count": null,
       "sample_models": [
         "reaperdoesntknow/DNA-175M",
         "reaperdoesntknow/DNA-50M"
       ],
-      "relevancy_score": 21.7
+      "relevancy_score": 22.7
+    },
+    {
+      "architecture_id": "ModernBertDecoderForCausalLM",
+      "total_models": 4,
+      "total_downloads": 26856,
+      "min_param_count": null,
+      "sample_models": [
+        "jhu-clsp/ettin-decoder-400m"
+      ],
+      "relevancy_score": 22.6
     },
     {
       "architecture_id": "CTRLLMHeadModel",
-      "total_models": 3,
-      "total_downloads": 20376,
+      "total_models": 4,
+      "total_downloads": 25901,
       "min_param_count": null,
       "sample_models": [
         "sshleifer/tiny-ctrl"
       ],
-      "relevancy_score": 21.7
+      "relevancy_score": 22.6
     },
     {
-      "architecture_id": "ModernBertDecoderForCausalLM",
-      "total_models": 3,
-      "total_downloads": 19997,
+      "architecture_id": "GPT2LMHeadCustomModel",
+      "total_models": 4,
+      "total_downloads": 20128,
       "min_param_count": null,
       "sample_models": [
-        "jhu-clsp/ettin-decoder-400m"
+        "bigcode/santacoder"
+      ],
+      "relevancy_score": 22.0
+    },
+    {
+      "architecture_id": "SolarOpenForCausalLM",
+      "total_models": 4,
+      "total_downloads": 19610,
+      "min_param_count": 102651793408,
+      "sample_models": [
+        "upstage/Solar-Open-100B"
+      ],
+      "relevancy_score": 22.0
+    },
+    {
+      "architecture_id": "XverseForCausalLM",
+      "total_models": 10,
+      "total_downloads": 8396,
+      "min_param_count": null,
+      "sample_models": [
+        "xverse/XVERSE-7B-Chat",
+        "xverse/XVERSE-13B",
+        "xverse/XVERSE-7B",
+        "xverse/XVERSE-13B-Chat",
+        "xverse/XVERSE-65B-Chat",
+        "xverse/XVERSE-65B",
+        "xverse/XVERSE-MoE-A4.2B"
+      ],
+      "relevancy_score": 21.9
+    },
+    {
+      "architecture_id": "VulavulaLlamaForCausalLM",
+      "total_models": 8,
+      "total_downloads": 10786,
+      "min_param_count": null,
+      "sample_models": [
+        "Papizo/caracal-swahili-math-rigid",
+        "theophilusowiti/Caracal_instruct"
+      ],
+      "relevancy_score": 21.9
+    },
+    {
+      "architecture_id": "LongcatCausalLM",
+      "total_models": 4,
+      "total_downloads": 18664,
+      "min_param_count": 561862880256,
+      "sample_models": [
+        "meituan-longcat/LongCat-Flash-Thinking-2601"
+      ],
+      "relevancy_score": 21.9
+    },
+    {
+      "architecture_id": "GPT2Model",
+      "total_models": 8,
+      "total_downloads": 9832,
+      "min_param_count": null,
+      "sample_models": [
+        "keshan/sinhala-gpt2",
+        "cerebras/Cerebras-GPT-13B"
       ],
       "relevancy_score": 21.7
     },
@@ -4779,73 +4925,56 @@
       "relevancy_score": 21.6
     },
     {
-      "architecture_id": "XverseForCausalLM",
-      "total_models": 9,
-      "total_downloads": 7392,
-      "min_param_count": null,
+      "architecture_id": "Olmo2RetrofitForCausalLM",
+      "total_models": 1,
+      "total_downloads": 516,
+      "min_param_count": 7298011136,
       "sample_models": [
-        "xverse/XVERSE-7B-Chat",
-        "xverse/XVERSE-13B",
-        "xverse/XVERSE-7B",
-        "xverse/XVERSE-13B-Chat",
-        "xverse/XVERSE-65B-Chat",
-        "xverse/XVERSE-65B",
-        "xverse/XVERSE-MoE-A4.2B"
+        "allenai/Olmo-3-7B-RL-Zero-Mix"
       ],
       "relevancy_score": 21.4
     },
     {
-      "architecture_id": "AILOForCausalLM",
-      "total_models": 9,
-      "total_downloads": 6734,
+      "architecture_id": "RobertaForCausalLM",
+      "total_models": 8,
+      "total_downloads": 7103,
       "min_param_count": null,
       "sample_models": [
-        "xxrickyxx/Ailo152m-v2",
-        "xxrickyxx/Ailo152m-events-en",
-        "xxrickyxx/Ailo152m-v2-ita"
-      ],
-      "relevancy_score": 21.2
-    },
-    {
-      "architecture_id": "LongcatCausalLM",
-      "total_models": 3,
-      "total_downloads": 15706,
-      "min_param_count": 561862880256,
-      "sample_models": [
-        "meituan-longcat/LongCat-Flash-Thinking-2601"
-      ],
-      "relevancy_score": 21.2
-    },
-    {
-      "architecture_id": "SolarOpenForCausalLM",
-      "total_models": 3,
-      "total_downloads": 14835,
-      "min_param_count": 102651793408,
-      "sample_models": [
-        "upstage/Solar-Open-100B"
-      ],
-      "relevancy_score": 21.1
-    },
-    {
-      "architecture_id": "GPT2LMHeadCustomModel",
-      "total_models": 3,
-      "total_downloads": 14230,
-      "min_param_count": null,
-      "sample_models": [
-        "bigcode/santacoder"
+        "uf-aice-lab/math-roberta",
+        "gokceuludogan/ChemBERTaLM"
       ],
       "relevancy_score": 21.0
     },
     {
-      "architecture_id": "VulavulaLlamaForCausalLM",
-      "total_models": 6,
-      "total_downloads": 8827,
+      "architecture_id": "TranceptionLMHeadModel",
+      "total_models": 8,
+      "total_downloads": 6753,
       "min_param_count": null,
       "sample_models": [
-        "Papizo/caracal-swahili-math-rigid",
-        "theophilusowiti/Caracal_instruct"
+        "PascalNotin/Tranception_Large",
+        "PascalNotin/Tranception_Small"
       ],
       "relevancy_score": 20.9
+    },
+    {
+      "architecture_id": "Qwen35ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 10762,
+      "min_param_count": null,
+      "sample_models": [
+        "JeffGreen311/Eve-V2-Unleashed-Qwen3.5-8B-Liberated-4K-4B-Merged"
+      ],
+      "relevancy_score": 20.7
+    },
+    {
+      "architecture_id": "MiniMaxText01ForCausalLM",
+      "total_models": 4,
+      "total_downloads": 10676,
+      "min_param_count": 456089655296,
+      "sample_models": [
+        "MiniMaxAI/MiniMax-Text-01"
+      ],
+      "relevancy_score": 20.7
     },
     {
       "architecture_id": "Int8OPTForCausalLM",
@@ -4860,66 +4989,104 @@
       "relevancy_score": 20.6
     },
     {
-      "architecture_id": "GPT2Model",
-      "total_models": 6,
-      "total_downloads": 7698,
-      "min_param_count": null,
-      "sample_models": [
-        "keshan/sinhala-gpt2",
-        "cerebras/Cerebras-GPT-13B"
-      ],
-      "relevancy_score": 20.6
-    },
-    {
-      "architecture_id": "RobertaForCausalLM",
-      "total_models": 6,
-      "total_downloads": 5729,
-      "min_param_count": null,
-      "sample_models": [
-        "uf-aice-lab/math-roberta",
-        "gokceuludogan/ChemBERTaLM"
-      ],
-      "relevancy_score": 20.0
-    },
-    {
       "architecture_id": "DenseLLM",
-      "total_models": 4,
-      "total_downloads": 7575,
+      "total_models": 5,
+      "total_downloads": 8991,
       "min_param_count": null,
       "sample_models": [
         "AlgoDriveAI/Akkadian_English_DenseLLM_1B",
         "AlgoDriveAI/Sanskrit_Akkadian_LLM_v1.0"
       ],
+      "relevancy_score": 20.6
+    },
+    {
+      "architecture_id": "GuppyLM",
+      "total_models": 8,
+      "total_downloads": 5620,
+      "min_param_count": null,
+      "sample_models": [
+        "arman-bd/guppylm-9M",
+        "tamsuiboy/guppylm-9M"
+      ],
+      "relevancy_score": 20.5
+    },
+    {
+      "architecture_id": "BailingMoeLinearV2ForCausalLM",
+      "total_models": 3,
+      "total_downloads": 1701,
+      "min_param_count": 16423448320,
+      "sample_models": [
+        "inclusionAI/Ring-mini-linear-2.0"
+      ],
+      "relevancy_score": 20.5
+    },
+    {
+      "architecture_id": "ModelStarOLMhead",
+      "total_models": 4,
+      "total_downloads": 8035,
+      "min_param_count": null,
+      "sample_models": [
+        "C-a-Star-Technology-Official/StarO-AI-2.69-Super"
+      ],
+      "relevancy_score": 20.1
+    },
+    {
+      "architecture_id": "TAMELM",
+      "total_models": 4,
+      "total_downloads": 7524,
+      "min_param_count": null,
+      "sample_models": [
+        "reaperdoesntknow/TameForCasualLM"
+      ],
       "relevancy_score": 20.0
     },
     {
-      "architecture_id": "TranceptionLMHeadModel",
-      "total_models": 6,
-      "total_downloads": 5328,
+      "architecture_id": "MosaicGPT",
+      "total_models": 4,
+      "total_downloads": 7506,
       "min_param_count": null,
       "sample_models": [
-        "PascalNotin/Tranception_Large",
-        "PascalNotin/Tranception_Small"
+        "anas-awadalla/mpt-1b-redpajama-200b"
+      ],
+      "relevancy_score": 20.0
+    },
+    {
+      "architecture_id": "MptForCausalLM",
+      "total_models": 4,
+      "total_downloads": 7296,
+      "min_param_count": null,
+      "sample_models": [
+        "explosion-testing/mpt-test"
+      ],
+      "relevancy_score": 19.9
+    },
+    {
+      "architecture_id": "GptOssPuzzleForCausalLM",
+      "total_models": 4,
+      "total_downloads": 6851,
+      "min_param_count": 90837823680,
+      "sample_models": [
+        "nvidia/gpt-oss-puzzle-88B"
       ],
       "relevancy_score": 19.8
     },
     {
-      "architecture_id": "Qwen35ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 7640,
-      "min_param_count": null,
+      "architecture_id": "LongcatFlashNgramForCausalLM",
+      "total_models": 4,
+      "total_downloads": 6743,
+      "min_param_count": 69073335552,
       "sample_models": [
-        "JeffGreen311/Eve-V2-Unleashed-Qwen3.5-8B-Liberated-4K-4B-Merged"
+        "meituan-longcat/LongCat-Flash-Lite"
       ],
       "relevancy_score": 19.7
     },
     {
-      "architecture_id": "MiniMaxText01ForCausalLM",
-      "total_models": 3,
-      "total_downloads": 7676,
-      "min_param_count": 456089655296,
+      "architecture_id": "CustomModel",
+      "total_models": 4,
+      "total_downloads": 6683,
+      "min_param_count": null,
       "sample_models": [
-        "MiniMaxAI/MiniMax-Text-01"
+        "DZER-Studios/Create_Vexion-LM"
       ],
       "relevancy_score": 19.7
     },
@@ -4935,6 +5102,16 @@
       "relevancy_score": 19.7
     },
     {
+      "architecture_id": "XMistralForCausalLM",
+      "total_models": 4,
+      "total_downloads": 6362,
+      "min_param_count": null,
+      "sample_models": [
+        "Hannibal046/xrag-7b"
+      ],
+      "relevancy_score": 19.6
+    },
+    {
       "architecture_id": "modeling_camelidae.LlamaForCausalLM",
       "total_models": 7,
       "total_downloads": 3781,
@@ -4947,53 +5124,22 @@
       "relevancy_score": 19.4
     },
     {
-      "architecture_id": "GuppyLM",
-      "total_models": 6,
-      "total_downloads": 4503,
+      "architecture_id": "URMForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4910,
       "min_param_count": null,
       "sample_models": [
-        "arman-bd/guppylm-9M",
-        "tamsuiboy/guppylm-9M"
+        "hudsongouge/rrt-40m-wiki-v1"
       ],
-      "relevancy_score": 19.4
+      "relevancy_score": 19.1
     },
     {
-      "architecture_id": "ModelStarOLMhead",
-      "total_models": 3,
-      "total_downloads": 6584,
+      "architecture_id": "FiPhi-NeuralMark-V3",
+      "total_models": 4,
+      "total_downloads": 5015,
       "min_param_count": null,
       "sample_models": [
-        "C-a-Star-Technology-Official/StarO-AI-2.69-Super"
-      ],
-      "relevancy_score": 19.4
-    },
-    {
-      "architecture_id": "BailingMoeLinearV2ForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1128,
-      "min_param_count": 16423448320,
-      "sample_models": [
-        "inclusionAI/Ring-mini-linear-2.0"
-      ],
-      "relevancy_score": 19.4
-    },
-    {
-      "architecture_id": "TAMELM",
-      "total_models": 3,
-      "total_downloads": 6345,
-      "min_param_count": null,
-      "sample_models": [
-        "reaperdoesntknow/TameForCasualLM"
-      ],
-      "relevancy_score": 19.3
-    },
-    {
-      "architecture_id": "GptOssPuzzleForCausalLM",
-      "total_models": 3,
-      "total_downloads": 5918,
-      "min_param_count": 90837823680,
-      "sample_models": [
-        "nvidia/gpt-oss-puzzle-88B"
+        "AccTB/FiPhi-NeuralMark-V3"
       ],
       "relevancy_score": 19.1
     },
@@ -5009,64 +5155,154 @@
       "relevancy_score": 19.0
     },
     {
-      "architecture_id": "MosaicGPT",
-      "total_models": 3,
-      "total_downloads": 5483,
+      "architecture_id": "BTLMLMHeadModel",
+      "total_models": 4,
+      "total_downloads": 4768,
       "min_param_count": null,
       "sample_models": [
-        "anas-awadalla/mpt-1b-redpajama-200b"
+        "cerebras/btlm-3b-8k-base"
       ],
       "relevancy_score": 19.0
     },
     {
-      "architecture_id": "CustomModel",
-      "total_models": 3,
-      "total_downloads": 5512,
+      "architecture_id": "NebulaXModel",
+      "total_models": 4,
+      "total_downloads": 4864,
       "min_param_count": null,
       "sample_models": [
-        "DZER-Studios/Create_Vexion-LM"
+        "Agnuxo/NEBULA-X-DEMO"
       ],
       "relevancy_score": 19.0
     },
     {
-      "architecture_id": "MptForCausalLM",
-      "total_models": 3,
-      "total_downloads": 5334,
+      "architecture_id": "QHEARTForECGQA",
+      "total_models": 4,
+      "total_downloads": 4752,
       "min_param_count": null,
       "sample_models": [
-        "explosion-testing/mpt-test"
+        "Manhph2211/Q-HEART"
+      ],
+      "relevancy_score": 19.0
+    },
+    {
+      "architecture_id": "Qwen2ForSequenceClassification",
+      "total_models": 4,
+      "total_downloads": 4606,
+      "min_param_count": 71457234944,
+      "sample_models": [
+        "nvidia/Qwen2.5-CascadeRL-RM-72B"
       ],
       "relevancy_score": 18.9
     },
     {
-      "architecture_id": "LongcatFlashNgramForCausalLM",
-      "total_models": 3,
-      "total_downloads": 5152,
-      "min_param_count": 69073335552,
+      "architecture_id": "YuanForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4479,
+      "min_param_count": null,
       "sample_models": [
-        "meituan-longcat/LongCat-Flash-Lite"
+        "IEITYuan/Yuan2-M32-hf"
       ],
       "relevancy_score": 18.9
     },
     {
-      "architecture_id": "XMistralForCausalLM",
-      "total_models": 3,
-      "total_downloads": 4790,
+      "architecture_id": "LongcatNextForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4591,
+      "min_param_count": 74257230752,
+      "sample_models": [
+        "meituan-longcat/LongCat-Next"
+      ],
+      "relevancy_score": 18.9
+    },
+    {
+      "architecture_id": "Speech2TextTransformerForConditionalGeneration",
+      "total_models": 4,
+      "total_downloads": 4489,
       "min_param_count": null,
       "sample_models": [
-        "Hannibal046/xrag-7b"
+        "valhalla/s2t_mustc_multilinguial_medium"
+      ],
+      "relevancy_score": 18.9
+    },
+    {
+      "architecture_id": "SimambaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4552,
+      "min_param_count": null,
+      "sample_models": [
+        "soumil1/simamba-midpoint-10m-slimpajama-500m"
+      ],
+      "relevancy_score": 18.9
+    },
+    {
+      "architecture_id": "GPT2CustomLMHeadModel",
+      "total_models": 4,
+      "total_downloads": 4613,
+      "min_param_count": null,
+      "sample_models": [
+        "fxmarty/tiny-testing-gpt2-remote-code"
+      ],
+      "relevancy_score": 18.9
+    },
+    {
+      "architecture_id": "CinnabarLMForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4550,
+      "min_param_count": null,
+      "sample_models": [
+        "MihaiPopa-1/CinnabarLM-4M-Base-Preview"
+      ],
+      "relevancy_score": 18.9
+    },
+    {
+      "architecture_id": "TFGPT2LMHeadModel",
+      "total_models": 4,
+      "total_downloads": 4305,
+      "min_param_count": null,
+      "sample_models": [
+        "mymusise/gpt2-medium-chinese"
+      ],
+      "relevancy_score": 18.8
+    },
+    {
+      "architecture_id": "CPMAntForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4345,
+      "min_param_count": null,
+      "sample_models": [
+        "openbmb/cpm-ant-10b"
+      ],
+      "relevancy_score": 18.8
+    },
+    {
+      "architecture_id": "RoFormerForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4260,
+      "min_param_count": null,
+      "sample_models": [
+        "junnyu/roformer_chinese_sim_char_base"
+      ],
+      "relevancy_score": 18.8
+    },
+    {
+      "architecture_id": "CodeShell4bitForCausalLM",
+      "total_models": 4,
+      "total_downloads": 4065,
+      "min_param_count": null,
+      "sample_models": [
+        "WisdomShell/CodeShell-7B-Chat-int4"
       ],
       "relevancy_score": 18.7
     },
     {
-      "architecture_id": "FiPhi-NeuralMark-V3",
+      "architecture_id": "VStreamLlamaForCausalLM",
       "total_models": 3,
-      "total_downloads": 4331,
+      "total_downloads": 4487,
       "min_param_count": null,
       "sample_models": [
-        "AccTB/FiPhi-NeuralMark-V3"
+        "IVGSZ/Flash-VStream-7b"
       ],
-      "relevancy_score": 18.5
+      "relevancy_score": 18.6
     },
     {
       "architecture_id": "YiForCausalLM",
@@ -5078,75 +5314,76 @@
         "OrionStarAI/OrionStar-Yi-34B-Chat",
         "FreedomIntelligence/HuatuoGPT2-34B"
       ],
+      "relevancy_score": 18.5
+    },
+    {
+      "architecture_id": "ChatUniViLlamaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3843,
+      "min_param_count": null,
+      "sample_models": [
+        "Chat-UniVi/Chat-UniVi-7B-v1.5"
+      ],
+      "relevancy_score": 18.5
+    },
+    {
+      "architecture_id": "A194LogitEnsembleForCausalLM",
+      "total_models": 3,
+      "total_downloads": 4359,
+      "min_param_count": null,
+      "sample_models": [
+        "LikC1606/chinesebabylm-a195-hanzi-best-20260611"
+      ],
+      "relevancy_score": 18.5
+    },
+    {
+      "architecture_id": "MegatronForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3509,
+      "min_param_count": null,
+      "sample_models": [
+        "hyunwoongko/megatron-11B"
+      ],
       "relevancy_score": 18.4
     },
     {
-      "architecture_id": "URMForCausalLM",
+      "architecture_id": "Qwen3OmniMoeForConditionalGeneration",
       "total_models": 3,
-      "total_downloads": 4236,
-      "min_param_count": null,
+      "total_downloads": 4136,
+      "min_param_count": 35273974321,
       "sample_models": [
-        "hudsongouge/rrt-40m-wiki-v1"
+        "88plug/Qwen3-Omni-30B-W4A16"
       ],
       "relevancy_score": 18.4
     },
     {
-      "architecture_id": "NebulaXModel",
-      "total_models": 3,
-      "total_downloads": 4196,
+      "architecture_id": "BottleneckT5LMWithPerturb",
+      "total_models": 5,
+      "total_downloads": 2955,
       "min_param_count": null,
       "sample_models": [
-        "Agnuxo/NEBULA-X-DEMO"
-      ],
-      "relevancy_score": 18.4
-    },
-    {
-      "architecture_id": "QHEARTForECGQA",
-      "total_models": 3,
-      "total_downloads": 4022,
-      "min_param_count": null,
-      "sample_models": [
-        "Manhph2211/Q-HEART"
+        "thesephist/contra-bottleneck-t5-large-wikipedia",
+        "thesephist/contra-bottleneck-t5-xl-wikipedia"
       ],
       "relevancy_score": 18.3
     },
     {
-      "architecture_id": "LongcatNextForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3963,
-      "min_param_count": 74257230752,
-      "sample_models": [
-        "meituan-longcat/LongCat-Next"
-      ],
-      "relevancy_score": 18.3
-    },
-    {
-      "architecture_id": "Qwen2ForSequenceClassification",
-      "total_models": 3,
-      "total_downloads": 3943,
-      "min_param_count": 71457234944,
-      "sample_models": [
-        "nvidia/Qwen2.5-CascadeRL-RM-72B"
-      ],
-      "relevancy_score": 18.3
-    },
-    {
-      "architecture_id": "CinnabarLMForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3892,
+      "architecture_id": "BartForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3385,
       "min_param_count": null,
       "sample_models": [
-        "MihaiPopa-1/CinnabarLM-4M-Base-Preview"
+        "sanchit-gandhi/tiny-random-bart-fp16"
       ],
       "relevancy_score": 18.3
     },
     {
-      "architecture_id": "SimambaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3894,
+      "architecture_id": "ElectraForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3369,
       "min_param_count": null,
       "sample_models": [
-        "soumil1/simamba-midpoint-10m-slimpajama-500m"
+        "smeoni/nbme-electra-large-generator"
       ],
       "relevancy_score": 18.3
     },
@@ -5161,74 +5398,74 @@
       "relevancy_score": 18.3
     },
     {
-      "architecture_id": "GPT2CustomLMHeadModel",
-      "total_models": 3,
-      "total_downloads": 3811,
+      "architecture_id": "HNetForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3267,
       "min_param_count": null,
       "sample_models": [
-        "fxmarty/tiny-testing-gpt2-remote-code"
+        "emarro/fineweb_hnet_78M_learned_N"
       ],
       "relevancy_score": 18.2
     },
     {
-      "architecture_id": "BTLMLMHeadModel",
-      "total_models": 3,
-      "total_downloads": 3727,
+      "architecture_id": "GeoChatLlamaForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3301,
       "min_param_count": null,
       "sample_models": [
-        "cerebras/btlm-3b-8k-base"
+        "MBZUAI/geochat-7B"
       ],
       "relevancy_score": 18.2
     },
     {
-      "architecture_id": "YuanForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3827,
+      "architecture_id": "OpenMoeForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3250,
       "min_param_count": null,
       "sample_models": [
-        "IEITYuan/Yuan2-M32-hf"
+        "OrionZheng/openmoe-base"
       ],
       "relevancy_score": 18.2
     },
     {
-      "architecture_id": "CPMAntForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3534,
+      "architecture_id": "ErnieForCausalLM",
+      "total_models": 4,
+      "total_downloads": 3173,
       "min_param_count": null,
       "sample_models": [
-        "openbmb/cpm-ant-10b"
+        "mohitsha/tiny-ernie-random-remote-code"
       ],
       "relevancy_score": 18.1
     },
     {
-      "architecture_id": "TFGPT2LMHeadModel",
-      "total_models": 3,
-      "total_downloads": 3487,
+      "architecture_id": "NGen4OW10TForCausalLM",
+      "total_models": 4,
+      "total_downloads": 2940,
       "min_param_count": null,
       "sample_models": [
-        "mymusise/gpt2-medium-chinese"
+        "TNSA/NGen-4OW-10T-Expiremental"
       ],
       "relevancy_score": 18.0
     },
     {
-      "architecture_id": "Speech2TextTransformerForConditionalGeneration",
-      "total_models": 3,
-      "total_downloads": 3509,
+      "architecture_id": "SLMModel",
+      "total_models": 4,
+      "total_downloads": 2779,
       "min_param_count": null,
       "sample_models": [
-        "valhalla/s2t_mustc_multilinguial_medium"
+        "kiruthiga-99/slm-tinystories"
       ],
-      "relevancy_score": 18.0
+      "relevancy_score": 17.9
     },
     {
-      "architecture_id": "RoFormerForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3446,
+      "architecture_id": "FinanceDecoder",
+      "total_models": 4,
+      "total_downloads": 2872,
       "min_param_count": null,
       "sample_models": [
-        "junnyu/roformer_chinese_sim_char_base"
+        "tjarvis91/Q-Coder-50M-Sovereign"
       ],
-      "relevancy_score": 18.0
+      "relevancy_score": 17.9
     },
     {
       "architecture_id": "NorT5ForConditionalGeneration",
@@ -5243,14 +5480,24 @@
       "relevancy_score": 17.9
     },
     {
-      "architecture_id": "CodeShell4bitForCausalLM",
-      "total_models": 3,
-      "total_downloads": 3066,
+      "architecture_id": "Olmo2ForSequenceClassification",
+      "total_models": 4,
+      "total_downloads": 2750,
       "min_param_count": null,
       "sample_models": [
-        "WisdomShell/CodeShell-7B-Chat-int4"
+        "LifeWiki-ai/OLMo-2-1124-7B-RM"
       ],
       "relevancy_score": 17.8
+    },
+    {
+      "architecture_id": "darkit-3-1m",
+      "total_models": 3,
+      "total_downloads": 2897,
+      "min_param_count": null,
+      "sample_models": [
+        "darkai-1/darkit-v3-1M"
+      ],
+      "relevancy_score": 17.7
     },
     {
       "architecture_id": "BlueLMForCausalLM",
@@ -5264,67 +5511,6 @@
       "relevancy_score": 17.6
     },
     {
-      "architecture_id": "BottleneckT5LMWithPerturb",
-      "total_models": 4,
-      "total_downloads": 2454,
-      "min_param_count": null,
-      "sample_models": [
-        "thesephist/contra-bottleneck-t5-large-wikipedia",
-        "thesephist/contra-bottleneck-t5-xl-wikipedia"
-      ],
-      "relevancy_score": 17.6
-    },
-    {
-      "architecture_id": "darkit-3-1m",
-      "total_models": 3,
-      "total_downloads": 2897,
-      "min_param_count": null,
-      "sample_models": [
-        "darkai-1/darkit-v3-1M"
-      ],
-      "relevancy_score": 17.6
-    },
-    {
-      "architecture_id": "ChatUniViLlamaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2709,
-      "min_param_count": null,
-      "sample_models": [
-        "Chat-UniVi/Chat-UniVi-7B-v1.5"
-      ],
-      "relevancy_score": 17.5
-    },
-    {
-      "architecture_id": "ElectraForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2696,
-      "min_param_count": null,
-      "sample_models": [
-        "smeoni/nbme-electra-large-generator"
-      ],
-      "relevancy_score": 17.5
-    },
-    {
-      "architecture_id": "HNetForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2711,
-      "min_param_count": null,
-      "sample_models": [
-        "emarro/fineweb_hnet_78M_learned_N"
-      ],
-      "relevancy_score": 17.5
-    },
-    {
-      "architecture_id": "BartForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2712,
-      "min_param_count": null,
-      "sample_models": [
-        "sanchit-gandhi/tiny-random-bart-fp16"
-      ],
-      "relevancy_score": 17.5
-    },
-    {
       "architecture_id": "TransnormerForCausalLM",
       "total_models": 4,
       "total_downloads": 2289,
@@ -5333,37 +5519,7 @@
         "OpenNLPLab/TransNormerLLM-385M",
         "OpenNLPLab/TransNormerLLM-1B"
       ],
-      "relevancy_score": 17.4
-    },
-    {
-      "architecture_id": "GeoChatLlamaForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2558,
-      "min_param_count": null,
-      "sample_models": [
-        "MBZUAI/geochat-7B"
-      ],
-      "relevancy_score": 17.4
-    },
-    {
-      "architecture_id": "MegatronForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2638,
-      "min_param_count": null,
-      "sample_models": [
-        "hyunwoongko/megatron-11B"
-      ],
-      "relevancy_score": 17.4
-    },
-    {
-      "architecture_id": "VStreamLlamaForCausalLM",
-      "total_models": 2,
-      "total_downloads": 2934,
-      "min_param_count": null,
-      "sample_models": [
-        "IVGSZ/Flash-VStream-7b"
-      ],
-      "relevancy_score": 17.4
+      "relevancy_score": 17.5
     },
     {
       "architecture_id": "KonkanGPT",
@@ -5374,27 +5530,7 @@
         "omdeep22/Gonyai-teo2",
         "omdeep22/Gonyai-v1"
       ],
-      "relevancy_score": 17.3
-    },
-    {
-      "architecture_id": "ErnieForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2492,
-      "min_param_count": null,
-      "sample_models": [
-        "mohitsha/tiny-ernie-random-remote-code"
-      ],
-      "relevancy_score": 17.3
-    },
-    {
-      "architecture_id": "OpenMoeForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2454,
-      "min_param_count": null,
-      "sample_models": [
-        "OrionZheng/openmoe-base"
-      ],
-      "relevancy_score": 17.3
+      "relevancy_score": 17.4
     },
     {
       "architecture_id": "EmuForCausalLM",
@@ -5408,66 +5544,6 @@
       "relevancy_score": 17.2
     },
     {
-      "architecture_id": "Qwen3OmniMoeForConditionalGeneration",
-      "total_models": 2,
-      "total_downloads": 2744,
-      "min_param_count": 35273974321,
-      "sample_models": [
-        "88plug/Qwen3-Omni-30B-W4A16"
-      ],
-      "relevancy_score": 17.2
-    },
-    {
-      "architecture_id": "SLMModel",
-      "total_models": 3,
-      "total_downloads": 2235,
-      "min_param_count": null,
-      "sample_models": [
-        "kiruthiga-99/slm-tinystories"
-      ],
-      "relevancy_score": 17.1
-    },
-    {
-      "architecture_id": "Olmo2ForSequenceClassification",
-      "total_models": 3,
-      "total_downloads": 2200,
-      "min_param_count": null,
-      "sample_models": [
-        "LifeWiki-ai/OLMo-2-1124-7B-RM"
-      ],
-      "relevancy_score": 17.1
-    },
-    {
-      "architecture_id": "NGen4OW10TForCausalLM",
-      "total_models": 3,
-      "total_downloads": 2196,
-      "min_param_count": null,
-      "sample_models": [
-        "TNSA/NGen-4OW-10T-Expiremental"
-      ],
-      "relevancy_score": 17.1
-    },
-    {
-      "architecture_id": "A194LogitEnsembleForCausalLM",
-      "total_models": 2,
-      "total_downloads": 2564,
-      "min_param_count": null,
-      "sample_models": [
-        "LikC1606/chinesebabylm-a195-hanzi-best-20260611"
-      ],
-      "relevancy_score": 17.1
-    },
-    {
-      "architecture_id": "FinanceDecoder",
-      "total_models": 3,
-      "total_downloads": 2133,
-      "min_param_count": null,
-      "sample_models": [
-        "tjarvis91/Q-Coder-50M-Sovereign"
-      ],
-      "relevancy_score": 17.0
-    },
-    {
       "architecture_id": "DarwinDuoOrchestrator",
       "total_models": 3,
       "total_downloads": 1989,
@@ -5476,16 +5552,6 @@
         "FINAL-Bench/Darwin-60B-DUO"
       ],
       "relevancy_score": 16.9
-    },
-    {
-      "architecture_id": "GeoVForCausalLM",
-      "total_models": 3,
-      "total_downloads": 1736,
-      "min_param_count": null,
-      "sample_models": [
-        "GeoV/GeoV-9b"
-      ],
-      "relevancy_score": 16.6
     },
     {
       "architecture_id": "GraphLlamaForCausalLM",
@@ -5498,6 +5564,26 @@
       "relevancy_score": 16.6
     },
     {
+      "architecture_id": "RWKV",
+      "total_models": 3,
+      "total_downloads": 1773,
+      "min_param_count": null,
+      "sample_models": [
+        "konpep/aether-rwkv-25m"
+      ],
+      "relevancy_score": 16.6
+    },
+    {
+      "architecture_id": "YUAZForCausalLM",
+      "total_models": 3,
+      "total_downloads": 1741,
+      "min_param_count": null,
+      "sample_models": [
+        "Yuaz-Club/yuaz-mini-cheng-dx-1b"
+      ],
+      "relevancy_score": 16.6
+    },
+    {
       "architecture_id": "TeleFLMForCausalLM",
       "total_models": 3,
       "total_downloads": 1716,
@@ -5505,7 +5591,27 @@
       "sample_models": [
         "CofeAI/Tele-FLM-1T"
       ],
-      "relevancy_score": 16.5
+      "relevancy_score": 16.6
+    },
+    {
+      "architecture_id": "GeoVForCausalLM",
+      "total_models": 3,
+      "total_downloads": 1736,
+      "min_param_count": null,
+      "sample_models": [
+        "GeoV/GeoV-9b"
+      ],
+      "relevancy_score": 16.6
+    },
+    {
+      "architecture_id": "DuchifatCore",
+      "total_models": 3,
+      "total_downloads": 1720,
+      "min_param_count": null,
+      "sample_models": [
+        "Raziel1234/Duchifat-2"
+      ],
+      "relevancy_score": 16.6
     },
     {
       "architecture_id": "LingoWhaleForCausalLM",
@@ -5518,14 +5624,14 @@
       "relevancy_score": 16.5
     },
     {
-      "architecture_id": "DuchifatCore",
+      "architecture_id": "HenlaConfedForCausalLM",
       "total_models": 3,
-      "total_downloads": 1720,
+      "total_downloads": 1548,
       "min_param_count": null,
       "sample_models": [
-        "Raziel1234/Duchifat-2"
+        "RthItalia/HENLA-CONFED-3B-PREFIX-V4-STEP300"
       ],
-      "relevancy_score": 16.5
+      "relevancy_score": 16.3
     },
     {
       "architecture_id": "DotsVLMForCausalLM",
@@ -5538,26 +5644,6 @@
       "relevancy_score": 15.8
     },
     {
-      "architecture_id": "RWKV",
-      "total_models": 2,
-      "total_downloads": 1180,
-      "min_param_count": null,
-      "sample_models": [
-        "konpep/aether-rwkv-25m"
-      ],
-      "relevancy_score": 15.5
-    },
-    {
-      "architecture_id": "YUAZForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1156,
-      "min_param_count": null,
-      "sample_models": [
-        "Yuaz-Club/yuaz-mini-cheng-dx-1b"
-      ],
-      "relevancy_score": 15.4
-    },
-    {
       "architecture_id": "CrystalCoderLMHeadModel",
       "total_models": 1,
       "total_downloads": 1243,
@@ -5566,16 +5652,6 @@
         "LLM360/Crystal"
       ],
       "relevancy_score": 15.3
-    },
-    {
-      "architecture_id": "HenlaConfedForCausalLM",
-      "total_models": 2,
-      "total_downloads": 1028,
-      "min_param_count": null,
-      "sample_models": [
-        "RthItalia/HENLA-CONFED-3B-PREFIX-V4-STEP300"
-      ],
-      "relevancy_score": 15.2
     },
     {
       "architecture_id": "MoEGPT2",
@@ -5588,6 +5664,16 @@
       "relevancy_score": 15.0
     },
     {
+      "architecture_id": "LlavaStableLMEpochForCausalLM",
+      "total_models": 1,
+      "total_downloads": 822,
+      "min_param_count": null,
+      "sample_models": [
+        "NousResearch/Obsidian-3B-V0.5"
+      ],
+      "relevancy_score": 14.4
+    },
+    {
       "architecture_id": "JetNemotronForCausalLM",
       "total_models": 1,
       "total_downloads": 824,
@@ -5598,14 +5684,14 @@
       "relevancy_score": 14.4
     },
     {
-      "architecture_id": "LlavaStableLMEpochForCausalLM",
+      "architecture_id": "XModelForCausalLM",
       "total_models": 1,
-      "total_downloads": 822,
+      "total_downloads": 691,
       "min_param_count": null,
       "sample_models": [
-        "NousResearch/Obsidian-3B-V0.5"
+        "XiaoduoAILab/Xmodel_LM"
       ],
-      "relevancy_score": 14.4
+      "relevancy_score": 14.1
     },
     {
       "architecture_id": "JapaneseStableLMAlphaForCausalLM",
@@ -5626,16 +5712,6 @@
         "Salesforce/codet5p-16b"
       ],
       "relevancy_score": 14.1
-    },
-    {
-      "architecture_id": "XModelForCausalLM",
-      "total_models": 1,
-      "total_downloads": 691,
-      "min_param_count": null,
-      "sample_models": [
-        "XiaoduoAILab/Xmodel_LM"
-      ],
-      "relevancy_score": 14.0
     },
     {
       "architecture_id": "YayiForCausalLM",
@@ -5668,16 +5744,6 @@
       "relevancy_score": 13.8
     },
     {
-      "architecture_id": "OpenBAForConditionalGeneration",
-      "total_models": 1,
-      "total_downloads": 594,
-      "min_param_count": null,
-      "sample_models": [
-        "OpenNLG/OpenBA-V1-Based"
-      ],
-      "relevancy_score": 13.7
-    },
-    {
       "architecture_id": "D3PMSanskritModel",
       "total_models": 1,
       "total_downloads": 592,
@@ -5688,12 +5754,22 @@
       "relevancy_score": 13.7
     },
     {
-      "architecture_id": "GQAGPT2",
+      "architecture_id": "OpenBAForConditionalGeneration",
       "total_models": 1,
-      "total_downloads": 560,
+      "total_downloads": 594,
       "min_param_count": null,
       "sample_models": [
-        "NamrataThakur/Small_Language_Model_GQA_48M_Pretrained"
+        "OpenNLG/OpenBA-V1-Based"
+      ],
+      "relevancy_score": 13.7
+    },
+    {
+      "architecture_id": "GPTBigCodeLMHeadModel",
+      "total_models": 1,
+      "total_downloads": 547,
+      "min_param_count": null,
+      "sample_models": [
+        "bigcode/santacoderpack"
       ],
       "relevancy_score": 13.6
     },
@@ -5708,22 +5784,12 @@
       "relevancy_score": 13.6
     },
     {
-      "architecture_id": "GPTBigCodeLMHeadModel",
+      "architecture_id": "GQAGPT2",
       "total_models": 1,
-      "total_downloads": 547,
+      "total_downloads": 560,
       "min_param_count": null,
       "sample_models": [
-        "bigcode/santacoderpack"
-      ],
-      "relevancy_score": 13.6
-    },
-    {
-      "architecture_id": "GPT2",
-      "total_models": 1,
-      "total_downloads": 550,
-      "min_param_count": null,
-      "sample_models": [
-        "NamrataThakur/Small_Language_Model_MHA_53M_Pretrained"
+        "NamrataThakur/Small_Language_Model_GQA_48M_Pretrained"
       ],
       "relevancy_score": 13.6
     },
@@ -5738,14 +5804,14 @@
       "relevancy_score": 13.6
     },
     {
-      "architecture_id": "CoherenceMomentumModel",
+      "architecture_id": "GPT2",
       "total_models": 1,
-      "total_downloads": 523,
+      "total_downloads": 550,
       "min_param_count": null,
       "sample_models": [
-        "aisingapore/coherence-momentum"
+        "NamrataThakur/Small_Language_Model_MHA_53M_Pretrained"
       ],
-      "relevancy_score": 13.5
+      "relevancy_score": 13.6
     },
     {
       "architecture_id": "LlaMAForCausalLM",
@@ -5754,6 +5820,16 @@
       "min_param_count": null,
       "sample_models": [
         "circulus/alpaca-7b"
+      ],
+      "relevancy_score": 13.6
+    },
+    {
+      "architecture_id": "CoherenceMomentumModel",
+      "total_models": 1,
+      "total_downloads": 523,
+      "min_param_count": null,
+      "sample_models": [
+        "aisingapore/coherence-momentum"
       ],
       "relevancy_score": 13.5
     },
@@ -5768,22 +5844,22 @@
       "relevancy_score": 13.4
     },
     {
-      "architecture_id": "HunYuanForCausalLM",
-      "total_models": 1,
-      "total_downloads": 513,
-      "min_param_count": null,
-      "sample_models": [
-        "tencent/Hunyuan-7B-Pretrain-0124"
-      ],
-      "relevancy_score": 13.4
-    },
-    {
       "architecture_id": "GLaMMForCausalLM",
       "total_models": 1,
       "total_downloads": 512,
       "min_param_count": null,
       "sample_models": [
         "MBZUAI/GLaMM-FullScope"
+      ],
+      "relevancy_score": 13.4
+    },
+    {
+      "architecture_id": "HunYuanForCausalLM",
+      "total_models": 1,
+      "total_downloads": 513,
+      "min_param_count": null,
+      "sample_models": [
+        "tencent/Hunyuan-7B-Pretrain-0124"
       ],
       "relevancy_score": 13.4
     },

--- a/transformer_lens/tools/model_registry/data/verification_history.json
+++ b/transformer_lens/tools/model_registry/data/verification_history.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-07-01T11:28:07.646010",
+  "last_updated": "2026-07-02T02:19:51.172022",
   "records": [
     {
       "model_id": "Macropodus/macbert4mdcspell_v1",
@@ -16398,8 +16398,8 @@
       "verified_by": "verify_models",
       "transformerlens_version": null,
       "notes": "Below threshold: P1=50.0% < 100.0% (failed: all_components) \u2014 96/171 components failed (96 critical)",
-      "invalidated": false,
-      "invalidation_reason": null
+      "invalidated": true,
+      "invalidation_reason": "Superseded by the clean re-run (P1=100) after the component-benchmark fix that skips SSM mixer-internal submodules; the 96/171 component failures were the isolated harness feeding d_model-shaped inputs to SSM-internal projections, not a real divergence."
     },
     {
       "model_id": "state-spaces/mamba-130m-hf",
@@ -16428,8 +16428,8 @@
       "verified_by": "verify_models",
       "transformerlens_version": null,
       "notes": "Below threshold: P3=94.7% but required tests failed: logits_equivalence \u2014 Tensors differ: max_diff=0.375000, mean_rel=0.002045",
-      "invalidated": false,
-      "invalidation_reason": null
+      "invalidated": true,
+      "invalidation_reason": "bf16 precision of compatibility-mode center_unembed (root-caused by toggle: off=0.000 both dtypes, fp32=4.2e-5); superseded by the clean fp32 run (P3=100). Not an algorithmic bug."
     },
     {
       "model_id": "NYTK/PULI-HuBA-mamba-130M",
@@ -16708,6 +16708,156 @@
       "verified_by": "verify_models",
       "transformerlens_version": null,
       "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "state-spaces/mamba-130m-hf",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "dominguesm/mambarim-110m",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "NYTK/PULI-HuBA-mamba-130M",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "state-spaces/mamba-370m-hf",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "state-spaces/mamba-790m-hf",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "AntonV/mamba2-130m-hf",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "deqing/convergent-mamba2-300M-adamw-original",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues, low text quality",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "deqing/mamba2-300M-v5-mamba2",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "evolai/evolai_mamba_naive_kl",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "limloop/whiff-mamba2-50M-v0.1",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "yujiepan/qwen3-next-moe-tiny-random",
+      "architecture_id": "Qwen3NextForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "Evelyn67/Qwen3.5-2B-Her",
+      "architecture_id": "Qwen3_5ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "GoodStartLabs/gin-rummy-hbc-qwen3.5-0.8b",
+      "architecture_id": "Qwen3_5ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
+      "architecture_id": "NemotronHForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+      "architecture_id": "NemotronHForCausalLM",
+      "verified_date": "2026-07-02",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
       "invalidated": false,
       "invalidation_reason": null
     }

--- a/transformer_lens/tools/model_registry/data/verification_history.json
+++ b/transformer_lens/tools/model_registry/data/verification_history.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-06-27T00:21:21.662427",
+  "last_updated": "2026-07-01T11:28:07.646010",
   "records": [
     {
       "model_id": "Macropodus/macbert4mdcspell_v1",
@@ -16388,6 +16388,326 @@
       "verified_by": "verify_models",
       "transformerlens_version": null,
       "notes": "Below threshold: P1=50.0% < 100.0% (failed: forward_pass_logits) \u2014 Tensors differ: max_diff=0.020484, mean_rel=0.006617",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "state-spaces/mamba-130m-hf",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Below threshold: P1=50.0% < 100.0% (failed: all_components) \u2014 96/171 components failed (96 critical)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "state-spaces/mamba-130m-hf",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "AntonV/mamba2-130m-hf",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "ibm-granite/granite-4.0-tiny-preview",
+      "architecture_id": "GraniteMoeHybridForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Below threshold: P3=94.7% but required tests failed: logits_equivalence \u2014 Tensors differ: max_diff=0.375000, mean_rel=0.002045",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "NYTK/PULI-HuBA-mamba-130M",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "deqing/mamba2-300M-v5-mamba2",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "ibm-granite/granite-4.0-tiny-preview",
+      "architecture_id": "GraniteMoeHybridForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "ibm-granite/granite-4.0-1b",
+      "architecture_id": "GraniteMoeHybridForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "yujiepan/qwen3-next-moe-tiny-random",
+      "architecture_id": "Qwen3NextForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P2=92.3% (failed: gated_hooks_fire); P3=94.7% (failed: gated_hooks_fire)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "GoodStartLabs/gin-rummy-hbc-qwen3.5-0.8b",
+      "architecture_id": "Qwen3_5ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P2=92.3% (failed: gated_hooks_fire); P3=94.7% (failed: gated_hooks_fire)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "Evelyn67/Qwen3.5-2B-Her",
+      "architecture_id": "Qwen3_5ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P2=92.3% (failed: gated_hooks_fire); P3=94.7% (failed: gated_hooks_fire)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
+      "architecture_id": "NemotronHForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+      "architecture_id": "NemotronHForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "dominguesm/mambarim-110m",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "state-spaces/mamba-370m-hf",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "EchoLabs33/mamba-130m-hxq",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Below threshold: P1=0.0% < 100.0% (failed: all_components, forward_pass_logits) \u2014 24/51 components failed (24 critical)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "deqing/convergent-mamba2-300M-adamw-original",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues, low text quality: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "limloop/whiff-mamba2-50M-v0.1",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "EchoLabs33/mamba2-1.3b-hxq",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Below threshold: P1=0.0% < 100.0% (failed: all_components, forward_pass_logits) \u2014 50/99 components failed (50 critical)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "ibm-granite/granite-4.0-350m",
+      "architecture_id": "GraniteMoeHybridForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "ibm-granite/granite-4.0-1b-base",
+      "architecture_id": "GraniteMoeHybridForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "WithinUsAI/IBM-Grok4-Ultra.Fast.Coder-1B",
+      "architecture_id": "GraniteMoeHybridForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "GoodStartLabs/gin-rummy-hbc-qwen3.5-2b",
+      "architecture_id": "Qwen3_5ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "ZirTech/OmniMath-2B",
+      "architecture_id": "Qwen3_5ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "continuum-ai/qwen3.5-0.8b-general-forged",
+      "architecture_id": "Qwen3_5ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "optimum-intel-internal-testing/tiny-random-qwen3-next",
+      "architecture_id": "Qwen3NextForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "tiny-random/qwen3-next-moe",
+      "architecture_id": "Qwen3NextForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "trl-internal-testing/tiny-NemotronHForCausalLM-nano",
+      "architecture_id": "NemotronHForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "trl-internal-testing/tiny-NemotronHForCausalLM-super",
+      "architecture_id": "NemotronHForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "trl-internal-testing/tiny-NemotronHForCausalLM-ultra",
+      "architecture_id": "NemotronHForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "state-spaces/mamba-790m-hf",
+      "architecture_id": "MambaForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
+      "invalidated": false,
+      "invalidation_reason": null
+    },
+    {
+      "model_id": "evolai/evolai_mamba_naive_kl",
+      "architecture_id": "Mamba2ForCausalLM",
+      "verified_date": "2026-07-01",
+      "verified_by": "verify_models",
+      "transformerlens_version": null,
+      "notes": "Full verification completed with issues: P3=90.0% (failed: attention_output_centering, mlp_output_centering)",
       "invalidated": false,
       "invalidation_reason": null
     }

--- a/transformer_lens/tools/model_registry/verify_models.py
+++ b/transformer_lens/tools/model_registry/verify_models.py
@@ -114,7 +114,8 @@ def _phases_to_run(arch: str, phases: list[int]) -> list[int]:
 
     An adapter's ``applicable_phases`` declares which text phases (1-4) it covers. Phases 7/8
     are gated separately by ``is_multimodal``/``is_audio`` in the benchmark, so they are never
-    filtered out here. An empty result means the architecture is skipped (e.g. SSMs).
+    filtered out here. An empty result means none of the requested phases apply to this
+    architecture (SSM / recurrent families run all four).
     """
     from transformer_lens.factories.architecture_adapter_factory import (
         SUPPORTED_ARCHITECTURES,
@@ -837,11 +838,9 @@ def verify_models(
                 _skip_model(model_id, arch, note, progress, quiet)
                 continue
 
-        # Step 0b: Check adapter-level phase applicability. Architectures
-        # with applicable_phases=[] (e.g. SSMs) skip verify_models entirely
-        # because the benchmark suite has transformer-shaped assumptions that
-        # would need a dedicated refactor to cover them. Verification for
-        # these architectures lives in the integration test suite.
+        # Step 0b: Check adapter-level phase applicability. applicable_phases=[]
+        # means no phase applies (a genuinely unsupported architecture — rare);
+        # SSM / recurrent families run the full [1, 2, 3, 4].
         from transformer_lens.factories.architecture_adapter_factory import (
             SUPPORTED_ARCHITECTURES,
         )


### PR DESCRIPTION
# Description

Adds an interpretability surface for SSM/recurrent-mixer models to `TransformerBridge`, and extends `verify_models` to cover the SSM architectures.

Until now the bridge could run SSM models, but exposed almost none of their internals to interp tooling: no effective-attention view, no recurrent-state read, no way to intervene on the scan, and no shared vocabulary across the different SSM families. This PR closes that gap for every active SSM/hybrid architecture and wires the same quantities to the same hook names regardless of family, so `ActivationCache` can dispatch to them generically.

Motivation: mechanistic-interp work on state-space and linear-attention models (Mamba, the "Hidden Attention of Mamba" line of work, gated-delta-net) needs the same read/patch affordances we already have for attention. This makes SSM layers first-class alongside attention in the bridge.

## What's added

#### Read surface (all gated by independent references, see Verification):
- `compute_effective_attention` – materializes the effective-attention matrix `M = L ⊙ (C Bᵀ)` for **Mamba-1**, **Mamba-2**, and gated-delta-net (GDN). GDN's is documented as an explicit gated-linear-attention *heuristic* (drops the delta-rule key-removal), not a faithful decomposition.
- `compute_ssm_state` – reconstructs the recurrent state `Sₜ` from cached hooks for **Mamba-1**, **Mamba-2**, and **GDN** (GDN replays the *full* delta rule, key-removal included, and L2-normalizes Q/K like the fused kernel, so it is faithful).

#### Intervention surface:
- Opt-in `eager_scan` path that swaps HF's fused kernel for a readable Python scan so `hook_ssm_write` (per-step write) and `hook_ssm_state` (post-scan state trajectory) fire and can be patched for **Mamba-1**, **Mamba-2** (+ NemotronH / GraniteMoeHybrid hybrids), and **GDN**. Patching `hook_ssm_write` propagates through the recurrence. `hook_ssm_state` affects only the same-position readout. Default is off, so the standard forward is bit-for-bit unchanged.

#### Family-agnostic plumbing:
- `SSMMixerProtocol` + `find_ssm_mixer` (locates the mixer regardless of slot: `.mixer` / `.linear_attn`), and `SSMStateHookMixin` – the single definition point for the canonical `hook_ssm_*` vocabulary across all three families.
- `ActivationCache.compute_ssm_effective_attention`, `compute_ssm_state`, and `ssm_layers` dispatch across homogeneous and hybrid models (stacked tensor for pure models, per-layer dict for hybrids).

#### Architectures covered: 
- Mamba-1
- Mamba-2
- NemotronH (hybrid)
- GraniteMoeHybrid (hybrid)
- gated-delta-net (Qwen3.5 / Qwen3-Next).

#### `verify_models` / benchmarks:
- SSM adapters now run the full phase set `[1,2,3,4]` (P1 forward-parity vs raw HF is exact since the mixer delegates to HF, P4 generation) instead of being skipped.
- Component-output benchmark skips SSM mixer *internals* (they take channel-first / d_inner / dt_rank / state shapes, not the `[batch, seq, d_model]` residual the isolated harness feeds) while still testing the mixer node end-to-end.
- Weight-centering benchmarks now return `SKIPPED` (not a false failure) for attention-less / passthrough-mixer blocks.
- Hook-registration treats the gated-`q_proj` forward-time `NotImplementedError` (Qwen3.5/Next) as a skip, matching the setter-time applicability gate.
- Real checkpoints across all families were run through `verify_models`; results recorded in the registry.

#### Docs: 
- new `docs/source/content/ssm_interpretability.md` (canonical hook vocabulary + `eager_scan` opt-in example), linked in the docs index
- README touch-up.

## Notable design / correctness notes

- Reconstructions are validated against **independent fp64 step recurrences** and **HF-output parity**, not against the implementation itself (non-circular gates).
- The Granite `logits_equivalence` divergence surfaced in P3 was determined to be caused by bf16 precision of compatibility-mode `center_unembed` (toggle: off = 0.000 in both dtypes, fp32 = 4.2e-5, bf16 = 0.375). The clean fp32 run passes P3=100.
- Eager-scan device allocation is input-device-correct (regression covered on cpu/cuda/mps).

## Dependencies

None new – uses the SSM/recurrent modules already provided by `transformers`. Some tests and `verify_models` runs require the corresponding HF checkpoints and are availability-gated (skip cleanly when absent).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

