### PR TITLE
Keep input_tokens on the model device in generate()

### DIFF
--- a/tests/unit/test_generate_no_tokenizer.py
+++ b/tests/unit/test_generate_no_tokenizer.py
@@ -3,6 +3,7 @@
 Regression test for https://github.com/TransformerLensOrg/TransformerLens/issues/483
 """
 
+import pytest
 import torch
 
 from transformer_lens import HookedTransformer
@@ -106,6 +107,50 @@ def test_generate_without_tokenizer_stop_at_eos_requires_eos_id():
         raise AssertionError("Should have raised AssertionError")
     except AssertionError as e:
         assert "eos_token_id" in str(e), f"Unexpected error message: {e}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires a CUDA device")
+def test_generate_cpu_tokens_cuda_model():
+    """generate() with CPU token input and the model on CUDA must not mix devices.
+
+    Regression test for https://github.com/TransformerLensOrg/TransformerLens/issues/1508:
+    input_tokens used to stay on the input's original device after the input was
+    moved to the model's device, breaking the sampling-path and output torch.cat.
+    """
+    cfg = HookedTransformerConfig(
+        n_layers=1,
+        d_model=16,
+        d_head=4,
+        n_heads=4,
+        n_ctx=32,
+        d_vocab=20,
+        attn_only=True,
+        device="cuda",
+    )
+    model = HookedTransformer(cfg)
+
+    tokens = torch.zeros((1, 5), dtype=torch.long)  # deliberately left on CPU
+
+    # Sampling path: concatenates input_tokens with sampled tokens each step.
+    output = model.generate(
+        tokens,
+        max_new_tokens=3,
+        stop_at_eos=False,
+        return_type="tokens",
+        verbose=False,
+    )
+    assert output.shape == (1, 8), f"Expected shape (1, 8), got {output.shape}"
+
+    # Greedy path: concatenates input_tokens with sampled tokens for the output.
+    output = model.generate(
+        tokens,
+        max_new_tokens=3,
+        do_sample=False,
+        stop_at_eos=False,
+        return_type="tokens",
+        verbose=False,
+    )
+    assert output.shape == (1, 8), f"Expected shape (1, 8), got {output.shape}"
 
 
 def test_generate_string_input_without_tokenizer_errors():

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -2031,6 +2031,11 @@ class HookedTransformer(HookedRootModule):
                     self.tokenizer.padding_side = _orig_padding_side
             device = get_device_for_block_index(0, self.cfg)
             input = input.to(device)
+            if input_tokens is not None:
+                # Re-alias to the moved tensor: input_tokens must live on the model's
+                # device so later concatenations with sampled tokens (freq_penalty
+                # sampling and the final output) don't mix devices.
+                input_tokens = input
             if use_past_kv_cache:
                 past_kv_cache = TransformerLensKeyValueCache.init_cache(
                     self.cfg, self.cfg.device, batch_size


### PR DESCRIPTION
# Description

`HookedTransformer.generate()` crashes on CUDA machines when the input is a token tensor on a different device than the model (e.g. CPU tokens passed to a model whose `cfg.device` is `"cuda"`, the default when CUDA is available):

```
RuntimeError: Expected all tensors to be on the same device, but got tensors is on cuda:0, different from other tensors on cpu (when checking argument in method wrapper_CUDA_cat)
```

**Root cause:** `input_tokens` is bound to the original input tensor *before* `input = input.to(device)` moves the input to the model's device, so it keeps pointing at the original CPU tensor. Sampled tokens are produced on the model's device, so `torch.cat((input_tokens, ...))` mixes devices — both in the freq-penalty sampling path and in the final output concatenation (the latter also hits `do_sample=False`). The ordering came in with #999.

**Fix:** after `input = input.to(device)`, re-alias `input_tokens = input` (guarded by `input_tokens is not None`, which is exactly the str/tokens input case). Re-aliasing rather than calling `.to(device)` again avoids a second host-to-device copy of the same data.

This is easiest to hit with tokenizer-free models (algorithmic tasks), which is why 4 of the 6 existing tests in `tests/unit/test_generate_no_tokenizer.py` fail on any CUDA-visible machine at current `dev` while passing on CPU-only CI. With this fix they pass on both. `generate_stream()` and `TransformerBridge.generate()` are not affected (both already move their token tensor before use), so no Bridge mirroring is needed.

**Tests:** added `test_generate_cpu_tokens_cuda_model`, a CUDA-gated (`skipif`) regression test that explicitly passes CPU tokens to a CUDA model and covers both the sampling and greedy paths. Verified it fails without the fix and passes with it.

Ran locally on a CUDA machine (RTX 5070, torch 2.10.0+cu128, Python 3.12):
- `pytest tests/unit/test_generate_no_tokenizer.py` — 4 failed / 2 passed before, 7 passed after
- `pytest tests/unit -m "not slow"` — passes
- `mypy transformer_lens/HookedTransformer.py`, `black`/`isort`/`pycln` checks — clean

Fixes #1508

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
