### PR TITLE
Document all four adapter registration locations

### DIFF
--- a/docs/source/content/adapter_development/adapter-creation-guide.md
+++ b/docs/source/content/adapter_development/adapter-creation-guide.md
@@ -182,7 +182,7 @@ Implement only the ones you need:
 
 ### Registration
 
-Three files to update:
+Four locations to update:
 
 1. `transformer_lens/model_bridge/supported_architectures/__init__.py` — add the import and append to `__all__`.
 2. `transformer_lens/factories/architecture_adapter_factory.py` — add to the import block and to `SUPPORTED_ARCHITECTURES`:
@@ -207,7 +207,16 @@ Three files to update:
 
    The canonical author is the org that originally trains and publishes this model family (e.g., `meta-llama` for Llama, `google` for Gemma, `mistralai` for Mistral). Without this entry, the HF scraper's `min_downloads` threshold can silently drop small canonical variants. For example, a foundation model with only ~20 downloads still belongs in the registry. Multiple canonical orgs are allowed (e.g., Llama is canonical for `meta-llama`, `huggyllama`, `codellama`, and `SimpleStories`).
 
-Forgetting registration is the most common silent failure — the adapter exists but `boot_transformers` can't find it.
+4. `transformer_lens/tools/model_registry/generate_report.py` — add a concise entry to `ARCHITECTURE_DESCRIPTIONS` so generated model-registry reports use an architecture-specific description instead of the generic fallback:
+
+   ```python
+   ARCHITECTURE_DESCRIPTIONS = {
+       ...
+       "<HFArchitectureClass>": "<Short human-readable description>",
+   }
+   ```
+
+Forgetting a registration location is a common silent failure: the adapter may exist while model loading, discovery, or generated reporting remains incomplete.
 
 ### Tests
 
@@ -279,12 +288,12 @@ Both must be clean. Don't paper over mypy errors with `# type: ignore` — fix t
 
 **Don't reach for abstraction prematurely.** If you've added a base class or protocol with only one or two concrete uses, you're probably better off without it. The same goes for config knobs that don't have a current consumer.
 
-**Confirm the boring stuff is done.** Both registration sites (`__init__.py` and `architecture_adapter_factory.py`), `mypy` and format checks clean, tests doing real work rather than asserting mocks return their mock values.
+**Confirm the boring stuff is done.** All four [registration locations](#registration), `mypy` and format checks clean, tests doing real work rather than asserting mocks return their mock values.
 
 ## Common pitfalls
 
 - **Forgetting `n_key_value_heads`.** Without it, GQA models silently reshape weights as if they were MHA — verification fails with cryptic shape errors.
-- **Missing registration.** Adapter exists but the factory can't find it. Update both `__init__.py` and `architecture_adapter_factory.py`.
+- **Missing registration.** Adapter exists, but loading, model discovery, or generated reporting is incomplete. Update all four [registration locations](#registration).
 - **Skipping `setup_component_testing` for RoPE.** Rotary embeddings need to be wired through to each attention bridge or component testing produces nonsense.
 - **Reusing `model.norm` when the path is `model.final_layernorm`.** Module paths look similar across architectures but rarely match exactly — always verify against the actual HF source.
 - **Tautological tests.** "Test that mock returns mock_value" is not a test. Tests should exercise real shapes, real forward passes, real hook resolution.

--- a/docs/source/content/adapter_development/adapter-specification.md
+++ b/docs/source/content/adapter_development/adapter-specification.md
@@ -22,7 +22,7 @@ An Architecture Adapter is a Python class that extends `ArchitectureAdapter` (fr
 
 ## Registration Checklist
 
-After creating the adapter, register it in these files:
+After creating the adapter, register it in all four locations:
 
 1. **`transformer_lens/model_bridge/supported_architectures/__init__.py`**
    - Add import: `from transformer_lens.model_bridge.supported_architectures.<module> import <ClassName>`
@@ -31,6 +31,13 @@ After creating the adapter, register it in these files:
 2. **`transformer_lens/factories/architecture_adapter_factory.py`**
    - Add import (in the existing import block from `supported_architectures`)
    - Add entry to `SUPPORTED_ARCHITECTURES` dict: `"<HFArchitectureClass>": <AdapterClass>`
+
+3. **`transformer_lens/tools/model_registry/__init__.py`**
+   - Add the architecture name to `HF_SUPPORTED_ARCHITECTURES`
+   - Add the architecture's foundation-model organizations to `CANONICAL_AUTHORS_BY_ARCH`
+
+4. **`transformer_lens/tools/model_registry/generate_report.py`**
+   - Add a concise architecture description to `ARCHITECTURE_DESCRIPTIONS`
 
 ## Config Attributes
 


### PR DESCRIPTION
# Description

Closes #1511.

The adapter creation guide listed three registration locations while the formal adapter specification listed only two. Both disagreed with the existing four-place invariant in `contributing.md` and `supported_architectures/AGENTS.md`.

This change:

- documents `tools/model_registry/generate_report.py` and `ARCHITECTURE_DESCRIPTIONS` as the fourth registration location;
- adds the two missing model-registry locations to the adapter specification; and
- updates the guide's final checklist and common-pitfall reminder to cover all four locations.

This keeps contributor instructions consistent and reduces the chance that a new adapter loads successfully but has incomplete discovery or generated reporting. No new dependencies are required.

## Validation

- `uv run --locked --python 3.12 build-docs` (succeeded; no warnings from the changed files)
- `make check-format`
- `uv run --locked --python 3.12 mypy .`

## Type of change

- [x] This change requires a documentation update

# Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] No code behavior or interfaces were changed
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
