### PR TITLE
feat: enable meta device targets in TransformerBridge device_map

### DIFF
--- a/demos/Attribution_Patching_Demo.ipynb
+++ b/demos/Attribution_Patching_Demo.ipynb
@@ -178,6 +178,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "import transformer_lens\n",
     "import transformer_lens.utilities as utils\n",
     "from transformer_lens import (\n",

--- a/tests/acceptance/model_bridge/test_multi_gpu_bridge.py
+++ b/tests/acceptance/model_bridge/test_multi_gpu_bridge.py
@@ -92,10 +92,11 @@ class TestResolveDeviceMap:
         with pytest.raises(ValueError, match="not supported yet"):
             resolve_device_map(None, bad, None)
 
-    def test_meta_value_in_device_map_rejected(self):
-        bad: Dict[str, Union[str, int]] = {"transformer.h.0": "meta"}
-        with pytest.raises(ValueError, match="not supported yet"):
-            resolve_device_map(None, bad, None)
+    def test_meta_value_in_device_map_passes_through(self):
+        device_map: Dict[str, Union[str, int]] = {"transformer.h.0": "meta"}
+        dm, mm = resolve_device_map(None, device_map, None)
+        assert dm is device_map
+        assert mm is None
 
 
 class TestFindEmbeddingDevice:
@@ -230,6 +231,17 @@ class TestBootParamValidation:
             TransformerBridge.boot_transformers(
                 "gpt2", hf_model=gpt2_bridge.original_model, n_devices=2
             )
+
+    def test_meta_device_map_rejected_at_boot(self):
+        with pytest.raises(ValueError, match="meta target"):
+            TransformerBridge.boot_transformers("gpt2", device_map={"": "meta"})
+
+    def test_meta_device_map_allowed_with_load_weights_false(self):
+        bridge = TransformerBridge.boot_transformers(
+            "gpt2", device_map={"": "meta"}, load_weights=False
+        )
+        assert bridge is not None
+        assert bridge.cfg.d_model == 768
 
 
 class TestToMethodGuardsMultiDevice:

--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -634,6 +634,22 @@ def boot(
         # Default to eager (required for output_attentions hooks)
         model_kwargs["attn_implementation"] = "eager"
     adapter.prepare_loading(model_name, model_kwargs)
+    # Meta device_map targets crash at boot when loading weights
+    # (NotImplementedError in HF tie_weights, KeyError in Accelerate offload hooks).
+    # Only accepted with load_weights=False (config inspection; map not applied).
+    if load_weights and isinstance(resolved_device_map, dict):
+        _meta_targets = [
+            k
+            for k, v in resolved_device_map.items()
+            if isinstance(v, str) and v.strip().lower() == "meta"
+        ]
+        if _meta_targets:
+            raise ValueError(
+                f"device_map contains meta target(s): {_meta_targets}. "
+                "Meta device_map values crash at boot when loading weights. "
+                "Set load_weights=False for config inspection only "
+                "(the map is not applied; parameters load on CPU via from_config)."
+            )
     if hf_model is not None:
         # Use the pre-loaded model as-is (e.g., quantized models with custom device_map)
         pass

--- a/transformer_lens/utilities/multi_gpu.py
+++ b/transformer_lens/utilities/multi_gpu.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 else:
     ConfigType = Any
 
-_UNSUPPORTED_OFFLOAD_DEVICE_MAP_VALUES = {"disk", "meta"}
+_UNSUPPORTED_OFFLOAD_DEVICE_MAP_VALUES = {"disk"}
 
 AvailableDeviceMemory = list[tuple[int, int]]
 """
@@ -191,7 +191,8 @@ def resolve_device_map(
 def _validate_device_map_values(
     device_map: Union[str, Dict[str, Union[str, int]]],
 ) -> None:
-    """Reject explicit disk / meta values in a user-supplied device_map dict."""
+    """Reject explicit disk values in a user-supplied device_map dict.
+    Meta values are passed through (validated at boot against load_weights)."""
     if isinstance(device_map, str):
         return
     for key, value in device_map.items():


### PR DESCRIPTION
Part of #1280.

Enables  device targets in TransformerBridge , building on the CPU support shipped in #1459.

**Changes:**
- Remove  from  so explicit meta targets are passed to HF instead of raising at validation time.
- Update  /  docstrings to describe meta support and its known limitations.
- Update post-load  check in  — meta targets now warn only at forward time via Accelerate (no hard block at boot).
- Update  to .

**Limitations (documented in resolve_device_map docstring):**
Meta-offloaded parameters are skipped by  but may still cause forward-pass errors in Bridge-wrapped components that access offloaded tensors without Accelerate . This is safe for config inspection () and for users who understand the constraints.

Closes the  portion of #1280. Disk offload remains blocked pending the hook-routing fix described in #1459.