### PR TITLE
Fix n_devices max_memory caps

### DIFF
--- a/demos/Activation_Patching_in_TL_Demo.ipynb
+++ b/demos/Activation_Patching_in_TL_Demo.ipynb
@@ -125,6 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "import transformer_lens\n",
     "import transformer_lens.utilities as utils\n",
     "from transformer_lens.model_bridge import TransformerBridge"

--- a/tests/acceptance/model_bridge/test_multi_gpu_bridge.py
+++ b/tests/acceptance/model_bridge/test_multi_gpu_bridge.py
@@ -41,7 +41,7 @@ class TestResolveDeviceMap:
         assert mm is None
 
     def test_user_max_memory_passes_through(self):
-        user_mm: Dict[Union[str, int], str] = {0: "20GiB"}
+        user_mm: Dict[Union[str, int], Union[str, int]] = {0: "20GiB"}
         dm, mm = resolve_device_map(None, "auto", None, max_memory=user_mm)
         assert dm == "auto"
         assert mm is user_mm
@@ -73,10 +73,27 @@ class TestResolveDeviceMap:
         assert isinstance(mm, dict)
         assert set(mm.keys()) == {0, 1}
 
+    def test_n_devices_uses_concrete_cuda_memory_caps(self, monkeypatch):
+        free_memory = {0: 11_000_000_000, 1: 22_000_000_000, 2: 33_000_000_000}
+
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+        monkeypatch.setattr(torch.cuda, "device_count", lambda: 3)
+        monkeypatch.setattr(
+            torch.cuda,
+            "mem_get_info",
+            lambda index: (free_memory[index], free_memory[index] + 1_000_000_000),
+        )
+
+        dm, mm = resolve_device_map(2, None, None)
+
+        assert dm == "balanced"
+        assert mm == {0: free_memory[0], 1: free_memory[1]}
+        assert "auto" not in mm.values()
+
     def test_n_devices_respects_user_max_memory(self):
         if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
             pytest.skip("Requires 2+ CUDA devices.")
-        user_mm: Dict[Union[str, int], str] = {0: "10GiB", 1: "10GiB"}
+        user_mm: Dict[Union[str, int], Union[str, int]] = {0: "10GiB", 1: "10GiB"}
         dm, mm = resolve_device_map(2, None, None, max_memory=user_mm)
         assert dm == "balanced"
         assert mm == user_mm

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -220,7 +220,7 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
         hf_model: Optional[Any] = None,
         device_map: Optional[Union[str, Dict[str, Union[str, int]]]] = None,
         n_devices: Optional[int] = None,
-        max_memory: Optional[Dict[Union[str, int], str]] = None,
+        max_memory: Optional[Dict[Union[str, int], Union[str, int]]] = None,
         n_ctx: Optional[int] = None,
         revision: Optional[str] = None,
         checkpoint_index: Optional[int] = None,

--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -381,7 +381,7 @@ def boot(
     # Use at your own risk, report any issues here: https://github.com/TransformerLensOrg/TransformerLens/issues
     device_map: str | dict[str, str | int] | None = None,
     n_devices: int | None = None,
-    max_memory: dict[str | int, str] | None = None,
+    max_memory: dict[str | int, str | int] | None = None,
 ) -> TransformerBridge:
     """Boot a model from HuggingFace.
 

--- a/transformer_lens/utilities/multi_gpu.py
+++ b/transformer_lens/utilities/multi_gpu.py
@@ -26,6 +26,8 @@ The first entry of each tuple will be the device index.
 The second entry will be how much memory is currently available.
 """
 
+MaxMemory = Dict[Union[str, int], Union[str, int]]
+
 
 def calculate_available_device_cuda_memory(i: int) -> int:
     """Calculates how much memory is available at this moment for the device at the indicated index
@@ -39,6 +41,15 @@ def calculate_available_device_cuda_memory(i: int) -> int:
     total = torch.cuda.get_device_properties(i).total_memory
     allocated = torch.cuda.memory_allocated(i)
     return total - allocated
+
+
+def _get_available_cuda_memory_for_device(i: int) -> int:
+    """Return a concrete byte budget accepted by Accelerate's ``max_memory``."""
+    try:
+        free_memory, _ = torch.cuda.mem_get_info(i)
+    except (AttributeError, RuntimeError):
+        return calculate_available_device_cuda_memory(i)
+    return int(free_memory)
 
 
 def determine_available_memory_for_available_devices(max_devices: int) -> AvailableDeviceMemory:
@@ -153,8 +164,8 @@ def resolve_device_map(
     n_devices: Optional[int],
     device_map: Optional[Union[str, Dict[str, Union[str, int]]]],
     device: Optional[Union[str, torch.device]],
-    max_memory: Optional[Dict[Union[str, int], str]] = None,
-) -> Tuple[Optional[Union[str, Dict[str, Union[str, int]]]], Optional[Dict[Union[str, int], str]]]:
+    max_memory: Optional[MaxMemory] = None,
+) -> Tuple[Optional[Union[str, Dict[str, Union[str, int]]]], Optional[MaxMemory]]:
     """Resolve ``n_devices`` / ``device_map`` / ``device`` into HF ``from_pretrained`` kwargs.
 
     Returns ``(device_map, max_memory)`` tuple ready to pass into ``model_kwargs``.
@@ -165,9 +176,9 @@ def resolve_device_map(
           offload targets are still rejected because Bridge component wrappers can bypass
           Accelerate's offload hooks during forward passes.
         - ``n_devices=None`` or ``1``: returns ``(None, None)`` — single-device path.
-        - ``n_devices > 1``: returns ``("balanced", {0: "auto", ..., n-1: "auto"})``.
+        - ``n_devices > 1``: returns ``("balanced", {0: bytes, ..., n-1: bytes})``.
           ``"balanced"`` is accelerate's string directive for balanced layer dispatch;
-          the ``max_memory`` dict caps visibility to exactly ``n_devices`` GPUs.
+          concrete byte budgets cap visibility to exactly ``n_devices`` GPUs.
     """
     if device_map is not None and device is not None:
         raise ValueError("device and device_map are mutually exclusive — pass one.")
@@ -182,8 +193,10 @@ def resolve_device_map(
         raise ValueError(
             f"n_devices={n_devices} but only {torch.cuda.device_count()} CUDA devices present."
         )
-    resolved_max_memory: Dict[Union[str, int], str] = (
-        dict(max_memory) if max_memory else {i: "auto" for i in range(n_devices)}
+    resolved_max_memory: MaxMemory = (
+        dict(max_memory)
+        if max_memory is not None
+        else {i: _get_available_cuda_memory_for_device(i) for i in range(n_devices)}
     )
     return "balanced", resolved_max_memory
 


### PR DESCRIPTION
Fixes #1496.

## Summary
- Replace the invalid `n_devices` default `max_memory={0: "auto", ...}` with concrete CUDA byte budgets for devices `0..n_devices-1`.
- Keep user-supplied `max_memory` values unchanged.
- Update Bridge type hints to reflect that HuggingFace accepts integer byte budgets as well as strings.
- Add a mocked-CUDA regression test so the failing resolver path is covered on CPU CI.

## Why
Accelerate rejects `"auto"` as a `max_memory` value with `ValueError: size auto is not in a valid format`. `n_devices` should continue to resolve to `device_map="balanced"`, but the generated caps need to be concrete values accepted by HF/Accelerate.

## Validation
- `make format`
- `make check-format`
- `uv run --python 3.11 mypy .`
- `uv run --python 3.11 pytest tests/unit/utilities/test_multi_gpu_unit.py -q`
- `uv run --python 3.11 pytest tests/acceptance/model_bridge/test_multi_gpu_bridge.py::TestResolveDeviceMap -q`
- `uv run --python 3.11 pytest tests/acceptance/model_bridge/test_multi_gpu_bridge.py -q`
- `make unit-test`