### PR TITLE
Add TransformerBridge adapter for lightweight decoder-only pretrainin…

### DIFF
--- a/TransformerLens/tests/integration/model_bridge/test_pretrain_adapter.py
+++ b/TransformerLens/tests/integration/model_bridge/test_pretrain_adapter.py
@@ -1,0 +1,312 @@
+"""Integration tests for PretrainArchitectureAdapter -- numerical parity
+against a real (not structural-mock) reference model.
+
+Uses `tests/mocks/tiny_pretrain_model.py`'s `TinyPretrainModel`, which
+implements genuine adjacent-pair RoPE and RMSNorm math (unlike
+`_pretrain_mocks.py`'s unit-test mocks, which stub RoPE with constant
+cos/sin and only need to get attribute names and call-signatures right).
+
+Covers: source/bridge logit parity (dense, full-MoE, mixed dense/MoE,
+untied embeddings); that this file's fixtures supply a `cfg` truthfully
+describing the wrapped model's head/vocab dimensions (a fixture property,
+not something `build_pretrain_bridge` itself enforces -- see
+`TestIntegrationFixturesSupplyATruthfulConfig`); residual-stream
+decomposition via `run_with_cache`; a forward-hook intervention
+cross-checked against an independent way of expressing the same edit; and
+float64 construction-time preservation.
+
+Note on scope: since the adapter delegates the whole forward to the
+source model rather than reimplementing attention/RoPE, exact logit
+parity mainly demonstrates that wrapping and output normalization don't
+alter an unhooked forward, not that the RoPE convention itself is
+correct (the same implementation runs on both sides of the comparison).
+`TestResidualStreamDecomposition` and `TestHookIntervention` are the
+stronger evidence for correct intervention points.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from tests.mocks.tiny_pretrain_model import TinyPretrainModel
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.model_bridge.supported_architectures.pretrain import (
+    ARCHITECTURE_NAME,
+    build_pretrain_bridge,
+)
+
+
+def _make_cfg(
+    *,
+    d_model: int,
+    n_layers: int,
+    n_heads: int = 2,
+    d_vocab: int = 64,
+) -> TransformerBridgeConfig:
+    """Build a bridge config matching this file's TinyPretrainModel
+    fixtures (n_heads=2, vocab_size=64 by default). See
+    `TestIntegrationFixturesSupplyATruthfulConfig` for why this matching
+    matters and what happens when it doesn't."""
+    return TransformerBridgeConfig(
+        d_model=d_model,
+        d_head=d_model // n_heads,
+        n_layers=n_layers,
+        n_ctx=128,
+        n_heads=n_heads,
+        d_vocab=d_vocab,
+        d_mlp=d_model * 2,
+        architecture=ARCHITECTURE_NAME,
+    )
+
+
+class TestSourceBridgeLogitParity:
+    """Bridge output must equal the source model's own `"logits"` output
+    exactly -- not within tolerance. The adapter never translates weights
+    into a second parameter layout, so there is no floating-point drift
+    to tolerate; any mismatch here is a real bug, not numerical noise."""
+
+    def test_dense_model_logit_parity_exact(self) -> None:
+        torch.manual_seed(0)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=2, d_ff=32, vocab_size=64)
+        model.eval()
+        tokens = torch.randint(0, 64, (1, 5))
+        with torch.no_grad():
+            source_logits = model(tokens)["logits"]
+
+        bridge = build_pretrain_bridge(model, _make_cfg(d_model=16, n_layers=2))
+        with torch.no_grad():
+            bridge_logits = bridge(tokens)
+
+        torch.testing.assert_close(bridge_logits, source_logits, atol=0, rtol=0)
+
+    def test_full_moe_model_logit_parity_exact(self) -> None:
+        """Every block's MLP is MoE (moe_layer_indices covers all layers)."""
+        torch.manual_seed(0)
+        model = TinyPretrainModel(
+            d_model=16,
+            n_heads=2,
+            n_layers=2,
+            d_ff=32,
+            vocab_size=64,
+            n_experts=4,
+            top_k=2,
+            moe_layer_indices=frozenset({0, 1}),
+        )
+        model.eval()
+        tokens = torch.randint(0, 64, (1, 5))
+        with torch.no_grad():
+            source_logits = model(tokens)["logits"]
+
+        bridge = build_pretrain_bridge(model, _make_cfg(d_model=16, n_layers=2))
+        with torch.no_grad():
+            bridge_logits = bridge(tokens)
+
+        torch.testing.assert_close(bridge_logits, source_logits, atol=0, rtol=0)
+
+    def test_mixed_dense_moe_model_logit_parity_exact(self) -> None:
+        """One block dense, one block MoE -- the dispatcher must route each
+        block's MLP correctly within a single model, not just across
+        separately-constructed all-dense/all-MoE models."""
+        torch.manual_seed(0)
+        model = TinyPretrainModel(
+            d_model=16,
+            n_heads=2,
+            n_layers=2,
+            d_ff=32,
+            vocab_size=64,
+            n_experts=4,
+            top_k=2,
+            moe_layer_indices=frozenset({1}),
+        )
+        model.eval()
+        tokens = torch.randint(0, 64, (1, 5))
+        with torch.no_grad():
+            source_logits = model(tokens)["logits"]
+
+        bridge = build_pretrain_bridge(model, _make_cfg(d_model=16, n_layers=2))
+        with torch.no_grad():
+            bridge_logits = bridge(tokens)
+
+        torch.testing.assert_close(bridge_logits, source_logits, atol=0, rtol=0)
+
+    def test_untied_embeddings_logit_parity_exact(self) -> None:
+        torch.manual_seed(0)
+        model = TinyPretrainModel(
+            d_model=16,
+            n_heads=2,
+            n_layers=1,
+            d_ff=32,
+            vocab_size=64,
+            tie_embeddings=False,
+        )
+        model.eval()
+        tokens = torch.randint(0, 64, (1, 5))
+        with torch.no_grad():
+            source_logits = model(tokens)["logits"]
+
+        bridge = build_pretrain_bridge(model, _make_cfg(d_model=16, n_layers=1))
+        with torch.no_grad():
+            bridge_logits = bridge(tokens)
+
+        torch.testing.assert_close(bridge_logits, source_logits, atol=0, rtol=0)
+
+
+class TestIntegrationFixturesSupplyATruthfulConfig:
+    """Integration fixtures must supply a config matching the source
+    model. `build_pretrain_bridge` does not itself validate this -- `cfg`
+    is caller-owned, per ordinary TransformerBridge convention -- so a
+    mismatch shows up only in `bridge.cfg`, silently, never in the
+    logits (see the second test)."""
+
+    def test_cfg_matches_model_head_and_vocab_dimensions(self) -> None:
+        torch.manual_seed(0)
+        n_heads = 2
+        vocab_size = 64
+        model = TinyPretrainModel(
+            d_model=16, n_heads=n_heads, n_layers=2, d_ff=32, vocab_size=vocab_size
+        )
+        model.eval()
+        cfg = _make_cfg(d_model=16, n_layers=2, n_heads=n_heads, d_vocab=vocab_size)
+        bridge = build_pretrain_bridge(model, cfg)
+
+        assert bridge.cfg.n_heads == n_heads
+        assert bridge.cfg.d_head == 16 // n_heads
+        assert bridge.cfg.d_vocab == model.embed.num_embeddings
+
+    def test_build_pretrain_bridge_does_not_validate_cfg_against_model(self) -> None:
+        """A cfg describing a different architecture than the wrapped
+        model still builds and still produces exact logit parity
+        (delegation never reads cfg) -- only bridge.cfg is wrong.
+
+        Current framework convention; not an adapter guarantee. This test
+        documents present behavior, not a requirement -- if
+        build_pretrain_bridge later gains cfg-vs-model validation, this
+        test should be updated (or removed) rather than treated as a
+        regression to preserve."""
+        torch.manual_seed(0)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        model.eval()
+        tokens = torch.randint(0, 64, (1, 5))
+        with torch.no_grad():
+            source_logits = model(tokens)["logits"]
+
+        wrong_cfg = _make_cfg(d_model=16, n_layers=1, n_heads=4, d_vocab=256)
+        bridge = build_pretrain_bridge(model, wrong_cfg)
+        with torch.no_grad():
+            bridge_logits = bridge(tokens)
+
+        torch.testing.assert_close(bridge_logits, source_logits, atol=0, rtol=0)
+        assert bridge.cfg.n_heads != model.blocks[0].attn.n_heads
+        assert bridge.cfg.d_vocab != model.embed.num_embeddings
+
+
+class TestResidualStreamDecomposition:
+    """`run_with_cache`'s resid hooks must decompose the way the residual
+    stream actually works, not just be present under the right names
+    (attribute/key presence is already covered by the structural unit
+    tests) -- resid_pre + attn_out == resid_mid, resid_mid + mlp_out ==
+    resid_post, and one block's resid_post is the next block's resid_pre."""
+
+    def test_resid_stream_decomposes_exactly_via_run_with_cache(self) -> None:
+        torch.manual_seed(0)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=2, d_ff=32, vocab_size=64)
+        model.eval()
+        bridge = build_pretrain_bridge(model, _make_cfg(d_model=16, n_layers=2))
+        tokens = torch.randint(0, 64, (1, 5))
+
+        with torch.no_grad():
+            _, cache = bridge.run_with_cache(tokens)
+
+        torch.testing.assert_close(
+            cache["blocks.0.hook_resid_pre"], cache["hook_embed"], atol=0, rtol=0
+        )
+        torch.testing.assert_close(
+            cache["blocks.0.hook_resid_mid"],
+            cache["blocks.0.hook_resid_pre"] + cache["blocks.0.hook_attn_out"],
+        )
+        torch.testing.assert_close(
+            cache["blocks.0.hook_resid_post"],
+            cache["blocks.0.hook_resid_mid"] + cache["blocks.0.hook_mlp_out"],
+        )
+        torch.testing.assert_close(
+            cache["blocks.1.hook_resid_pre"],
+            cache["blocks.0.hook_resid_post"],
+            atol=0,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            cache["blocks.1.hook_resid_post"],
+            cache["blocks.1.hook_resid_mid"] + cache["blocks.1.hook_mlp_out"],
+        )
+
+
+class TestHookIntervention:
+    """A forward-hook edit at `blocks.{i}.mlp.hook_out` must land at the
+    point the residual-stream decomposition says it should -- cross-
+    checked against an independently-expressed version of the same edit
+    (forcing resid_post to equal resid_mid), rather than only checking
+    that *some* change occurred."""
+
+    def test_mlp_hook_ablation_matches_independent_resid_post_override(self) -> None:
+        torch.manual_seed(0)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=2, d_ff=32, vocab_size=64)
+        model.eval()
+        bridge = build_pretrain_bridge(model, _make_cfg(d_model=16, n_layers=2))
+        tokens = torch.randint(0, 64, (1, 5))
+
+        with torch.no_grad():
+            baseline_logits, baseline_cache = bridge.run_with_cache(tokens)
+        resid_mid0 = baseline_cache["blocks.0.hook_resid_mid"].clone()
+
+        def zero_mlp_out(value: torch.Tensor, hook) -> torch.Tensor:
+            return torch.zeros_like(value)
+
+        def force_resid_post_to_resid_mid(value: torch.Tensor, hook) -> torch.Tensor:
+            return resid_mid0
+
+        with torch.no_grad():
+            via_mlp_ablation = bridge.run_with_hooks(
+                tokens, fwd_hooks=[("blocks.0.mlp.hook_out", zero_mlp_out)]
+            )
+            via_resid_override = bridge.run_with_hooks(
+                tokens,
+                fwd_hooks=[("blocks.0.hook_resid_post", force_resid_post_to_resid_mid)],
+            )
+
+        # Sanity: the intervention actually changed something.
+        assert not torch.equal(via_mlp_ablation, baseline_logits)
+        # The real check: two different-looking edits that are
+        # mathematically the same edit must produce identical output.
+        torch.testing.assert_close(via_mlp_ablation, via_resid_override, atol=0, rtol=0)
+
+
+class TestDtypePreservation:
+    """float64 is checked for preservation through construction only, not
+    full numerical parity at that dtype -- RoPE's cos/sin computation
+    involves trig functions whose float32-vs-float64 rounding can
+    legitimately differ from the bridge's own dtype-casting path in ways
+    unrelated to correctness, so exact-equality parity isn't a meaningful
+    check at non-default dtypes the way it is at float32."""
+
+    def test_float64_construction_preserves_dtype_and_tied_weights(self) -> None:
+        torch.manual_seed(0)
+        model = TinyPretrainModel(
+            d_model=16,
+            n_heads=2,
+            n_layers=1,
+            d_ff=32,
+            vocab_size=64,
+            tie_embeddings=True,
+        ).to(torch.float64)
+        assert model.lm_head.weight is model.embed.weight
+
+        bridge = build_pretrain_bridge(model, _make_cfg(d_model=16, n_layers=1))
+
+        assert next(model.parameters()).dtype == torch.float64
+        assert model.lm_head.weight is model.embed.weight
+
+        tokens = torch.randint(0, 64, (1, 4))
+        with torch.no_grad():
+            output = bridge(tokens)
+        assert output.dtype == torch.float64
+        assert torch.isfinite(output).all()

--- a/TransformerLens/tests/mocks/tiny_pretrain_model.py
+++ b/TransformerLens/tests/mocks/tiny_pretrain_model.py
@@ -1,0 +1,193 @@
+"""A tiny, self-contained decoder-only reference model (RoPE, RMSNorm,
+gated SwiGLU MLP, optional MoE) used only by the pretrain-adapter
+integration tests, to exercise real numerical parity rather than a purely
+structural mock.
+
+Deliberately uses the *adjacent-pair* RoPE convention
+(`[x0, x1] -> [-x1, x0]`), not HuggingFace's rotate-half (contiguous-half)
+convention -- this is the concrete case `PretrainArchitectureAdapter`'s
+docstring is about: an existing HF-oriented attention bridge would silently
+apply the wrong rotation to a model using this convention.
+
+Also deliberately computes RoPE `cos`/`sin` once per forward pass and
+passes them into every block call as extra positional args
+(`block(x, cos, sin)`), matching the target architecture's convention.
+This matters beyond efficiency: `BlockBridge` wraps a bare-tensor output
+in a 1-tuple for single-positional-argument "standalone hidden_states"
+calls (an HF-compatibility convention). A loop calling `block(x)` alone
+would need to unwrap `[0]` from each result -- modifying the source
+model's forward specifically because it's being bridged. Passing
+`cos`/`sin` positionally avoids that, so the forward loop needs no
+changes at all.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _rotate_adjacent_pairs(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., 0::2]
+    x2 = x[..., 1::2]
+    return torch.stack((-x2, x1), dim=-1).flatten(-2)
+
+
+def _apply_rotary_adjacent_pairs(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> torch.Tensor:
+    cos = cos.repeat_interleave(2, dim=-1)
+    sin = sin.repeat_interleave(2, dim=-1)
+    return x * cos + _rotate_adjacent_pairs(x) * sin
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(d_model))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        variance = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.eps)
+        return x * self.weight
+
+
+class Attention(nn.Module):
+    """Receives precomputed `cos`/`sin` rather than computing them
+    internally -- matches the real target architecture, where rotary
+    tables are computed once per forward pass and shared across blocks."""
+
+    def __init__(self, d_model: int, n_heads: int):
+        super().__init__()
+        self.n_heads = n_heads
+        self.d_head = d_model // n_heads
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.o = nn.Linear(d_model, d_model, bias=False)
+
+    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        b, s, d = x.shape
+        qkv = self.qkv(x).view(b, s, 3, self.n_heads, self.d_head).permute(2, 0, 3, 1, 4)
+        q, k, v = qkv[0], qkv[1], qkv[2]  # each: [b, n_heads, s, d_head]
+
+        q = _apply_rotary_adjacent_pairs(q, cos, sin)
+        k = _apply_rotary_adjacent_pairs(k, cos, sin)
+
+        attn = torch.softmax(
+            (q @ k.transpose(-2, -1)) / (self.d_head**0.5)
+            + torch.triu(torch.full((s, s), float("-inf"), device=x.device), diagonal=1),
+            dim=-1,
+        )
+        out = (attn @ v).transpose(1, 2).reshape(b, s, d)
+        return self.o(out)
+
+
+class DenseMLP(nn.Module):
+    def __init__(self, d_model: int, d_ff: int):
+        super().__init__()
+        self.gate = nn.Linear(d_model, d_ff, bias=False)
+        self.up = nn.Linear(d_model, d_ff, bias=False)
+        self.down = nn.Linear(d_ff, d_model, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down(F.silu(self.gate(x)) * self.up(x))
+
+
+class MoEMLP(nn.Module):
+    def __init__(self, d_model: int, d_ff: int, n_experts: int, top_k: int):
+        super().__init__()
+        self.top_k = top_k
+        self.router = nn.Linear(d_model, n_experts, bias=False)
+        self.experts = nn.ModuleList([DenseMLP(d_model, d_ff) for _ in range(n_experts)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        weights = torch.softmax(self.router(x), dim=-1)
+        topk_weights, topk_idx = weights.topk(self.top_k, dim=-1)
+        out = torch.zeros_like(x)
+        for e in range(len(self.experts)):
+            mask = topk_idx == e
+            if not mask.any():
+                continue
+            gate = (mask.float() * topk_weights).sum(dim=-1, keepdim=True)
+            out = out + gate * self.experts[e](x)
+        return out
+
+
+class Block(nn.Module):
+    """Takes `cos`/`sin` as extra positional args alongside the hidden
+    state -- see the module docstring for why this matters beyond RoPE
+    plumbing."""
+
+    def __init__(self, d_model: int, n_heads: int, d_ff: int, mlp: nn.Module):
+        super().__init__()
+        self.norm1 = RMSNorm(d_model)
+        self.attn = Attention(d_model, n_heads)
+        self.norm2 = RMSNorm(d_model)
+        self.mlp = mlp
+
+    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), cos, sin)
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class TinyPretrainModel(nn.Module):
+    """Full tiny reference model for numerical-parity integration tests.
+    Matches `PretrainArchitectureAdapter`'s expected attribute paths:
+    `embed`, `blocks`, `norm_f`, `lm_head`.
+    """
+
+    def __init__(
+        self,
+        d_model: int = 32,
+        n_heads: int = 4,
+        n_layers: int = 2,
+        d_ff: int = 64,
+        vocab_size: int = 256,
+        n_experts: int = 4,
+        top_k: int = 2,
+        moe_layer_indices: frozenset[int] = frozenset(),
+        tie_embeddings: bool = True,
+        rope_base: float = 10000.0,
+    ):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, d_model)
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    d_model,
+                    n_heads,
+                    d_ff,
+                    mlp=(
+                        MoEMLP(d_model, d_ff, n_experts, top_k)
+                        if i in moe_layer_indices
+                        else DenseMLP(d_model, d_ff)
+                    ),
+                )
+                for i in range(n_layers)
+            ]
+        )
+        self.norm_f = RMSNorm(d_model)
+        self.lm_head = nn.Linear(d_model, vocab_size, bias=False)
+        if tie_embeddings:
+            self.lm_head.weight = self.embed.weight
+
+        d_head = d_model // n_heads
+        inv_freq = 1.0 / (rope_base ** (torch.arange(0, d_head, 2).float() / d_head))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, tokens: torch.Tensor) -> dict:
+        b, s = tokens.shape
+        x = self.embed(tokens)
+
+        # Computed once per forward pass, passed into every block -- the
+        # real target architecture's convention (see module docstring).
+        pos = torch.arange(s, device=tokens.device, dtype=self.inv_freq.dtype)
+        freqs = torch.outer(pos, self.inv_freq)
+        cos, sin = freqs.cos(), freqs.sin()
+
+        for block in self.blocks:
+            x = block(x, cos, sin)
+        x = self.norm_f(x)
+        return {"logits": self.lm_head(x)}

--- a/TransformerLens/tests/unit/model_bridge/generalized_components/test_moe_bridge_tuple_output.py
+++ b/TransformerLens/tests/unit/model_bridge/generalized_components/test_moe_bridge_tuple_output.py
@@ -1,0 +1,88 @@
+"""Tests for MoEBridge tuple-output validation and router-score hooks.
+
+Unlike the pretrain-adapter's TestDenseOrMoEFeedForwardBridgeTupleOutput
+(which patches _delegate.forward and therefore exercises
+DenseOrMoEFeedForwardBridge.forward in isolation), these tests call
+MoEBridge.forward() directly via a stub original_component, so they cover
+MoEBridge's own tuple-validation contract rather than the dispatcher's.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from transformer_lens.model_bridge.generalized_components import MoEBridge
+
+
+class _StubMoEModule(nn.Module):
+    """Minimal nn.Module whose forward is swapped in per-test, standing in
+    for a real MoE layer wrapped by MoEBridge."""
+
+    def __init__(self, fake_forward):
+        super().__init__()
+        # Give the module at least one parameter so
+        # `next(self.parameters())` in MoEBridge.forward doesn't raise
+        # StopIteration and skip the dtype-cast branch entirely.
+        self.dummy = nn.Linear(4, 4)
+        self._fake_forward = fake_forward
+
+    def forward(self, *args, **kwargs):
+        return self._fake_forward(*args, **kwargs)
+
+
+def _bridge_with_stub(fake_forward) -> MoEBridge:
+    bridge = MoEBridge(name="mlp")
+    bridge.set_original_component(_StubMoEModule(fake_forward))
+    return bridge
+
+
+class TestMoEBridgeTupleOutput:
+    def test_empty_tuple_raises_clear_type_error(self) -> None:
+        bridge = _bridge_with_stub(lambda *a, **kw: ())
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            bridge(torch.ones(1, 3, 4))
+
+    def test_non_tensor_metadata_preserved_without_router_hook(self) -> None:
+        bridge = _bridge_with_stub(lambda *a, **kw: (torch.zeros(1, 3, 4), "not_router_scores"))
+        fired = {"called": False}
+
+        def mark_fired(value, hook):
+            fired["called"] = True
+
+        bridge.hook_router_scores.add_hook(mark_fired)
+
+        output = bridge(torch.ones(1, 3, 4))
+
+        assert isinstance(output, tuple)
+        assert output[1] == "not_router_scores"
+        torch.testing.assert_close(output[0], torch.zeros(1, 3, 4))
+        assert fired["called"] is False
+
+    def test_tensor_router_scores_still_fire_hook(self) -> None:
+        router_scores = torch.rand(1, 3, 8)
+        bridge = _bridge_with_stub(lambda *a, **kw: (torch.zeros(1, 3, 4), router_scores))
+        captured = {}
+
+        def capture_router_scores(value, hook):
+            captured["router_scores"] = value
+            return value
+
+        bridge.hook_router_scores.add_hook(capture_router_scores)
+
+        output = bridge(torch.ones(1, 3, 4))
+
+        assert isinstance(output, tuple)
+        torch.testing.assert_close(output[1], router_scores)
+        assert "router_scores" in captured
+        torch.testing.assert_close(captured["router_scores"], router_scores)
+
+    def test_non_tensor_first_element_raises_clear_type_error(self) -> None:
+        """Exercises the output[0]-validation added to MoEBridge itself
+        (not just the dispatcher) -- a malformed first element should
+        raise a clear TypeError here rather than failing inside
+        HookPoint's own type checking."""
+        bridge = _bridge_with_stub(lambda *a, **kw: ("not_a_tensor", torch.zeros(1, 3, 4)))
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            bridge(torch.ones(1, 3, 4))

--- a/TransformerLens/tests/unit/model_bridge/supported_architectures/_pretrain_mocks.py
+++ b/TransformerLens/tests/unit/model_bridge/supported_architectures/_pretrain_mocks.py
@@ -1,0 +1,214 @@
+"""Shared mock modules and fixtures for PretrainArchitectureAdapter and
+PretrainModelContainer unit tests. Not a test file itself (no `test_`
+prefix, so pytest won't collect it) -- imported by both
+test_pretrain_adapter.py and test_pretrain_model_container.py.
+
+Fully self-contained: builds tiny mock `nn.Module`s that reproduce the
+relevant module tree (embed / blocks / norm1 / attn / norm2 / mlp / norm_f /
+lm_head) rather than depending on any external training-framework package.
+No weight loading, no network access.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from transformer_lens.config.transformer_bridge_config import TransformerBridgeConfig
+from transformer_lens.model_bridge.supported_architectures.pretrain import (
+    ARCHITECTURE_NAME,
+)
+
+# --------------------------------------------------------------------------
+# Tiny mock module tree, matching the real target architecture's
+# block-calling convention (cos/sin as extra positional args -- see
+# tiny_pretrain_model.py's module docstring). Real RoPE/RMSNorm math isn't
+# needed here (covered by integration parity tests); only correct
+# attribute names/shapes/call-signatures for component_mapping to wire up.
+# --------------------------------------------------------------------------
+
+
+class TinyRMSNorm(nn.Module):
+    def __init__(self, d_model: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.weight
+
+
+class TinyAttention(nn.Module):
+    """Opaque attention stand-in: linear-in, linear-out, no real RoPE math.
+    Takes (and ignores) cos/sin positionally, matching the real target
+    architecture's block-calling convention."""
+
+    def __init__(self, d_model: int, n_heads: int):
+        super().__init__()
+        self.n_heads = n_heads
+        self.qkv = nn.Linear(d_model, 3 * d_model)
+        self.out = nn.Linear(d_model, d_model)
+
+    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        b, s, d = x.shape
+        qkv = self.qkv(x)
+        q, k, v = qkv.chunk(3, dim=-1)
+        attn = torch.softmax(q @ k.transpose(-2, -1) / (d**0.5), dim=-1)
+        return self.out(attn @ v)
+
+
+class TinyDenseMLP(nn.Module):
+    def __init__(self, d_model: int, d_ff: int):
+        super().__init__()
+        self.gate = nn.Linear(d_model, d_ff, bias=False)
+        self.up = nn.Linear(d_model, d_ff, bias=False)
+        self.down = nn.Linear(d_ff, d_model, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down(torch.nn.functional.silu(self.gate(x)) * self.up(x))
+
+
+class TinyMoE(nn.Module):
+    def __init__(self, d_model: int, d_ff: int, n_experts: int, top_k: int):
+        super().__init__()
+        self.top_k = top_k
+        self.router = nn.Linear(d_model, n_experts, bias=False)
+        self.experts = nn.ModuleList([TinyDenseMLP(d_model, d_ff) for _ in range(n_experts)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        weights = torch.softmax(self.router(x), dim=-1)
+        topk_weights, topk_idx = weights.topk(self.top_k, dim=-1)
+        out = torch.zeros_like(x)
+        for expert_idx in range(len(self.experts)):
+            mask = (topk_idx == expert_idx).any(dim=-1, keepdim=True)
+            if mask.any():
+                out = out + mask * self.experts[expert_idx](x)
+        return out
+
+
+class TinyBlock(nn.Module):
+    def __init__(self, d_model: int, n_heads: int, d_ff: int, mlp: nn.Module):
+        super().__init__()
+        self.norm1 = TinyRMSNorm(d_model)
+        self.attn = TinyAttention(d_model, n_heads)
+        self.norm2 = TinyRMSNorm(d_model)
+        self.mlp = mlp
+
+    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), cos, sin)
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class TinyPretrainModel(nn.Module):
+    """Minimal decoder-only model matching the adapter's expected paths:
+    embed / blocks / norm_f / lm_head. `moe_layer_indices` (possibly empty)
+    controls which blocks get a `TinyMoE` mlp instead of a dense one.
+    """
+
+    def __init__(
+        self,
+        d_model: int = 32,
+        n_heads: int = 4,
+        n_layers: int = 2,
+        d_ff: int = 64,
+        vocab_size: int = 256,
+        n_experts: int = 4,
+        top_k: int = 2,
+        moe_layer_indices: frozenset[int] = frozenset(),
+        tie_embeddings: bool = True,
+    ):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, d_model)
+        self.blocks = nn.ModuleList(
+            [
+                TinyBlock(
+                    d_model,
+                    n_heads,
+                    d_ff,
+                    mlp=(
+                        TinyMoE(d_model, d_ff, n_experts, top_k)
+                        if i in moe_layer_indices
+                        else TinyDenseMLP(d_model, d_ff)
+                    ),
+                )
+                for i in range(n_layers)
+            ]
+        )
+        self.norm_f = TinyRMSNorm(d_model)
+        self.lm_head = nn.Linear(d_model, vocab_size, bias=False)
+        if tie_embeddings:
+            self.lm_head.weight = self.embed.weight
+        self.d_head = d_model // n_heads
+
+    def _forward_impl(self, tokens: torch.Tensor) -> dict:
+        b, s = tokens.shape
+        x = self.embed(tokens)
+        # Dummy cos/sin (no real RoPE math needed for these structural
+        # tests) but real tensors, passed positionally into every block --
+        # matches the real target architecture's convention.
+        cos = torch.ones(s, self.d_head // 2)
+        sin = torch.zeros(s, self.d_head // 2)
+        for block in self.blocks:
+            x = block(x, cos, sin)
+        x = self.norm_f(x)
+        return {"logits": self.lm_head(x)}
+
+    def forward(self, tokens: torch.Tensor, **kwargs) -> dict:
+        # **kwargs declared so pytest fixtures can pass through
+        # run_with_cache's force-injected kwargs -- the actual kwarg-
+        # forwarding contracts (strict vs. **kwargs-accepting source
+        # forwards) are exercised directly against ForwardStrict/
+        # ForwardVarKwargs below instead.
+        return self._forward_impl(tokens)
+
+
+class ForwardStrict(nn.Module):
+    """Declares no **kwargs catch-all -- exercises the "must filter"
+    branch of PretrainModelContainer's kwarg handling."""
+
+    def __init__(self):
+        super().__init__()
+        self.seen_kwargs: dict = {}
+
+    def forward(self, tokens: torch.Tensor, targets: torch.Tensor | None = None) -> dict:
+        self.seen_kwargs = {"targets": targets}
+        return {"logits": tokens.float()}
+
+
+class ForwardVarKwargs(nn.Module):
+    """Declares **kwargs -- exercises the "pass everything through" branch
+    of PretrainModelContainer's kwarg handling."""
+
+    def __init__(self):
+        super().__init__()
+        self.seen_kwargs: dict = {}
+
+    def forward(self, tokens: torch.Tensor, **kwargs) -> dict:
+        self.seen_kwargs = kwargs
+        return {"logits": tokens.float()}
+
+
+class MalformedMLP(nn.Module):
+    """Has neither a dense MLP's (gate, up, down) nor an MoE layer's
+    (router, experts) attributes -- used to test the adapter's failure
+    path."""
+
+    def __init__(self, d_model: int):
+        super().__init__()
+        self.some_other_layer = nn.Linear(d_model, d_model)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.some_other_layer(x)
+
+
+def make_cfg(d_model: int = 32, n_layers: int = 2) -> TransformerBridgeConfig:
+    return TransformerBridgeConfig(
+        d_model=d_model,
+        d_head=d_model // 4,
+        n_layers=n_layers,
+        n_ctx=128,
+        n_heads=4,
+        d_vocab=256,
+        d_mlp=d_model * 2,
+        architecture=ARCHITECTURE_NAME,
+    )

--- a/TransformerLens/tests/unit/model_bridge/supported_architectures/test_pretrain_adapter.py
+++ b/TransformerLens/tests/unit/model_bridge/supported_architectures/test_pretrain_adapter.py
@@ -1,0 +1,448 @@
+"""Unit tests for PretrainArchitectureAdapter and DenseOrMoEFeedForwardBridge
+-- component mapping, structural dispatch, and bridge-construction-level
+behavior. Container, builder, and wrapped-model lifecycle behavior (kwarg
+filtering, output-contract normalization, hook registration for the hidden
+MLP delegate, train/eval, dtype/device) lives in
+test_pretrain_model_container.py.
+
+Fully self-contained (see _pretrain_mocks.py): tiny mock `nn.Module`s, no
+external package dependency, no network access.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from transformer_lens.model_bridge.generalized_components import (
+    DelegatedAttentionBlockBridge,
+)
+from transformer_lens.model_bridge.sources._bridge_builder import (
+    build_bridge_from_module,
+)
+from transformer_lens.model_bridge.supported_architectures.pretrain import (
+    ARCHITECTURE_NAME,
+    DenseOrMoEFeedForwardBridge,
+    NativeForwardAttentionBridge,
+    PretrainArchitectureAdapter,
+    PretrainModelContainer,
+    build_pretrain_bridge,
+)
+
+from ._pretrain_mocks import (
+    MalformedMLP,
+    TinyDenseMLP,
+    TinyMoE,
+    TinyPretrainModel,
+    make_cfg,
+)
+
+_make_cfg = make_cfg  # local alias, matches call sites below
+
+
+class TestPretrainAdapterConstruction:
+    def test_adapter_sets_required_config_flags(self) -> None:
+        adapter = PretrainArchitectureAdapter(_make_cfg())
+        assert adapter.cfg.normalization_type == "RMS"
+        assert adapter.cfg.positional_embedding_type == "rotary"
+        assert adapter.cfg.final_rms is True
+        assert adapter.cfg.gated_mlp is True
+        assert adapter.cfg.attn_only is False
+
+    def test_adapter_mutates_the_passed_in_cfg_object_in_place(self) -> None:
+        """Documented, intentional behavior (matches nanogpt.py's adapter
+        convention) -- not an accidental side effect. This test guards the
+        specific claim: the object passed in is the object mutated, not a
+        copy."""
+        cfg = _make_cfg()
+        adapter = PretrainArchitectureAdapter(cfg)
+        assert adapter.cfg is cfg
+        assert cfg.normalization_type == "RMS"
+
+    def test_component_mapping_has_expected_top_level_keys(self) -> None:
+        adapter = PretrainArchitectureAdapter(_make_cfg())
+        mapping = adapter.get_component_mapping()
+        assert set(mapping.keys()) == {"embed", "blocks", "ln_final", "unembed"}
+
+    def test_mlp_mapping_always_uses_the_dispatcher(self) -> None:
+        """Unconditional now -- no cfg.num_experts branch to depend on."""
+        adapter = PretrainArchitectureAdapter(_make_cfg())
+        mlp_component = adapter.component_mapping["blocks"].submodules["mlp"]
+        assert isinstance(mlp_component, DenseOrMoEFeedForwardBridge)
+
+
+class TestNativeForwardAttentionBridge:
+    def test_opaque_attention_bridge_does_not_advertise_per_head_aliases(self) -> None:
+        """The opaque attention wrap has no Q/K/V/O submodules, so it must
+        not advertise AttentionBridge's class-level hook_aliases/
+        property_aliases (which assume those submodules exist) or the
+        split-QKV-fork machinery -- see NativeForwardAttentionBridge's
+        docstring."""
+        adapter = PretrainArchitectureAdapter(_make_cfg())
+        attn = adapter.component_mapping["blocks"].submodules["attn"]
+
+        assert isinstance(attn, NativeForwardAttentionBridge)
+        assert attn.hook_aliases == {}
+        assert attn.property_aliases == {}
+        assert attn.supports_split_qkv_fork is False
+
+        # Also check the actual constructed runtime bridge, not just the
+        # adapter's own component_mapping -- proves bridge construction
+        # didn't reintroduce the aliases along the way.
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(
+            d_model=32, n_heads=4, n_layers=1, d_ff=64, vocab_size=256
+        )
+        bridge = build_pretrain_bridge(model, cfg)
+        assert bridge.blocks[0].attn.hook_aliases == {}
+
+    def test_block_level_attention_output_still_reaches_hook_out(self) -> None:
+        """Clearing the per-head aliases must not also silence the block's
+        own attn.hook_out -- that's the actual hook point this adapter's
+        block-level hook coverage relies on."""
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(
+            d_model=32, n_heads=4, n_layers=1, d_ff=64, vocab_size=256
+        )
+        bridge = build_pretrain_bridge(model, cfg)
+        tokens = torch.randint(0, 256, (1, 5))
+        _, cache = bridge.run_with_cache(tokens)
+        assert "blocks.0.attn.hook_out" in cache
+
+    def test_blocks_use_delegated_attention_block_bridge(self) -> None:
+        """The adapter reuses DelegatedAttentionBlockBridge rather than
+        plain BlockBridge, since NativeForwardAttentionBridge's
+        supports_split_qkv_fork = False means the block-level
+        hook_attn_in/hook_q_input/hook_k_input/hook_v_input aliases would
+        otherwise dangle (point at HookPoints that are never created)."""
+        adapter = PretrainArchitectureAdapter(_make_cfg())
+        assert isinstance(adapter.component_mapping["blocks"], DelegatedAttentionBlockBridge)
+
+    def test_split_qkv_hook_names_are_absent_but_attention_output_remains_available(
+        self,
+    ) -> None:
+        """hook_attn_in/hook_q_input/hook_k_input/hook_v_input must not
+        appear as resolvable hook names anywhere in the built bridge --
+        DelegatedAttentionBlockBridge strips the block-level aliases, and
+        NativeForwardAttentionBridge never creates the underlying
+        attention-level HookPoints in the first place. hook_attn_out is
+        untouched by either change and must still resolve, both as the
+        block-level alias and as the attention component's own hook_out."""
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(
+            d_model=32, n_heads=4, n_layers=1, d_ff=64, vocab_size=256
+        )
+        bridge = build_pretrain_bridge(model, cfg)
+        hook_dict = bridge.hook_dict
+        for dangling in (
+            "blocks.0.hook_attn_in",
+            "blocks.0.hook_q_input",
+            "blocks.0.hook_k_input",
+            "blocks.0.hook_v_input",
+            "blocks.0.attn.hook_attn_in",
+            "blocks.0.attn.hook_q_input",
+            "blocks.0.attn.hook_k_input",
+            "blocks.0.attn.hook_v_input",
+        ):
+            assert dangling not in hook_dict, f"{dangling} should not resolve"
+        assert "blocks.0.hook_attn_out" in hook_dict
+        assert "blocks.0.attn.hook_out" in hook_dict
+
+
+class TestDenseOrMoEFeedForwardBridgeDispatch:
+    def test_dispatches_to_moe_delegate_for_moe_module(self) -> None:
+        cfg = _make_cfg()
+        bridge = DenseOrMoEFeedForwardBridge(name="mlp", config=cfg)
+        moe_module = TinyMoE(d_model=32, d_ff=64, n_experts=4, top_k=2)
+        bridge.set_original_component(moe_module)
+
+        from transformer_lens.model_bridge.generalized_components import MoEBridge
+
+        assert isinstance(bridge._delegate, MoEBridge)
+
+    def test_dispatches_to_dense_delegate_for_dense_module(self) -> None:
+        cfg = _make_cfg()
+        bridge = DenseOrMoEFeedForwardBridge(name="mlp", config=cfg)
+        dense_module = TinyDenseMLP(d_model=32, d_ff=64)
+        bridge.set_original_component(dense_module)
+
+        from transformer_lens.model_bridge.generalized_components import GatedMLPBridge
+
+        assert isinstance(bridge._delegate, GatedMLPBridge)
+
+    def test_raises_clear_error_for_malformed_module(self) -> None:
+        cfg = _make_cfg()
+        bridge = DenseOrMoEFeedForwardBridge(name="mlp", config=cfg)
+        malformed = MalformedMLP(d_model=32)
+
+        with pytest.raises(ValueError, match="doesn't know how to wrap it"):
+            bridge.set_original_component(malformed)
+
+
+class TestDenseOrMoEFeedForwardBridgeDispatchValidatesTypes:
+    """hasattr alone would let a module win a branch by attribute-name
+    coincidence even if the attributes are the wrong type. These tests
+    exercise the basic type checks added to set_original_component so
+    such a mismatch is caught here, with a clear message naming the
+    actual field and type, rather than failing later inside MoEBridge/
+    GatedMLPBridge or during forward."""
+
+    def test_router_of_wrong_type_raises_type_error(self) -> None:
+        class BadRouterMoE(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.router = "not_a_module"  # right name, wrong type
+                self.experts = torch.nn.ModuleList(
+                    [TinyDenseMLP(d_model=32, d_ff=64) for _ in range(4)]
+                )
+
+        cfg = _make_cfg()
+        bridge = DenseOrMoEFeedForwardBridge(name="mlp", config=cfg)
+        with pytest.raises(TypeError, match="router"):
+            bridge.set_original_component(BadRouterMoE())
+
+    def test_experts_of_wrong_type_raises_type_error(self) -> None:
+        class BadExpertsMoE(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.router = torch.nn.Linear(32, 4)
+                self.experts = "not_a_module_collection"  # right name, wrong type
+
+        cfg = _make_cfg()
+        bridge = DenseOrMoEFeedForwardBridge(name="mlp", config=cfg)
+        with pytest.raises(TypeError, match="experts"):
+            bridge.set_original_component(BadExpertsMoE())
+
+    def test_plain_list_of_experts_is_rejected(self) -> None:
+        """Modules held in an ordinary Python list are not registered as
+        children -- their parameters would silently drop out of
+        parameters()/state_dict()/.to(...)/train()/eval(), contradicting
+        this adapter's lifecycle guarantees. Rejected even though every
+        element is itself a valid nn.Module."""
+
+        class ListExpertsMoE(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.router = torch.nn.Linear(32, 4)
+                self.experts = [TinyDenseMLP(d_model=32, d_ff=64) for _ in range(4)]
+
+        cfg = _make_cfg()
+        bridge = DenseOrMoEFeedForwardBridge(name="mlp", config=cfg)
+        with pytest.raises(TypeError, match="registered module collection"):
+            bridge.set_original_component(ListExpertsMoE())
+
+    def test_gate_of_wrong_type_raises_type_error(self) -> None:
+        class BadGateDense(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.gate = "not_a_module"  # right name, wrong type
+                self.up = torch.nn.Linear(32, 64, bias=False)
+                self.down = torch.nn.Linear(64, 32, bias=False)
+
+        cfg = _make_cfg()
+        bridge = DenseOrMoEFeedForwardBridge(name="mlp", config=cfg)
+        with pytest.raises(TypeError, match="gate"):
+            bridge.set_original_component(BadGateDense())
+
+
+class TestDenseOrMoEFeedForwardBridgeTupleOutput:
+    """Exercises the dispatcher's own tuple-output handling directly, by
+    patching an already-wired delegate's forward -- independent of
+    whether GatedMLPBridge/MoEBridge happen to return a tuple today. The
+    dispatcher explicitly supports and validates this shape, so it's
+    tested as its own contract rather than assumed from what the real
+    delegates currently do."""
+
+    def _dispatcher_with_patched_delegate(self, fake_forward):
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(
+            d_model=16,
+            n_heads=2,
+            n_layers=1,
+            d_ff=32,
+            vocab_size=64,
+            n_experts=4,
+            top_k=2,
+            moe_layer_indices=frozenset({0}),
+        )
+        bridge = build_pretrain_bridge(model, cfg)
+        dispatcher = bridge.blocks[0].mlp
+        dispatcher._delegate.forward = fake_forward
+        return dispatcher
+
+    def test_tensor_first_tuple_passes_through_with_hook_applied(self) -> None:
+        dispatcher = self._dispatcher_with_patched_delegate(
+            lambda *a, **kw: (torch.zeros(1, 3, 16), "aux")
+        )
+        output = dispatcher(torch.ones(1, 3, 16))
+        assert isinstance(output, tuple)
+        assert output[1] == "aux"
+        torch.testing.assert_close(output[0], torch.zeros(1, 3, 16))
+
+    def test_empty_tuple_raises_clear_type_error(self) -> None:
+        dispatcher = self._dispatcher_with_patched_delegate(lambda *a, **kw: ())
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            dispatcher(torch.ones(1, 3, 16))
+
+    def test_non_tensor_first_element_raises_clear_type_error(self) -> None:
+        dispatcher = self._dispatcher_with_patched_delegate(
+            lambda *a, **kw: ("not_a_tensor", torch.zeros(1))
+        )
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            dispatcher(torch.ones(1, 3, 16))
+
+
+class TestPretrainAdapterBridgeConstruction:
+    @pytest.fixture
+    def dense_bridge(self):
+        cfg = _make_cfg(n_layers=2)
+        model = TinyPretrainModel(
+            d_model=32, n_heads=4, n_layers=2, d_ff=64, vocab_size=256
+        )
+        return build_pretrain_bridge(model, cfg)
+
+    @pytest.fixture
+    def moe_bridge(self):
+        cfg = _make_cfg(n_layers=2)
+        model = TinyPretrainModel(
+            d_model=32,
+            n_heads=4,
+            n_layers=2,
+            d_ff=64,
+            vocab_size=256,
+            n_experts=4,
+            top_k=2,
+            moe_layer_indices=frozenset({1}),
+        )
+        return build_pretrain_bridge(model, cfg)
+
+    def test_bridge_has_correct_block_count(self, dense_bridge) -> None:
+        assert len(dense_bridge.blocks) == 2
+
+    def test_bridge_has_embed_unembed_and_final_norm(self, dense_bridge) -> None:
+        assert hasattr(dense_bridge, "embed")
+        assert hasattr(dense_bridge, "unembed")
+        assert hasattr(dense_bridge, "ln_final")
+
+    def test_forward_returns_logits_of_expected_shape(self, dense_bridge) -> None:
+        tokens = torch.randint(0, 256, (1, 5))
+        with torch.no_grad():
+            output = dense_bridge(tokens)
+        assert output.shape == (1, 5, 256)
+
+    def test_run_with_cache_exposes_resid_hooks(self, dense_bridge) -> None:
+        tokens = torch.randint(0, 256, (1, 5))
+        _, cache = dense_bridge.run_with_cache(tokens)
+        assert any("resid_pre" in k for k in cache.keys())
+        assert any("resid_post" in k for k in cache.keys())
+
+    def test_no_per_head_attention_hooks(self, dense_bridge) -> None:
+        """This adapter deliberately does not expose hook_q/hook_k/hook_v --
+        see PretrainArchitectureAdapter's class docstring."""
+        tokens = torch.randint(0, 256, (1, 5))
+        _, cache = dense_bridge.run_with_cache(tokens)
+        assert not any("hook_q" in k for k in cache.keys())
+        assert not any("hook_pattern" in k for k in cache.keys())
+
+    def test_moe_bridge_forward_runs(self, moe_bridge) -> None:
+        tokens = torch.randint(0, 256, (1, 5))
+        with torch.no_grad():
+            output = moe_bridge(tokens)
+        assert output.shape == (1, 5, 256)
+        assert not torch.isnan(output).any()
+
+    def test_moe_block_uses_dispatcher(self, moe_bridge) -> None:
+        assert isinstance(moe_bridge.blocks[1].mlp, DenseOrMoEFeedForwardBridge)
+
+    def test_moe_layer_hooks_are_registered_at_the_dispatcher_path(self, moe_bridge) -> None:
+        """Verifies actual cache keys, not just isinstance -- the claim in
+        DenseOrMoEFeedForwardBridge's docstring that hooks fire at
+        blocks.{i}.mlp.hook_in/hook_out regardless of dense-vs-MoE."""
+        tokens = torch.randint(0, 256, (1, 5))
+        _, cache = moe_bridge.run_with_cache(tokens)
+        assert "blocks.1.mlp.hook_in" in cache
+        assert "blocks.1.mlp.hook_out" in cache
+        # Layer 0 is dense in this fixture -- same path convention applies.
+        assert "blocks.0.mlp.hook_in" in cache
+        assert "blocks.0.mlp.hook_out" in cache
+
+
+class TestMoEConfigFieldIndependence:
+    def test_bridge_behaves_identically_with_moe_config_fields_populated(self) -> None:
+        """MoEBridge itself (transformer_lens/model_bridge/generalized_
+        components/moe.py) never reads cfg.num_experts or
+        cfg.experts_per_token. Populating them with realistic values must
+        not change behavior.
+        Uses an actual MoE layer (moe_layer_indices={0}) -- both models
+        being dense would let this pass without ever constructing
+        MoEBridge, so the dispatch type is asserted directly too."""
+        from transformer_lens.model_bridge.generalized_components import MoEBridge
+
+        torch.manual_seed(0)
+        model_a = TinyPretrainModel(
+            d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64,
+            n_experts=4, top_k=2, moe_layer_indices=frozenset({0}),
+        )
+        cfg_without = _make_cfg(n_layers=1)
+        bridge_without = build_pretrain_bridge(model_a, cfg_without)
+
+        torch.manual_seed(0)
+        model_b = TinyPretrainModel(
+            d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64,
+            n_experts=4, top_k=2, moe_layer_indices=frozenset({0}),
+        )
+        cfg_with = _make_cfg(n_layers=1)
+        cfg_with.num_experts = 4
+        cfg_with.experts_per_token = 2
+        bridge_with = build_pretrain_bridge(model_b, cfg_with)
+
+        assert isinstance(bridge_without.blocks[0].mlp._delegate, MoEBridge)
+        assert isinstance(bridge_with.blocks[0].mlp._delegate, MoEBridge)
+
+        tokens = torch.randint(0, 64, (1, 3))
+        with torch.no_grad():
+            out_without = bridge_without(tokens)
+            out_with = bridge_with(tokens)
+        torch.testing.assert_close(out_without, out_with, atol=0, rtol=0)
+
+
+class TestPretrainAdapterTiedEmbeddings:
+    def test_tied_embedding_bridge_construction_succeeds(self) -> None:
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(
+            d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64, tie_embeddings=True
+        )
+        bridge = build_pretrain_bridge(model, cfg)
+        tokens = torch.randint(0, 64, (1, 3))
+        with torch.no_grad():
+            output = bridge(tokens)
+        assert output.shape == (1, 3, 64)
+
+    def test_untied_embedding_bridge_construction_succeeds(self) -> None:
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(
+            d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64, tie_embeddings=False
+        )
+        bridge = build_pretrain_bridge(model, cfg)
+        tokens = torch.randint(0, 64, (1, 3))
+        with torch.no_grad():
+            output = bridge(tokens)
+        assert output.shape == (1, 3, 64)
+
+
+class TestBuildBridgeFromModuleDirectlyStillWorks:
+    """Advanced/internal path -- build_pretrain_bridge is the intended
+    public entry point, but direct build_bridge_from_module use (with the
+    container applied manually) must keep working too."""
+
+    def test_direct_build_bridge_from_module_with_manual_container(self) -> None:
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        bridge = build_bridge_from_module(
+            PretrainModelContainer(model),
+            architecture=ARCHITECTURE_NAME,
+            tl_config=cfg,
+        )
+        tokens = torch.randint(0, 64, (1, 3))
+        with torch.no_grad():
+            output = bridge(tokens)
+        assert output.shape == (1, 3, 64)

--- a/TransformerLens/tests/unit/model_bridge/supported_architectures/test_pretrain_model_container.py
+++ b/TransformerLens/tests/unit/model_bridge/supported_architectures/test_pretrain_model_container.py
@@ -1,0 +1,537 @@
+"""Container, builder, and wrapped-model lifecycle behavior for
+PretrainModelContainer and build_pretrain_bridge -- kwarg filtering,
+output-contract normalization, train/eval mode propagation, and
+dtype/tied-weight preservation. Hook registration tests for the hidden
+MLP delegate
+(implemented by DenseOrMoEFeedForwardBridge) live here too, since what
+they verify -- real parameters staying reachable through
+`original_model.inner` -- is a lifecycle concern, not a mapping one.
+Adapter-mapping-level behavior lives in test_pretrain_adapter.py.
+
+Fully self-contained (see _pretrain_mocks.py): tiny mock `nn.Module`s, no
+external package dependency, no network access.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from transformer_lens.model_bridge.supported_architectures.pretrain import (
+    PretrainModelContainer,
+    _LogitsAttrDict,
+    build_pretrain_bridge,
+)
+
+from ._pretrain_mocks import (
+    ForwardStrict,
+    ForwardVarKwargs,
+    TinyPretrainModel,
+    make_cfg,
+)
+
+_make_cfg = make_cfg  # local alias, matches call sites below
+
+
+class TestPretrainModelContainerKwargFiltering:
+    def test_output_attentions_is_stripped_for_strict_signature(self) -> None:
+        """The one TransformerBridge-injected kwarg (run_with_cache
+        forces output_attentions=True) must not reach a source forward with
+        no **kwargs catch-all."""
+        model = ForwardStrict()
+        container = PretrainModelContainer(model)
+        container(torch.tensor([[1, 2, 3]]), targets=None, output_attentions=True)
+        assert model.seen_kwargs == {"targets": None}
+
+    def test_output_attentions_is_stripped_even_for_var_kwargs_signature(self) -> None:
+        """Stripped unconditionally, regardless of whether the source would
+        have accepted it anyway -- keeps behavior uniform across source
+        forward signatures."""
+        model = ForwardVarKwargs()
+        container = PretrainModelContainer(model)
+        container(torch.tensor([[1, 2, 3]]), output_attentions=True, some_other_kwarg=42)
+        assert model.seen_kwargs == {"some_other_kwarg": 42}
+
+    def test_unrelated_kwarg_typo_is_not_silently_swallowed(self) -> None:
+        """A genuine caller mistake (e.g. `target=` instead of `targets=`)
+        must raise, not be silently discarded alongside the one kwarg this
+        container is actually responsible for stripping."""
+        model = ForwardStrict()
+        container = PretrainModelContainer(model)
+        with pytest.raises(TypeError):
+            container(torch.tensor([[1, 2, 3]]), target=torch.tensor([1]))
+
+
+class TestPretrainModelContainerHookRegistration:
+    """The delegate is hidden from nn.Module registration (see
+    DenseOrMoEFeedForwardBridge), so blocks.{i}.mlp.hook_in/out are the
+    only publicly registered MLP hook points. Forward, gradients, dtype
+    conversion, and state_dict() still reach the hidden delegate's real
+    weights through the raw wrapped model."""
+
+    def _build(self):
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        return build_pretrain_bridge(model, cfg)
+
+    def test_only_the_dispatcher_hook_out_is_registered(self) -> None:
+        bridge = self._build()
+        tokens = torch.randint(0, 64, (1, 4))
+        with torch.no_grad():
+            _, cache = bridge.run_with_cache(tokens)
+        assert "blocks.0.mlp.hook_out" in cache
+        assert "blocks.0.mlp._delegate.hook_out" not in cache
+
+    def test_broad_hook_selector_applies_intervention_exactly_once(self) -> None:
+        bridge = self._build()
+        tokens = torch.randint(0, 64, (1, 4))
+        calls: list[str] = []
+
+        def recording_add_one(value: torch.Tensor, hook) -> torch.Tensor:
+            calls.append(hook.name)
+            return value + 1.0
+
+        def broad_filter(name: str) -> bool:
+            return "mlp" in name and "hook_out" in name
+
+        with torch.no_grad():
+            bridge.run_with_hooks(tokens, fwd_hooks=[(broad_filter, recording_add_one)])
+
+        assert calls == ["blocks.0.mlp.hook_out"]
+
+    def test_gradients_still_reach_the_hidden_delegates_weights(self) -> None:
+        bridge = self._build()
+        tokens = torch.randint(0, 64, (1, 4))
+        bridge(tokens).sum().backward()
+        mlp = bridge.original_model.inner.blocks[0].mlp
+        assert mlp.gate.weight.grad is not None
+        assert mlp.gate.weight.grad.abs().sum().item() > 0
+
+    def test_bridge_to_dtype_reaches_the_hidden_delegates_weights(self) -> None:
+        bridge = self._build()
+        bridge.to(dtype=torch.float64)
+
+        assert bridge.original_model.inner.embed.weight.dtype == torch.float64
+        assert bridge.original_model.inner.blocks[0].mlp.gate.weight.dtype == torch.float64
+
+        tokens = torch.randint(0, 64, (1, 4))
+        with torch.no_grad():
+            output = bridge(tokens)
+        assert output.dtype == torch.float64
+
+    def test_state_dict_includes_the_hidden_delegates_weights(self) -> None:
+        bridge = self._build()
+        source_weight = bridge.original_model.inner.blocks[0].mlp.gate.weight
+
+        state = bridge.state_dict()
+        matching = [v for k, v in state.items() if k.endswith("blocks.0.mlp.gate.weight")]
+
+        assert len(matching) == 1
+        torch.testing.assert_close(matching[0], source_weight)
+
+    def test_repeated_hook_lifecycle_still_works(self) -> None:
+        """Guards against a future assumption that every internally-used
+        GeneralizedComponent must be registered -- the dispatcher's own
+        hooks are, and that's what reset_hooks()/run_with_cache rely on."""
+        bridge = self._build()
+        tokens = torch.randint(0, 64, (1, 4))
+        with torch.no_grad():
+            bridge.run_with_cache(tokens)
+            bridge.reset_hooks()
+            _, cache = bridge.run_with_cache(tokens)
+        assert "blocks.0.mlp.hook_out" in cache
+
+
+class TestTrainEvalModePropagation:
+    """bridge.train()/.eval() propagate to the wrapped model:
+    build_pretrain_bridge reassigns the returned bridge's class to a small
+    generated TransformerBridge subclass (see
+    _get_mode_propagating_bridge_class) whose overridden train() also sets
+    mode on original_model; inherited eval() calls train(False), so it
+    reaches the override too without needing its own override. This
+    closes a gap in TransformerBridge's own train()/eval(), which only
+    walk component_mapping and never reach original_model on their own."""
+
+    def test_bridge_eval_propagates_to_wrapped_model(self) -> None:
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        bridge = build_pretrain_bridge(model, cfg)
+
+        assert model.training is True
+        bridge.eval()
+        assert model.training is False
+
+    def test_bridge_train_propagates_to_wrapped_model(self) -> None:
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        bridge = build_pretrain_bridge(model, cfg)
+
+        model.eval()
+        assert model.training is False
+        bridge.train()
+        assert model.training is True
+
+    def test_caller_can_still_set_mode_directly_on_their_own_model_reference(self) -> None:
+        """Setting mode via the raw model reference still works and stays
+        in sync -- both paths write to the same underlying module."""
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        build_pretrain_bridge(model, cfg)
+
+        model.eval()
+        assert model.training is False
+        model.train()
+        assert model.training is True
+
+    def test_train_and_eval_return_the_bridge_itself(self) -> None:
+        """nn.Module convention: train()/eval() return self, so callers can
+        chain (`model.train().to(device)`, etc). The generated subclass
+        must preserve this, not just the mode-propagation side effect."""
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        bridge = build_pretrain_bridge(model, cfg)
+
+        assert bridge.train(False) is bridge
+        assert bridge.train(True) is bridge
+        assert bridge.eval() is bridge
+
+    def test_bridge_can_be_reconstructed_from_supported_state(self) -> None:
+        """The adapter's actual persistence contract is: rebuild the
+        bridge from the source model class + cfg + the source model's
+        *raw* state_dict, then confirm behavior (outputs, train/eval
+        propagation) survives the round trip.
+
+        The state_dict must be snapshotted BEFORE `build_pretrain_bridge`
+        is called. Building the bridge wraps the model's submodules in
+        place (each one gains an `_original_component` wrapper for
+        hooking), so `model.state_dict()` taken *after* wrapping has
+        keys like `embed._original_component.weight` instead of
+        `embed.weight` -- a fresh, unwrapped `TinyPretrainModel` can't
+        load that. Capturing the state_dict first, then wrapping a
+        second fresh model and loading the pre-wrap snapshot into it,
+        avoids that trap.
+
+        Only the source model's state_dict is used -- not
+        `bridge.state_dict()` -- since the bridge doesn't own an
+        independent set of learned weights; it exposes the wrapped
+        source model's parameters under bridge-shaped names.
+
+        This is deliberately weaker than whole-object `pickle.dumps`,
+        which would also require every nested `TransformerBridge`
+        implementation detail (e.g. `AttentionBridge`'s hook
+        conversions) to be picklable -- a guarantee unrelated to this
+        adapter and not part of what it needs to promise. If a stronger
+        whole-object-pickle guarantee is later required, it belongs in a
+        `TransformerBridge`-level test, not here.
+        """
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+
+        # Snapshot BEFORE wrapping -- see docstring.
+        raw_model_state = {key: value.detach().clone() for key, value in model.state_dict().items()}
+
+        bridge = build_pretrain_bridge(model, cfg)
+        bridge.eval()
+
+        restored_model = TinyPretrainModel(
+            d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64
+        )
+        restored_model.load_state_dict(raw_model_state)
+
+        restored_bridge = build_pretrain_bridge(restored_model, cfg)
+        restored_bridge.eval()
+
+        tokens = torch.randint(0, 64, (1, 4))
+        with torch.no_grad():
+            expected = bridge(tokens)
+            actual = restored_bridge(tokens)
+
+        expected_logits = expected.logits if hasattr(expected, "logits") else expected
+        actual_logits = actual.logits if hasattr(actual, "logits") else actual
+        torch.testing.assert_close(actual_logits, expected_logits, atol=0, rtol=0)
+
+        assert restored_bridge.training is False
+        assert restored_model.training is False
+
+        restored_bridge.train()
+        assert restored_model.training is True
+
+    def test_repeated_construction_reuses_the_same_generated_class(self) -> None:
+        """Guards the cache's stated purpose: build_pretrain_bridge should
+        not generate a new mode-propagating subclass on every call -- two
+        independently-built bridges from the same base bridge class must
+        share one generated class."""
+        cfg_a = _make_cfg(n_layers=1)
+        model_a = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        bridge_a = build_pretrain_bridge(model_a, cfg_a)
+
+        cfg_b = _make_cfg(n_layers=1)
+        model_b = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        bridge_b = build_pretrain_bridge(model_b, cfg_b)
+
+        assert type(bridge_a) is type(bridge_b)
+
+
+class TestDtypeAndTiedWeightPreservation:
+    def test_non_default_dtype_and_tied_weights_survive_construction(self) -> None:
+        torch.manual_seed(0)
+        model = TinyPretrainModel(
+            d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64, tie_embeddings=True
+        ).to(torch.float64)
+        assert model.lm_head.weight is model.embed.weight
+
+        cfg = _make_cfg(n_layers=1)
+        bridge = build_pretrain_bridge(model, cfg)
+
+        assert next(model.parameters()).dtype == torch.float64
+        assert model.lm_head.weight is model.embed.weight
+
+        tokens = torch.randint(0, 64, (1, 3))
+        with torch.no_grad():
+            output = bridge(tokens)
+        assert output.dtype == torch.float64
+
+
+class TestBuildPretrainBridgeErgonomics:
+    def test_explicit_model_name_is_forwarded(self) -> None:
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        bridge = build_pretrain_bridge(model, cfg, model_name="my-custom-name")
+        assert bridge.cfg.model_name == "my-custom-name"
+
+    def test_omitting_optional_kwargs_still_works(self) -> None:
+        """The default (no device/dtype/model_name passed) path, exercised
+        everywhere else in this file, must keep working unchanged."""
+        cfg = _make_cfg(n_layers=1)
+        model = TinyPretrainModel(d_model=16, n_heads=2, n_layers=1, d_ff=32, vocab_size=64)
+        bridge = build_pretrain_bridge(model, cfg)
+        tokens = torch.randint(0, 64, (1, 3))
+        with torch.no_grad():
+            output = bridge(tokens)
+        assert output.shape == (1, 3, 64)
+
+
+class TestPretrainModelContainerOutputContract:
+    def test_container_normalizes_dict_output_to_logits_attr_dict(self) -> None:
+        model = TinyPretrainModel(
+            d_model=16,
+            n_heads=2,
+            n_layers=1,
+            d_ff=32,
+            vocab_size=64,
+        )
+        container = PretrainModelContainer(model)
+        tokens = torch.randint(0, 64, (1, 3))
+
+        with torch.no_grad():
+            output = container(tokens)
+
+        assert isinstance(output, _LogitsAttrDict)
+        assert output.logits is output["logits"]
+        assert output.logits.shape == (1, 3, 64)
+
+    def test_container_returns_a_fresh_wrapper_on_each_call(self) -> None:
+        model = TinyPretrainModel(
+            d_model=16,
+            n_heads=2,
+            n_layers=1,
+            d_ff=32,
+            vocab_size=64,
+        )
+        container = PretrainModelContainer(model)
+        tokens = torch.randint(0, 64, (1, 3))
+
+        with torch.no_grad():
+            out1 = container(tokens)
+            out2 = container(tokens)
+
+        assert isinstance(out1, _LogitsAttrDict)
+        assert isinstance(out2, _LogitsAttrDict)
+        assert out1 is not out2
+        assert out1["logits"] is not out2["logits"]
+        torch.testing.assert_close(out1["logits"], out2["logits"])
+
+    def test_container_does_not_reuse_or_mutate_output_mapping(self) -> None:
+        model = TinyPretrainModel(
+            d_model=16,
+            n_heads=2,
+            n_layers=1,
+            d_ff=32,
+            vocab_size=64,
+        ).eval()
+        container = PretrainModelContainer(model)
+        tokens = torch.randint(0, 64, (1, 3))
+
+        with torch.no_grad():
+            out1 = container(tokens)
+
+        out1["sentinel"] = True
+
+        with torch.no_grad():
+            out2 = container(tokens)
+
+        assert out1 is not out2
+        assert "sentinel" not in out2
+        torch.testing.assert_close(out1["logits"], out2["logits"])
+
+    def test_dict_missing_logits_key_raises_value_error(self) -> None:
+        class ForwardWrongKey(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> dict:
+                return {"scores": tokens.float()}
+
+        container = PretrainModelContainer(ForwardWrongKey())
+        with pytest.raises(ValueError, match="'logits'"):
+            container(torch.tensor([[1, 2, 3]]))
+
+    def test_dict_with_heterogeneous_keys_still_raises_value_error(self) -> None:
+        """sorted(output.keys()) would raise TypeError on non-comparable
+        mixed key types (e.g. str and int); the error message must use
+        list() instead, so an invalid model output produces the intended
+        ValueError, not an unrelated sorting error."""
+
+        class ForwardHeterogeneousKeys(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> dict:
+                return {"scores": tokens.float(), 1: "metadata"}
+
+        container = PretrainModelContainer(ForwardHeterogeneousKeys())
+        with pytest.raises(ValueError, match="'logits'"):
+            container(torch.tensor([[1, 2, 3]]))
+
+    def test_dict_with_non_tensor_logits_raises_type_error(self) -> None:
+        class ForwardBadLogitsType(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> dict:
+                return {"logits": "not a tensor"}
+
+        container = PretrainModelContainer(ForwardBadLogitsType())
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            container(torch.tensor([[1, 2, 3]]))
+
+    def test_already_logits_attr_dict_passes_through_by_identity(self) -> None:
+        """An already-wrapped output must not be re-wrapped."""
+        already_wrapped = _LogitsAttrDict({"logits": torch.zeros(1)})
+
+        class ForwardAlreadyWrapped(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> _LogitsAttrDict:
+                return already_wrapped
+
+        container = PretrainModelContainer(ForwardAlreadyWrapped())
+        output = container(torch.tensor([[1, 2, 3]]))
+        assert output is already_wrapped
+
+    def test_malformed_logits_attr_dict_raises_value_error_not_keyerror(self) -> None:
+        """Not a realistic target-model failure (_LogitsAttrDict is
+        private), but closes the contract: a malformed instance gets the
+        same clear ValueError an ordinary dict missing 'logits' gets,
+        rather than a raw KeyError leaking out."""
+        malformed = _LogitsAttrDict({"scores": torch.zeros(1)})
+
+        class ForwardMalformedWrapped(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> _LogitsAttrDict:
+                return malformed
+
+        container = PretrainModelContainer(ForwardMalformedWrapped())
+        with pytest.raises(ValueError, match="'logits'"):
+            container(torch.tensor([[1, 2, 3]]))
+
+    def test_hf_style_object_with_logits_attribute_passes_through_unchanged(self) -> None:
+        """A source model that already satisfies hasattr(output, 'logits')
+        on its own (an HF-ModelOutput-like object, not a dict) needs no
+        normalization at all."""
+
+        class FakeModelOutput:
+            def __init__(self, logits: torch.Tensor):
+                self.logits = logits
+
+        already_hf_style = FakeModelOutput(torch.zeros(1))
+
+        class ForwardHFStyle(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> FakeModelOutput:
+                return already_hf_style
+
+        container = PretrainModelContainer(ForwardHFStyle())
+        output = container(torch.tensor([[1, 2, 3]]))
+        assert output is already_hf_style
+
+    def test_property_backed_logits_is_only_evaluated_once(self) -> None:
+        """.logits must be read once and cached locally, not re-evaluated
+        on every access -- matters for a property-backed .logits, which
+        could otherwise do redundant (or side-effecting) work per access."""
+        access_count = 0
+
+        class PropertyBackedOutput:
+            @property
+            def logits(self) -> torch.Tensor:
+                nonlocal access_count
+                access_count += 1
+                return torch.zeros(1)
+
+        class ForwardPropertyBacked(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> PropertyBackedOutput:
+                return PropertyBackedOutput()
+
+        container = PretrainModelContainer(ForwardPropertyBacked())
+        container(torch.tensor([[1, 2, 3]]))
+        assert access_count == 1
+
+    def test_object_with_non_tensor_logits_attribute_raises_type_error(self) -> None:
+        class BadModelOutput:
+            logits = "not a tensor"
+
+        class ForwardBadModelOutput(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> BadModelOutput:
+                return BadModelOutput()
+
+        container = PretrainModelContainer(ForwardBadModelOutput())
+        with pytest.raises(TypeError, match=r"\.logits"):
+            container(torch.tensor([[1, 2, 3]]))
+
+    def test_bare_tensor_output_passes_through_unchanged(self) -> None:
+        class ForwardBareTensor(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> torch.Tensor:
+                return tokens.float()
+
+        container = PretrainModelContainer(ForwardBareTensor())
+        tokens = torch.tensor([[1, 2, 3]])
+        output = container(tokens)
+        assert torch.equal(output, tokens.float())
+
+    def test_tuple_with_tensor_first_element_passes_through_unchanged(self) -> None:
+        """TransformerBridge extracts output[0] as logits for tuple
+        returns -- no normalization needed."""
+
+        class ForwardTuple(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> tuple:
+                return (tokens.float(), "some_aux_value")
+
+        container = PretrainModelContainer(ForwardTuple())
+        output = container(torch.tensor([[1, 2, 3]]))
+        assert isinstance(output, tuple)
+        assert output[1] == "some_aux_value"
+
+    def test_tuple_with_non_tensor_first_element_raises_type_error(self) -> None:
+        class ForwardBadTuple(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> tuple:
+                return ("not a tensor", tokens)
+
+        container = PretrainModelContainer(ForwardBadTuple())
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            container(torch.tensor([[1, 2, 3]]))
+
+    def test_list_output_raises_type_error(self) -> None:
+        class ForwardList(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> list:
+                return [tokens.float()]
+
+        container = PretrainModelContainer(ForwardList())
+        with pytest.raises(TypeError, match="must return"):
+            container(torch.tensor([[1, 2, 3]]))
+
+    def test_string_output_raises_type_error(self) -> None:
+        class ForwardString(nn.Module):
+            def forward(self, tokens: torch.Tensor) -> str:
+                return "wrong"
+
+        container = PretrainModelContainer(ForwardString())
+        with pytest.raises(TypeError, match="must return"):
+            container(torch.tensor([[1, 2, 3]]))

--- a/TransformerLens/tests/unit/model_bridge/test_bridge_train_mode_propagation.py
+++ b/TransformerLens/tests/unit/model_bridge/test_bridge_train_mode_propagation.py
@@ -1,0 +1,100 @@
+"""Regression tests for TransformerBridge train/eval mode propagation.
+
+`original_model` is stored outside the registered module tree, so
+inherited `nn.Module.train()` does not reach it. These tests verify that
+bridge mode changes propagate to the wrapped model, whose mode-dependent
+layers (Dropout) rely on that flag. Architecture-independent stub bridge;
+no HF Hub access, no weights.
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+from transformer_lens.model_bridge.bridge import TransformerBridge
+from transformer_lens.model_bridge.generalized_components import LinearBridge
+
+
+class _StubModel(nn.Module):
+    """Minimal source model with a mode-dependent layer (Dropout), so
+    train/eval propagation has an observable behavioral consequence, not
+    just a flag."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = nn.Linear(4, 4)
+        self.drop = nn.Dropout(0.5)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.drop(self.proj(x))
+
+
+class _StubAdapter(ArchitectureAdapter):
+    """Smallest adapter TransformerBridge will accept: a one-entry
+    component_mapping. The key is `stub_proj` (not `proj` or `embed`)
+    because TransformerBridge reserves several canonical attribute names
+    on itself; a colliding key fails at add_module time."""
+
+    def __init__(self, cfg: TransformerBridgeConfig) -> None:
+        super().__init__(cfg)
+        self.component_mapping = {"stub_proj": LinearBridge(name="proj")}
+
+
+def _make_stub_bridge() -> tuple[TransformerBridge, _StubModel]:
+    cfg = TransformerBridgeConfig(
+        d_model=4,
+        d_head=2,
+        n_layers=1,
+        n_ctx=8,
+        n_heads=2,
+        d_vocab=8,
+        architecture="StubForTest",
+    )
+    model = _StubModel()
+    bridge = TransformerBridge(model, _StubAdapter(cfg), tokenizer=None)
+    return bridge, model
+
+
+class TestTrainEvalModePropagation:
+    """bridge.train()/.eval() must reach original_model.
+
+    Without the TransformerBridge.train() override these fail with
+    original_model.training stuck at its wrap-time value (bridge.training
+    flips, the wrapped model's does not) -- i.e. bridge.eval() would leave
+    dropout active."""
+
+    def test_eval_propagates_to_original_model(self) -> None:
+        bridge, model = _make_stub_bridge()
+        assert model.training is True  # nn.Module default at wrap time
+        bridge.eval()
+        assert bridge.training is False
+        assert model.training is False
+
+    def test_train_propagates_to_original_model(self) -> None:
+        bridge, model = _make_stub_bridge()
+        bridge.eval()
+        assert model.training is False
+        bridge.train()
+        assert bridge.training is True
+        assert model.training is True
+
+    def test_train_and_eval_return_the_bridge_itself(self) -> None:
+        """nn.Module convention: train()/eval() return self so callers can
+        chain (`bridge.eval().to(device)`, etc.)."""
+        bridge, _ = _make_stub_bridge()
+        assert bridge.train(False) is bridge
+        assert bridge.train(True) is bridge
+        assert bridge.eval() is bridge
+
+    def test_direct_mode_on_original_model_stays_in_sync(self) -> None:
+        """Setting mode via the caller's own reference to the source model
+        still works -- both paths write the same underlying flags, so
+        neither clobbers the other."""
+        bridge, model = _make_stub_bridge()
+        bridge.eval()
+        model.train()
+        assert model.training is True
+        bridge.eval()
+        assert model.training is False

--- a/TransformerLens/tests/unit/tools/test_model_registry.py
+++ b/TransformerLens/tests/unit/tools/test_model_registry.py
@@ -1,0 +1,876 @@
+"""Unit tests for transformer_lens.tools.model_registry.
+
+Tests cover:
+- schemas.py: Round-trip serialization, backwards compat
+- verification.py: add_record, invalidate, is_verified, get_record
+- api.py: get_supported_models, is_model_supported, get_registry_stats
+- validate.py: validate_json_schema with valid and invalid data
+- registry_io.py: update_model_status, add_verification_record
+- alias_drift.py: check_drift, DriftReport
+- verify_models.py: _sanitize_note
+"""
+
+import json
+from datetime import date, datetime
+
+import pytest
+
+# ============================================================
+# Fixture: temp data directory with minimal valid JSON files
+# ============================================================
+
+
+@pytest.fixture
+def registry_data_dir(temp_dir):
+    """Create a temp directory with minimal valid registry JSON files."""
+    supported = {
+        "generated_at": "2026-01-01",
+        "scan_info": {"total_scanned": 100, "task_filter": "text-generation"},
+        "total_architectures": 2,
+        "total_models": 3,
+        "total_verified": 1,
+        "models": [
+            {
+                "architecture_id": "GPT2LMHeadModel",
+                "model_id": "openai-community/gpt2",
+                "status": 1,
+                "verified_date": "2026-01-01",
+                "metadata": None,
+                "note": None,
+                "phase1_score": 100.0,
+                "phase2_score": 95.0,
+                "phase3_score": 90.0,
+            },
+            {
+                "architecture_id": "GPT2LMHeadModel",
+                "model_id": "sshleifer/tiny-gpt2",
+                "status": 0,
+                "verified_date": None,
+                "metadata": None,
+                "note": None,
+                "phase1_score": None,
+                "phase2_score": None,
+                "phase3_score": None,
+            },
+            {
+                "architecture_id": "LlamaForCausalLM",
+                "model_id": "meta-llama/Llama-2-7b-hf",
+                "status": 1,
+                "verified_date": "2026-01-01",
+                "metadata": None,
+                "note": None,
+                "phase1_score": 100.0,
+                "phase2_score": 100.0,
+                "phase3_score": 100.0,
+            },
+        ],
+    }
+    (temp_dir / "supported_models.json").write_text(json.dumps(supported, indent=2))
+
+    gaps = {
+        "generated_at": "2026-01-01",
+        "scan_info": {"total_scanned": 100, "task_filter": "text-generation"},
+        "total_unsupported_architectures": 1,
+        "total_unsupported_models": 50,
+        "gaps": [
+            {
+                "architecture_id": "FalconForCausalLM",
+                "total_models": 50,
+                "sample_models": ["tiiuae/falcon-7b"],
+            },
+        ],
+    }
+    (temp_dir / "architecture_gaps.json").write_text(json.dumps(gaps, indent=2))
+
+    history = {
+        "last_updated": "2026-01-01T12:00:00",
+        "records": [
+            {
+                "model_id": "openai-community/gpt2",
+                "architecture_id": "GPT2LMHeadModel",
+                "verified_date": "2026-01-01",
+                "verified_by": "test",
+                "transformerlens_version": "3.0.0",
+                "notes": "Test verification",
+                "invalidated": False,
+                "invalidation_reason": None,
+            },
+        ],
+    }
+    (temp_dir / "verification_history.json").write_text(json.dumps(history, indent=2))
+
+    return temp_dir
+
+
+# ============================================================
+# Test schemas.py: Round-trip serialization
+# ============================================================
+
+
+class TestModelEntry:
+    """Tests for ModelEntry serialization."""
+
+    def test_round_trip(self):
+        from transformer_lens.tools.model_registry.schemas import ModelEntry
+
+        entry = ModelEntry(
+            architecture_id="GPT2LMHeadModel",
+            model_id="openai-community/gpt2",
+            status=1,
+            verified_date=date(2026, 1, 1),
+            phase1_score=100.0,
+            phase2_score=95.5,
+            phase3_score=None,
+        )
+        d = entry.to_dict()
+        restored = ModelEntry.from_dict(d)
+        assert restored.architecture_id == entry.architecture_id
+        assert restored.model_id == entry.model_id
+        assert restored.status == entry.status
+        assert restored.verified_date == entry.verified_date
+        assert restored.phase1_score == entry.phase1_score
+        assert restored.phase2_score == entry.phase2_score
+        assert restored.phase3_score is None
+
+    def test_backwards_compat_verified_bool(self):
+        """Old format had 'verified: true' instead of 'status: 1'."""
+        from transformer_lens.tools.model_registry.schemas import ModelEntry
+
+        old_data = {
+            "architecture_id": "GPT2LMHeadModel",
+            "model_id": "gpt2",
+            "verified": True,
+        }
+        entry = ModelEntry.from_dict(old_data)
+        assert entry.status == 1
+
+    def test_backwards_compat_verified_false(self):
+        from transformer_lens.tools.model_registry.schemas import ModelEntry
+
+        old_data = {
+            "architecture_id": "GPT2LMHeadModel",
+            "model_id": "gpt2",
+            "verified": False,
+        }
+        entry = ModelEntry.from_dict(old_data)
+        assert entry.status == 0
+
+    def test_status_takes_precedence_over_verified(self):
+        """When both 'status' and 'verified' are present, status wins."""
+        from transformer_lens.tools.model_registry.schemas import ModelEntry
+
+        data = {
+            "architecture_id": "GPT2LMHeadModel",
+            "model_id": "gpt2",
+            "status": 3,
+            "verified": True,
+        }
+        entry = ModelEntry.from_dict(data)
+        assert entry.status == 3
+
+
+class TestModelMetadata:
+    def test_round_trip(self):
+        from transformer_lens.tools.model_registry.schemas import ModelMetadata
+
+        meta = ModelMetadata(
+            downloads=1000,
+            likes=50,
+            last_modified=datetime(2026, 1, 15, 10, 30),
+            tags=["text-generation", "en"],
+            parameter_count=125000000,
+        )
+        d = meta.to_dict()
+        restored = ModelMetadata.from_dict(d)
+        assert restored.downloads == 1000
+        assert restored.likes == 50
+        assert restored.last_modified == datetime(2026, 1, 15, 10, 30)
+        assert restored.tags == ["text-generation", "en"]
+        assert restored.parameter_count == 125000000
+
+    def test_from_dict_defaults(self):
+        from transformer_lens.tools.model_registry.schemas import ModelMetadata
+
+        meta = ModelMetadata.from_dict({})
+        assert meta.downloads == 0
+        assert meta.likes == 0
+        assert meta.last_modified is None
+        assert meta.tags == []
+        assert meta.parameter_count is None
+
+
+class TestSupportedModelsReport:
+    def test_round_trip(self):
+        from transformer_lens.tools.model_registry.schemas import (
+            ModelEntry,
+            ScanInfo,
+            SupportedModelsReport,
+        )
+
+        report = SupportedModelsReport(
+            generated_at=date(2026, 1, 1),
+            scan_info=ScanInfo(total_scanned=100, task_filter="text-generation"),
+            total_architectures=1,
+            total_models=1,
+            total_verified=1,
+            models=[
+                ModelEntry(
+                    architecture_id="GPT2LMHeadModel",
+                    model_id="gpt2",
+                    status=1,
+                ),
+            ],
+        )
+        d = report.to_dict()
+        restored = SupportedModelsReport.from_dict(d)
+        assert restored.total_models == 1
+        assert len(restored.models) == 1
+        assert restored.models[0].model_id == "gpt2"
+
+
+class TestArchitectureGapsReport:
+    def test_round_trip(self):
+        from transformer_lens.tools.model_registry.schemas import (
+            ArchitectureGap,
+            ArchitectureGapsReport,
+            ScanInfo,
+        )
+
+        report = ArchitectureGapsReport(
+            generated_at=date(2026, 1, 1),
+            scan_info=ScanInfo(total_scanned=100, task_filter="text-generation"),
+            total_unsupported_architectures=1,
+            total_unsupported_models=50,
+            gaps=[ArchitectureGap("FalconForCausalLM", 50, ["tiiuae/falcon-7b"])],
+        )
+        d = report.to_dict()
+        restored = ArchitectureGapsReport.from_dict(d)
+        assert restored.total_unsupported_architectures == 1
+        assert len(restored.gaps) == 1
+
+
+# ============================================================
+# Test verification.py
+# ============================================================
+
+
+class TestVerificationHistory:
+    def test_add_record(self):
+        from transformer_lens.tools.model_registry.verification import (
+            VerificationHistory,
+            VerificationRecord,
+        )
+
+        history = VerificationHistory()
+        record = VerificationRecord(
+            model_id="gpt2",
+            architecture_id="GPT2LMHeadModel",
+            verified_date=date(2026, 1, 1),
+            verified_by="test",
+        )
+        history.add_record(record)
+        assert len(history.records) == 1
+        assert history.last_updated is not None
+
+    def test_is_verified(self):
+        from transformer_lens.tools.model_registry.verification import (
+            VerificationHistory,
+            VerificationRecord,
+        )
+
+        history = VerificationHistory()
+        assert not history.is_verified("gpt2")
+
+        record = VerificationRecord(
+            model_id="gpt2",
+            architecture_id="GPT2LMHeadModel",
+            verified_date=date(2026, 1, 1),
+        )
+        history.add_record(record)
+        assert history.is_verified("gpt2")
+
+    def test_get_record_returns_most_recent_valid(self):
+        from transformer_lens.tools.model_registry.verification import (
+            VerificationHistory,
+            VerificationRecord,
+        )
+
+        history = VerificationHistory()
+        r1 = VerificationRecord(
+            model_id="gpt2",
+            architecture_id="GPT2LMHeadModel",
+            verified_date=date(2026, 1, 1),
+            notes="first",
+        )
+        r2 = VerificationRecord(
+            model_id="gpt2",
+            architecture_id="GPT2LMHeadModel",
+            verified_date=date(2026, 2, 1),
+            notes="second",
+        )
+        history.add_record(r1)
+        history.add_record(r2)
+        result = history.get_record("gpt2")
+        assert result is not None
+        assert result.notes == "second"
+
+    def test_invalidate(self):
+        from transformer_lens.tools.model_registry.verification import (
+            VerificationHistory,
+            VerificationRecord,
+        )
+
+        history = VerificationHistory()
+        record = VerificationRecord(
+            model_id="gpt2",
+            architecture_id="GPT2LMHeadModel",
+            verified_date=date(2026, 1, 1),
+        )
+        history.add_record(record)
+        result = history.invalidate("gpt2", "outdated")
+        assert result is True
+        assert not history.is_verified("gpt2")
+
+    def test_invalidate_nonexistent(self):
+        from transformer_lens.tools.model_registry.verification import (
+            VerificationHistory,
+        )
+
+        history = VerificationHistory()
+        result = history.invalidate("nonexistent", "reason")
+        assert result is False
+
+    def test_round_trip(self):
+        from transformer_lens.tools.model_registry.verification import (
+            VerificationHistory,
+            VerificationRecord,
+        )
+
+        history = VerificationHistory()
+        history.add_record(
+            VerificationRecord(
+                model_id="gpt2",
+                architecture_id="GPT2LMHeadModel",
+                verified_date=date(2026, 1, 1),
+                verified_by="test",
+                transformerlens_version="3.0.0",
+                notes="ok",
+            )
+        )
+        d = history.to_dict()
+        restored = VerificationHistory.from_dict(d)
+        assert len(restored.records) == 1
+        assert restored.records[0].model_id == "gpt2"
+
+
+# ============================================================
+# Test api.py (with fixture data dir)
+# ============================================================
+
+
+class TestApi:
+    def test_get_supported_models(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import api
+
+        monkeypatch.setattr(api, "_DATA_DIR", registry_data_dir)
+        api.clear_cache()
+
+        models = api.get_supported_models()
+        assert len(models) == 3
+
+    def test_get_supported_models_filter_arch(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import api
+
+        monkeypatch.setattr(api, "_DATA_DIR", registry_data_dir)
+        api.clear_cache()
+
+        models = api.get_supported_models(architecture="LlamaForCausalLM")
+        assert len(models) == 1
+        assert models[0].model_id == "meta-llama/Llama-2-7b-hf"
+
+    def test_get_supported_models_verified_only(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import api
+
+        monkeypatch.setattr(api, "_DATA_DIR", registry_data_dir)
+        api.clear_cache()
+
+        models = api.get_supported_models(verified_only=True)
+        assert len(models) == 2
+
+    def test_is_model_supported(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import api
+
+        monkeypatch.setattr(api, "_DATA_DIR", registry_data_dir)
+        api.clear_cache()
+
+        assert api.is_model_supported("openai-community/gpt2")
+        assert not api.is_model_supported("nonexistent/model")
+
+    def test_get_registry_stats(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import api
+
+        monkeypatch.setattr(api, "_DATA_DIR", registry_data_dir)
+        api.clear_cache()
+
+        stats = api.get_registry_stats()
+        assert stats["total_supported_models"] == 3
+        assert stats["total_verified"] == 1
+        assert stats["total_unsupported_architectures"] == 1
+
+    def test_get_model_info_not_found(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import api
+        from transformer_lens.tools.model_registry.exceptions import ModelNotFoundError
+
+        monkeypatch.setattr(api, "_DATA_DIR", registry_data_dir)
+        api.clear_cache()
+
+        with pytest.raises(ModelNotFoundError):
+            api.get_model_info("nonexistent/model")
+
+    def test_get_architecture_models(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import api
+
+        monkeypatch.setattr(api, "_DATA_DIR", registry_data_dir)
+        api.clear_cache()
+
+        models = api.get_architecture_models("GPT2LMHeadModel")
+        assert len(models) == 2
+        assert "openai-community/gpt2" in models
+
+    def test_get_supported_architectures(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import api
+
+        monkeypatch.setattr(api, "_DATA_DIR", registry_data_dir)
+        api.clear_cache()
+
+        archs = api.get_supported_architectures()
+        assert "GPT2LMHeadModel" in archs
+        assert "LlamaForCausalLM" in archs
+        assert len(archs) == 2
+
+
+# ============================================================
+# Test validate.py
+# ============================================================
+
+
+class TestValidate:
+    def test_validate_valid_supported_models(self, registry_data_dir):
+        from transformer_lens.tools.model_registry.validate import validate_json_schema
+
+        result = validate_json_schema(
+            registry_data_dir / "supported_models.json", "supported_models"
+        )
+        assert result.valid
+        assert result.error_count == 0
+
+    def test_validate_valid_architecture_gaps(self, registry_data_dir):
+        from transformer_lens.tools.model_registry.validate import validate_json_schema
+
+        result = validate_json_schema(
+            registry_data_dir / "architecture_gaps.json", "architecture_gaps"
+        )
+        assert result.valid
+
+    def test_validate_valid_verification_history(self, registry_data_dir):
+        from transformer_lens.tools.model_registry.validate import validate_json_schema
+
+        result = validate_json_schema(
+            registry_data_dir / "verification_history.json", "verification_history"
+        )
+        assert result.valid
+
+    def test_validate_invalid_missing_required_field(self):
+        from transformer_lens.tools.model_registry.validate import (
+            validate_supported_models_report,
+        )
+
+        invalid_data = {"models": []}  # missing generated_at, totals
+        result = validate_supported_models_report(invalid_data)
+        assert not result.valid
+        assert result.error_count > 0
+
+    def test_validate_invalid_model_entry(self):
+        from transformer_lens.tools.model_registry.validate import _validate_model_entry
+
+        errors = _validate_model_entry(
+            {"architecture_id": "", "model_id": "ok", "status": 5},
+            "test",
+        )
+        # architecture_id too short and status > 3
+        assert len(errors) >= 2
+
+
+# ============================================================
+# Test verify_models.py: _sanitize_note
+# ============================================================
+
+
+class TestSanitizeNote:
+    def test_none_input(self):
+        from transformer_lens.tools.model_registry.verify_models import _sanitize_note
+
+        assert _sanitize_note(None) is None
+
+    def test_strips_hf_token(self):
+        from transformer_lens.tools.model_registry.verify_models import _sanitize_note
+
+        note = "Error with token hf_abcdefghijklmnopqrstuvwx in request"
+        result = _sanitize_note(note)
+        assert "hf_abcdefghijklmnopqrstuvwx" not in result
+        assert "HF_TOKEN" in result
+
+    def test_gated_repo_message(self):
+        from transformer_lens.tools.model_registry.verify_models import _sanitize_note
+
+        note = (
+            "Access denied: gated repo at "
+            "https://huggingface.co/meta-llama/Llama-2-7b-hf please accept terms"
+        )
+        result = _sanitize_note(note)
+        assert result == "Config unavailable: Gated repo (meta-llama/Llama-2-7b-hf)"
+
+    def test_plain_note_unchanged(self):
+        from transformer_lens.tools.model_registry.verify_models import _sanitize_note
+
+        note = "Estimated 48 GB exceeds 16 GB limit"
+        assert _sanitize_note(note) == note
+
+
+# ============================================================
+# Test registry_io.py
+# ============================================================
+
+
+class TestRegistryIO:
+    def test_update_model_status_existing(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import registry_io
+
+        monkeypatch.setattr(
+            registry_io,
+            "_SUPPORTED_MODELS_PATH",
+            registry_data_dir / "supported_models.json",
+        )
+
+        result = registry_io.update_model_status(
+            model_id="sshleifer/tiny-gpt2",
+            arch_id="GPT2LMHeadModel",
+            status=1,
+            phase_scores={1: 100.0, 2: 95.0, 3: 90.0},
+        )
+        assert result is True
+
+        with open(registry_data_dir / "supported_models.json") as f:
+            data = json.load(f)
+        entry = next(m for m in data["models"] if m["model_id"] == "sshleifer/tiny-gpt2")
+        assert entry["status"] == 1
+        assert entry["phase1_score"] == 100.0
+        assert data["total_verified"] == 3  # was 2 verified, now 3
+
+    def test_update_model_status_not_found_non_verified(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import registry_io
+
+        monkeypatch.setattr(
+            registry_io,
+            "_SUPPORTED_MODELS_PATH",
+            registry_data_dir / "supported_models.json",
+        )
+
+        result = registry_io.update_model_status(
+            model_id="nonexistent/model",
+            arch_id="UnknownArch",
+            status=3,  # FAILED -- should not add
+        )
+        assert result is False
+
+    def test_update_model_status_adds_verified_if_missing(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import registry_io
+
+        monkeypatch.setattr(
+            registry_io,
+            "_SUPPORTED_MODELS_PATH",
+            registry_data_dir / "supported_models.json",
+        )
+
+        result = registry_io.update_model_status(
+            model_id="brand-new/model",
+            arch_id="GPT2LMHeadModel",
+            status=1,  # VERIFIED -- should add
+            phase_scores={1: 100.0},
+        )
+        assert result is True
+        with open(registry_data_dir / "supported_models.json") as f:
+            data = json.load(f)
+        assert data["total_models"] == 4
+
+    def test_add_verification_record(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import registry_io
+
+        monkeypatch.setattr(
+            registry_io,
+            "_VERIFICATION_HISTORY_PATH",
+            registry_data_dir / "verification_history.json",
+        )
+
+        registry_io.add_verification_record(
+            model_id="sshleifer/tiny-gpt2",
+            arch_id="GPT2LMHeadModel",
+            notes="Test verification",
+            verified_by="unit_test",
+        )
+
+        with open(registry_data_dir / "verification_history.json") as f:
+            data = json.load(f)
+        assert len(data["records"]) == 2  # was 1, now 2
+        assert data["records"][-1]["model_id"] == "sshleifer/tiny-gpt2"
+        assert data["records"][-1]["verified_by"] == "unit_test"
+
+    def test_update_model_status_with_sanitize(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import registry_io
+
+        monkeypatch.setattr(
+            registry_io,
+            "_SUPPORTED_MODELS_PATH",
+            registry_data_dir / "supported_models.json",
+        )
+
+        def fake_sanitize(note):
+            return "SANITIZED"
+
+        registry_io.update_model_status(
+            model_id="openai-community/gpt2",
+            arch_id="GPT2LMHeadModel",
+            status=3,
+            note="raw note with hf_secrettoken12345678901",
+            sanitize_fn=fake_sanitize,
+        )
+        with open(registry_data_dir / "supported_models.json") as f:
+            data = json.load(f)
+        entry = next(m for m in data["models"] if m["model_id"] == "openai-community/gpt2")
+        assert entry["note"] == "SANITIZED"
+
+
+# ============================================================
+# Test alias_drift.py
+# ============================================================
+
+
+class TestAliasDrift:
+    def test_check_drift_finds_aliases_not_in_registry(self, registry_data_dir, monkeypatch):
+        from transformer_lens.tools.model_registry import registry_io
+        from transformer_lens.tools.model_registry.alias_drift import check_drift
+
+        monkeypatch.setattr(
+            registry_io,
+            "_SUPPORTED_MODELS_PATH",
+            registry_data_dir / "supported_models.json",
+        )
+
+        report = check_drift()
+        # MODEL_ALIASES has ~258 entries; the fixture registry has 3 models
+        # So most aliases should show up as "in aliases not in registry"
+        assert len(report.in_aliases_not_registry) > 0
+        assert report.has_drift
+
+    def test_drift_report_serialization(self):
+        from transformer_lens.tools.model_registry.alias_drift import DriftReport
+
+        report = DriftReport(
+            in_aliases_not_registry=["model-a"],
+            in_registry_not_aliases=["model-b"],
+        )
+        d = report.to_dict()
+        assert d["summary"]["aliases_only"] == 1
+        assert d["summary"]["registry_only"] == 1
+        assert d["has_drift"] is True
+
+    def test_no_drift_report(self):
+        from transformer_lens.tools.model_registry.alias_drift import DriftReport
+
+        report = DriftReport()
+        assert not report.has_drift
+        d = report.to_dict()
+        assert d["has_drift"] is False
+
+
+class TestQuantizationClassification:
+    """Pattern-based classification of quantized model IDs."""
+
+    # Cross-check (not incompatible, not is_quantized_model) catches list overlap.
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "TheBloke/Llama-2-7B-Chat-AWQ",
+            "casperhansen/llama-3-8b-instruct-awq",
+            "TheBloke/Llama-2-7B-Chat-GPTQ",
+            "unsloth/llama-3-8b-bnb-4bit",
+            "RedHatAI/Llama-3.1-8B-Instruct-int8",
+            "neuralmagic/Llama-3-8B-Instruct-w4a16",
+            "mobiuslabsgmbh/Llama-3-8B-instruct-hqq-4bit",
+        ],
+    )
+    def test_hf_loadable_quantized(self, model_id):
+        from transformer_lens.tools.model_registry.registry_io import (
+            is_hf_loadable_quantized,
+            is_incompatible_quantized,
+            is_quantized_model,
+        )
+
+        assert is_hf_loadable_quantized(model_id)
+        assert not is_incompatible_quantized(model_id)
+        assert not is_quantized_model(model_id)
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "TheBloke/Llama-2-7B-Chat-GGUF",
+            "mlx-community/Mistral-7B-v0.1-mlx",
+            "Qwen/Qwen2-0.5B-Instruct-MLX",  # bare -MLX suffix, no org prefix
+            "Felprot75/Llama-3.1-8B-Lexi-Uncensored-V2-mlx_4bit",  # underscore variant
+            "neuralmagic/Llama-3-8B-Instruct-FP8",
+            "nvidia/Llama-3.3-70B-Instruct-NVFP4",
+        ],
+    )
+    def test_incompatible_quantized(self, model_id):
+        from transformer_lens.tools.model_registry.registry_io import (
+            is_incompatible_quantized,
+            is_quantized_model,
+        )
+
+        assert is_incompatible_quantized(model_id)
+        assert is_quantized_model(model_id)
+
+    # Real model IDs whose substrings could be misread as quant markers — guards against over-broad patterns.
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "meta-llama/Llama-3.1-8B-Instruct",
+            "Qwen/Qwen2.5-7B-Instruct",
+            "google/gemma-2-9b-it",
+            "SimpleStories/SimpleStories-30M",
+            "EleutherAI/pythia-2.8b",
+        ],
+    )
+    def test_non_quantized_models_not_misclassified(self, model_id):
+        from transformer_lens.tools.model_registry.registry_io import (
+            is_hf_loadable_quantized,
+            is_incompatible_quantized,
+            required_quant_library_for_model,
+        )
+
+        assert not is_hf_loadable_quantized(model_id)
+        assert not is_incompatible_quantized(model_id)
+        assert required_quant_library_for_model(model_id) is None
+
+    @pytest.mark.parametrize(
+        "model_id, expected_library",
+        [
+            ("unsloth/llama-3-8b-bnb-4bit", "bitsandbytes"),
+            ("RedHatAI/Llama-3.1-8B-Instruct-int8", "bitsandbytes"),
+            ("TheBloke/Llama-2-7B-Chat-GPTQ", "auto_gptq"),
+            ("TheBloke/Llama-2-7B-Chat-AWQ", "awq"),
+            # hqq-4bit matches both -hqq and -4bit; pattern order must resolve to hqq.
+            ("mobiuslabsgmbh/Llama-3-8B-instruct-hqq-4bit", "hqq"),
+            ("neuralmagic/Llama-3-8B-Instruct-w4a16", "auto_gptq"),
+        ],
+    )
+    def test_required_quant_library(self, model_id, expected_library):
+        from transformer_lens.tools.model_registry.registry_io import (
+            required_quant_library_for_model,
+        )
+
+        assert required_quant_library_for_model(model_id) == expected_library
+
+
+class TestRegistrySyncedWithFactory:
+    """Assert HF_SUPPORTED_ARCHITECTURES and CANONICAL_AUTHORS_BY_ARCH stay in
+    sync with architecture_adapter_factory.SUPPORTED_ARCHITECTURES.
+
+    The module docstring of transformer_lens.tools.model_registry states the
+    invariant: HF_SUPPORTED_ARCHITECTURES "must correspond to adapters
+    registered in architecture_adapter_factory.py", with two documented
+    exception groups (internal-only architectures and factory-internal alias
+    casings). This class enforces that invariant bidirectionally so a future
+    adapter PR that forgets the registry update fails CI.
+    """
+
+    # Factory keys that are NOT expected in the registry sets.
+    # Two groups, matching the module docstring on HF_SUPPORTED_ARCHITECTURES:
+    #   1. Internal-only architectures that never appear on HuggingFace Hub.
+    #   2. Factory-internal alias casings that route to canonical adapters
+    #      under names HF does not emit in config.architectures[].
+    INTENTIONAL_EXCLUDES = frozenset(
+        {
+            # Group 1: internal-only architectures that never appear on HuggingFace Hub.
+            "NanoGPTForCausalLM",
+            "MinGPTForCausalLM",
+            "NeelSoluOldForCausalLM",
+            "GPT2LMHeadCustomModel",
+            "TransformerLensNative",
+            "TransformerLensPretrain",
+            # Group 2: factory-internal alias casings (HF emits the canonical name).
+            "Gemma1ForCausalLM",  # HF emits: GemmaForCausalLM
+            "NeoForCausalLM",  # HF emits: GPTNeoForCausalLM
+            "NeoXForCausalLM",  # HF emits: GPTNeoXForCausalLM
+        }
+    )
+
+    def test_every_factory_arch_is_in_hf_supported(self):
+        """Every non-excluded factory key must be present in HF_SUPPORTED_ARCHITECTURES."""
+        from transformer_lens.factories.architecture_adapter_factory import (
+            SUPPORTED_ARCHITECTURES,
+        )
+        from transformer_lens.tools.model_registry import HF_SUPPORTED_ARCHITECTURES
+
+        missing = sorted(
+            k
+            for k in SUPPORTED_ARCHITECTURES
+            if k not in self.INTENTIONAL_EXCLUDES and k not in HF_SUPPORTED_ARCHITECTURES
+        )
+        assert not missing, (
+            f"Factory keys missing from HF_SUPPORTED_ARCHITECTURES: {missing}. "
+            "Add them to HF_SUPPORTED_ARCHITECTURES, or list them in "
+            "INTENTIONAL_EXCLUDES with a one-line reason."
+        )
+
+    def test_every_factory_arch_has_canonical_authors(self):
+        """Every non-excluded factory key must have a CANONICAL_AUTHORS_BY_ARCH entry."""
+        from transformer_lens.factories.architecture_adapter_factory import (
+            SUPPORTED_ARCHITECTURES,
+        )
+        from transformer_lens.tools.model_registry import CANONICAL_AUTHORS_BY_ARCH
+
+        missing = sorted(
+            k
+            for k in SUPPORTED_ARCHITECTURES
+            if k not in self.INTENTIONAL_EXCLUDES and k not in CANONICAL_AUTHORS_BY_ARCH
+        )
+        assert not missing, (
+            f"Factory keys missing from CANONICAL_AUTHORS_BY_ARCH: {missing}. "
+            "Add them to CANONICAL_AUTHORS_BY_ARCH, or list them in "
+            "INTENTIONAL_EXCLUDES with a one-line reason."
+        )
+
+    def test_hf_supported_keys_have_a_factory_adapter(self):
+        """Every HF_SUPPORTED_ARCHITECTURES entry must correspond to a wired factory adapter."""
+        from transformer_lens.factories.architecture_adapter_factory import (
+            SUPPORTED_ARCHITECTURES,
+        )
+        from transformer_lens.tools.model_registry import HF_SUPPORTED_ARCHITECTURES
+
+        orphaned = sorted(k for k in HF_SUPPORTED_ARCHITECTURES if k not in SUPPORTED_ARCHITECTURES)
+        assert (
+            not orphaned
+        ), f"HF_SUPPORTED_ARCHITECTURES entries with no factory adapter: {orphaned}"
+
+    def test_canonical_authors_keys_have_a_factory_adapter(self):
+        """Every CANONICAL_AUTHORS_BY_ARCH entry must correspond to a wired factory adapter."""
+        from transformer_lens.factories.architecture_adapter_factory import (
+            SUPPORTED_ARCHITECTURES,
+        )
+        from transformer_lens.tools.model_registry import CANONICAL_AUTHORS_BY_ARCH
+
+        orphaned = sorted(k for k in CANONICAL_AUTHORS_BY_ARCH if k not in SUPPORTED_ARCHITECTURES)
+        assert (
+            not orphaned
+        ), f"CANONICAL_AUTHORS_BY_ARCH entries with no factory adapter: {orphaned}"

--- a/TransformerLens/transformer_lens/factories/architecture_adapter_factory.py
+++ b/TransformerLens/transformer_lens/factories/architecture_adapter_factory.py
@@ -1,0 +1,268 @@
+"""Architecture adapter factory.
+
+This module provides a factory for creating architecture adapters, including
+support for external registration and entry-point discovery.
+"""
+
+import warnings
+from importlib.metadata import entry_points
+
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+from transformer_lens.model_bridge.supported_architectures import (
+    ApertusArchitectureAdapter,
+    BaichuanArchitectureAdapter,
+    BartArchitectureAdapter,
+    BertArchitectureAdapter,
+    BloomArchitectureAdapter,
+    CodeGenArchitectureAdapter,
+    CohereArchitectureAdapter,
+    DeepSeekV2ArchitectureAdapter,
+    DeepSeekV3ArchitectureAdapter,
+    FalconArchitectureAdapter,
+    Gemma1ArchitectureAdapter,
+    Gemma2ArchitectureAdapter,
+    Gemma3ArchitectureAdapter,
+    Gemma3MultimodalArchitectureAdapter,
+    Gemma3nArchitectureAdapter,
+    Gemma4ArchitectureAdapter,
+    Glm4MoeArchitectureAdapter,
+    GlmMoeDsaArchitectureAdapter,
+    GPT2ArchitectureAdapter,
+    Gpt2LmHeadCustomArchitectureAdapter,
+    GPTBigCodeArchitectureAdapter,
+    GptjArchitectureAdapter,
+    GPTOSSArchitectureAdapter,
+    GraniteArchitectureAdapter,
+    GraniteMoeArchitectureAdapter,
+    GraniteMoeHybridArchitectureAdapter,
+    HubertArchitectureAdapter,
+    HunYuanDenseV1ArchitectureAdapter,
+    InternLM2ArchitectureAdapter,
+    Lfm2MoeArchitectureAdapter,
+    LlamaArchitectureAdapter,
+    LlavaArchitectureAdapter,
+    LlavaNextArchitectureAdapter,
+    LlavaOnevisionArchitectureAdapter,
+    Mamba2ArchitectureAdapter,
+    MambaArchitectureAdapter,
+    MingptArchitectureAdapter,
+    MistralArchitectureAdapter,
+    MixtralArchitectureAdapter,
+    MPTArchitectureAdapter,
+    NanogptArchitectureAdapter,
+    NativeArchitectureAdapter,
+    NeelSoluOldArchitectureAdapter,
+    NemotronHArchitectureAdapter,
+    NeoArchitectureAdapter,
+    NeoxArchitectureAdapter,
+    Olmo2ArchitectureAdapter,
+    Olmo3ArchitectureAdapter,
+    OlmoArchitectureAdapter,
+    OlmoeArchitectureAdapter,
+    OpenElmArchitectureAdapter,
+    OptArchitectureAdapter,
+    Phi3ArchitectureAdapter,
+    PhiArchitectureAdapter,
+    PhiMoEArchitectureAdapter,
+    PretrainArchitectureAdapter,
+    Qwen2ArchitectureAdapter,
+    Qwen3_5ArchitectureAdapter,
+    Qwen3_5MultimodalArchitectureAdapter,
+    Qwen3ArchitectureAdapter,
+    Qwen3MoeArchitectureAdapter,
+    Qwen3NextArchitectureAdapter,
+    QwenArchitectureAdapter,
+    SmolLM3ArchitectureAdapter,
+    StableLmArchitectureAdapter,
+    T5ArchitectureAdapter,
+    T5GemmaArchitectureAdapter,
+    XGLMArchitectureAdapter,
+)
+
+# Export supported architectures
+SUPPORTED_ARCHITECTURES = {
+    "ApertusForCausalLM": ApertusArchitectureAdapter,
+    "BaiChuanForCausalLM": BaichuanArchitectureAdapter,
+    "BaichuanForCausalLM": BaichuanArchitectureAdapter,
+    "BartForConditionalGeneration": BartArchitectureAdapter,
+    "BertForMaskedLM": BertArchitectureAdapter,
+    "BloomForCausalLM": BloomArchitectureAdapter,
+    "CodeGenForCausalLM": CodeGenArchitectureAdapter,
+    "CohereForCausalLM": CohereArchitectureAdapter,
+    "DeepseekV2ForCausalLM": DeepSeekV2ArchitectureAdapter,
+    "DeepseekV3ForCausalLM": DeepSeekV3ArchitectureAdapter,
+    "FalconForCausalLM": FalconArchitectureAdapter,
+    "GemmaForCausalLM": Gemma1ArchitectureAdapter,  # Default to Gemma1 as it's the original version
+    "Gemma1ForCausalLM": Gemma1ArchitectureAdapter,
+    "Gemma2ForCausalLM": Gemma2ArchitectureAdapter,
+    "Gemma3ForCausalLM": Gemma3ArchitectureAdapter,
+    "Gemma3ForConditionalGeneration": Gemma3MultimodalArchitectureAdapter,
+    "Gemma3nForConditionalGeneration": Gemma3nArchitectureAdapter,
+    "Gemma4ForConditionalGeneration": Gemma4ArchitectureAdapter,
+    # The unified (encoder-free) 12B variant's text decoder is a strict structural
+    # subset of gemma4 (no PLE, no MoE — both optional in the adapter), with the
+    # same module paths. Requires transformers >= 5.10 to load.
+    "Gemma4UnifiedForConditionalGeneration": Gemma4ArchitectureAdapter,
+    "GraniteForCausalLM": GraniteArchitectureAdapter,
+    "GraniteMoeForCausalLM": GraniteMoeArchitectureAdapter,
+    "GraniteMoeHybridForCausalLM": GraniteMoeHybridArchitectureAdapter,
+    "GlmMoeDsaForCausalLM": GlmMoeDsaArchitectureAdapter,
+    "Glm4MoeForCausalLM": Glm4MoeArchitectureAdapter,
+    "GPT2LMHeadModel": GPT2ArchitectureAdapter,
+    "GPTBigCodeForCausalLM": GPTBigCodeArchitectureAdapter,
+    "GptOssForCausalLM": GPTOSSArchitectureAdapter,
+    "GPT2LMHeadCustomModel": Gpt2LmHeadCustomArchitectureAdapter,
+    "GPTJForCausalLM": GptjArchitectureAdapter,
+    "HubertForCTC": HubertArchitectureAdapter,
+    "HubertModel": HubertArchitectureAdapter,
+    "HunYuanDenseV1ForCausalLM": HunYuanDenseV1ArchitectureAdapter,
+    "InternLM2ForCausalLM": InternLM2ArchitectureAdapter,
+    "LlamaForCausalLM": LlamaArchitectureAdapter,
+    "LlavaForConditionalGeneration": LlavaArchitectureAdapter,
+    "LlavaNextForConditionalGeneration": LlavaNextArchitectureAdapter,
+    "LlavaOnevisionForConditionalGeneration": LlavaOnevisionArchitectureAdapter,
+    "Lfm2MoeForCausalLM": Lfm2MoeArchitectureAdapter,
+    "Mamba2ForCausalLM": Mamba2ArchitectureAdapter,
+    "MambaForCausalLM": MambaArchitectureAdapter,
+    "NemotronHForCausalLM": NemotronHArchitectureAdapter,
+    "MixtralForCausalLM": MixtralArchitectureAdapter,
+    "MistralForCausalLM": MistralArchitectureAdapter,
+    "MPTForCausalLM": MPTArchitectureAdapter,
+    "NeoForCausalLM": NeoArchitectureAdapter,
+    "NeoXForCausalLM": NeoxArchitectureAdapter,
+    "NeelSoluOldForCausalLM": NeelSoluOldArchitectureAdapter,
+    "OlmoForCausalLM": OlmoArchitectureAdapter,
+    "Olmo2ForCausalLM": Olmo2ArchitectureAdapter,
+    "Olmo3ForCausalLM": Olmo3ArchitectureAdapter,
+    "OlmoeForCausalLM": OlmoeArchitectureAdapter,
+    "OpenELMForCausalLM": OpenElmArchitectureAdapter,
+    "OPTForCausalLM": OptArchitectureAdapter,
+    "PhiForCausalLM": PhiArchitectureAdapter,
+    "Phi3ForCausalLM": Phi3ArchitectureAdapter,
+    "PhiMoEForCausalLM": PhiMoEArchitectureAdapter,
+    "QwenForCausalLM": QwenArchitectureAdapter,
+    "Qwen2ForCausalLM": Qwen2ArchitectureAdapter,
+    "Qwen3ForCausalLM": Qwen3ArchitectureAdapter,
+    "Qwen3MoeForCausalLM": Qwen3MoeArchitectureAdapter,
+    "Qwen3NextForCausalLM": Qwen3NextArchitectureAdapter,
+    "Qwen3_5ForCausalLM": Qwen3_5ArchitectureAdapter,
+    "Qwen3_5ForConditionalGeneration": Qwen3_5MultimodalArchitectureAdapter,
+    "SmolLM3ForCausalLM": SmolLM3ArchitectureAdapter,
+    "StableLmForCausalLM": StableLmArchitectureAdapter,
+    "T5ForConditionalGeneration": T5ArchitectureAdapter,
+    "MT5ForConditionalGeneration": T5ArchitectureAdapter,
+    "T5GemmaForConditionalGeneration": T5GemmaArchitectureAdapter,
+    "XGLMForCausalLM": XGLMArchitectureAdapter,
+    "NanoGPTForCausalLM": NanogptArchitectureAdapter,
+    "TransformerLensNative": NativeArchitectureAdapter,
+    "TransformerLensPretrain": PretrainArchitectureAdapter,
+    "MinGPTForCausalLM": MingptArchitectureAdapter,
+    "GPTNeoForCausalLM": NeoArchitectureAdapter,
+    "GPTNeoXForCausalLM": NeoxArchitectureAdapter,
+}
+
+
+class ArchitectureAdapterFactory:
+    """Factory for creating architecture adapters.
+
+    Supports external registration via `register_adapter()` and automatic
+    discovery of adapters from installed packages via entry points.
+    """
+
+    _adapters = dict(SUPPORTED_ARCHITECTURES)
+    _entry_points_discovered = False
+
+    @classmethod
+    def register_adapter(
+        cls, architecture_name: str, adapter_class: type["ArchitectureAdapter"]
+    ) -> None:
+        """Register a custom architecture adapter at runtime.
+
+        This allows users to add their own architecture adapters without
+        modifying TransformerLens source code.
+
+        Args:
+            architecture_name: The HuggingFace architecture class name
+                (e.g. ``"Qwen3ForCausalLM"``).
+            adapter_class: The adapter class to register.
+
+        Example:
+            >>> from transformer_lens.config import TransformerBridgeConfig
+            >>> from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+            >>> from transformer_lens.factories.architecture_adapter_factory import ArchitectureAdapterFactory
+            >>> class MyAdapter(ArchitectureAdapter):
+            ...     def __init__(self, cfg):
+            ...         super().__init__(cfg)
+            >>> ArchitectureAdapterFactory.register_adapter("MyModelForCausalLM", MyAdapter)
+            >>> cfg = TransformerBridgeConfig(
+            ...     d_model=512, d_head=64, n_layers=6, n_ctx=1024,
+            ...     architecture="MyModelForCausalLM",
+            ... )
+            >>> adapter = ArchitectureAdapterFactory.select_architecture_adapter(cfg)
+            >>> isinstance(adapter, MyAdapter)
+            True
+        """
+        cls._adapters[architecture_name] = adapter_class
+
+    @classmethod
+    def discover_entry_points(cls) -> None:
+        """Discover and register architecture adapters from installed packages.
+
+        Packages can declare adapters in their ``pyproject.toml``:
+        ```toml
+        [project.entry-points."transformer_lens.architectures"]
+        "MyModelForCausalLM" = "my_package.adapters:MyArchitectureAdapter"
+        ```
+        """
+        if cls._entry_points_discovered:
+            return
+        try:
+            eps = entry_points(group="transformer_lens.architectures")
+        except Exception as e:
+            warnings.warn(
+                f"Failed to discover entry points: {e}. " f"External adapters may not be available."
+            )
+        else:
+            for ep in eps:
+                try:
+                    if ep.name in cls._adapters:
+                        dist_name = (
+                            getattr(ep.dist, "name", "unknown")
+                            if ep.dist is not None
+                            else "unknown"
+                        )
+                        warnings.warn(
+                            f"Custom architecture adapter {ep.name} provided by {dist_name} "
+                            f"attempted to override a native adapter. If you'd like to use this "
+                            f"custom adapter, register it explicitly with register_adapter"
+                        )
+                        continue
+                    cls._adapters[ep.name] = ep.load()
+                except Exception as e:
+                    warnings.warn(
+                        f"Failed to load entry point '{ep.name}': {e}. " f"Skipping this adapter."
+                    )
+        cls._entry_points_discovered = True
+
+    @classmethod
+    def select_architecture_adapter(cls, cfg: TransformerBridgeConfig) -> ArchitectureAdapter:
+        """Select the appropriate architecture adapter for the given config.
+
+        Args:
+            cfg: The TransformerBridgeConfig to select the adapter for.
+
+        Returns:
+            The selected architecture adapter.
+
+        Raises:
+            ValueError: If no adapter is found for the given config.
+        """
+        cls.discover_entry_points()
+        if cfg.architecture is not None:
+            if cfg.architecture in cls._adapters:
+                return cls._adapters[cfg.architecture](cfg)
+            else:
+                raise ValueError(f"Unsupported architecture: {cfg.architecture}")
+
+        raise ValueError(f"TransformerBridgeConfig must have architecture set, got: {cfg}")

--- a/TransformerLens/transformer_lens/model_bridge/bridge.py
+++ b/TransformerLens/transformer_lens/model_bridge/bridge.py
@@ -1,0 +1,4228 @@
+"""Bridge module for connecting different model architectures.
+
+This module provides the bridge components that wrap remote model components and provide
+a consistent interface for accessing their weights and performing operations.
+"""
+
+import logging
+import re
+import warnings
+from collections.abc import Generator
+from contextlib import contextmanager
+from functools import lru_cache
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+    overload,
+)
+
+import einops
+import numpy as np
+import torch
+import tqdm
+from torch import nn
+
+from transformer_lens import utilities as utils
+from transformer_lens.ActivationCache import ActivationCache
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.FactoredMatrix import FactoredMatrix
+from transformer_lens.hook_points import HookIntrospectionMixin, HookPoint
+from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+from transformer_lens.model_bridge.component_setup import set_original_components
+from transformer_lens.model_bridge.composition_scores import CompositionScores
+from transformer_lens.model_bridge.exceptions import StopAtLayerException
+from transformer_lens.model_bridge.generalized_components.base import (
+    GeneralizedComponent,
+)
+from transformer_lens.model_bridge.generalized_components.block import (
+    _BLOCK_INTERNAL_MODULES,
+    _NORM_PREFIXES,
+    _VARIANT_SUBMODULE_SET,
+    VARIANT_SUBMODULE_NAMES,
+)
+from transformer_lens.model_bridge.get_params_util import get_bridge_params
+from transformer_lens.utilities.aliases import resolve_alias
+from transformer_lens.utilities.devices import move_to_and_update_config
+from transformer_lens.utilities.lm_utils import lm_cross_entropy_loss
+
+if TYPE_CHECKING:
+    from transformer_lens.ActivationCache import ActivationCache
+
+_BLOCK_PATTERN = re.compile("blocks\\.(\\d+)")
+
+
+def _resolve_attr_path(obj: nn.Module, attr_path: str) -> torch.Tensor:
+    """Walk a dot-separated attribute path and return the final tensor."""
+    result = obj
+    for attr in attr_path.split("."):
+        result = getattr(result, attr)
+    return cast(torch.Tensor, result)
+
+
+def build_alias_to_canonical_map(hook_dict, prefix=""):
+    """Build a mapping from alias hook names to their canonical names.
+
+    Args:
+        hook_dict: Dictionary mapping hook names to HookPoint objects
+        prefix: Prefix for nested keys
+
+    Returns:
+        Dictionary mapping alias names to canonical names
+
+    Example:
+        If hook_dict contains:
+        - "blocks.0.hook_q" -> HookPoint(name="blocks.0.attn.q.hook_out")
+
+        Returns:
+        - {"blocks.0.hook_q": "blocks.0.attn.q.hook_out"}
+    """
+    aliases = {}
+    for key, value in hook_dict.items():
+        full_key = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            aliases.update(build_alias_to_canonical_map(value, full_key))
+        elif hasattr(value, "name"):
+            if key != value.name:
+                aliases[full_key] = value.name
+    return aliases
+
+
+class TransformerBridge(HookIntrospectionMixin, nn.Module):
+    """Bridge between HuggingFace and TransformerLens models.
+
+    This class provides a standardized interface to access components of a transformer
+    model, regardless of the underlying architecture. It uses an architecture adapter
+    to map between the TransformerLens and HuggingFace model structures.
+
+    Tokenization notes
+    ------------------
+
+    :meth:`to_tokens`, :meth:`to_str_tokens`, :meth:`get_token_position`,
+    :meth:`forward` (string input), and :meth:`generate` accept ``prepend_bos``
+    to control BOS prepending. Resolution: explicit arg →
+    ``cfg.default_prepend_bos`` (defaults ``True``, even for non-BOS-trained
+    models — attention heads tend to use position 0 as a resting state).
+    **Pass ``prepend_bos=False`` when tokenizing a fragment of a larger
+    prompt** — off-by-one position errors usually trace back here.
+
+    Reconciliation with ``cfg.tokenizer_prepends_bos`` (tokenizers that add
+    BOS automatically) is handled internally — pass the value you want;
+    the bridge adds or strips manually as needed. When
+    ``cfg.tokenizer_appends_eos=True`` (OLMo, Apertus, etc.),
+    :meth:`to_tokens` also strips trailing EOS tokens so the model receives
+    a continuation rather than a terminated sequence; this path is
+    bridge-specific.
+
+    BPE/SentencePiece tokenizers treat ``"hello"``, ``" hello"``, and
+    ``"Hello"`` as distinct tokens. Concatenated prompts may not tokenize
+    as the sum of parts — inspect with :meth:`to_str_tokens` when in doubt.
+
+    BOS token and chat templates
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    ``model.tokenizer`` is configured with ``add_bos_token=True`` and is
+    **not** the stock HuggingFace tokenizer. Direct ``.encode()`` calls
+    will prepend BOS automatically.
+
+    When passing pre-applied chat-template text (i.e., the output of
+    ``tokenizer.apply_chat_template(..., tokenize=False)``), pass
+    ``prepend_bos=False`` to :meth:`to_tokens` to avoid a double BOS::
+
+        # Correct pattern for chat templates:
+        text = model.tokenizer.apply_chat_template(messages, tokenize=False)
+        tokens = model.to_tokens(text, prepend_bos=False)
+
+    The chat template already embeds the model's expected BOS token in
+    the rendered text; letting :meth:`to_tokens` add another would produce
+    a malformed sequence like ``[BOS, BOS, ...]``.
+
+    To inspect what tokens will actually be fed to the model during
+    generation, use :meth:`to_tokens` directly or pass
+    ``return_input_tokens=True`` to :meth:`generate`.
+    """
+
+    hook_aliases: Dict[str, Union[str, List[str]]] = {
+        # Prefer embed_ln.hook_out for post-LN models (Bloom, BERT)
+        "hook_embed": ["embed_ln.hook_out", "embed.hook_out"],
+        "hook_pos_embed": ["pos_embed.hook_out", "rotary_emb.hook_out"],
+        "hook_unembed": "unembed.hook_out",
+    }
+
+    def __init__(self, model: nn.Module, adapter: ArchitectureAdapter, tokenizer: Any):
+        """Initialize the bridge.
+
+        Args:
+            model: The model to bridge (must be a PyTorch nn.Module or PreTrainedModel)
+            adapter: The architecture adapter to use
+            tokenizer: The tokenizer to use (required)
+        """
+        super().__init__()
+        self.__dict__["original_model"] = model
+        self.adapter = adapter
+        self.cfg = adapter.cfg
+        self.tokenizer = tokenizer
+        if self.cfg.d_vocab == -1 and self.tokenizer is not None:
+            if hasattr(self.tokenizer, "get_vocab"):
+                vocab = self.tokenizer.get_vocab()
+                self.cfg.d_vocab = max(vocab.values()) + 1
+            elif hasattr(self.tokenizer, "vocab"):
+                self.cfg.d_vocab = max(self.tokenizer.vocab.values()) + 1
+            else:
+                self.cfg.d_vocab = getattr(self.tokenizer, "vocab_size", 50257)
+        if self.cfg.d_vocab_out == -1:
+            self.cfg.d_vocab_out = self.cfg.d_vocab
+        self.compatibility_mode = False
+        self._hook_cache = None
+        self._hook_registry: Dict[str, HookPoint] = {}
+        self._hook_registry_initialized = False
+        self._hook_alias_registry: Dict[str, Union[str, List[str]]] = {}
+        self._property_alias_registry: Dict[str, str] = {}
+        # real_components maps TL keys to (remote_path, actual_instance) tuples
+        # For list components, actual_instance will be a list of component instances
+        self.real_components: Dict[str, tuple] = {}
+        if not hasattr(self.cfg, "device") or self.cfg.device is None:
+            try:
+                self.cfg.device = str(next(self.original_model.parameters()).device)
+            except StopIteration:
+                self.cfg.device = "cpu"
+        if not hasattr(adapter, "component_mapping") or adapter.component_mapping is None:
+            raise ValueError("Adapter must have a component_mapping attribute")
+        original_model = self.__dict__["original_model"]
+        set_original_components(self, self.adapter, original_model)
+        self._initialize_hook_registry()
+        self._register_aliases()
+        self._register_all_aliases_recursive()
+        self._setup_hook_compatibility()
+        self._initialize_hooks_to_cache()
+        self.processor = None
+
+    @classmethod
+    def boot_transformers(
+        cls,
+        model_name: str,
+        hf_config_overrides: Optional[dict] = None,
+        device: Optional[Union[str, torch.device]] = None,
+        dtype: torch.dtype = torch.float32,
+        tokenizer: Optional[Any] = None,
+        load_weights: bool = True,
+        trust_remote_code: bool = False,
+        model_class: Optional[type] = None,
+        hf_model: Optional[Any] = None,
+        device_map: Optional[Union[str, Dict[str, Union[str, int]]]] = None,
+        n_devices: Optional[int] = None,
+        max_memory: Optional[Dict[Union[str, int], str]] = None,
+        n_ctx: Optional[int] = None,
+        revision: Optional[str] = None,
+        checkpoint_index: Optional[int] = None,
+        checkpoint_value: Optional[int] = None,
+    ) -> "TransformerBridge":
+        """Boot a model from HuggingFace (alias for sources.transformers.boot).
+
+        Returns raw HF weights by default — logits/activations match HF, *not*
+        legacy ``HookedTransformer`` (which folds LayerNorm + centers weights).
+        Call ``enable_compatibility_mode()`` on the result for HookedTransformer-
+        equivalent numerics. Generation, argmax, and CE loss are unaffected.
+
+        Attention implementation is forced to ``"eager"`` so hooks can capture scores
+        and patterns. For an apples-to-apples HF comparison, load the HF model with
+        ``attn_implementation="eager"`` too; comparing against the default ``"sdpa"``
+        shows ~1e-3 fp32 drift from kernel-level op reordering, not a bridge bug.
+
+        Args:
+            model_name: The name of the model to load.
+            hf_config_overrides: Optional overrides applied to the HuggingFace config before model load.
+            device: The device to use. If None, will be determined automatically. Mutually exclusive
+                with ``device_map``.
+            dtype: The dtype to use for the model.
+            tokenizer: Optional pre-initialized tokenizer to use; if not provided one will be created.
+            load_weights: If False, load model without weights (on meta device) for config inspection only.
+            trust_remote_code: Whether to trust remote code for custom model architectures.
+            model_class: Optional HuggingFace model class to use instead of the default
+                auto-detected class (e.g., BertForNextSentencePrediction).
+            hf_model: Optional pre-loaded HuggingFace model to use instead of loading one. Useful
+                for models loaded with custom configurations (e.g., quantization via
+                BitsAndBytesConfig). When provided, load_weights is ignored. If the pre-loaded
+                model was built with a ``device_map``, ``cfg.device`` and ``cfg.n_devices`` are
+                derived from its ``hf_device_map`` automatically.
+            device_map: HuggingFace-style device map for dispatched inference. Pass ``"auto"``,
+                ``"balanced"``, ``"sequential"``, or an explicit ``{submodule_path: device}``
+                dict. Explicit maps may include CPU targets; disk / meta offload targets are
+                still rejected because Bridge component wrappers need additional offload-hook
+                routing work. Mutually exclusive with ``device``.
+            n_devices: Convenience shortcut: split the model across this many CUDA devices.
+                Translated to a ``max_memory`` dict over devices 0..n_devices-1 and passed as
+                ``device_map`` to HF. Requires CUDA with at least this many visible devices.
+            max_memory: Optional per-device memory budget, passed through to HF's dispatcher.
+                Only used when ``device_map`` or ``n_devices`` is in effect.
+            n_ctx: Optional context length override. Writes to the appropriate HF config field
+                for this model automatically (callers don't need to know the field name).
+                Warns if larger than the model's default context length.
+            revision: Optional HF revision (branch, tag, or commit). Forwarded to the underlying
+                ``AutoConfig.from_pretrained`` and ``AutoModelForCausalLM.from_pretrained`` calls.
+                Mutually exclusive with ``checkpoint_index`` / ``checkpoint_value``.
+            checkpoint_index: Index into the available training checkpoints for the model family
+                (currently ``EleutherAI/pythia*`` and ``stanford-crfm/*``). Resolved to a revision
+                string via known per-family naming conventions.
+            checkpoint_value: Training step or token count of the desired checkpoint. Alternative
+                to ``checkpoint_index``; must match an entry in the family's checkpoint label list.
+
+        Returns:
+            The bridge to the loaded model.
+        """
+        from transformer_lens.model_bridge.sources.transformers import boot
+
+        return boot(
+            model_name=model_name,
+            hf_config_overrides=hf_config_overrides,
+            device=device,
+            dtype=dtype,
+            tokenizer=tokenizer,
+            load_weights=load_weights,
+            trust_remote_code=trust_remote_code,
+            model_class=model_class,
+            hf_model=hf_model,
+            device_map=device_map,
+            n_devices=n_devices,
+            max_memory=max_memory,
+            n_ctx=n_ctx,
+            revision=revision,
+            checkpoint_index=checkpoint_index,
+            checkpoint_value=checkpoint_value,
+        )
+
+    @classmethod
+    def boot_native(
+        cls,
+        config: Union[TransformerBridgeConfig, dict],
+        tokenizer: Optional[Any] = None,
+        device: Optional[Union[str, torch.device]] = None,
+        dtype: Optional[torch.dtype] = None,
+        model_name: str = "native",
+    ) -> "TransformerBridge":
+        """Build a bridge around a small, randomly-initialized TL-native model.
+
+        No HuggingFace Hub call, no ``transformers`` import. ``config.init_mode``
+        and ``config.seed`` control reproducibility.
+        """
+        import copy as _copy
+
+        from transformer_lens.config import TransformerBridgeConfig as _Cfg
+        from transformer_lens.model_bridge.sources._bridge_builder import (
+            build_bridge_from_module,
+        )
+        from transformer_lens.model_bridge.sources.native import (
+            NativeModel,
+            initialize_native_model,
+        )
+
+        cfg: TransformerBridgeConfig
+        if isinstance(config, dict):
+            cfg = _Cfg.from_dict(config)
+        else:
+            # Deep-copy so NativeModel's default-resolution writes don't land
+            # on the caller's config.
+            cfg = _copy.deepcopy(config)
+
+        # Foreign architecture strings would dispatch to the wrong adapter and
+        # crash deep in prepare_model. Refuse them with a pointing message.
+        if cfg.architecture not in (None, "TransformerLensNative"):
+            raise ValueError(
+                f"boot_native cannot build a {cfg.architecture!r} model — "
+                f"it only constructs the TL-native architecture. Either clear "
+                f"config.architecture or set it to 'TransformerLensNative', "
+                f"or use boot_transformers / build_bridge_from_module for "
+                f"non-native architectures."
+            )
+        architecture = "TransformerLensNative"
+
+        # Fork RNG around construction + init when seeded so neither nn.Linear's
+        # default reset_parameters nor our scoped init perturb the caller's RNG.
+        # Unseeded calls let global RNG advance normally.
+        if cfg.seed is not None:
+            with torch.random.fork_rng(devices=[]):
+                model = NativeModel(cfg)
+                initialize_native_model(model, cfg)
+        else:
+            model = NativeModel(cfg)
+            initialize_native_model(model, cfg)
+
+        if device is not None:
+            model = model.to(device)
+        if dtype is not None:
+            model = model.to(dtype=dtype)
+
+        return build_bridge_from_module(
+            model,
+            architecture=architecture,
+            tl_config=cfg,
+            tokenizer=tokenizer,
+            dtype=dtype,
+            device=device,
+            model_name=model_name,
+        )
+
+    @property
+    def original_model(self) -> nn.Module:
+        """Get the original model."""
+        if "original_model" not in self.__dict__:
+            raise AttributeError("original_model has not been set")
+        return self.__dict__["original_model"]
+
+    @original_model.setter
+    def original_model(self, value: nn.Module) -> None:
+        """Set the original model."""
+        self.__dict__["original_model"] = value
+
+    def _register_aliases(self) -> None:
+        """Register bridge-level aliases.
+
+        This is called at the END of __init__ when all components are set up.
+        It registers the top-level bridge aliases (hook_embed, hook_pos_embed, etc.)
+        and creates direct attribute references.
+        """
+        if self.hook_aliases:
+            self._hook_alias_registry.update(self.hook_aliases)
+            for alias_name, target_path in self.hook_aliases.items():
+                try:
+                    if isinstance(target_path, list):
+                        for single_target in target_path:
+                            try:
+                                target_obj = self
+                                for part in single_target.split("."):
+                                    target_obj = getattr(target_obj, part)
+                                object.__setattr__(self, alias_name, target_obj)
+                                break
+                            except AttributeError:
+                                continue
+                    else:
+                        target_obj = self
+                        for part in target_path.split("."):
+                            target_obj = getattr(target_obj, part)
+                        object.__setattr__(self, alias_name, target_obj)
+                except AttributeError:
+                    pass
+
+    def _set_processed_weight_attributes(self) -> None:
+        """Create 3D processed weight attributes for attention components.
+
+        For each attention component, if it has 2D weights (q.weight, k.weight, v.weight),
+        reshape them to 3D format [n_heads, d_model, d_head] and set as:
+        - _processed_W_Q
+        - _processed_W_K
+        - _processed_W_V
+        - _processed_b_Q
+        - _processed_b_K
+        - _processed_b_V
+
+        This allows property aliases (W_Q, W_K, W_V) to return 3D format for
+        HookedTransformer compatibility while keeping 2D format for calculations.
+        """
+
+        n_heads = self.cfg.n_heads
+        d_head = self.cfg.d_head
+        d_model = self.cfg.d_model
+        if not hasattr(self, "blocks"):
+            return
+        for block in self.blocks:
+            if "attn" not in block._modules:
+                continue
+            attn = block.attn
+            if not (hasattr(attn, "q") and hasattr(attn.q, "weight")):
+                continue
+            try:
+                w_q_2d = attn.q.weight.data
+                w_k_2d = attn.k.weight.data
+                w_v_2d = attn.v.weight.data
+                attn._processed_W_Q = einops.rearrange(
+                    w_q_2d, "m (i h) -> i m h", i=n_heads, h=d_head
+                )
+                attn._processed_W_K = einops.rearrange(
+                    w_k_2d, "m (i h) -> i m h", i=n_heads, h=d_head
+                )
+                attn._processed_W_V = einops.rearrange(
+                    w_v_2d, "m (i h) -> i m h", i=n_heads, h=d_head
+                )
+                if hasattr(attn.q, "bias") and attn.q.bias is not None:
+                    b_q_2d = attn.q.bias.data
+                    b_k_2d = attn.k.bias.data
+                    b_v_2d = attn.v.bias.data
+                    attn._processed_b_Q = einops.rearrange(
+                        b_q_2d, "(i h) -> i h", i=n_heads, h=d_head
+                    )
+                    attn._processed_b_K = einops.rearrange(
+                        b_k_2d, "(i h) -> i h", i=n_heads, h=d_head
+                    )
+                    attn._processed_b_V = einops.rearrange(
+                        b_v_2d, "(i h) -> i h", i=n_heads, h=d_head
+                    )
+                if hasattr(attn, "o") and hasattr(attn.o, "weight"):
+                    w_o_2d = attn.o.weight.data
+                    w_o_transposed = w_o_2d.T
+                    attn._processed_W_O = einops.rearrange(
+                        w_o_transposed, "m (i h) -> i h m", i=n_heads, h=d_head
+                    )
+                    if hasattr(attn.o, "bias") and attn.o.bias is not None:
+                        attn._processed_b_O = attn.o.bias.data
+            except Exception:
+                pass
+
+    def _register_all_aliases_recursive(self) -> None:
+        """Recursively register aliases on all bridge components.
+
+        This walks through all components and calls _register_aliases() on each one.
+        Used after weight processing to ensure aliases point to processed weights.
+        """
+        if hasattr(self, "_register_aliases"):
+            self._register_aliases()
+        for module in self.modules():
+            if module is not self and hasattr(module, "_register_aliases"):
+                getattr(module, "_register_aliases")()
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Override setattr to track HookPoint objects dynamically."""
+        super().__setattr__(name, value)
+        if isinstance(value, HookPoint):
+            value.name = name
+            self._hook_registry[name] = value
+        elif hasattr(value, "get_hooks") and callable(getattr(value, "get_hooks")):
+            component_hooks = value.get_hooks()
+            for hook_name, hook in component_hooks.items():
+                full_name = f"{name}.{hook_name}"
+                hook.name = full_name
+                self._hook_registry[full_name] = hook
+
+    def _initialize_hook_registry(self) -> None:
+        """Initialize the hook registry by scanning existing components."""
+        if self._hook_registry_initialized:
+            return
+        self._scan_existing_hooks(self, "")
+        self._hook_registry_initialized = True
+
+    def _collect_component_aliases(self, component_mapping, prefix=""):
+        """Recursively collect aliases from components."""
+        aliases = {}
+        if isinstance(component_mapping, dict):
+            for name, component in component_mapping.items():
+                sub_prefix = f"{prefix}.{name}" if prefix else name
+                aliases.update(self._collect_component_aliases(component, sub_prefix))
+        else:
+            if hasattr(component_mapping, "hook_aliases") and component_mapping.hook_aliases:
+                for alias_name, target in component_mapping.hook_aliases.items():
+                    full_alias = f"{prefix}.{alias_name}" if prefix else alias_name
+                    full_target = f"{prefix}.{target}" if prefix else target
+                    aliases[full_alias] = full_target
+            if hasattr(component_mapping, "submodules") and component_mapping.submodules:
+                for sub_name, sub_component in component_mapping.submodules.items():
+                    sub_prefix = f"{prefix}.{sub_name}" if prefix else sub_name
+                    aliases.update(self._collect_component_aliases(sub_component, sub_prefix))
+        return aliases
+
+    @staticmethod
+    @lru_cache(maxsize=128)
+    def _compute_hook_aliases_cached(
+        hook_names_tuple: Tuple[str, ...], component_aliases_tuple: Tuple[Tuple[str, str], ...]
+    ) -> Tuple[Tuple[str, str], ...]:
+        """Cached computation of hook aliases. Takes immutable inputs for caching."""
+        aliases = {}
+        component_aliases = dict(component_aliases_tuple)
+        for hook_name in hook_names_tuple:
+            for alias_pattern, target_pattern in component_aliases.items():
+                if "blocks." in target_pattern and "blocks." in hook_name:
+                    block_match = _BLOCK_PATTERN.search(hook_name)
+                    if block_match:
+                        block_num = block_match.group(1)
+                        dynamic_alias_pattern = alias_pattern.replace(
+                            "blocks.", f"blocks.{block_num}."
+                        )
+                        dynamic_target_pattern = target_pattern.replace(
+                            "blocks.", f"blocks.{block_num}."
+                        )
+                        if hook_name.endswith(dynamic_target_pattern):
+                            target_len = len(dynamic_target_pattern)
+                            alias_name = hook_name[:-target_len] + dynamic_alias_pattern
+                            aliases[alias_name] = hook_name
+                elif hook_name.endswith(target_pattern):
+                    target_len = len(target_pattern)
+                    alias_name = hook_name[:-target_len] + alias_pattern
+                    aliases[alias_name] = hook_name
+        return tuple(aliases.items())
+
+    def _collect_hook_aliases_from_registry(self):
+        """Collect aliases based on existing hooks in the registry."""
+        if hasattr(self.adapter, "component_mapping"):
+            component_aliases = self._collect_component_aliases(self.adapter.component_mapping)
+            hook_names_tuple = tuple(sorted(self._hook_registry.keys()))
+            component_aliases_tuple = tuple(sorted(component_aliases.items()))  # type: ignore[operator]
+            aliases_tuple = self._compute_hook_aliases_cached(
+                hook_names_tuple, component_aliases_tuple
+            )
+            return dict(aliases_tuple)
+        return {}
+
+    def _add_aliases_to_hooks(self, hooks: Dict[str, HookPoint]) -> None:
+        """Add aliases to hooks in place."""
+        component_aliases = self._collect_hook_aliases_from_registry()
+        all_aliases = {**self.hook_aliases, **component_aliases}
+        if not all_aliases:
+            return
+        for alias_name, target in all_aliases.items():
+            if isinstance(target, list):
+                for single_target in target:
+                    try:
+                        target_hook = resolve_alias(self, alias_name, {alias_name: single_target})
+                        if target_hook is not None:
+                            hooks[alias_name] = target_hook
+                            break
+                    except AttributeError:
+                        continue
+            else:
+                try:
+                    target_hook = resolve_alias(self, alias_name, {alias_name: target})
+                    if target_hook is not None:
+                        hooks[alias_name] = target_hook
+                except AttributeError:
+                    continue
+
+    def _scan_existing_hooks(self, module: nn.Module, prefix: str = "") -> None:
+        """Scan existing modules for hooks and add them to registry."""
+        visited = set()
+        # Protect canonical HookPoint names from alias overwrites
+        named_hook_ids: set = set()
+
+        def scan_module(mod: nn.Module, path: str = "") -> None:
+            obj_id = id(mod)
+            if obj_id in visited:
+                return
+            visited.add(obj_id)
+            if hasattr(mod, "get_hooks") and callable(getattr(mod, "get_hooks")):
+                component_hooks = mod.get_hooks()  # type: ignore[operator]
+                if isinstance(component_hooks, dict):
+                    hooks_dict = cast(Dict[str, HookPoint], component_hooks)
+                    for hook_name, hook in hooks_dict.items():
+                        full_name = f"{path}.{hook_name}" if path else hook_name
+                        hook_id = id(hook)
+                        if hook_id not in named_hook_ids:
+                            hook.name = full_name
+                            named_hook_ids.add(hook_id)
+                        self._hook_registry[full_name] = hook
+            for attr_name in dir(mod):
+                if attr_name.startswith("_"):
+                    continue
+                if attr_name == "original_component" or attr_name == "original_model":
+                    continue
+                if attr_name in [
+                    "OV",
+                    "QK",
+                    "W_V",
+                    "W_O",
+                    "W_Q",
+                    "W_K",
+                    "W_in",
+                    "W_gate",
+                    "W_out",
+                    "b_V",
+                    "b_O",
+                    "b_Q",
+                    "b_K",
+                    "b_in",
+                    "b_out",
+                ]:
+                    continue
+                try:
+                    attr = getattr(mod, attr_name)
+                except (AttributeError, NameError, RuntimeError, TypeError):
+                    continue
+                name = f"{path}.{attr_name}" if path else attr_name
+                if isinstance(attr, HookPoint):
+                    hook_id = id(attr)
+                    if hook_id not in named_hook_ids:
+                        attr.name = name
+                        named_hook_ids.add(hook_id)
+                    self._hook_registry[name] = attr
+            for child_name, child_module in mod.named_children():
+                if (
+                    child_name == "original_component"
+                    or child_name == "_original_component"
+                    or child_name == "original_model"
+                ):
+                    continue
+                child_path = f"{path}.{child_name}" if path else child_name
+                scan_module(child_module, child_path)
+
+        scan_module(module, prefix)
+
+    @property
+    def hook_dict(self) -> dict[str, HookPoint]:
+        """Get all HookPoint objects in the model for compatibility with TransformerLens."""
+        hooks = self._hook_registry.copy()
+        self._add_aliases_to_hooks(hooks)
+        return hooks
+
+    @property
+    def n_params_total(self) -> int:
+        """Total number of parameters in the model, including embeddings, biases,
+        and layer norm weights.
+
+        Mirrors :attr:`HookedTransformer.n_params_total`. Use this when you want
+        the actual parameter count for memory budgeting, comparison with
+        HuggingFace's ``model.num_parameters()``, or alignment with reported
+        model sizes in papers (e.g. the Pythia suite).
+
+        Returns:
+            int: ``sum(p.numel() for p in self.parameters())``
+        """
+        return sum(p.numel() for p in self.parameters())
+
+    def clear_hook_registry(self) -> None:
+        """Clear the hook registry and force re-initialization."""
+        self._hook_registry.clear()
+        self._hook_registry_initialized = False
+
+    def _initialize_hooks_to_cache(self) -> None:
+        """Initialize the hooks to cache when running the model with cache."""
+        self.hooks_to_cache = {}
+        default_cached_hooks_names = [
+            "embed.hook_in",
+            "embed.hook_out",
+            "pos_embed.hook_in",
+            "pos_embed.hook_out",
+            "rotary_embed.hook_in",
+            "rotary_embed.hook_out",
+            "ln_final.hook_in",
+            "ln_final.hook_scale",
+            "ln_final.hook_normalized",
+            "ln_final.hook_out",
+            "unembed.hook_in",
+            "unembed.hook_out",
+        ]
+        for block_idx in range(self.cfg.n_layers):
+            default_cached_hooks_names.append(f"blocks.{block_idx}.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln1.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln1.hook_scale")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln1.hook_normalized")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln1.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln1_post.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln1_post.hook_scale")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln1_post.hook_normalized")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln1_post.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.q.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.q.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.q_norm.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.q_norm.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.k.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.k.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.k_norm.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.k_norm.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.v.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.v.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.o.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.o.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.hook_attn_scores")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.hook_pattern")  # type: ignore[operator]
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.hook_hidden_states")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.attn.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln2.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln2.hook_scale")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln2.hook_normalized")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln2.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln2_post.hook_in")  # type: ignore[operator]
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln2_post.hook_scale")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln2_post.hook_normalized")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.ln2_post.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.mlp.hook_in")  # type: ignore[operator]
+            default_cached_hooks_names.append(f"blocks.{block_idx}.mlp.in.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.mlp.in.hook_out")  # type: ignore[operator]
+            default_cached_hooks_names.append(f"blocks.{block_idx}.mlp.out.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.mlp.out.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.mlp.gate.hook_in")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.mlp.gate.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.mlp.hook_out")
+            default_cached_hooks_names.append(f"blocks.{block_idx}.hook_out")
+        for hook_name in default_cached_hooks_names:
+            if hook_name in self._hook_registry:
+                self.hooks_to_cache[hook_name] = self._hook_registry[hook_name]  # type: ignore[arg-type]
+
+    def __getattr__(self, name: str) -> Any:
+        """Provide a clear error message for missing attributes."""
+        if name in self.__dict__:  # type: ignore[arg-type]
+            return self.__dict__[name]
+        # Use __dict__ directly to avoid recursion
+        if "_modules" in self.__dict__ and name in self.__dict__["_modules"]:  # type: ignore[arg-type]
+            return self.__dict__["_modules"][name]
+        if "original_model" in self.__dict__ and self.__dict__["original_model"] is not None:
+            try:
+                name_split = name.split(".")
+                if len(name_split) > 1:
+                    current = getattr(self.__dict__["original_model"], name_split[0])
+                    for part in name_split[1:]:  # type: ignore[operator]
+                        current = getattr(current, part)
+                    return current
+                else:
+                    return getattr(self.__dict__["original_model"], name)
+            except AttributeError:
+                pass  # type: ignore[operator,assignment]
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
+    def __str__(self) -> str:
+        """Get a string representation of the bridge.
+        # type: ignore[operator]
+               Returns:
+                   A string describing the bridge's components # type: ignore[operator]
+        """
+        lines = ["TransformerBridge:"]
+        mapping = self.adapter.get_component_mapping()
+        lines.extend(self._format_component_mapping(mapping, indent=1))
+        return "\n".join(lines)
+
+    def enable_compatibility_mode(
+        self,
+        disable_warnings: bool = False,
+        no_processing: bool = False,
+        fold_ln: bool = True,
+        center_writing_weights: bool = True,
+        center_unembed: bool = True,
+        fold_value_biases: bool = True,
+        refactor_factored_attn_matrices: bool = False,
+    ) -> None:
+        """Apply HookedTransformer-equivalent weight processing and legacy hook compatibility.
+
+        Defaults match HookedTransformer's load-time processing (fold_ln + weight
+        centering) — required for analyses that reason in HookedTransformer's
+        post-processed coordinate system: logit lens, direct logit attribution,
+        residual-stream norms. Also enables legacy hook/component name aliases.
+
+        Hook semantic parity (issue #1317): ``hook_q_input``, ``hook_k_input``,
+        ``hook_v_input``, ``hook_attn_in``, and ``hook_mlp_in`` fire on the
+        pre-norm residual. Carve-outs: post-norm architectures (OLMo 2,
+        BERT-style) read the post-attention residual instead, and MLA blocks
+        (DeepSeek V2/V3/R1) do not expose the split-qkv aliases. ``hook_mlp_in``
+        is gated on ``cfg.use_hook_mlp_in``; toggle it via
+        :py:meth:`set_use_hook_mlp_in`.
+
+        Args:
+            disable_warnings: Whether to disable warnings about legacy components/hooks
+            no_processing: Whether to disable ALL pre-processing steps of the model.
+                If True, overrides fold_ln, center_writing_weights, and center_unembed to False.
+            fold_ln: Whether to fold layer norm weights into the subsequent linear layers.
+                Default: True. Ignored if no_processing=True.
+            center_writing_weights: Whether to center the writing weights (W_out in attention and MLPs).
+                Default: True. Ignored if no_processing=True.
+            center_unembed: Whether to center the unembedding matrix.
+                Default: True. Ignored if no_processing=True.
+            fold_value_biases: Whether to fold value biases into output bias.
+                Default: True. Ignored if no_processing=True.
+            refactor_factored_attn_matrices: Whether to refactor factored attention matrices.
+                Default: False. Ignored if no_processing=True.
+        """
+        from transformer_lens.utilities.bridge_components import (
+            apply_fn_to_all_components,
+        )
+
+        self.compatibility_mode = True
+
+        def set_compatibility_mode(component: Any) -> None:
+            """Set compatibility mode on a component."""
+            component.compatibility_mode = True
+            component.disable_warnings = disable_warnings
+
+        apply_fn_to_all_components(self, set_compatibility_mode)
+        self.clear_hook_registry()
+        # Drop pre-ln capture handles from any prior call so they don't accumulate.
+        if hasattr(self, "blocks"):
+            for block in self.blocks:
+                if hasattr(block, "_teardown_pre_ln_capture"):
+                    block._teardown_pre_ln_capture()
+        try:
+            if not no_processing:
+                self.process_weights(
+                    fold_ln=fold_ln,
+                    center_writing_weights=center_writing_weights,
+                    center_unembed=center_unembed,
+                    fold_value_biases=fold_value_biases,
+                    refactor_factored_attn_matrices=refactor_factored_attn_matrices,
+                )
+        finally:
+            # Re-initialize hooks even on failure so bridge stays usable
+            self._initialize_hook_registry()
+            self._setup_hook_compatibility()
+            self._register_all_aliases_recursive()
+
+    def _setup_hook_compatibility(self) -> None:
+        """Setup hook compatibility transformations to match HookedTransformer behavior.
+
+        This method sets up hook conversions and wrappers that ensure Bridge hooks
+        have the same shapes and behavior as HookedTransformer hooks. This includes:
+        1. hook_z reshaping from [batch, seq, d_model] to [batch, seq, n_heads, d_head]
+        2. Wrapping HF attention forward to inject position embeddings/attention masks
+        3. Architecture-specific setup (e.g., rotary embedding references)
+
+        This is called during __init__ and should always be run, regardless of whether
+        compatibility mode or weight processing is enabled.
+
+        Note: This method is idempotent - can be called multiple times safely.
+        """
+        if hasattr(self.adapter, "setup_hook_compatibility"):
+            self.adapter.setup_hook_compatibility(self)
+        elif hasattr(self.adapter, "setup_no_processing_hooks"):
+            self.adapter.setup_no_processing_hooks(self)
+        blocks_to_process = []
+        if hasattr(self, "blocks"):
+            blocks_to_process.extend(self.blocks)
+        if hasattr(self, "encoder_blocks"):
+            blocks_to_process.extend(self.encoder_blocks)
+        if hasattr(self, "decoder_blocks"):
+            blocks_to_process.extend(self.decoder_blocks)
+        for block in blocks_to_process:
+            for attn_name in ["attn", "self_attn", "cross_attn"]:
+                if hasattr(block, attn_name):
+                    attn = getattr(block, attn_name)
+                    if hasattr(attn, "setup_hook_compatibility"):
+                        attn.setup_hook_compatibility()
+                    elif hasattr(attn, "setup_no_processing_hooks"):
+                        attn.setup_no_processing_hooks()
+
+    def process_weights(
+        self,
+        verbose: bool = False,
+        fold_ln: bool = True,
+        center_writing_weights: bool = True,
+        center_unembed: bool = True,
+        fold_value_biases: bool = True,
+        refactor_factored_attn_matrices: bool = False,
+    ) -> None:
+        """Process weights directly using ProcessWeights and architecture adapter.
+
+        This method applies weight processing transformations to improve model interpretability
+        without requiring a reference HookedTransformer model. Works with all architectures
+        supported by TransformerBridge, including GPT-OSS and other new models.
+
+        Args:
+            verbose: If True, print detailed progress messages. Default: False
+            fold_ln: Fold LayerNorm weights/biases into subsequent layers. Default: True
+            center_writing_weights: Center weights that write to residual stream. Default: True
+            center_unembed: Center unembedding weights (translation invariant). Default: True
+            fold_value_biases: Fold value biases into output bias. Default: True
+            refactor_factored_attn_matrices: Experimental QK/OV factorization. Default: False
+        """
+        from transformer_lens.weight_processing import ProcessWeights
+
+        if verbose:
+            print(f"Processing weights for {self.cfg.model_name}...")
+
+        # Soft capping (tanh) is not translation-invariant; centering would change output.
+        if center_unembed and getattr(self.cfg, "output_logits_soft_cap", -1.0) > 0.0:
+            import logging
+
+            logging.warning(
+                "center_unembed=True is incompatible with logit softcapping "
+                "(output_logits_soft_cap=%.1f). Disabling center_unembed.",
+                self.cfg.output_logits_soft_cap,
+            )
+            center_unembed = False
+
+        if verbose:
+            print("  Extracting state dict from existing model...")
+        state_dict = self.state_dict()
+        adapter = self.adapter
+
+        # Untie embed/unembed weights (GPT-2) so centering affects only unembed
+        embed_key = "embed.weight"
+        unembed_key = "unembed.weight"
+
+        if embed_key in state_dict and unembed_key in state_dict:
+            # Check if they point to the same tensor (weight tying)
+            if state_dict[embed_key].data_ptr() == state_dict[unembed_key].data_ptr():
+                if verbose:
+                    print("  Breaking weight tying between embed and unembed in state dict...")
+                # Clone the unembed weight to break the tie
+                state_dict[unembed_key] = state_dict[unembed_key].clone()
+
+        if adapter and hasattr(adapter, "preprocess_weights"):
+            adapter._fold_ln_requested = fold_ln  # type: ignore[union-attr]
+            state_dict = adapter.preprocess_weights(state_dict)
+
+        # Use unified ProcessWeights.process_weights() like HookedTransformer does.
+        # Float32 upcasting for precision is handled centrally in process_weights().
+        if verbose:
+            print("  Processing weights (fold_ln, center_writing_weights, etc.)...")
+        state_dict = ProcessWeights.process_weights(
+            state_dict,
+            self.cfg,
+            fold_ln=fold_ln,
+            center_writing_weights=center_writing_weights,
+            center_unembed=center_unembed,
+            fold_value_biases=fold_value_biases,
+            refactor_factored_attn_matrices=refactor_factored_attn_matrices,
+            adapter=adapter,
+        )
+
+        # Normalize HF-prefix keys to TL format for weight routing
+        import re
+
+        hf_to_tl_prefix = {}
+        for tl_name, (remote_path, _component) in self.real_components.items():
+            if remote_path and remote_path != tl_name:
+                hf_to_tl_prefix[remote_path] = tl_name
+
+        normalized_state_dict = {}
+        for key, value in state_dict.items():
+            new_key = key
+            for hf_prefix, tl_prefix in hf_to_tl_prefix.items():
+                if key.startswith(hf_prefix + "."):
+                    suffix = key[len(hf_prefix) + 1 :]
+                    new_key = f"{tl_prefix}.{suffix}"
+                    break
+            normalized_state_dict[new_key] = value
+        state_dict = normalized_state_dict
+
+        if verbose:
+            print("  Distributing weights to generalized components...")
+        ProcessWeights.distribute_weights_to_components(
+            state_dict=state_dict,
+            component_mapping=self.real_components,
+        )
+
+    def _calculate_loss(self, logits, tokens, loss_per_token=False):
+        """Calculate cross-entropy loss."""
+        shift_logits = logits[..., :-1, :].contiguous()
+        shift_labels = tokens[..., 1:].contiguous()
+        loss_fct = torch.nn.CrossEntropyLoss(reduction="none" if loss_per_token else "mean")
+        flat_logits = shift_logits.view(-1, shift_logits.size(-1))
+        flat_labels = shift_labels.view(-1)
+        loss = loss_fct(flat_logits, flat_labels)
+        if loss_per_token:
+            return loss.view(shift_labels.shape)
+        else:
+            return loss
+
+    def _extract_hf_weights(self):
+        """Extract weights from the original HuggingFace model."""
+        hf_state_dict = self.state_dict()
+        for layer_idx in range(self.cfg.n_layers):
+            combined_qkv_key = f"transformer.h.{layer_idx}.attn.c_attn.weight"
+            combined_qkv_bias_key = f"transformer.h.{layer_idx}.attn.c_attn.bias"
+            if combined_qkv_key in hf_state_dict:
+                separate_keys_to_remove = [
+                    f"transformer.h.{layer_idx}.attn.q.weight",
+                    f"transformer.h.{layer_idx}.attn.q.bias",
+                    f"transformer.h.{layer_idx}.attn.k.weight",
+                    f"transformer.h.{layer_idx}.attn.k.bias",
+                    f"transformer.h.{layer_idx}.attn.v.weight",
+                    f"transformer.h.{layer_idx}.attn.v.bias",
+                ]
+                for key_to_remove in separate_keys_to_remove:
+                    if key_to_remove in hf_state_dict:
+                        del hf_state_dict[key_to_remove]
+        return hf_state_dict
+
+    def to_tokens(
+        self,
+        input: Union[str, List[str]],
+        prepend_bos: Optional[bool] = None,
+        padding_side: Optional[str] = None,
+        move_to_device: bool = True,
+        truncate: bool = True,
+    ) -> torch.Tensor:
+        """Converts a string to a tensor of tokens.
+
+        See the class-level "Tokenization notes" for full ``prepend_bos``
+        semantics, the ``default_prepend_bos`` /
+        ``tokenizer_prepends_bos`` interaction, and the whitespace-
+        sensitivity gotcha. **Pass ``prepend_bos=False`` whenever you're
+        tokenizing only part of a prompt.**
+
+        Args:
+            input: The input to tokenize.
+            prepend_bos: Overrides ``self.cfg.default_prepend_bos``. Defaults
+                to ``None`` (use the cfg setting). Pass ``True`` or ``False``
+                to override locally.
+            padding_side: Which side to pad on when tokenizing multiple
+                strings of different lengths. Defaults to the tokenizer's
+                ``padding_side``.
+            move_to_device: Whether to move the result to ``cfg.device``.
+            truncate: Whether to truncate inputs longer than ``cfg.n_ctx``.
+
+        Returns:
+            Token tensor of shape ``[batch, pos]``.
+        """
+        assert self.tokenizer is not None, "Cannot use to_tokens without a tokenizer"
+        if prepend_bos is None:
+            prepend_bos = getattr(self.cfg, "default_prepend_bos", True)
+        if padding_side is None:
+            padding_side = getattr(self.tokenizer, "padding_side", "right")
+        tokenizer_prepends_bos = getattr(self.cfg, "tokenizer_prepends_bos", True)
+        if prepend_bos and (not tokenizer_prepends_bos):
+            input = utils.get_input_with_manually_prepended_bos(self.tokenizer.bos_token, input)
+        if isinstance(input, str):
+            input = [input]
+        tokens = self.tokenizer(
+            input,
+            return_tensors="pt",
+            padding=True,
+            truncation=truncate,
+            max_length=self.cfg.n_ctx if truncate else None,
+        )["input_ids"]
+        # Strip auto-appended EOS tokens (e.g., OLMo)
+        if (
+            getattr(self.cfg, "tokenizer_appends_eos", False)
+            and self.tokenizer.eos_token_id is not None
+        ):
+            # Remove trailing EOS, keep at least 1 token
+            while tokens.shape[-1] > 1 and (tokens[:, -1] == self.tokenizer.eos_token_id).all():
+                tokens = tokens[:, :-1]
+        if not prepend_bos and tokenizer_prepends_bos:
+            tokens = utils.get_tokens_with_bos_removed(self.tokenizer, tokens)
+        if move_to_device:
+            tokens = tokens.to(self.cfg.device)
+        return tokens
+
+    def to_string(
+        self, tokens: Union[List[int], torch.Tensor, np.ndarray]
+    ) -> Union[str, List[str]]:
+        """Convert tokens to string(s).
+
+        Args:
+            tokens: Tokens to convert
+
+        Returns:
+            Decoded string(s)
+        """
+        if not isinstance(tokens, torch.Tensor):
+            tokens = torch.tensor(tokens)
+        if len(tokens.shape) == 2:
+            return self.tokenizer.batch_decode(tokens, clean_up_tokenization_spaces=False)
+        elif len(tokens.shape) <= 1:
+            return self.tokenizer.decode(tokens, clean_up_tokenization_spaces=False)
+        else:
+            raise ValueError(f"Invalid shape passed in: {tokens.shape}")
+
+    def to_str_tokens(
+        self,
+        input: Union[str, torch.Tensor, np.ndarray, List],
+        prepend_bos: Optional[bool] = None,
+        padding_side: Optional[str] = None,
+    ) -> Union[List[str], List[List[str]]]:
+        """Map text or tokens to a list of tokens as strings.
+
+        See the class-level "Tokenization notes" for full ``prepend_bos``
+        semantics. **Pass ``prepend_bos=False`` whenever you're tokenizing
+        only part of a prompt.** When ``input`` is already a tensor or
+        array, ``prepend_bos`` and ``padding_side`` are ignored.
+
+        Args:
+            input: A string, list of strings, or tensor/array of token IDs.
+            prepend_bos: Overrides ``self.cfg.default_prepend_bos``. Only
+                applies when ``input`` is a string. Defaults to ``None``
+                (use the cfg setting).
+            padding_side: Which side to pad on. Only applies when ``input``
+                is a string.
+
+        Returns:
+            List of token strings.
+        """
+        if isinstance(input, list):
+            return cast(
+                List[List[str]],
+                [self.to_str_tokens(item, prepend_bos, padding_side) for item in input],
+            )
+        elif isinstance(input, str):
+            tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)[0]
+        elif isinstance(input, torch.Tensor):
+            tokens = input.squeeze()
+            if tokens.dim() == 0:
+                tokens = tokens.unsqueeze(0)
+            assert (
+                tokens.dim() == 1
+            ), f"Invalid tokens input to to_str_tokens, has shape: {tokens.shape}"
+        elif isinstance(input, np.ndarray):
+            tokens_np = input.squeeze()
+            if tokens_np.ndim == 0:
+                tokens_np = np.expand_dims(tokens_np, axis=0)
+            assert (
+                tokens_np.ndim == 1
+            ), f"Invalid tokens input to to_str_tokens, has shape: {tokens_np.shape}"
+            tokens = torch.tensor(tokens_np)
+        else:
+            raise ValueError(f"Invalid input type to to_str_tokens: {type(input)}")
+        # v5 compat: wrap each token so batch_decode decodes them individually
+        tokens_list = [[int(t)] for t in tokens.tolist()]
+        str_tokens = self.tokenizer.batch_decode(tokens_list, clean_up_tokenization_spaces=False)
+        return str_tokens
+
+    def to_single_token(self, string: str) -> int:
+        """Map a string that makes up a single token to the id for that token.
+
+        Args:
+            string: The string to convert
+
+        Returns:
+            Token ID
+
+        Raises:
+            AssertionError: If string is not a single token
+        """
+        token = self.to_tokens(string, prepend_bos=False).squeeze()
+        if token.numel() != 1:
+            raise AssertionError(f"Input string: {string} is not a single token!")
+        return int(token.item())
+
+    def get_token_position(
+        self,
+        single_token: Union[str, int],
+        input: Union[str, torch.Tensor],
+        mode="first",
+        prepend_bos: Optional[Union[bool, None]] = None,
+        padding_side: Optional[Union[Literal["left", "right"], None]] = None,
+    ):
+        """Get the position of a single_token in a string or sequence of tokens.
+
+        Raises an error if the token is not present.
+
+        When ``input`` is a string it's tokenized internally — see the
+        class-level "Tokenization notes" for ``prepend_bos`` semantics.
+        Off-by-one position errors usually mean ``prepend_bos`` is on
+        when it shouldn't be (or vice versa); pass ``prepend_bos=False``
+        when ``input`` is a fragment of a larger prompt.
+
+        Args:
+            single_token (Union[str, int]): The token to search for. Can
+                be a token index, or a string (but the string must correspond to a single token).
+            input (Union[str, torch.Tensor]): The sequence to
+                search in. Can be a string or a rank 1 tensor of tokens or a rank 2 tensor of tokens
+                with a dummy batch dimension.
+            mode (str, optional): If there are multiple matches, which match to return. Supports
+                "first" or "last". Defaults to "first".
+            prepend_bos (bool, optional): Overrides ``self.cfg.default_prepend_bos``. Only
+                applies when ``input`` is a string. Defaults to ``None`` (use the cfg setting).
+            padding_side (Union[Literal["left", "right"], None], optional): Specifies which
+                side to pad when tokenizing multiple strings of different lengths.
+        """
+        if isinstance(input, str):
+            tokens = self.to_tokens(input, prepend_bos=prepend_bos, padding_side=padding_side)
+        else:
+            tokens = input
+        if len(tokens.shape) == 2:
+            assert (
+                tokens.shape[0] == 1
+            ), f"If tokens are rank two, they must have shape [1, seq_len], not {tokens.shape}"
+            tokens = tokens[0]
+        if isinstance(single_token, str):
+            single_token = self.to_single_token(single_token)
+        elif isinstance(single_token, torch.Tensor):
+            single_token = single_token.item()
+        indices = torch.arange(len(tokens), device=tokens.device)[tokens == single_token]
+        assert len(indices) > 0, "The token does not occur in the prompt"
+        if mode == "first":
+            return indices[0].item()
+        elif mode == "last":
+            return indices[-1].item()
+        else:
+            raise ValueError(f"mode must be 'first' or 'last', not {mode}")
+
+    def to_single_str_token(self, int_token: int) -> str:
+        """Get the single token corresponding to an int in string form.
+
+        Args:
+            int_token: The token ID
+
+        Returns:
+            The token string
+        """
+        assert isinstance(int_token, int)
+        token = self.to_str_tokens(torch.tensor([int_token]))
+        if isinstance(token, list) and len(token) == 1:
+            return str(token[0])
+        raise AssertionError("Expected a single string token.")
+
+    def blocks_with(self, submodule: str) -> List[Tuple[int, "GeneralizedComponent"]]:
+        """Return (index, block) pairs for blocks with the named bridged submodule.
+
+        Checks _modules (not hasattr) so HF-internal attrs don't match.
+        Use instead of assuming blocks[0] is representative on hybrid models.
+        """
+        if not hasattr(self, "blocks"):
+            return []
+        return [(i, block) for i, block in enumerate(self.blocks) if submodule in block._modules]
+
+    def stack_params_for(
+        self, submodule: str, attr_path: str, reshape_fn: Optional[Callable] = None
+    ) -> Tuple[List[int], torch.Tensor]:
+        """Stack a parameter across matching blocks only. Returns (layer_indices, tensor).
+
+        Use for hybrid models where not all blocks have the submodule.
+        """
+        matching = self.blocks_with(submodule)
+        if not matching:
+            raise ValueError(
+                f"No blocks have submodule '{submodule}'. "
+                f"Available submodules can be checked with blocks_with()."
+            )
+        indices: List[int] = []
+        weights: List[torch.Tensor] = []
+        for idx, block in matching:
+            w = _resolve_attr_path(block, attr_path)
+            if reshape_fn is not None:
+                w = reshape_fn(w)
+            weights.append(w)
+            indices.append(idx)
+        return indices, torch.stack(weights, dim=0)
+
+    def _stack_block_params(
+        self, attr_path: str, reshape_fn: Optional[Callable] = None
+    ) -> torch.Tensor:
+        """Stack a parameter across all blocks; falls back to matching-only on hybrids.
+
+        On hybrid models, logs a warning about index mapping and returns only
+        blocks that have the submodule. First path segment is checked against
+        _modules; deeper segments resolve via getattr (intentional — W_Q etc.
+        are exposed via __getattr__ delegation).
+        """
+        first_attr = attr_path.split(".")[0]
+        matching_blocks = [
+            (i, block) for i, block in enumerate(self.blocks) if first_attr in block._modules
+        ]
+
+        if len(matching_blocks) == 0:
+            raise AttributeError(
+                f"No blocks have submodule '{first_attr}'. "
+                f"Use bridge.blocks_with('{first_attr}') to check availability."
+            )
+
+        if len(matching_blocks) < len(self.blocks):
+            indices = [i for i, _ in matching_blocks]
+            logging.warning(
+                "Hybrid model: only %d/%d blocks have '%s'. Returning stacked tensor "
+                "for layers %s only. Tensor index i corresponds to original layer "
+                "indices[i], not layer i. For explicit index mapping, use "
+                "bridge.stack_params_for('%s', '%s').",
+                len(matching_blocks),
+                len(self.blocks),
+                first_attr,
+                indices,
+                first_attr,
+                attr_path,
+            )
+
+        weights: List[torch.Tensor] = []
+        for _, block in matching_blocks:
+            w = _resolve_attr_path(block, attr_path)
+            if reshape_fn is not None:
+                w = reshape_fn(w)
+            weights.append(w)
+        # Under a device_map split, per-block tensors live on different devices.
+        # torch.stack requires a common device; gather onto cfg.device (the embedding /
+        # input device — a natural "home" for cross-layer reductions).
+        if getattr(self.cfg, "n_devices", 1) > 1 and weights and self.cfg.device is not None:
+            target_device = torch.device(self.cfg.device)
+            weights = [w.to(target_device) for w in weights]
+        return torch.stack(weights, dim=0)
+
+    def _reshape_qkv(self, w: torch.Tensor) -> torch.Tensor:
+        """Reshape 2D [d_model, d_model] QKV weight to 3D [n_heads, d_model, d_head]."""
+        if w.shape == (self.cfg.d_model, self.cfg.d_model):
+            d_head = self.cfg.d_model // self.cfg.n_heads
+            return w.reshape(self.cfg.n_heads, self.cfg.d_model, d_head)
+        return w
+
+    def _reshape_o(self, w: torch.Tensor) -> torch.Tensor:
+        """Reshape 2D [d_model, d_model] O weight to 3D [n_heads, d_head, d_model]."""
+        if w.shape == (self.cfg.d_model, self.cfg.d_model):
+            d_head = self.cfg.d_model // self.cfg.n_heads
+            return w.reshape(self.cfg.n_heads, d_head, self.cfg.d_model)
+        return w
+
+    @property
+    def W_K(self) -> torch.Tensor:
+        """Stack the key weights across all layers."""
+        return self._stack_block_params("attn.W_K", self._reshape_qkv)
+
+    @property
+    def W_Q(self) -> torch.Tensor:
+        """Stack the query weights across all layers."""
+        return self._stack_block_params("attn.W_Q", self._reshape_qkv)
+
+    @property
+    def W_V(self) -> torch.Tensor:
+        """Stack the value weights across all layers."""
+        return self._stack_block_params("attn.W_V", self._reshape_qkv)
+
+    @property
+    def W_O(self) -> torch.Tensor:
+        """Stack the attn output weights across all layers."""
+        return self._stack_block_params("attn.W_O", self._reshape_o)
+
+    @property
+    def W_in(self) -> torch.Tensor:
+        """Stack the MLP input weights across all layers."""
+        return self._stack_block_params("mlp.W_in")
+
+    @property
+    def W_gate(self) -> Union[torch.Tensor, None]:
+        """Stack the MLP gate weights across all layers (gated MLPs only)."""
+        if getattr(self.cfg, "gated_mlp", False):
+            return self._stack_block_params("mlp.W_gate")
+        return None
+
+    @property
+    def W_out(self) -> torch.Tensor:
+        """Stack the MLP output weights across all layers."""
+        return self._stack_block_params("mlp.W_out")
+
+    @property
+    def b_K(self) -> torch.Tensor:
+        """Stack the key biases across all layers."""
+        return self._stack_block_params("attn.b_K")
+
+    @property
+    def b_Q(self) -> torch.Tensor:
+        """Stack the query biases across all layers."""
+        return self._stack_block_params("attn.b_Q")
+
+    @property
+    def b_V(self) -> torch.Tensor:
+        """Stack the value biases across all layers."""
+        return self._stack_block_params("attn.b_V")
+
+    @property
+    def b_O(self) -> torch.Tensor:
+        """Stack the attn output biases across all layers."""
+        return self._stack_block_params("attn.b_O")
+
+    @property
+    def b_in(self) -> torch.Tensor:
+        """Stack the MLP input biases across all layers."""
+        return self._stack_block_params("mlp.b_in")
+
+    @property
+    def b_out(self) -> torch.Tensor:
+        """Stack the MLP output biases across all layers."""
+        return self._stack_block_params("mlp.b_out")
+
+    @property
+    def W_U(self) -> torch.Tensor:
+        """Unembedding matrix (d_model, d_vocab). Maps residual stream to logits."""
+        return self.unembed.W_U
+
+    @property
+    def b_U(self) -> torch.Tensor:
+        """Unembedding bias (d_vocab)."""
+        return self.unembed.b_U
+
+    @property
+    def W_E(self) -> torch.Tensor:
+        """Token embedding matrix (d_vocab, d_model)."""
+        return self.embed.W_E
+
+    @property
+    def QK(self):
+        """QK circuit. On hybrids, returns attn layers only (with warning). See QK_for_attn_layers()."""
+        return FactoredMatrix(self.W_Q, self.W_K.transpose(-2, -1))
+
+    @property
+    def OV(self):
+        """OV circuit. On hybrids, returns attn layers only (with warning). See OV_for_attn_layers()."""
+        return FactoredMatrix(self.W_V, self.W_O)
+
+    def QK_for_attn_layers(self) -> Tuple[List[int], FactoredMatrix]:
+        """QK circuit for attention layers only. Returns (layer_indices, FactoredMatrix)."""
+        q_indices, W_Q = self.stack_params_for("attn", "attn.W_Q", self._reshape_qkv)
+        _, W_K = self.stack_params_for("attn", "attn.W_K", self._reshape_qkv)
+        return q_indices, FactoredMatrix(W_Q, W_K.transpose(-2, -1))
+
+    def OV_for_attn_layers(self) -> Tuple[List[int], FactoredMatrix]:
+        """OV circuit for attention layers only. Returns (layer_indices, FactoredMatrix)."""
+        v_indices, W_V = self.stack_params_for("attn", "attn.W_V", self._reshape_qkv)
+        _, W_O = self.stack_params_for("attn", "attn.W_O", self._reshape_o)
+        return v_indices, FactoredMatrix(W_V, W_O)
+
+    # ------------------------------------------------------------------
+    # Mechanistic interpretability analysis methods
+    # ------------------------------------------------------------------
+
+    def tokens_to_residual_directions(
+        self,
+        tokens: Union[str, int, torch.Tensor],
+    ) -> torch.Tensor:
+        """Map tokens to their unembedding vectors (residual stream directions).
+
+        Returns the columns of W_U corresponding to the given tokens — i.e. the
+        directions in the residual stream that the model dots with to produce the
+        logit for each token.
+
+        WARNING: If you use this without folding in LayerNorm (compatibility mode),
+        the results will be misleading because LN weights change the unembed map.
+
+        Args:
+            tokens: A single token (str, int, or scalar tensor), a 1-D tensor of
+                token IDs, or a 2-D batch of token IDs.
+
+        Returns:
+            Tensor of unembedding vectors with shape matching the input token shape
+            plus a trailing d_model dimension.
+        """
+        if isinstance(tokens, torch.Tensor) and tokens.numel() > 1:
+            residual_directions = self.W_U[:, tokens]
+            residual_directions = einops.rearrange(
+                residual_directions, "d_model ... -> ... d_model"
+            )
+            return residual_directions
+        else:
+            if isinstance(tokens, str):
+                token = self.to_single_token(tokens)
+            elif isinstance(tokens, int):
+                token = tokens
+            elif isinstance(tokens, torch.Tensor) and tokens.numel() == 1:
+                token = int(tokens.item())
+            else:
+                raise ValueError(f"Invalid token type: {type(tokens)}")
+            residual_direction = self.W_U[:, token]
+            return residual_direction
+
+    # Variant → attr paths for the output bias that feeds the residual stream.
+    _VARIANT_OUTPUT_BIAS_ATTRS: Dict[str, tuple] = {
+        "attn": ("b_O",),
+        "linear_attn": ("out_proj.bias",),
+        "mamba": ("out_proj.bias",),
+        "mixer": ("out_proj.bias",),
+        "ssm": ("out_proj.bias",),
+    }
+
+    def _get_block_variant_bias(self, block: "GeneralizedComponent") -> Optional[torch.Tensor]:
+        """Return the output bias from this block's variant submodule, or None."""
+        for name in VARIANT_SUBMODULE_NAMES:
+            if name not in block._modules:
+                continue
+            variant = block._modules[name]
+            for attr_path in self._VARIANT_OUTPUT_BIAS_ATTRS.get(name, ()):
+                obj = variant
+                try:
+                    for attr in attr_path.split("."):
+                        obj = getattr(obj, attr)
+                except AttributeError:
+                    continue
+                if obj is not None and isinstance(obj, torch.Tensor):
+                    return obj
+        return None
+
+    def accumulated_bias(
+        self,
+        layer: int,
+        mlp_input: bool = False,
+        include_mlp_biases: bool = True,
+    ) -> torch.Tensor:
+        """Sum of variant + MLP output biases through the residual stream up to `layer`.
+
+        Includes all layer types (attn, SSM, linear-attn). Set mlp_input=True
+        to include the variant bias of the target layer itself.
+        """
+        accumulated = torch.zeros(self.cfg.d_model, device=self.cfg.device)
+        for i in range(layer):
+            block = self.blocks[i]
+            b_O = self._get_block_variant_bias(block)
+            if b_O is not None:
+                accumulated = accumulated + b_O.to(accumulated.device)
+            if include_mlp_biases and "mlp" in block._modules:
+                b_out = getattr(block.mlp, "b_out", None)
+                if b_out is not None:
+                    accumulated = accumulated + b_out.to(accumulated.device)
+        if mlp_input:
+            assert layer < self.cfg.n_layers, "Cannot include attn_bias from beyond the final layer"
+            block = self.blocks[layer]
+            b_O = self._get_block_variant_bias(block)
+            if b_O is not None:
+                accumulated = accumulated + b_O.to(accumulated.device)
+        return accumulated
+
+    def all_composition_scores(self, mode: str) -> CompositionScores:
+        """Composition scores for all attention head pairs. Returns CompositionScores.
+
+        See https://transformer-circuits.pub/2021/framework/index.html
+        On hybrid models, only attention layers are included; layer_indices
+        maps tensor position i to original layer number.
+        """
+        attn_blocks = self.blocks_with("attn")
+        if not attn_blocks:
+            raise ValueError("No attention layers found — cannot compute composition scores.")
+
+        indices = [idx for idx, _ in attn_blocks]
+        blocks_list = [block for _, block in attn_blocks]
+
+        def _stack(attr_path: str, reshape_fn: Optional[Callable] = None) -> torch.Tensor:
+            weights: List[torch.Tensor] = []
+            for block in blocks_list:
+                w = _resolve_attr_path(block, attr_path)
+                if reshape_fn is not None:
+                    w = reshape_fn(w)
+                weights.append(w)
+            # See _stack_block_params: gather per-block tensors onto cfg.device when split.
+            if getattr(self.cfg, "n_devices", 1) > 1 and weights and self.cfg.device is not None:
+                target_device = torch.device(self.cfg.device)
+                weights = [w.to(target_device) for w in weights]
+            return torch.stack(weights, dim=0)
+
+        W_V = _stack("attn.W_V", self._reshape_qkv)
+        W_O = _stack("attn.W_O", self._reshape_o)
+        left = FactoredMatrix(W_V, W_O)
+
+        if mode == "Q":
+            W_Q = _stack("attn.W_Q", self._reshape_qkv)
+            W_K = _stack("attn.W_K", self._reshape_qkv)
+            right = FactoredMatrix(W_Q, W_K.transpose(-2, -1))
+        elif mode == "K":
+            W_Q = _stack("attn.W_Q", self._reshape_qkv)
+            W_K = _stack("attn.W_K", self._reshape_qkv)
+            right = FactoredMatrix(W_Q, W_K.transpose(-2, -1)).T
+        elif mode == "V":
+            right = left
+        else:
+            raise ValueError(f"mode must be one of ['Q', 'K', 'V'] not {mode}")
+
+        scores = utils.composition_scores(left, right, broadcast_dims=True)
+        n_attn = len(indices)
+        idx_tensor = torch.arange(n_attn, device=self.cfg.device)
+        mask = idx_tensor[:, None, None, None] < idx_tensor[None, None, :, None]
+        scores = torch.where(mask, scores, torch.zeros_like(scores))
+
+        labels = [f"L{l}H{h}" for l in indices for h in range(self.cfg.n_heads)]
+        return CompositionScores(scores=scores, layer_indices=indices, head_labels=labels)
+
+    def composition_layer_indices(self) -> List[int]:
+        """Original layer indices for attention layers (maps composition score positions)."""
+        return [idx for idx, _ in self.blocks_with("attn")]
+
+    def block_hooks(self, layer_idx: int) -> List[str]:
+        """Sorted hook names available on block `layer_idx` (block-relative paths)."""
+        prefix = f"blocks.{layer_idx}."
+        return sorted(name[len(prefix) :] for name in self.hook_dict if name.startswith(prefix))
+
+    def block_submodules(self, layer_idx: int) -> List[str]:
+        """Return bridged submodule names on block `layer_idx`."""
+        block = self.blocks[layer_idx]
+        return [name for name in block._modules if name not in _BLOCK_INTERNAL_MODULES]
+
+    def layer_types(self) -> List[str]:
+        """Per-block type labels, e.g. ["attn+mlp", "ssm+mlp", ...]. Deterministic order."""
+        types = []
+        for block in self.blocks:
+            variants = [n for n in VARIANT_SUBMODULE_NAMES if n in block._modules]
+            universals = sorted(
+                n
+                for n in block._modules
+                if n not in _VARIANT_SUBMODULE_SET
+                and n not in _BLOCK_INTERNAL_MODULES
+                and not n.startswith(_NORM_PREFIXES)
+            )
+            parts = variants + universals
+            types.append("+".join(parts) if parts else "unknown")
+        return types
+
+    @property
+    def all_head_labels(self) -> list[str]:
+        """Human-readable labels for all attention heads, e.g. ['L0H0', 'L0H1', ...]."""
+        return [f"L{l}H{h}" for l in range(self.cfg.n_layers) for h in range(self.cfg.n_heads)]
+
+    @property
+    def attn_head_labels(self) -> list[str]:
+        """Head labels for attention layers only — matches all_composition_scores() dims."""
+        return [
+            f"L{l}H{h}" for l in self.composition_layer_indices() for h in range(self.cfg.n_heads)
+        ]
+
+    def parameters(self, recurse: bool = True) -> Iterator[nn.Parameter]:
+        """Returns parameters following standard PyTorch semantics.
+
+        This method delegates to the underlying HuggingFace model's parameters().
+        For TransformerLens-style parameter generator, use tl_parameters() instead.
+
+        Args:
+            recurse: If True, yields parameters of this module and all submodules
+
+        Returns:
+            Iterator of nn.Parameter objects
+        """
+        return self.original_model.parameters(recurse=recurse)
+
+    def named_parameters(
+        self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
+    ) -> Iterator[tuple[str, nn.Parameter]]:
+        """Returns named parameters following standard PyTorch semantics.
+
+        This method delegates to the underlying HuggingFace model's named_parameters().
+        For TransformerLens-style generator, use tl_named_parameters() instead.
+
+        Args:
+            prefix: Prefix to prepend to all parameter names
+            recurse: If True, yields parameters of this module and all submodules
+            remove_duplicate: If True, removes duplicate parameters
+
+        Returns:
+            Iterator of (name, parameter) tuples
+        """
+        return self.original_model.named_parameters(prefix, recurse, remove_duplicate)
+
+    def tl_parameters(self) -> dict[str, torch.Tensor]:
+        """Returns TransformerLens-style parameter dictionary.
+
+        Parameter names follow TransformerLens conventions (e.g., 'blocks.0.attn.W_Q') and may
+        include processed weights (non-leaf tensors). This format is expected by SVDInterpreter
+        among other analysis tools.
+
+        Returns:
+            Dictionary mapping TransformerLens parameter names to tensors
+
+        Example:
+            >>> bridge = TransformerBridge.boot_transformers("gpt2")
+            >>> tl_params = bridge.tl_parameters()
+            >>> W_Q = tl_params["blocks.0.attn.W_Q"]  # Shape: [n_heads, d_model, d_head]
+        """
+        return self.get_params()
+
+    def tl_named_parameters(self) -> Iterator[tuple[str, torch.Tensor]]:
+        """Returns iterator of TransformerLens-style named parameters.
+
+        This provides the same parameters as tl_parameters() but as an iterator
+        for consistency with PyTorch's named_parameters() API pattern.
+
+        Returns:
+            Iterator of (name, tensor) tuples with TransformerLens naming conventions
+
+        Example:
+            >>> bridge = TransformerBridge.boot_transformers("gpt2")
+            >>> for name, param in bridge.tl_named_parameters():
+            ...     if "attn.W_Q" in name:
+            ...         print(f"{name}: {param.shape}")  # doctest: +ELLIPSIS
+            blocks.0.attn.W_Q: torch.Size([12, 768, 64])
+            ...
+        """
+        return iter(self.get_params().items())
+
+    def forward(
+        self,
+        input: Union[str, List[str], torch.Tensor],
+        return_type: Optional[str] = "logits",
+        loss_per_token: bool = False,
+        prepend_bos: Optional[bool] = None,
+        padding_side: Optional[str] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        start_at_layer: Optional[int] = None,
+        stop_at_layer: Optional[int] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        input_values: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Any:
+        """Forward pass through the model.
+
+        Args:
+            input: Input to the model
+            return_type: Type of output to return ('logits', 'loss', 'both', 'predictions', None)
+            loss_per_token: Whether to return loss per token
+            prepend_bos: Whether to prepend BOS token
+            padding_side: Which side to pad on
+            start_at_layer: Not implemented in TransformerBridge. The bridge delegates
+                to HuggingFace's model.forward() which owns the layer iteration loop,
+                making start_at_layer infeasible without monkey-patching HF internals
+                (fragile across HF versions) or exception-based layer skipping (corrupts
+                model state). Raises NotImplementedError if a non-None value is passed.
+            stop_at_layer: Layer to stop forward pass at
+            pixel_values: Optional image tensor for multimodal models (e.g., LLaVA, Gemma3).
+                The tensor is passed directly to the underlying HuggingFace model.
+                Only valid when cfg.is_multimodal is True.
+            input_values: Optional audio waveform tensor for audio models (e.g., HuBERT).
+                The tensor is passed directly to the underlying HuggingFace model.
+                Only valid when cfg.is_audio_model is True.
+            **kwargs: Additional arguments passed to model
+
+        Returns:
+            Model output based on return_type
+        """
+
+        if start_at_layer is not None:
+            raise NotImplementedError(
+                "start_at_layer is not supported in TransformerBridge. "
+                "The bridge delegates to HuggingFace's model.forward() which controls "
+                "the layer iteration loop. See the TransformerBridge review plan for a "
+                "detailed analysis of implementation approaches and their tradeoffs."
+            )
+
+        # Set stop_at_layer flag on all blocks if requested
+        if stop_at_layer is not None and hasattr(self, "blocks"):
+            for block in self.blocks:
+                block._stop_at_layer_idx = stop_at_layer
+
+        # Map HookedEncoderDecoder-style kwargs to HF-compatible names
+        if "decoder_input" in kwargs:
+            kwargs["decoder_input_ids"] = kwargs.pop("decoder_input")
+        if "one_zero_attention_mask" in kwargs:
+            if attention_mask is None:
+                attention_mask = kwargs.pop("one_zero_attention_mask")
+            else:
+                kwargs.pop("one_zero_attention_mask")
+
+        # Detect batched list input that will need padding. For this case we force
+        # left-padding internally and auto-compute attention_mask + position_ids
+        # (unless the caller passed them explicitly) so pad tokens don't contaminate
+        # attention or position embeddings.
+        _is_batched_list = (
+            isinstance(input, list)
+            and len(input) > 1
+            and not getattr(self.cfg, "is_audio_model", False)
+        )
+
+        try:
+            if isinstance(input, (str, list)):
+                if getattr(self.cfg, "is_audio_model", False):
+                    raise ValueError(
+                        "Audio models require tensor input (raw waveform), not text. "
+                        "Pass a torch.Tensor or use the input_values parameter."
+                    )
+                if _is_batched_list and padding_side is None:
+                    # Force left-padding so real tokens are flush-right.
+                    _orig_padding_side = self.tokenizer.padding_side
+                    self.tokenizer.padding_side = "left"
+                    try:
+                        input_ids = self.to_tokens(
+                            input, prepend_bos=prepend_bos, padding_side=padding_side
+                        )
+                    finally:
+                        self.tokenizer.padding_side = _orig_padding_side
+                else:
+                    input_ids = self.to_tokens(
+                        input, prepend_bos=prepend_bos, padding_side=padding_side
+                    )
+            else:
+                input_ids = input
+                # Promote 1D integer token tensors to 2D [batch=1, seq] to match
+                # HookedTransformer's contract. Float tensors (inputs_embeds,
+                # audio waveforms) are passed through unchanged.
+                if (
+                    isinstance(input_ids, torch.Tensor)
+                    and input_ids.ndim == 1
+                    and not input_ids.is_floating_point()
+                ):
+                    input_ids = input_ids.unsqueeze(0)
+
+            # Detect inputs_embeds: if the tensor is floating point, it's pre-computed
+            # embeddings (e.g., from multimodal models) rather than token IDs.
+            _is_inputs_embeds = (
+                isinstance(input_ids, torch.Tensor) and input_ids.is_floating_point()
+            )
+
+            # Auto-compute attention_mask + position_ids for batched list input
+            # when the caller didn't supply them. Matches HF generation convention.
+            if (
+                _is_batched_list
+                and attention_mask is None
+                and self.tokenizer is not None
+                and self.tokenizer.pad_token_id is not None
+                and not _is_inputs_embeds
+            ):
+                _prev_side = self.tokenizer.padding_side
+                self.tokenizer.padding_side = "left"
+                try:
+                    attention_mask = utils.get_attention_mask(
+                        self.tokenizer,
+                        input_ids,
+                        prepend_bos=getattr(self.cfg, "default_prepend_bos", True),
+                    ).to(self.cfg.device)
+                finally:
+                    self.tokenizer.padding_side = _prev_side
+                if "position_ids" not in kwargs:
+                    position_ids = attention_mask.long().cumsum(-1) - 1
+                    position_ids.masked_fill_(attention_mask == 0, 1)
+                    kwargs["position_ids"] = position_ids
+
+            if attention_mask is not None:
+                kwargs["attention_mask"] = attention_mask
+            if kwargs.pop("use_past_kv_cache", False) or kwargs.get("use_cache", False):
+                kwargs["use_cache"] = True
+            # Auto-generate decoder_input_ids for encoder-decoder models
+            if (
+                "decoder_input_ids" not in kwargs
+                and hasattr(self.original_model, "config")
+                and getattr(self.original_model.config, "is_encoder_decoder", False)
+            ):
+                decoder_start_token_id = getattr(
+                    self.original_model.config, "decoder_start_token_id", None
+                )
+                if decoder_start_token_id is not None:
+                    shifted = input_ids[:, :-1]
+                    start_tokens = torch.full(
+                        (input_ids.shape[0], 1),
+                        decoder_start_token_id,
+                        dtype=input_ids.dtype,
+                        device=input_ids.device,
+                    )
+                    kwargs["decoder_input_ids"] = torch.cat([start_tokens, shifted], dim=1)
+                else:
+                    kwargs["decoder_input_ids"] = input_ids
+
+            # Tell PosEmbedBridge to expand batch=1 position_ids to full batch.
+            if hasattr(self, "pos_embed"):
+                self.pos_embed._current_batch_size = input_ids.shape[0]
+
+            # Handle pixel_values for multimodal models
+            if pixel_values is not None:
+                if not getattr(self.cfg, "is_multimodal", False):
+                    raise ValueError(
+                        "pixel_values can only be passed to multimodal models "
+                        "(cfg.is_multimodal must be True)"
+                    )
+                kwargs["pixel_values"] = pixel_values
+
+            # Handle input_values for audio models
+            if input_values is not None:
+                if not getattr(self.cfg, "is_audio_model", False):
+                    raise ValueError(
+                        "input_values can only be passed to audio models "
+                        "(cfg.is_audio_model must be True)"
+                    )
+                kwargs["input_values"] = input_values
+
+            # Audio models use input_values (waveform), not input_ids
+            if getattr(self.cfg, "is_audio_model", False):
+                if input_values is not None:
+                    output = self.original_model(**kwargs)
+                elif isinstance(input, torch.Tensor):
+                    kwargs["input_values"] = input
+                    output = self.original_model(**kwargs)
+                else:
+                    raise ValueError(
+                        "Audio models require tensor input (raw waveform). "
+                        "Pass a torch.Tensor or use input_values parameter."
+                    )
+            elif _is_inputs_embeds:
+                output = self.original_model(inputs_embeds=input_ids, **kwargs)
+            else:
+                output = self.original_model(input_ids, **kwargs)
+            # Stash only the cache object (not the full output) for generate().
+            if getattr(self, "_capture_hf_cache", False):
+                self._last_hf_cache = getattr(output, "past_key_values", None)
+            if hasattr(output, "logits"):
+                logits = output.logits
+            elif isinstance(output, tuple) and len(output) > 0:
+                logits = output[0]
+            else:
+                logits = output
+            if return_type == "logits":
+                return logits
+            elif return_type == "loss":
+                if getattr(self.cfg, "is_audio_model", False):
+                    raise ValueError(
+                        "Audio models do not support return_type='loss'. "
+                        "CTC loss requires aligned frame-level labels."
+                    )
+                if _is_inputs_embeds:
+                    raise ValueError(
+                        "Cannot compute loss with inputs_embeds — token IDs required for labels."
+                    )
+                # Always use self.loss_fn for consistency with HT's formula
+                # (log_softmax + gather).  HF's output.loss uses F.cross_entropy
+                # which gives different results in bfloat16.
+                assert isinstance(
+                    logits, torch.Tensor
+                ), f"Expected logits tensor, got {type(logits)}"
+                return self.loss_fn(logits, input_ids, per_token=loss_per_token)
+            elif return_type == "both":
+                if getattr(self.cfg, "is_audio_model", False):
+                    raise ValueError(
+                        "Audio models do not support return_type='both'. "
+                        "CTC loss requires aligned frame-level labels."
+                    )
+                if _is_inputs_embeds:
+                    raise ValueError(
+                        "Cannot compute loss with inputs_embeds — token IDs required for labels."
+                    )
+                assert isinstance(
+                    logits, torch.Tensor
+                ), f"Expected logits tensor, got {type(logits)}"
+                loss = self.loss_fn(logits, input_ids, per_token=loss_per_token)
+                return (logits, loss)
+            elif return_type == "predictions":
+                assert (
+                    self.tokenizer is not None
+                ), "Must have a tokenizer to use return_type='predictions'"
+                if logits.shape[-1] == 2:
+                    # Next Sentence Prediction — 2-class output
+                    logprobs = logits.log_softmax(dim=-1)
+                    predictions = [
+                        "The sentences are sequential",
+                        "The sentences are NOT sequential",
+                    ]
+                    return predictions[logprobs.argmax(dim=-1).item()]
+                else:
+                    # Masked Language Modeling — decode [MASK] tokens
+                    logprobs = logits[input_ids == self.tokenizer.mask_token_id].log_softmax(dim=-1)
+                    predictions = self.tokenizer.decode(logprobs.argmax(dim=-1))
+                    if " " in predictions:
+                        predictions = predictions.split(" ")
+                        predictions = [f"Prediction {i}: {p}" for i, p in enumerate(predictions)]
+                    return predictions
+            elif return_type is None:
+                return None
+            else:
+                raise ValueError(f"Invalid return_type: {return_type}")
+        except StopAtLayerException as e:
+            # Execution stopped at the requested layer
+            return e.layer_output
+        finally:
+            # Clean up state that may be inconsistent after StopAtLayerException
+            if stop_at_layer is not None and hasattr(self, "blocks"):
+                # Reset the stop flag on all blocks
+                for block in self.blocks:
+                    block._stop_at_layer_idx = None
+
+                # Clear any stale KV cache — layers after the stop point didn't
+                # execute, so the cache is incomplete and would corrupt subsequent
+                # generate() calls that expect a full cache.
+                if hasattr(self, "_last_hf_cache"):
+                    del self._last_hf_cache
+
+    def get_hook_point(self, hook_name: str) -> Optional[HookPoint]:
+        """Get a hook point by name from the bridge's hook system."""
+        if hook_name in self._hook_registry:
+            return self._hook_registry[hook_name]
+        try:
+            parts = hook_name.split(".")
+            current = self
+            for part in parts:
+                current = getattr(current, part)
+            if isinstance(current, HookPoint):
+                return current
+        except AttributeError:
+            pass
+        return None
+
+    def loss_fn(
+        self,
+        logits: torch.Tensor,
+        tokens: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        per_token: bool = False,
+    ) -> torch.Tensor:
+        """Calculate cross-entropy loss.
+
+        Uses the same formula as HookedTransformer (log_softmax + gather) to ensure
+        numerically identical results when logits match.
+
+        Args:
+            logits: Model logits
+            tokens: Target tokens
+            attention_mask: Optional attention mask for padding
+            per_token: Whether to return per-token loss
+
+        Returns:
+            Loss tensor
+        """
+        if tokens.device != logits.device:
+            tokens = tokens.to(logits.device)
+        return lm_cross_entropy_loss(logits, tokens, attention_mask, per_token)
+
+    @overload
+    def run_with_cache(
+        self,
+        input: Union[str, List[str], torch.Tensor],
+        return_cache_object: Literal[True] = True,
+        remove_batch_dim: bool = False,
+        **kwargs,
+    ) -> Tuple[Any, ActivationCache]:
+        """Run with cache - placeholder implementation."""
+        pass
+
+    @overload
+    def run_with_cache(
+        self,
+        input: Union[str, List[str], torch.Tensor],
+        return_cache_object: Literal[False],
+        remove_batch_dim: bool = False,
+        **kwargs,
+    ) -> Tuple[Any, Dict[str, torch.Tensor]]:
+        """Run with cache - placeholder implementation."""
+        pass
+
+    def run_with_cache(
+        self,
+        input: Union[str, List[str], torch.Tensor],
+        return_cache_object: bool = True,
+        remove_batch_dim: bool = False,
+        names_filter: Optional[Union[str, List[str], Callable[[str], bool]]] = None,
+        stop_at_layer: Optional[int] = None,
+        **kwargs,
+    ) -> Tuple[Any, Union[ActivationCache, Dict[str, torch.Tensor]]]:
+        """Run the model and cache all activations.
+
+               Args:
+                   input: Input to the model
+                   return_cache_object: Whether to return ActivationCache object
+                   remove_batch_dim: Whether to remove batch dimension
+                   names_filter: Filter for which activations to cache (str, list of str, or callable)
+                   stop_at_layer: Layer to stop forward pass at (uses StopAtLayerException; cleans up KV cache on stop)
+                   device: Where to store cached activations (matches ActivationCache.to;
+                       does not move the model). Defaults to per-layer storage.
+                   **kwargs: Additional arguments
+        # type: ignore[name-defined]
+               Returns:
+                   Tuple of (output, cache)
+        """
+        aliases = build_alias_to_canonical_map(self.hook_dict)
+
+        def create_names_filter_fn(filter_input):
+            if filter_input is None:
+                return lambda name: True
+            elif isinstance(filter_input, str):
+                mapped_name = aliases.get(filter_input, None)
+                if mapped_name:
+                    return lambda name: name == mapped_name or name == filter_input
+                else:
+                    return lambda name: name == filter_input
+            elif isinstance(filter_input, list):
+                mapped_list = []
+                for item in filter_input:
+                    mapped_list.append(item)
+                    mapped_name = aliases.get(item, None)
+                    if mapped_name:
+                        mapped_list.append(mapped_name)
+                return lambda name: name in mapped_list
+            elif callable(filter_input):
+                return filter_input
+            else:
+                raise ValueError("names_filter must be a string, list of strings, or callable")
+
+        names_filter_fn = create_names_filter_fn(names_filter)
+        cache: Dict[str, torch.Tensor] = {}
+        hooks: List[Tuple[HookPoint, str]] = []
+        visited: set[int] = set()
+
+        # None → no-op .to(None), tensors stay on their current device.
+        cache_device = kwargs.pop("device", None)
+
+        def make_cache_hook(name: str):
+            def cache_hook(tensor: torch.Tensor, *, hook: Any) -> torch.Tensor:
+                if tensor is None:
+                    cache[name] = None
+                elif isinstance(tensor, torch.Tensor):
+                    cache[name] = tensor.detach().to(cache_device)
+                elif isinstance(tensor, tuple):
+                    if len(tensor) > 0 and isinstance(tensor[0], torch.Tensor):
+                        cache[name] = tensor[0].detach().to(cache_device)
+                    else:
+                        pass
+                else:
+                    try:
+                        if hasattr(tensor, "detach"):
+                            cache[name] = tensor.detach().to(cache_device)
+                    except Exception:
+                        pass
+                return tensor
+
+            return cache_hook
+
+        hook_dict = self.hook_dict
+        effective_stop_layer = None
+        if stop_at_layer is not None and hasattr(self, "blocks"):
+            if stop_at_layer < 0:
+                effective_stop_layer = len(self.blocks) + stop_at_layer
+            else:
+                effective_stop_layer = stop_at_layer
+        for hook_name, hook in hook_dict.items():
+            if names_filter_fn(hook_name):
+                if effective_stop_layer is not None:
+                    if hook_name.startswith("blocks."):
+                        try:
+                            layer_num = int(hook_name.split(".")[1])
+                            if layer_num >= effective_stop_layer:
+                                continue
+                        except (IndexError, ValueError):
+                            pass
+                hooks.append((hook, hook_name))
+        for hp, name in hooks:
+            hp.add_hook(make_cache_hook(name))
+        processed_args = [input]
+        if processed_args and isinstance(processed_args[0], str):
+            assert self.tokenizer is not None, "Tokenizer must be set to pass string input."
+            input_ids = self.to_tokens(processed_args[0])
+            input_ids = input_ids.to(next(self.original_model.parameters()).device)
+            kwargs["input_ids"] = input_ids
+            processed_args = processed_args[1:]
+        elif "input" in kwargs and isinstance(kwargs["input"], str):
+            assert self.tokenizer is not None, "Tokenizer must be set to pass string input."
+            input_ids = self.to_tokens(kwargs["input"])
+            input_ids = input_ids.to(next(self.original_model.parameters()).device)
+            kwargs["input_ids"] = input_ids
+            del kwargs["input"]
+        if stop_at_layer is not None and hasattr(self, "blocks"):
+            if stop_at_layer < 0:
+                stop_at_layer = len(self.blocks) + stop_at_layer
+            last_layer_to_process = stop_at_layer - 1
+
+            def stop_hook(tensor: torch.Tensor, *, hook: Any) -> torch.Tensor:
+                raise StopAtLayerException(tensor)
+
+            if stop_at_layer >= 0 and stop_at_layer < len(self.blocks):
+                # Stop at the beginning of the specified block, not at the end of the previous block
+                block_hook_name = f"blocks.{stop_at_layer}.hook_in"
+                hook_dict = self.hook_dict
+                if block_hook_name in hook_dict:
+                    hook_dict[block_hook_name].add_hook(stop_hook)
+                    hooks.append((hook_dict[block_hook_name], block_hook_name))
+        filtered_kwargs = kwargs.copy()
+        # `cache_device` is honored by `make_cache_hook` above (`tensor.detach().to(cache_device)`);
+        # the model and inputs stay where the caller put them, matching `ActivationCache.to`.
+        if cache_device is not None and getattr(self.cfg, "n_devices", 1) > 1:
+            # Moving a dispatched model to a single device collapses accelerate's
+            # split and breaks its routing hooks. The cache will stay spread across
+            # the per-layer devices; callers can .to(cache_device) on cache entries
+            # after the fact if they need a single-device cache.
+            warnings.warn(
+                f"run_with_cache(device={cache_device!r}) ignored: model is dispatched "
+                f"across {self.cfg.n_devices} devices via device_map. Cached activations "
+                "will remain on their per-layer devices.",
+                stacklevel=2,
+            )
+        try:
+            if "output_attentions" not in filtered_kwargs:
+                filtered_kwargs["output_attentions"] = True
+            if processed_args:
+                output = self.forward(processed_args[0], **filtered_kwargs)
+            elif "input_ids" in filtered_kwargs:
+                output = self.forward(
+                    filtered_kwargs["input_ids"],
+                    **{k: v for k, v in filtered_kwargs.items() if k != "input_ids"},
+                )
+            else:
+                output = self.forward(**filtered_kwargs)
+            if hasattr(output, "logits"):
+                output = output.logits
+        except StopAtLayerException as e:
+            output = e.layer_output
+        except Exception as e:
+            raise e
+        finally:
+            for hp, _ in hooks:
+                hp.remove_hooks(dir="fwd")
+        if self.compatibility_mode == True:
+            reverse_aliases = {}
+            for old_name, new_name in aliases.items():
+                if isinstance(new_name, list):
+                    for single_new_name in new_name:
+                        reverse_aliases[single_new_name] = old_name
+                else:
+                    reverse_aliases[new_name] = old_name
+            cache_items_to_add = {}
+            for cache_name, cached_value in cache.items():
+                for new_name, old_name in reverse_aliases.items():
+                    if cache_name == new_name:
+                        cache_items_to_add[old_name] = cached_value
+                        break
+            cache.update(cache_items_to_add)
+            for alias_name, target_name in aliases.items():
+                if isinstance(target_name, list):
+                    for single_target in target_name:
+                        if single_target in cache and alias_name not in cache:
+                            cache[alias_name] = cache[single_target]
+                            break
+                elif target_name in cache and alias_name not in cache:
+                    cache[alias_name] = cache[target_name]
+        if return_cache_object:
+            activation_cache = ActivationCache(cache, self, has_batch_dim=True)
+            if remove_batch_dim:
+                activation_cache.remove_batch_dim()
+            return (output, activation_cache)
+        else:
+            if remove_batch_dim:
+                for key in cache:
+                    if cache[key] is not None and isinstance(cache[key], torch.Tensor):
+                        if cache[key].size(0) == 1:
+                            cache[key] = cache[key][0]
+            return (output, cache)
+
+    def run_with_hooks(
+        self,
+        input: Union[str, List[str], torch.Tensor],
+        fwd_hooks: List[Tuple[Union[str, Callable], Callable]] = [],
+        bwd_hooks: List[Tuple[Union[str, Callable], Callable]] = [],
+        reset_hooks_end: bool = True,
+        clear_contexts: bool = False,
+        return_type: Optional[str] = "logits",
+        names_filter: Optional[Union[str, List[str], Callable[[str], bool]]] = None,
+        stop_at_layer: Optional[int] = None,
+        remove_batch_dim: bool = False,
+        **kwargs,
+    ) -> Any:
+        """Run the model with specified forward and backward hooks.
+
+        Args:
+            input: Input to the model
+            fwd_hooks: Forward hooks to apply
+            bwd_hooks: Backward hooks to apply
+            reset_hooks_end: Whether to reset hooks at the end
+            clear_contexts: Whether to clear hook contexts
+            return_type: What to return ("logits", "loss", etc.)
+            names_filter: Filter for hook names (not used directly, for compatibility)
+            stop_at_layer: Layer to stop at (uses StopAtLayerException; cleans up KV cache on stop)
+            remove_batch_dim: Whether to remove batch dimension from hook inputs (only works for batch_size==1)
+            **kwargs: Additional arguments
+
+        Returns:
+            Model output
+        """
+        added_hooks: List[Tuple[HookPoint, Literal["fwd", "bwd"]]] = []
+        effective_stop_layer = None
+        if stop_at_layer is not None and hasattr(self, "blocks"):
+            if stop_at_layer < 0:
+                effective_stop_layer = len(self.blocks) + stop_at_layer
+            else:
+                effective_stop_layer = stop_at_layer
+
+        def add_hook_to_point(
+            hook_point: HookPoint, hook_fn: Callable, name: str, dir: Literal["fwd", "bwd"] = "fwd"
+        ):
+            if effective_stop_layer is not None and name.startswith("blocks."):
+                try:
+                    layer_num = int(name.split(".")[1])
+                    if layer_num >= effective_stop_layer:
+                        return
+                except (IndexError, ValueError):
+                    pass
+            if self.compatibility_mode and name != hook_point.name:
+                alias_names_list: list[str] = []
+                if hook_point.name is not None:
+                    alias_names_list.append(hook_point.name)
+                alias_names_list.append(name)
+                hook_point.add_hook(hook_fn, dir=dir, alias_names=alias_names_list)
+            else:
+                hook_point.add_hook(hook_fn, dir=dir)
+            added_hooks.append((hook_point, dir))
+
+        if stop_at_layer is not None and hasattr(self, "blocks"):
+            if stop_at_layer < 0:
+                stop_at_layer = len(self.blocks) + stop_at_layer
+            last_layer_to_process = stop_at_layer - 1
+
+            def stop_hook(tensor: torch.Tensor, *, hook: Any) -> torch.Tensor:
+                raise StopAtLayerException(tensor)
+
+            if stop_at_layer >= 0 and stop_at_layer < len(self.blocks):
+                # Stop at the beginning of the specified block, not at the end of the previous block
+                block_hook_name = f"blocks.{stop_at_layer}.hook_in"
+                hook_dict = self.hook_dict
+                if block_hook_name in hook_dict:
+                    add_hook_to_point(hook_dict[block_hook_name], stop_hook, block_hook_name, "fwd")
+
+        def apply_hooks(hooks: List[Tuple[Union[str, Callable], Callable]], is_fwd: bool):
+            direction: Literal["fwd", "bwd"] = "fwd" if is_fwd else "bwd"
+            aliases = build_alias_to_canonical_map(self.hook_dict)
+            for hook_name_or_filter, hook_fn in hooks:
+                if remove_batch_dim:
+                    original_hook_fn = hook_fn
+
+                    # Default arg captures hook_fn by value (avoids closure issue)
+                    def wrapped_hook_fn(tensor, hook, _orig_fn=original_hook_fn):
+                        if tensor.shape[0] == 1:
+                            tensor_no_batch = tensor.squeeze(0)
+                            result = _orig_fn(tensor_no_batch, hook)
+                            if result.dim() == tensor_no_batch.dim():
+                                result = result.unsqueeze(0)
+                            return result
+                        else:
+                            return _orig_fn(tensor, hook)
+
+                    hook_fn = wrapped_hook_fn
+                if isinstance(hook_name_or_filter, str):
+                    hook_dict = self.hook_dict
+                    actual_hook_name = hook_name_or_filter
+                    if hook_name_or_filter in aliases:
+                        actual_hook_name = aliases[hook_name_or_filter]
+                    if actual_hook_name in hook_dict:
+                        add_hook_to_point(
+                            hook_dict[actual_hook_name], hook_fn, actual_hook_name, direction
+                        )
+                else:
+                    hook_dict = self.hook_dict
+                    seen_hooks = set()
+                    for name, hook_point in hook_dict.items():
+                        if hook_name_or_filter(name):
+                            hook_id = id(hook_point)
+                            if hook_id in seen_hooks:
+                                continue
+                            seen_hooks.add(hook_id)
+                            hook_name_to_use = hook_point.name if hook_point.name else name
+                            add_hook_to_point(hook_point, hook_fn, hook_name_to_use, direction)
+
+        try:
+            apply_hooks(fwd_hooks, True)
+            apply_hooks(bwd_hooks, False)
+            try:
+                output = self.forward(
+                    input, return_type=return_type, stop_at_layer=stop_at_layer, **kwargs
+                )
+            except StopAtLayerException as e:
+                output = e.layer_output
+            return output
+        finally:
+            if reset_hooks_end:
+                for hook_point, direction in added_hooks:
+                    hook_point.remove_hooks(dir=direction)
+
+    def _resolve_stopping_criteria(
+        self,
+        stop_strings: Optional[Union[str, List[str]]],
+        stopping_criteria: Optional[Any],
+    ) -> Optional[Any]:
+        """Combine ``stop_strings`` and ``stopping_criteria`` into one StoppingCriteriaList.
+
+        Returns ``None`` when neither is supplied (or both reduce to no-ops),
+        so callers can cheaply check whether any extra stop signal is active.
+        ``stop_strings`` is turned into a HuggingFace ``StopStringCriteria`` (which reproduces
+        HF's exact partial-token-aware, end-anchored matching: it fires when the stop string
+        ends the generated text, even if the string straddles token boundaries) and therefore
+        requires a tokenizer.
+        A user-supplied ``stopping_criteria`` may be a single ``StoppingCriteria``,
+        a list of them, or a ``StoppingCriteriaList``.
+
+        Raises:
+            ValueError: if ``stop_strings`` is supplied without a tokenizer.
+            TypeError: if ``stopping_criteria`` is not a ``StoppingCriteria``, a
+                list/tuple of them, or a ``StoppingCriteriaList``.
+        """
+        if stop_strings is None and stopping_criteria is None:
+            return None
+
+        from transformers import (  # local import: matches the file's transformers usage
+            StoppingCriteria,
+            StoppingCriteriaList,
+            StopStringCriteria,
+        )
+
+        criteria = StoppingCriteriaList()
+
+        if stop_strings is not None:
+            strings = [stop_strings] if isinstance(stop_strings, str) else list(stop_strings)
+            strings = [s for s in strings if s]  # drop empty strings (HF errors on them)
+            if strings:
+                if self.tokenizer is None:
+                    raise ValueError(
+                        "stop_strings requires a tokenizer (stop strings are detected by "
+                        "matching against the tokenizer vocabulary), but this TransformerBridge "
+                        "has no tokenizer. Pass a stopping_criteria callable that operates on "
+                        "token ids instead, or use hf_generate()."
+                    )
+                criteria.append(StopStringCriteria(tokenizer=self.tokenizer, stop_strings=strings))
+
+        if stopping_criteria is not None:
+            if isinstance(stopping_criteria, StoppingCriteriaList):
+                criteria.extend(stopping_criteria)
+            elif isinstance(stopping_criteria, (list, tuple)):
+                criteria.extend(stopping_criteria)
+            elif isinstance(stopping_criteria, StoppingCriteria):
+                criteria.append(stopping_criteria)
+            else:
+                raise TypeError(
+                    "stopping_criteria must be a transformers.StoppingCriteria, a list of "
+                    f"them, or a StoppingCriteriaList, but got {type(stopping_criteria).__name__}."
+                )
+
+        return criteria if len(criteria) > 0 else None
+
+    def _generate_tokens(
+        self,
+        current_tokens: torch.Tensor,
+        input_tokens: torch.Tensor,
+        batch_size: int,
+        *,
+        max_new_tokens: int,
+        do_sample: bool,
+        top_k: Optional[int],
+        top_p: Optional[float],
+        temperature: float,
+        freq_penalty: float,
+        repetition_penalty: float,
+        stop_at_eos: bool,
+        stop_tokens: List[int],
+        eos_token_for_padding: int,
+        finished_sequences: torch.Tensor,
+        use_past_kv_cache: bool,
+        use_stateful_cache: bool,
+        mamba_cache: Any,
+        mamba_conv_kernel: int,
+        is_encoder_decoder: bool,
+        _is_batched_list: bool,
+        _generate_from_embeds: bool,
+        encoder_input: Optional[torch.Tensor],
+        decoder_tokens: Optional[torch.Tensor],
+        generated_token_ids: Optional[List[torch.Tensor]],
+        pixel_values: Optional[torch.Tensor],
+        multimodal_kwargs: Dict[str, Any],
+        verbose: bool,
+        stopping_criteria_list: Optional[Any] = None,
+    ) -> Generator[Tuple[torch.Tensor, torch.Tensor, bool], None, None]:
+        """Core generation loop. Yields (sampled_tokens, final_logits, all_finished) per step.
+
+        Owns the forward pass, sampling, stop handling (EOS and any
+        ``stopping_criteria_list``), token accumulation, and KV cache management. Callers
+        are responsible for try/finally cleanup of ``_capture_hf_cache``.
+
+        ``stopping_criteria_list`` (from ``_resolve_stopping_criteria``) is evaluated on
+        the running sequence each step and folded into the finished-sequence mask alongside
+        EOS, so when it is ``None`` the loop runs the EOS-only path unchanged.
+        """
+        _hf_kv_cache = None
+        # A row may finish via EOS and/or any of the configured stopping criteria.
+        any_stop_active = stop_at_eos or stopping_criteria_list is not None
+
+        for gen_step_idx in tqdm.tqdm(range(max_new_tokens), disable=not verbose):
+            with torch.no_grad():
+                if is_encoder_decoder:
+                    logits = self(
+                        encoder_input,
+                        return_type="logits",
+                        decoder_input=decoder_tokens,
+                    )
+                else:
+                    forward_kwargs: Dict[str, Any] = {}
+                    # Compute attention mask and position_ids for batched
+                    # inputs with padding.
+                    if (
+                        _is_batched_list
+                        and self.tokenizer is not None
+                        and self.tokenizer.pad_token_id is not None
+                    ):
+                        _prev_side = self.tokenizer.padding_side
+                        self.tokenizer.padding_side = "left"
+                        attn_mask = utils.get_attention_mask(
+                            self.tokenizer,
+                            current_tokens,
+                            prepend_bos=getattr(self.cfg, "default_prepend_bos", True),
+                        ).to(self.cfg.device)
+                        self.tokenizer.padding_side = _prev_side
+                        forward_kwargs["attention_mask"] = attn_mask
+                        position_ids = attn_mask.long().cumsum(-1) - 1
+                        position_ids.masked_fill_(attn_mask == 0, 1)
+                        forward_kwargs["position_ids"] = position_ids
+                    if gen_step_idx == 0:
+                        if pixel_values is not None:
+                            forward_kwargs["pixel_values"] = pixel_values
+                        if multimodal_kwargs:
+                            forward_kwargs.update(multimodal_kwargs)
+                    if use_stateful_cache:
+                        forward_kwargs["cache_params"] = mamba_cache
+                        forward_kwargs["use_cache"] = True
+                        if gen_step_idx == 0:
+                            cache_position = torch.arange(
+                                0, mamba_conv_kernel, device=self.cfg.device
+                            )
+                            forward_kwargs["cache_position"] = cache_position
+                            logits = self(
+                                current_tokens,
+                                return_type="logits",
+                                **forward_kwargs,
+                            )
+                        else:
+                            input_seq_pos = input_tokens.shape[1] + gen_step_idx - 1
+                            cache_position = torch.tensor([input_seq_pos], device=self.cfg.device)
+                            forward_kwargs["cache_position"] = cache_position
+                            if "position_ids" in forward_kwargs:
+                                forward_kwargs["position_ids"] = forward_kwargs["position_ids"][
+                                    :, -1:
+                                ]
+                            logits = self(
+                                current_tokens[:, -1:],
+                                return_type="logits",
+                                **forward_kwargs,
+                            )
+                    elif use_past_kv_cache:
+                        forward_kwargs["use_cache"] = True
+                        if _hf_kv_cache is not None:
+                            forward_kwargs["past_key_values"] = _hf_kv_cache
+                            # HF v5 + macOS-arm64 NaNs when these are inferred
+                            # from cache state alone. Mirror HF generate(): pass
+                            # both an (batch, total_len) attention_mask and a
+                            # (batch, 1) position_ids for the new token.
+                            batch_size = current_tokens.shape[0]
+                            total_len = current_tokens.shape[1]
+                            device = current_tokens.device
+                            if "attention_mask" not in forward_kwargs:
+                                forward_kwargs["attention_mask"] = torch.ones(
+                                    (batch_size, total_len),
+                                    dtype=torch.long,
+                                    device=device,
+                                )
+                            if "position_ids" in forward_kwargs:
+                                forward_kwargs["position_ids"] = forward_kwargs["position_ids"][
+                                    :, -1:
+                                ]
+                            else:
+                                forward_kwargs["position_ids"] = torch.full(
+                                    (batch_size, 1),
+                                    total_len - 1,
+                                    dtype=torch.long,
+                                    device=device,
+                                )
+                            logits = self(
+                                current_tokens[:, -1:],
+                                return_type="logits",
+                                **forward_kwargs,
+                            )
+                        else:
+                            logits = self(
+                                current_tokens,
+                                return_type="logits",
+                                **forward_kwargs,
+                            )
+                    else:
+                        logits = self(current_tokens, return_type="logits", **forward_kwargs)
+                    if use_past_kv_cache and hasattr(self, "_last_hf_cache"):
+                        _hf_kv_cache = self._last_hf_cache or _hf_kv_cache
+                        del self._last_hf_cache
+                final_logits = logits[:, -1, :]
+
+                # Sample next token
+                penalty_tokens = (
+                    torch.stack(generated_token_ids, dim=1)
+                    if _generate_from_embeds and generated_token_ids
+                    else None
+                )
+                if do_sample:
+                    sampled_tokens = utils.sample_logits(
+                        final_logits,
+                        top_k=top_k,
+                        top_p=top_p,
+                        temperature=temperature,
+                        freq_penalty=freq_penalty,
+                        repetition_penalty=repetition_penalty,
+                        tokens=(
+                            penalty_tokens
+                            if _generate_from_embeds
+                            else (decoder_tokens if is_encoder_decoder else current_tokens)
+                        ),
+                    ).to(self.cfg.device)
+                else:
+                    sampled_tokens = utils.sample_logits(
+                        final_logits,
+                        temperature=0.0,
+                        repetition_penalty=repetition_penalty,
+                        tokens=(
+                            penalty_tokens
+                            if _generate_from_embeds
+                            else (decoder_tokens if is_encoder_decoder else current_tokens)
+                        ),
+                    ).to(self.cfg.device)
+
+                # Freeze rows that finished on an earlier step so they stop emitting
+                # real tokens. Applies to every active stop mechanism, not just EOS.
+                if any_stop_active:
+                    sampled_tokens[finished_sequences] = eos_token_for_padding
+
+                # Fold this step's EOS matches into the finished mask.
+                if stop_at_eos:
+                    finished_sequences.logical_or_(
+                        torch.isin(
+                            sampled_tokens.to(self.cfg.device),
+                            torch.tensor(stop_tokens).to(self.cfg.device),
+                        )
+                    )
+
+                # Update token sequences
+                if is_encoder_decoder:
+                    assert decoder_tokens is not None
+                    decoder_tokens = torch.cat([decoder_tokens, sampled_tokens.unsqueeze(1)], dim=1)
+                elif _generate_from_embeds:
+                    assert generated_token_ids is not None
+                    generated_token_ids.append(sampled_tokens)
+                    embed_fn = self.original_model.get_input_embeddings()  # type: ignore[operator]
+                    assert embed_fn is not None
+                    new_embed = embed_fn(sampled_tokens.unsqueeze(1)).to(current_tokens.dtype)
+                    current_tokens = torch.cat([current_tokens, new_embed], dim=1)
+                else:
+                    current_tokens = torch.cat([current_tokens, sampled_tokens.unsqueeze(1)], dim=1)
+
+                # Fold stop_strings / stopping_criteria into the finished mask. They are
+                # evaluated on the full running sequence (prompt + everything generated so
+                # far, including the token just appended) with this step's logits as the
+                # scores argument, matching transformers' StoppingCriteria contract. The
+                # combined list returns a per-row bool [batch] OR-ing every criterion.
+                # generate()/generate_stream() guarantee this is plain decoder-only token
+                # generation, so current_tokens is the running token sequence.
+                if stopping_criteria_list is not None:
+                    criteria_finished = stopping_criteria_list(current_tokens, final_logits).to(
+                        device=self.cfg.device, dtype=torch.bool
+                    )
+                    if criteria_finished.shape != finished_sequences.shape:
+                        raise ValueError(
+                            "A stopping criterion returned shape "
+                            f"{tuple(criteria_finished.shape)}, expected a per-row bool of "
+                            f"shape {tuple(finished_sequences.shape)} (one entry per sequence)."
+                        )
+                    finished_sequences.logical_or_(criteria_finished)
+
+                all_finished = bool(any_stop_active and finished_sequences.all().item())
+
+            yield sampled_tokens, final_logits, all_finished
+
+            if all_finished:
+                return
+
+    def generate(
+        self,
+        input: Union[str, List[str], torch.Tensor] = "",
+        max_new_tokens: int = 10,
+        stop_at_eos: bool = True,
+        eos_token_id: Optional[int] = None,
+        do_sample: bool = True,
+        top_k: Optional[int] = None,
+        top_p: Optional[float] = None,
+        temperature: float = 1.0,
+        freq_penalty: float = 0.0,
+        repetition_penalty: float = 1.0,
+        use_past_kv_cache: bool = True,
+        prepend_bos: Optional[bool] = None,
+        padding_side: Optional[str] = None,
+        return_type: Optional[str] = "input",
+        verbose: bool = True,
+        output_logits: bool = False,
+        return_cache: bool = False,
+        return_input_tokens: bool = False,
+        names_filter: Optional[Union[str, List[str], Callable[[str], bool]]] = None,
+        device: Optional[Union[str, torch.device]] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        stop_strings: Optional[Union[str, List[str]]] = None,
+        stopping_criteria: Optional[Any] = None,
+        **multimodal_kwargs,
+    ) -> (
+        str
+        | list[str]
+        | torch.Tensor
+        | Any
+        | tuple[Any, ActivationCache]
+        | tuple[Any, torch.Tensor]
+    ):  # Any for transformers.utils.ModelOutput
+        # Any: beartype forward ref limitation (beartype#546)
+        """Sample tokens from the model.
+
+        Sample tokens from the model until the model outputs eos_token or max_new_tokens is reached.
+        This implementation is based on HookedTransformer.generate() to ensure consistent behavior.
+
+        Args:
+            input: Text string, list of strings, or tensor of tokens
+            max_new_tokens: Maximum number of tokens to generate
+            stop_at_eos: If True, stop generating tokens when the model outputs eos_token
+            eos_token_id: The token ID to use for end of sentence
+            do_sample: If True, sample from the model's output distribution. Otherwise, use greedy search
+            top_k: Number of tokens to sample from. If None, sample from all tokens
+            top_p: Probability mass to sample from. If 1.0, sample from all tokens
+            temperature: Temperature for sampling. Higher values will make the model more random
+            freq_penalty: Frequency penalty for sampling - how much to penalise previous tokens
+            repetition_penalty: HuggingFace-style repetition penalty. Values > 1.0 discourage
+                repetition by dividing positive logits and multiplying negative logits for
+                previously seen tokens. Default 1.0 (no penalty).
+            use_past_kv_cache: If True, use KV caching for faster generation
+            prepend_bos: Whether to prepend a BOS token when tokenizing string inputs.
+                Defaults to None (uses ``cfg.default_prepend_bos``, typically True).
+                Pass ``prepend_bos=False`` when the input is pre-formatted chat-template
+                text that already contains the BOS token to avoid double-BOS.
+                Ignored when input is already a token tensor.
+            padding_side: Which side to pad when tokenizing multiple strings of different
+                lengths. For batched list inputs, left-padding is forced internally for
+                correct generation behavior. Defaults to None (tokenizer default).
+            return_type: The type of output to return - 'input', 'str', or 'tokens'
+            verbose: Not used in Bridge (kept for API compatibility)
+            output_logits: If True, return a ModelOutput with sequences and logits tuple
+            return_cache: If True, also return an ActivationCache for the full prompt +
+                generated sequence, identical to ``run_with_cache(output)``, and the call
+                returns an ``(output, cache)`` tuple. Implemented as one extra clean forward
+                over the output, so the cache includes every hook point (attention patterns
+                included). Supported only for single-sequence, decoder-only text generation;
+                encoder-decoder, SSM, multimodal, batched, and inputs_embeds inputs raise
+                NotImplementedError. The cache spans prompt + max_new_tokens and can be large,
+                use ``names_filter`` to scope it and/or ``device`` to offload it.
+            return_input_tokens: If True, return an ``(output, input_tokens)`` tuple where
+                ``input_tokens`` is the token tensor that was actually fed to the model
+                (after BOS handling). Useful for debugging tokenization, especially when
+                using chat templates where BOS handling can be subtle. Can be combined
+                with ``return_cache`` to get ``(output, cache, input_tokens)``.
+            names_filter: Passed to ``run_with_cache`` when ``return_cache=True``; restricts
+                which activations are cached (str, list of str, or callable).
+            device: Passed through when ``return_cache=True`` to offload the cached tensors
+                to this device (e.g. "cpu") to save accelerator memory.
+            pixel_values: Optional image tensor for multimodal models. Only passed on the
+                first generation step (the vision encoder processes the image once, then
+                embeddings are part of the token sequence for subsequent steps).
+            stop_strings: Optional string or list of strings. A sequence stops once its
+                generated text ends with one of these strings, using HuggingFace's
+                StopStringCriteria (partial-token-aware, end-anchored) matching.
+                Requires a tokenizer (raises ValueError otherwise).
+                Independent of stop_at_eos: either can stop a sequence.
+            stopping_criteria: Optional HuggingFace stopping criteria, a single
+                transformers.StoppingCriteria, a list of them, or a StoppingCriteriaList.
+                Each is called as criterion(input_ids, scores) after every step and ORed
+                with the other stop signals, where input_ids is the running sequence and
+                scores is this step's logits ([batch, d_vocab]). Each criterion must return
+                a per-row bool [batch] (or a scalar bool). stop_strings and stopping_criteria
+                are supported only for standard decoder-only text generation. Encoder-decoder,
+                inputs_embeds, and multimodal generation always raise NotImplementedError.
+                Stateful/SSM models raise only when run with use_past_kv_cache=False (the
+                default keeps them on the hooked loop). Each error names the supported
+                alternative.
+
+        Returns:
+            Generated sequence as string, list of strings, or tensor depending on input type and return_type.
+            If output_logits=True, returns a ModelOutput-like object with 'sequences' and 'logits' attributes.
+            If return_cache=True, returns an ``(output, ActivationCache)`` tuple where ``output`` is the
+            value that would otherwise be returned and the cache equals ``run_with_cache(output)``.
+            If return_input_tokens=True, returns an ``(output, input_tokens)`` tuple.
+            If both return_cache and return_input_tokens are True, returns ``(output, cache, input_tokens)``.
+
+        Example:
+            ``out, cache = model.generate(prompt, max_new_tokens=20, return_cache=True)`` returns a
+            normal ActivationCache over the full prompt + generated sequence (equivalent to
+            ``run_with_cache(out)``).
+
+            ``out, input_tokens = model.generate(prompt, return_input_tokens=True)`` returns
+            the tokens that were fed to the model, useful for verifying BOS handling with
+            chat templates.
+        """
+        # padding_side is handled internally: for batched list inputs, left-padding
+        # is forced to ensure correct generation. See _is_batched_list logic below.
+
+        # Stateful dispatch is decided after input parsing so we can fall back
+        # to hf_generate() for input types the stateful loop doesn't handle.
+        is_stateful_model = getattr(self.cfg, "is_stateful", False)
+
+        _is_batched_list = isinstance(input, list) and len(input) > 1
+
+        _generate_from_embeds = False
+        if isinstance(input, str):
+            input_tokens = self.to_tokens(
+                input, prepend_bos=prepend_bos, move_to_device=True, truncate=False
+            )
+            input_type = "str"
+        elif isinstance(input, list):
+            # Force left-padding for batched generation so real tokens are
+            # flush-right and logits[:, -1, :] is always the last real token.
+            if _is_batched_list:
+                _orig_padding_side = self.tokenizer.padding_side
+                self.tokenizer.padding_side = "left"
+            input_tokens = self.to_tokens(
+                input, prepend_bos=prepend_bos, move_to_device=True, truncate=False
+            )
+            if _is_batched_list:
+                self.tokenizer.padding_side = _orig_padding_side
+            input_type = "list"
+        elif isinstance(input, torch.Tensor) and input.is_floating_point():
+            # inputs_embeds: pre-computed embeddings (e.g., from multimodal models)
+            input_tokens = input.to(self.cfg.device)
+            input_type = "embeds"
+            _generate_from_embeds = True
+        else:
+            input_tokens = input.to(self.cfg.device)
+            input_type = "tokens"
+
+        # Determine return type
+        if return_type == "input":
+            if input_type in ["str", "list"]:
+                return_type = "str"
+            elif input_type == "embeds":
+                return_type = "tokens"
+            else:
+                return_type = "tokens"
+
+        batch_size = input_tokens.shape[0]
+
+        # Setup EOS token handling
+        stop_tokens = []
+        eos_token_for_padding = 0
+        if stop_at_eos:
+            tokenizer_has_eos_token = (
+                self.tokenizer is not None and self.tokenizer.eos_token_id is not None
+            )
+            if eos_token_id is None:
+                # Some chat models use a turn-end token that differs from the
+                # tokenizer's primary EOS. Let adapters provide the full stop
+                # set via cfg.eos_token_id; otherwise fall back to the tokenizer.
+                eos_token_id = getattr(self.cfg, "eos_token_id", None)
+                if eos_token_id is None:
+                    assert (
+                        tokenizer_has_eos_token
+                    ), "Must pass eos_token_id if stop_at_eos is True and tokenizer is None or has no eos_token_id"
+                    assert self.tokenizer is not None
+                    eos_token_id = self.tokenizer.eos_token_id
+
+            if isinstance(eos_token_id, int):
+                stop_tokens = [eos_token_id]
+                eos_token_for_padding = eos_token_id
+            else:
+                stop_tokens = list(eos_token_id)
+                if tokenizer_has_eos_token:
+                    assert self.tokenizer is not None
+                    eos_token_for_padding = self.tokenizer.eos_token_id
+                else:
+                    eos_token_for_padding = eos_token_id[0]
+
+        # Track which sequences have finished
+        finished_sequences = torch.zeros(batch_size, dtype=torch.bool, device=self.cfg.device)
+
+        # Optionally collect logits at each generation step for downstream tooling/tests
+        logits_seq_list: list[torch.Tensor] | None = [] if output_logits else None
+
+        # Detect encoder-decoder models (T5, BART, etc.)
+        is_encoder_decoder = hasattr(self.original_model, "config") and getattr(
+            self.original_model.config, "is_encoder_decoder", False
+        )
+
+        # return_cache recomputes run_with_cache on the generated output (see issue #697).
+        # That is well-defined only for single-sequence, decoder-only text generation, so
+        # reject the paths whose cache would be wrong/undefined, with a clear pointer to the
+        # run_with_cache workaround. Fail fast here, before any generation work.
+        if return_cache:
+            if is_encoder_decoder:
+                raise NotImplementedError(
+                    "generate(return_cache=True) is not supported for encoder-decoder "
+                    "models yet. Run run_with_cache on the generated output instead."
+                )
+            if is_stateful_model:
+                raise NotImplementedError(
+                    "generate(return_cache=True) is not supported for stateful/SSM models "
+                    "(e.g. Mamba); they do not expose standard transformer hook points."
+                )
+            if pixel_values is not None or multimodal_kwargs:
+                raise NotImplementedError(
+                    "generate(return_cache=True) is not supported for multimodal generation "
+                    "yet. Run run_with_cache on the generated output instead."
+                )
+            if _generate_from_embeds:
+                raise NotImplementedError(
+                    "generate(return_cache=True) requires token input, not inputs_embeds."
+                )
+            if batch_size > 1:
+                raise NotImplementedError(
+                    "generate(return_cache=True) is not supported for batched/multi-prompt "
+                    "generation yet. Pass a single prompt, or run run_with_cache on each "
+                    "output sequence."
+                )
+
+        # HF cache flows opaquely through the component chain via
+        # _reconstruct_attention() → _update_kv_cache() on each layer.
+        _hf_kv_cache = None
+        if use_past_kv_cache and is_encoder_decoder:
+            # Encoder-decoder models (T5, BART) don't support the opaque
+            # cache path — silently disable rather than crash, since
+            # use_past_kv_cache=True is the default.
+            use_past_kv_cache = False
+
+        # SSMs (Mamba/Mamba-2) run through a dedicated cache path so hooks
+        # fire on every step. Unsupported input types fall back to hf_generate().
+        use_stateful_cache = (
+            is_stateful_model
+            and use_past_kv_cache
+            and not is_encoder_decoder
+            and not _generate_from_embeds
+            and pixel_values is None
+            and not multimodal_kwargs
+        )
+
+        # stop_strings / stopping_criteria are applied inside the hooked _generate_tokens
+        # loop, so they are supported only on the standard decoder-only text path. Reject
+        # the paths that route around that loop with a clear error rather than silently
+        # dropping the kwargs. This must run before the stateful delegation below.
+        stopping_criteria_list = self._resolve_stopping_criteria(stop_strings, stopping_criteria)
+        if stopping_criteria_list is not None:
+            if is_encoder_decoder:
+                _unsupported = "encoder-decoder models"
+            elif _generate_from_embeds:
+                _unsupported = "inputs_embeds generation"
+            elif pixel_values is not None or multimodal_kwargs:
+                _unsupported = "multimodal (pixel_values) generation"
+            else:
+                _unsupported = None
+            if _unsupported is not None:
+                raise NotImplementedError(
+                    f"stop_strings/stopping_criteria are not supported for {_unsupported} in "
+                    "TransformerBridge.generate(). Call hf_generate(...), which runs "
+                    "HuggingFace's own generation loop and supports HF-native stopping on "
+                    "those inputs."
+                )
+            if is_stateful_model and not use_stateful_cache:
+                # Reached only for a stateful/SSM model with use_past_kv_cache=False: the
+                # hooked loop needs the stateful cache, so generate() would otherwise fall
+                # back to hf_generate() and drop these kwargs. The default cache setting
+                # keeps generation on the hooked loop, where stopping is applied.
+                raise NotImplementedError(
+                    "stop_strings/stopping_criteria on a stateful/SSM model require the "
+                    "stateful cache path, which runs only with use_past_kv_cache=True (the "
+                    "default). With use_past_kv_cache=False generate() falls back to "
+                    "hf_generate(). Set use_past_kv_cache=True to keep stopping on the hooked "
+                    "loop, or call hf_generate(...) directly for HF-native stopping."
+                )
+            # Finished rows are overwritten with this id so they stop emitting real tokens
+            # while the rest of a batch keeps going. stop_at_eos already set a sensible
+            # value, otherwise fall back to the tokenizer pad/eos id. (For a single
+            # sequence this id is never read: the loop exits when the row finishes.)
+            if not stop_at_eos:
+                _pad_id = None
+                if self.tokenizer is not None:
+                    _pad_id = (
+                        self.tokenizer.pad_token_id
+                        if self.tokenizer.pad_token_id is not None
+                        else self.tokenizer.eos_token_id
+                    )
+                if _pad_id is not None:
+                    eos_token_for_padding = _pad_id
+                elif batch_size > 1:
+                    raise ValueError(
+                        "Batched generation with stopping_criteria and stop_at_eos=False "
+                        "needs a padding token to freeze finished rows, but no tokenizer "
+                        "pad/eos id is available. Set stop_at_eos=True, use a tokenizer with "
+                        "a pad or eos token, or generate one sequence at a time."
+                    )
+
+        if is_stateful_model and not use_stateful_cache:
+            hf_kwargs: dict[str, Any] = {
+                "max_new_tokens": max_new_tokens,
+                "do_sample": do_sample,
+                "temperature": temperature,
+            }
+            if top_k is not None:
+                hf_kwargs["top_k"] = top_k
+            if top_p is not None:
+                hf_kwargs["top_p"] = top_p
+            if eos_token_id is not None:
+                hf_kwargs["eos_token_id"] = eos_token_id
+            return self.hf_generate(input, **hf_kwargs)
+
+        # SSM cache is built once and mutated in place across forward calls.
+        # Adapter owns the cache-type choice; new SSMs just override
+        # create_stateful_cache().
+        mamba_cache: Any = None
+        mamba_conv_kernel: int = 0
+        if use_stateful_cache:
+            hf_model: Any = self.original_model
+            mamba_conv_kernel = int(getattr(hf_model.config, "conv_kernel", 4))
+            cache_dtype = self.cfg.dtype or torch.float32
+            mamba_cache = self.adapter.create_stateful_cache(
+                hf_model=hf_model,
+                batch_size=batch_size,
+                device=self.cfg.device,
+                dtype=cache_dtype,
+            )
+
+        if use_past_kv_cache and not use_stateful_cache:
+            self._capture_hf_cache = True  # Signal forward() to stash cache
+
+        # Generate tokens
+        current_tokens = input_tokens.clone()
+        # For inputs_embeds generation, also track generated token IDs for decoding
+        if _generate_from_embeds:
+            generated_token_ids: list[torch.Tensor] = []
+        sampled_tokens_list = []
+
+        # For encoder-decoder models, keep encoder input fixed and grow decoder input
+        if is_encoder_decoder:
+            encoder_input = input_tokens.clone()
+            decoder_start_token_id = getattr(
+                self.original_model.config, "decoder_start_token_id", 0
+            )
+            decoder_tokens = torch.full(
+                (batch_size, 1),
+                decoder_start_token_id,
+                dtype=input_tokens.dtype,
+                device=self.cfg.device,
+            )
+
+        try:
+            for sampled_tokens, final_logits, all_finished in self._generate_tokens(
+                current_tokens,
+                input_tokens,
+                batch_size,
+                max_new_tokens=max_new_tokens,
+                do_sample=do_sample,
+                top_k=top_k,
+                top_p=top_p,
+                temperature=temperature,
+                freq_penalty=freq_penalty,
+                repetition_penalty=repetition_penalty,
+                stop_at_eos=stop_at_eos,
+                stop_tokens=stop_tokens,
+                eos_token_for_padding=eos_token_for_padding,
+                finished_sequences=finished_sequences,
+                use_past_kv_cache=use_past_kv_cache,
+                use_stateful_cache=use_stateful_cache,
+                mamba_cache=mamba_cache,
+                mamba_conv_kernel=mamba_conv_kernel,
+                is_encoder_decoder=is_encoder_decoder,
+                _is_batched_list=_is_batched_list,
+                _generate_from_embeds=_generate_from_embeds,
+                encoder_input=encoder_input if is_encoder_decoder else None,
+                decoder_tokens=decoder_tokens if is_encoder_decoder else None,
+                generated_token_ids=generated_token_ids if _generate_from_embeds else None,
+                pixel_values=pixel_values,
+                multimodal_kwargs=multimodal_kwargs if multimodal_kwargs else {},
+                verbose=verbose,
+                stopping_criteria_list=stopping_criteria_list,
+            ):
+                sampled_tokens_list.append(sampled_tokens.unsqueeze(1))
+                if logits_seq_list is not None:
+                    logits_seq_list.append(final_logits.clone())
+                if all_finished:
+                    break
+        finally:
+            self._capture_hf_cache = False
+            if hasattr(self, "_last_hf_cache"):
+                del self._last_hf_cache
+
+        # Concatenate all sampled tokens
+        sampled_tokens = torch.cat(sampled_tokens_list, dim=1)
+        if is_encoder_decoder:
+            # Reconstruct full decoder sequence: start token + generated tokens
+            output_tokens = torch.cat([decoder_tokens[:, :1], sampled_tokens], dim=1)
+        elif _generate_from_embeds:
+            # For inputs_embeds, we only have the generated token IDs (no input token IDs)
+            output_tokens = sampled_tokens
+        else:
+            output_tokens = torch.cat([input_tokens, sampled_tokens], dim=1)
+
+        # Build the formatted output (shape unchanged: ModelOutput / str / list[str] / tokens).
+        result: Any
+        if output_logits and logits_seq_list is not None:
+            from transformers.utils import ModelOutput  # type: ignore
+
+            def _logits_to_tuple(logits_list: list[torch.Tensor]) -> tuple[torch.Tensor, ...]:
+                assert logits_list is not None
+                # Convert list of [batch, vocab] tensors to tuple
+                return tuple(logits_list)
+
+            try:
+                from transformers.generation.utils import GenerateDecoderOnlyOutput
+
+                # HF-compatible ModelOutput structure.
+                # GenerateDecoderOnlyOutput expects: sequences, scores (optional), logits (optional)
+                result = GenerateDecoderOnlyOutput(
+                    sequences=cast(torch.LongTensor, output_tokens),
+                    # HF's type hint says tuple[FloatTensor] but should be tuple[FloatTensor, ...]
+                    # (variable-length tuple with one element per generated token)
+                    logits=_logits_to_tuple(logits_seq_list),  # type: ignore[arg-type]
+                )
+            except (ImportError, AttributeError):
+                # Fallback if GenerateDecoderOnlyOutput not available in this transformers version
+                result = ModelOutput(
+                    sequences=output_tokens,
+                    logits=_logits_to_tuple(logits_seq_list),
+                )
+        elif return_type == "str":
+            assert self.tokenizer is not None
+            if input_type == "str":
+                result = self.tokenizer.decode(output_tokens[0], skip_special_tokens=True)
+            else:
+                decoded_texts = [
+                    self.tokenizer.decode(tokens, skip_special_tokens=True)
+                    for tokens in output_tokens
+                ]
+                result = decoded_texts[0] if len(decoded_texts) == 1 else decoded_texts
+        else:  # return_type == "tokens"
+            result = output_tokens
+
+        if not return_cache and not return_input_tokens:
+            return result
+
+        if return_cache:
+            # return_cache: recompute one clean forward over the full generated sequence so the
+            # cache is identical to run_with_cache(output_tokens) - all hook points, including
+            # attention patterns. The guards above restrict this to single-sequence, decoder-only
+            # text generation (see issue #697).
+            _, cache = self.run_with_cache(output_tokens, names_filter=names_filter, device=device)
+            if return_input_tokens:
+                return result, cache, input_tokens
+            return result, cache
+
+        # return_input_tokens only (no cache)
+        return result, input_tokens
+
+    @torch.no_grad()
+    def generate_stream(
+        self,
+        input: Union[str, List[str], torch.Tensor] = "",
+        max_new_tokens: int = 10,
+        max_tokens_per_yield: int = 25,
+        stop_at_eos: bool = True,
+        eos_token_id: Optional[int] = None,
+        do_sample: bool = True,
+        top_k: Optional[int] = None,
+        top_p: Optional[float] = None,
+        temperature: float = 1.0,
+        freq_penalty: float = 0.0,
+        repetition_penalty: float = 1.0,
+        use_past_kv_cache: bool = True,
+        prepend_bos: Optional[bool] = None,
+        padding_side: Optional[str] = None,
+        return_type: Optional[str] = "input",
+        verbose: bool = True,
+        stop_strings: Optional[Union[str, List[str]]] = None,
+        stopping_criteria: Optional[Any] = None,
+    ) -> Generator[Union[torch.Tensor, str], None, None]:
+        """Stream tokens from the model as they are generated.
+
+        Yields batches of tokens progressively during generation rather than
+        waiting for the entire sequence. Uses the same core loop as generate().
+
+        Args:
+            input: Text string, list of strings, or tensor of tokens.
+            max_new_tokens: Maximum number of tokens to generate.
+            max_tokens_per_yield: Yield accumulated tokens every this many steps.
+            stop_at_eos: If True, stop when eos_token is produced.
+            eos_token_id: Token ID(s) for end of sentence. Defaults to tokenizer's.
+            do_sample: If True, sample; otherwise greedy.
+            top_k: Top-k sampling. None means no filtering.
+            top_p: Nucleus sampling threshold.
+            temperature: Sampling temperature.
+            freq_penalty: Frequency penalty for previous tokens.
+            repetition_penalty: HF-style repetition penalty (>1.0 discourages repeats).
+            use_past_kv_cache: Use KV caching for faster generation.
+            prepend_bos: Whether to prepend a BOS token when tokenizing string inputs.
+                Defaults to None (uses ``cfg.default_prepend_bos``, typically True).
+                Pass ``prepend_bos=False`` when the input is pre-formatted chat-template
+                text that already contains the BOS token to avoid double-BOS.
+                Ignored when input is already a token tensor.
+            padding_side: Which side to pad for batched list inputs. Left-padding
+                is forced internally for batched generation.
+            return_type: 'input' (match input type), 'str', or 'tokens'.
+            verbose: Show progress bar.
+            stop_strings: Optional string or list of strings. A sequence stops once its
+                generated text ends with one of them (HF StopStringCriteria). Requires a
+                tokenizer. See generate() for details.
+            stopping_criteria: Optional transformers StoppingCriteria, list, or
+                StoppingCriteriaList, called as criterion(input_ids, scores) each step
+                (scores is the step's logits). See generate() for the full contract.
+
+        Yields:
+            Token tensors [batch, seq_len] or strings, accumulated up to
+            max_tokens_per_yield tokens between yields. First yield includes
+            the input tokens; subsequent yields contain only new tokens.
+        """
+        # --- Input parsing (mirrors generate()) ---
+        _is_batched_list = isinstance(input, list) and len(input) > 1
+
+        if isinstance(input, str):
+            input_tokens = self.to_tokens(
+                input, prepend_bos=prepend_bos, move_to_device=True, truncate=False
+            )
+            input_type = "str"
+        elif isinstance(input, list):
+            if _is_batched_list:
+                _orig_ps = self.tokenizer.padding_side
+                self.tokenizer.padding_side = "left"
+            try:
+                input_tokens = self.to_tokens(
+                    input, prepend_bos=prepend_bos, move_to_device=True, truncate=False
+                )
+            finally:
+                if _is_batched_list:
+                    self.tokenizer.padding_side = _orig_ps
+            input_type = "list"
+        else:
+            input_tokens = input.to(self.cfg.device)
+            input_type = "tokens"
+
+        if return_type == "input":
+            return_type = "str" if input_type in ["str", "list"] else "tokens"
+
+        batch_size = input_tokens.shape[0]
+
+        # --- EOS setup ---
+        stop_tokens: List[int] = []
+        eos_token_for_padding = 0
+        if stop_at_eos:
+            tokenizer_has_eos_token = (
+                self.tokenizer is not None and self.tokenizer.eos_token_id is not None
+            )
+            if eos_token_id is None:
+                # Some chat models use a turn-end token that differs from the
+                # tokenizer's primary EOS. Let adapters provide the full stop
+                # set via cfg.eos_token_id; otherwise fall back to the tokenizer.
+                eos_token_id = getattr(self.cfg, "eos_token_id", None)
+                if eos_token_id is None:
+                    assert (
+                        tokenizer_has_eos_token
+                    ), "Must pass eos_token_id if stop_at_eos is True and tokenizer is None or has no eos_token_id"
+                    assert self.tokenizer is not None
+                    eos_token_id = self.tokenizer.eos_token_id
+            if isinstance(eos_token_id, int):
+                stop_tokens = [eos_token_id]
+                eos_token_for_padding = eos_token_id
+            else:
+                stop_tokens = list(eos_token_id)
+                if tokenizer_has_eos_token:
+                    assert self.tokenizer is not None
+                    eos_token_for_padding = self.tokenizer.eos_token_id
+                else:
+                    eos_token_for_padding = eos_token_id[0]
+
+        finished_sequences = torch.zeros(batch_size, dtype=torch.bool, device=self.cfg.device)
+
+        # stop_strings / stopping_criteria: build the combined criteria list (validates
+        # tokenizer for stop_strings). generate_stream only runs the decoder-only text
+        # path, so no path guards are needed here.
+        stopping_criteria_list = self._resolve_stopping_criteria(stop_strings, stopping_criteria)
+        if stopping_criteria_list is not None and not stop_at_eos:
+            _pad_id = None
+            if self.tokenizer is not None:
+                _pad_id = (
+                    self.tokenizer.pad_token_id
+                    if self.tokenizer.pad_token_id is not None
+                    else self.tokenizer.eos_token_id
+                )
+            if _pad_id is not None:
+                eos_token_for_padding = _pad_id
+            elif batch_size > 1:
+                raise ValueError(
+                    "Batched generate_stream with stopping_criteria and stop_at_eos=False "
+                    "needs a padding token to freeze finished rows, but no tokenizer pad/eos "
+                    "id is available. Set stop_at_eos=True or use a tokenizer with a pad/eos "
+                    "token."
+                )
+
+        # --- Cache setup ---
+        if use_past_kv_cache:
+            self._capture_hf_cache = True
+
+        current_tokens = input_tokens.clone()
+
+        # --- Streaming loop ---
+        # All yields are token tensors [batch, seq_len]. Each yield contains
+        # only the newly generated tokens since the previous yield (the first
+        # yield additionally prepends the input tokens for context).
+        accumulated_tokens: Optional[torch.Tensor] = None
+        tokens_since_last_yield = 0
+
+        def _maybe_decode(
+            tokens: torch.Tensor,
+        ) -> Union[torch.Tensor, str]:
+            if return_type == "str":
+                assert self.tokenizer is not None
+                return self.tokenizer.decode(tokens[0], skip_special_tokens=True)
+            return tokens
+
+        try:
+            for step_idx, (sampled_tokens, _, all_finished) in enumerate(
+                self._generate_tokens(
+                    current_tokens,
+                    input_tokens,
+                    batch_size,
+                    max_new_tokens=max_new_tokens,
+                    do_sample=do_sample,
+                    top_k=top_k,
+                    top_p=top_p,
+                    temperature=temperature,
+                    freq_penalty=freq_penalty,
+                    repetition_penalty=repetition_penalty,
+                    stop_at_eos=stop_at_eos,
+                    stop_tokens=stop_tokens,
+                    eos_token_for_padding=eos_token_for_padding,
+                    finished_sequences=finished_sequences,
+                    use_past_kv_cache=use_past_kv_cache,
+                    use_stateful_cache=False,
+                    mamba_cache=None,
+                    mamba_conv_kernel=0,
+                    is_encoder_decoder=False,
+                    _is_batched_list=_is_batched_list,
+                    _generate_from_embeds=False,
+                    encoder_input=None,
+                    decoder_tokens=None,
+                    generated_token_ids=None,
+                    pixel_values=None,
+                    multimodal_kwargs={},
+                    verbose=verbose,
+                    stopping_criteria_list=stopping_criteria_list,
+                )
+            ):
+                new_tokens = sampled_tokens.unsqueeze(-1)
+
+                if step_idx == 0:
+                    accumulated_tokens = torch.cat([input_tokens, new_tokens], dim=-1)
+                    tokens_since_last_yield = accumulated_tokens.shape[1]
+                else:
+                    if accumulated_tokens is None:
+                        accumulated_tokens = new_tokens
+                    else:
+                        accumulated_tokens = torch.cat([accumulated_tokens, new_tokens], dim=-1)
+                    tokens_since_last_yield += 1
+
+                if tokens_since_last_yield >= max_tokens_per_yield:
+                    yield _maybe_decode(accumulated_tokens)
+                    tokens_since_last_yield = 0
+                    accumulated_tokens = None
+
+                if all_finished:
+                    if accumulated_tokens is not None:
+                        yield _maybe_decode(accumulated_tokens)
+                        accumulated_tokens = None
+                    break
+
+            # Yield remainder after loop completes without break
+            if accumulated_tokens is not None:
+                yield _maybe_decode(accumulated_tokens)
+        finally:
+            self._capture_hf_cache = False
+            if hasattr(self, "_last_hf_cache"):
+                del self._last_hf_cache
+
+    def hf_generate(
+        self,
+        input: str | list[str] | torch.Tensor = "",
+        max_new_tokens: int = 10,
+        stop_at_eos: bool = True,
+        eos_token_id: int | None = None,
+        do_sample: bool = True,
+        top_k: int | None = None,
+        top_p: float | None = None,
+        temperature: float = 1.0,
+        use_past_kv_cache: bool = True,
+        return_type: str | None = "input",
+        pixel_values: torch.Tensor | None = None,
+        **generation_kwargs,
+    ) -> str | list[str] | torch.Tensor | Any:  # Any for HF ModelOutput types
+        # Any: beartype forward ref limitation (beartype#546)
+        """Generate text using the underlying HuggingFace model with full HF API support.
+
+        This method provides direct access to HuggingFace's generation API, forwarding all
+        generation parameters (including output_scores, output_logits, output_attentions,
+        output_hidden_states) directly to the underlying HF model. Use this when you need
+        full HuggingFace generation features not supported by the standard generate() method.
+
+        For standard generation compatible with HookedTransformer, use generate() instead.
+
+        Args:
+            input: Text string, list of strings, or tensor of tokens
+            max_new_tokens: Maximum number of tokens to generate
+            stop_at_eos: If True, stop generating tokens when the model outputs eos_token
+            eos_token_id: The token ID to use for end of sentence
+            do_sample: If True, sample from the model's output distribution
+            top_k: Number of tokens to sample from
+            top_p: Probability mass to sample from
+            temperature: Temperature for sampling
+            use_past_kv_cache: If True, use KV caching for faster generation
+            return_type: The type of output to return - 'input', 'str', or 'tokens'
+            **generation_kwargs: Additional HuggingFace generation parameters including:
+                - output_scores: Return generation scores
+                - output_logits: Return generation logits
+                - output_attentions: Return attention weights
+                - output_hidden_states: Return hidden states
+                - return_dict_in_generate: Return ModelOutput object
+                - And any other HF generation parameters
+
+        Returns:
+            Generated sequence as string, list of strings, tensor, or HF ModelOutput
+            depending on input type, return_type, and generation_kwargs.
+
+        Example::
+
+            # Get full HF ModelOutput with logits and attentions
+            from transformer_lens import HookedTransformer
+            model = HookedTransformer.from_pretrained("tiny-stories-1M")
+            result = model.hf_generate(
+                "Hello world",
+                max_new_tokens=5,
+                output_logits=True,
+                output_attentions=True,
+                return_dict_in_generate=True
+            )
+            print(result.sequences)  # Generated tokens
+            print(result.logits)  # Logits for each generation step
+            print(result.attentions)  # Attention weights
+        """
+        # Handle string input by tokenizing it
+        if isinstance(input, str):
+            inputs = self.tokenizer(input, return_tensors="pt", padding=False, truncation=False).to(
+                self.cfg.device
+            )
+            input_ids = inputs["input_ids"]
+            input_type = "str"
+        elif isinstance(input, list):
+            inputs = self.tokenizer(input, return_tensors="pt", padding=True, truncation=False).to(
+                self.cfg.device
+            )
+            input_ids = inputs["input_ids"]
+            input_type = "list"
+        else:
+            input_ids = input
+            if input_ids.device != self.cfg.device:
+                input_ids = input_ids.to(self.cfg.device)
+            input_type = "tokens"
+
+        # Build generation_kwargs from explicit args and kwargs
+        generation_kwargs = dict(generation_kwargs) if generation_kwargs is not None else {}
+        generation_kwargs.update(
+            {
+                "max_new_tokens": max_new_tokens,
+                "do_sample": do_sample,
+                "temperature": temperature,
+                "pad_token_id": self.tokenizer.eos_token_id,
+            }
+        )
+
+        if top_k is not None:
+            generation_kwargs["top_k"] = top_k
+        if top_p is not None:
+            generation_kwargs["top_p"] = top_p
+        if eos_token_id is not None:
+            generation_kwargs["eos_token_id"] = eos_token_id
+        elif stop_at_eos and self.tokenizer.eos_token_id is not None:
+            generation_kwargs["eos_token_id"] = self.tokenizer.eos_token_id
+
+        if pixel_values is not None:
+            generation_kwargs["pixel_values"] = pixel_values
+
+        if use_past_kv_cache:
+            generation_kwargs["use_cache"] = True
+
+        # HF dict flags that trigger ModelOutput returns
+        hf_dict_flags = (
+            "output_scores",
+            "output_logits",
+            "output_attentions",
+            "output_hidden_states",
+        )
+
+        # If any HF-style output flags are provided, ensure return_dict_in_generate is set
+        any_flag_set = False
+        for f in hf_dict_flags:
+            if generation_kwargs.get(f) is not None:
+                generation_kwargs[f] = bool(generation_kwargs[f])
+                any_flag_set = True
+
+        if any_flag_set:
+            generation_kwargs.setdefault("return_dict_in_generate", True)
+
+        # Generate using the original HuggingFace model
+        with torch.no_grad():
+            outputs = self.original_model.generate(input_ids, **generation_kwargs)  # type: ignore[operator]
+
+        # Check if output is a ModelOutput
+        try:
+            from transformers.utils import ModelOutput  # type: ignore
+
+            is_model_output = isinstance(outputs, ModelOutput)
+        except Exception:
+            is_model_output = False
+
+        # Return based on return_type and input format
+        if return_type == "input" or return_type is None:
+            if input_type == "str":
+                # Decode the full output back to string
+                if is_model_output and hasattr(outputs, "sequences"):
+                    return self.tokenizer.decode(outputs.sequences[0], skip_special_tokens=True)
+                return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+            elif input_type == "list":
+                # Decode each sequence in the batch
+                if is_model_output and hasattr(outputs, "sequences"):
+                    return [
+                        self.tokenizer.decode(seq, skip_special_tokens=True)
+                        for seq in outputs.sequences
+                    ]
+                return [self.tokenizer.decode(seq, skip_special_tokens=True) for seq in outputs]
+            else:
+                # Return the full token sequence including input
+                return outputs
+        elif return_type == "tokens":
+            return outputs
+        else:
+            # For other return types, default to the decoded text
+            if input_type == "str":
+                if is_model_output and hasattr(outputs, "sequences"):
+                    return self.tokenizer.decode(outputs.sequences[0], skip_special_tokens=True)
+                return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+            elif input_type == "list":
+                if is_model_output and hasattr(outputs, "sequences"):
+                    return [
+                        self.tokenizer.decode(seq, skip_special_tokens=True)
+                        for seq in outputs.sequences
+                    ]
+                return [self.tokenizer.decode(seq, skip_special_tokens=True) for seq in outputs]
+            else:
+                return outputs
+
+    def prepare_multimodal_inputs(
+        self,
+        text: Union[str, List[str]],
+        images: Optional[Any] = None,
+    ) -> Dict[str, torch.Tensor]:
+        """Prepare multimodal inputs using the model's processor.
+
+        Converts text and images into model-ready tensors (input_ids, pixel_values,
+        attention_mask, etc.) using the HuggingFace processor loaded during boot().
+
+        Args:
+            text: Text prompt(s), typically containing image placeholder tokens
+                (e.g., "<image>" for LLaVA).
+            images: PIL Image or list of PIL Images to process. Pass None for
+                text-only inputs on a multimodal model.
+
+        Returns:
+            Dictionary with 'input_ids', 'pixel_values', 'attention_mask', etc.
+            All tensors are moved to the model's device.
+
+        Raises:
+            ValueError: If model is not multimodal or processor is not available.
+        """
+        if not getattr(self.cfg, "is_multimodal", False):
+            raise ValueError(
+                "prepare_multimodal_inputs() requires a multimodal model "
+                "(cfg.is_multimodal must be True)"
+            )
+        if self.processor is None:
+            raise ValueError(
+                "No processor available. Load model with boot_transformers() or "
+                "set bridge.processor = AutoProcessor.from_pretrained(...) manually."
+            )
+        inputs = self.processor(text=text, images=images, return_tensors="pt")
+        return {k: v.to(self.cfg.device) if hasattr(v, "to") else v for k, v in inputs.items()}
+
+    def to(self, *args, **kwargs) -> "TransformerBridge":
+        """Move model to device and/or change dtype.
+
+        Args:
+            args: Positional arguments for nn.Module.to
+            kwargs: Keyword arguments for nn.Module.to
+            print_details: Whether to print details about device/dtype changes (default: True)
+
+        Returns:
+            Self for chaining
+        """
+        # Extract print_details if provided
+        print_details = kwargs.pop("print_details", True)
+
+        # Handle both device and dtype changes
+        # torch.nn.Module.to() supports: to(device), to(dtype), to(device, dtype),
+        # to(device=...), to(dtype=...), to(device=..., dtype=...)
+        target_device, target_dtype = None, None
+
+        if len(args) >= 1:
+            first_arg = args[0]
+            if isinstance(first_arg, (torch.device, str)):
+                target_device = first_arg
+            elif isinstance(first_arg, torch.dtype):
+                target_dtype = first_arg
+        if len(args) >= 2:
+            second_arg = args[1]
+            if isinstance(second_arg, torch.dtype):
+                target_dtype = second_arg
+
+        # these override positional args
+        if "device" in kwargs:
+            target_device = kwargs["device"]
+        if "dtype" in kwargs:
+            target_dtype = kwargs["dtype"]
+
+        # Moving a multi-device (device_map-dispatched) model to a single device would
+        # collapse the split and break accelerate's hook routing. Warn and drop the
+        # device move; still honor dtype changes.
+        if target_device is not None and getattr(self.cfg, "n_devices", 1) > 1:
+            warnings.warn(
+                f"TransformerBridge.to({target_device!r}) ignored: model is dispatched "
+                f"across {self.cfg.n_devices} devices via device_map. Reload with "
+                "device=... (and no device_map/n_devices) to move to a single device.",
+                stacklevel=2,
+            )
+            target_device = None
+
+        if target_device is not None:
+            move_to_and_update_config(self, target_device, print_details)
+        if target_dtype is not None:
+            move_to_and_update_config(self, target_dtype, print_details)
+
+        # Move the original model with all original args/kwargs (with print_details removed).
+        # When we've nulled target_device for multi-GPU safety, strip device args so the
+        # underlying module isn't moved either.
+        if target_device is None and (len(args) > 0 or "device" in kwargs):
+            kwargs.pop("device", None)
+            # Filter positional args: drop devices/strings, keep dtypes.
+            args = tuple(a for a in args if not isinstance(a, (torch.device, str)))
+        self.original_model = self.original_model.to(*args, **kwargs)
+        return self
+
+    def cuda(self, device: Optional[Union[int, torch.device]] = None) -> "TransformerBridge":
+        """Move model to CUDA.
+
+        Args:
+            device: CUDA device
+
+        Returns:
+            Self for chaining
+        """
+        if isinstance(device, int):
+            return self.to(f"cuda:{device}")
+        elif device is None:
+            return self.to("cuda")
+        else:
+            return self.to(device)
+
+    def cpu(self) -> "TransformerBridge":
+        """Move model to CPU.
+
+        Returns:
+            Self for chaining
+        """
+        return self.to(torch.device("cpu"))
+
+    def mps(self) -> "TransformerBridge":
+        """Move model to MPS.
+
+        Returns:
+            Self for chaining
+        """
+        return self.to(torch.device("mps"))
+
+    def train(self, mode: bool = True) -> "TransformerBridge":
+        """Set training mode, propagating to the wrapped source model.
+
+        ``nn.Module.train()`` only recurses into *registered* submodules.
+        ``original_model`` is intentionally stored outside the registered
+        module tree (assigned via ``self.__dict__`` rather than
+        ``nn.Module.__setattr__``); consequently, inherited ``train()``
+        does not reach it -- without this override, ``bridge.eval()`` /
+        ``bridge.train()`` silently leave dropout and other mode-dependent
+        layers in whatever mode the source model was in at wrap time.
+
+        ``eval()`` needs no override of its own: ``nn.Module.eval()`` calls
+        ``self.train(False)``, which dispatches here.
+
+        Args:
+            mode:
+                ``True`` for training mode, ``False`` for evaluation mode.
+
+        Returns:
+            The bridge itself (``nn.Module`` chaining convention).
+        """
+        super().train(mode)
+        original = getattr(self, "original_model", None)
+        if isinstance(original, torch.nn.Module):
+            original.train(mode)
+        return self
+
+    def add_hook(
+        self,
+        name: Union[str, Callable[[str], bool]],
+        hook_fn,
+        dir="fwd",
+        is_permanent=False,
+    ):
+        """Add a hook to a specific component or to all components matching a filter.
+
+        Args:
+            name: Either a string hook point name (e.g. "blocks.0.attn.hook_q")
+                or a callable filter ``(str) -> bool`` that is applied to every
+                hook point name; the hook is added to each point where the filter
+                returns True.
+            hook_fn: The hook function ``(activation, hook) -> activation | None``.
+            dir: Hook direction, ``"fwd"`` or ``"bwd"``.
+            is_permanent: If True the hook survives ``reset_hooks()`` calls.
+        """
+        if callable(name) and not isinstance(name, str):
+            hook_dict = self.hook_dict
+            seen_hooks: set[int] = set()
+            for hook_name, hook_point in hook_dict.items():
+                if name(hook_name):
+                    hook_id = id(hook_point)
+                    if hook_id in seen_hooks:
+                        continue
+                    seen_hooks.add(hook_id)
+                    hook_point.add_hook(hook_fn, dir=dir, is_permanent=is_permanent)
+            return
+
+        component = self
+        parts = name.split(".")
+        for part in parts[:-1]:
+            if hasattr(component, part):
+                component = getattr(component, part)
+            else:
+                raise AttributeError(f"Component path '{'.'.join(parts[:-1])}' not found")
+        hook_name = parts[-1]
+        if hasattr(component, hook_name):
+            hook_point = getattr(component, hook_name)
+            if isinstance(hook_point, HookPoint):
+                hook_point.add_hook(hook_fn, dir=dir, is_permanent=is_permanent)
+            else:
+                raise AttributeError(
+                    f"'{hook_name}' is not a hook point. Found object of type: {type(hook_point)} with value: {hook_point}"
+                )
+        else:
+            raise AttributeError(f"Hook point '{hook_name}' not found on component")
+
+    def add_perma_hook(
+        self,
+        name: Union[str, Callable[[str], bool]],
+        hook_fn,
+        dir="fwd",
+    ) -> None:
+        """Add a permanent hook that survives ``reset_hooks()`` calls.
+
+        Convenience wrapper for ``add_hook(..., is_permanent=True)``. To remove,
+        call ``reset_hooks(including_permanent=True)`` or remove from the
+        underlying ``HookPoint`` directly.
+        """
+        self.add_hook(name, hook_fn, dir=dir, is_permanent=True)
+
+    def reset_hooks(self, clear_contexts=True):
+        """Remove all hooks from the model."""
+
+        def remove_hooks_recursive(module):
+            if isinstance(module, GeneralizedComponent):
+                module.remove_hooks()
+            for child in module.children():
+                remove_hooks_recursive(child)
+
+        remove_hooks_recursive(self)
+
+    def hooks(self, fwd_hooks=[], bwd_hooks=[], reset_hooks_end=True, clear_contexts=False):
+        """Context manager for temporarily adding hooks.
+
+        Args:
+            fwd_hooks: List of (hook_name, hook_fn) tuples for forward hooks
+            bwd_hooks: List of (hook_name, hook_fn) tuples for backward hooks
+            reset_hooks_end: If True, removes hooks when context exits
+            clear_contexts: Unused (for compatibility with HookedTransformer)
+
+        Example:
+            with model.hooks(fwd_hooks=[("hook_embed", my_hook)]):
+                output = model("Hello world")
+        """
+
+        @contextmanager
+        def _hooks_context():
+            added_hooks: List[Tuple[HookPoint, Literal["fwd", "bwd"]]] = []
+
+            def add_hook_to_point(
+                hook_point: HookPoint,
+                hook_fn: Callable,
+                name: str,
+                dir: Literal["fwd", "bwd"] = "fwd",
+            ):
+                if self.compatibility_mode and name != hook_point.name:
+                    alias_names_list: list[str] = []
+                    if hook_point.name is not None:
+                        alias_names_list.append(hook_point.name)
+                    alias_names_list.append(name)
+                    hook_point.add_hook(hook_fn, dir=dir, alias_names=alias_names_list)
+                else:
+                    hook_point.add_hook(hook_fn, dir=dir)
+                added_hooks.append((hook_point, dir))
+
+            def apply_hooks(hooks: List[Tuple[Union[str, Callable], Callable]], is_fwd: bool):
+                direction: Literal["fwd", "bwd"] = "fwd" if is_fwd else "bwd"
+                aliases = build_alias_to_canonical_map(self.hook_dict)
+                for hook_name_or_filter, hook_fn in hooks:
+                    if isinstance(hook_name_or_filter, str):
+                        hook_dict = self.hook_dict
+                        actual_hook_name = hook_name_or_filter
+                        if hook_name_or_filter in aliases:
+                            actual_hook_name = aliases[hook_name_or_filter]
+                        if actual_hook_name in hook_dict:
+                            add_hook_to_point(
+                                hook_dict[actual_hook_name], hook_fn, actual_hook_name, direction
+                            )
+                    else:
+                        hook_dict = self.hook_dict
+                        seen_hooks = set()
+                        for name, hook_point in hook_dict.items():
+                            if hook_name_or_filter(name):
+                                hook_id = id(hook_point)
+                                if hook_id in seen_hooks:
+                                    continue
+                                seen_hooks.add(hook_id)
+                                hook_name_to_use = hook_point.name if hook_point.name else name
+                                add_hook_to_point(hook_point, hook_fn, hook_name_to_use, direction)
+
+            try:
+                apply_hooks(fwd_hooks, True)
+                apply_hooks(bwd_hooks, False)
+                yield self
+            finally:
+                if reset_hooks_end:
+                    for hook_point, direction in added_hooks:
+                        hook_point.remove_hooks(dir=direction)
+
+        return _hooks_context()
+
+    def set_use_attn_result(self, use_attn_result: bool):
+        """Toggle whether to explicitly calculate and expose the result for each attention head.
+
+        Useful for interpretability but can easily burn through GPU memory.
+        """
+        if use_attn_result:
+            self._validate_attention_fork_supported("use_attn_result")
+        self.cfg.use_attn_result = use_attn_result
+        self._propagate_attention_flag("use_attn_result", use_attn_result)
+
+    def set_use_split_qkv_input(self, use_split_qkv_input: bool):
+        """Toggle independent residual copies for Q/K/V so each path can be patched alone.
+
+        Mutually exclusive with `use_attn_in` — set that flag off first if it's on.
+        """
+        if use_split_qkv_input:
+            if bool(getattr(self.cfg, "use_attn_in", False)):
+                raise ValueError(
+                    "use_split_qkv_input and use_attn_in are mutually exclusive. "
+                    "Call set_use_attn_in(False) before enabling use_split_qkv_input."
+                )
+            self._validate_attention_fork_supported("use_split_qkv_input")
+        self.cfg.use_split_qkv_input = use_split_qkv_input
+        self._propagate_attention_flag("use_split_qkv_input", use_split_qkv_input)
+
+    def set_use_attn_in(self, use_attn_in: bool):
+        """Toggle a single 4D residual copy feeding all three Q/K/V projections.
+
+        Mutually exclusive with `use_split_qkv_input` — set that flag off first
+        if it's on. When on, `hook_attn_in` fires at
+        `[batch, pos, n_heads, d_model]`, enabling coarse-grained interventions
+        on the residual-stream copy shared across Q/K/V.
+        """
+        if use_attn_in:
+            if bool(getattr(self.cfg, "use_split_qkv_input", False)):
+                raise ValueError(
+                    "use_attn_in and use_split_qkv_input are mutually exclusive. "
+                    "Call set_use_split_qkv_input(False) before enabling use_attn_in."
+                )
+            self._validate_attention_fork_supported("use_attn_in")
+        self.cfg.use_attn_in = use_attn_in
+        self._propagate_attention_flag("use_attn_in", use_attn_in)
+
+    def set_use_hook_mlp_in(self, use_hook_mlp_in: bool) -> None:
+        """Toggle the pre-ln2 ``hook_mlp_in`` HookPoint, matching legacy semantics.
+
+        See :py:meth:`HookedTransformer.set_use_hook_mlp_in`.
+        """
+        self.cfg.use_hook_mlp_in = use_hook_mlp_in
+        if not hasattr(self, "blocks"):
+            return
+        for block in self.blocks:
+            block_cfg = getattr(block, "config", None)
+            if block_cfg is not None and block_cfg is not self.cfg:
+                try:
+                    block_cfg.use_hook_mlp_in = use_hook_mlp_in
+                except Exception:
+                    pass
+            block._use_hook_mlp_in = use_hook_mlp_in
+
+    def _propagate_attention_flag(self, flag_name: str, value: bool) -> None:
+        """Mirror `bridge.cfg.<flag>` onto every block's attention config.
+
+        Some adapters (Llama family) deep-copy the block template during
+        `setup_blocks_bridge`, cloning the attention bridge's config along
+        with it. Others (Pythia, GPT-2) override `__deepcopy__` to share the
+        config. Setting the flag only on `self.cfg` silently misses the
+        cloned-config case. Propagating explicitly keeps both patterns
+        honest — a no-op when configs are shared, a correctness fix when
+        they aren't.
+        """
+        if not hasattr(self, "blocks"):
+            return
+        for block in self.blocks:
+            attn = block._modules.get("attn") if hasattr(block, "_modules") else None
+            if attn is None:
+                continue
+            attn_cfg = getattr(attn, "config", None)
+            if attn_cfg is not None and attn_cfg is not self.cfg:
+                try:
+                    setattr(attn_cfg, flag_name, value)
+                except Exception:
+                    # Some cfg objects may be frozen/immutable. Skip silently —
+                    # the block simply won't honor the flag, which is the
+                    # same outcome as before this fix.
+                    pass
+
+    def _validate_attention_fork_supported(self, flag_name: str) -> None:
+        """Raise / warn if the model can't honor a fine-grained attention flag.
+
+        The post-ln1 fork path lives on JointQKVAttentionBridge and
+        PositionEmbeddingsAttentionBridge. Plain AttentionBridge delegates to
+        HF and exposes no fork point; we raise rather than setting the flag
+        silently. For hybrid models (some attention layers, some not), we warn
+        and list which layers will honor the flag.
+        """
+        # Deferred imports: tight circular dependency with bridge setup.
+        from transformer_lens.model_bridge.generalized_components.joint_qkv_attention import (
+            JointQKVAttentionBridge,
+        )
+        from transformer_lens.model_bridge.generalized_components.position_embeddings_attention import (
+            PositionEmbeddingsAttentionBridge,
+        )
+
+        if not hasattr(self, "blocks"):
+            raise NotImplementedError(
+                f"{flag_name}: this bridge has no `blocks` attribute, so no "
+                "attention bridges to apply the flag to."
+            )
+        supported_classes = (JointQKVAttentionBridge, PositionEmbeddingsAttentionBridge)
+        supporting_layers: list[int] = []
+        attn_classes: set[str] = set()
+        total_with_attn = 0
+        for idx, block in enumerate(self.blocks):
+            attn = block._modules.get("attn") if hasattr(block, "_modules") else None
+            if attn is None:
+                continue
+            total_with_attn += 1
+            attn_classes.add(type(attn).__name__)
+            if isinstance(attn, supported_classes):
+                supporting_layers.append(idx)
+        if total_with_attn == 0:
+            raise NotImplementedError(f"{flag_name}: no attention bridges found on self.blocks.")
+        if not supporting_layers:
+            raise NotImplementedError(
+                f"{flag_name}: none of this model's attention bridges support "
+                "the fine-grained Q/K/V hook fork. Found attention classes: "
+                f"{sorted(attn_classes)}. Supported classes: "
+                f"{[c.__name__ for c in supported_classes]}. Plain "
+                "AttentionBridge delegates to HuggingFace and exposes no hook "
+                "point before the Q/K/V projection."
+            )
+        if len(supporting_layers) < total_with_attn:
+            skipped = total_with_attn - len(supporting_layers)
+            warnings.warn(
+                f"{flag_name}: {skipped} of {total_with_attn} attention layers "
+                "use an attention-bridge class that cannot honor this flag "
+                f"(attention classes present: {sorted(attn_classes)}). "
+                f"The flag will affect layers: {supporting_layers}.",
+                stacklevel=3,
+            )
+
+    def _is_valid_bridge_path(self, hf_path: str) -> bool:
+        """Check if a HuggingFace path corresponds to a valid bridge component.
+
+        This validates that the path follows the bridge component structure and doesn't
+        contain nested HuggingFace components that should have been wrapped.
+
+        Args:
+            hf_path: HuggingFace path after removing _original_component
+
+        Returns:
+            True if the path is valid, False if it contains nested HF components
+        """
+        # Split the path into parts
+        parts = hf_path.split(".")
+
+        # Get the component mapping for validation
+        component_mapping = self.adapter.component_mapping
+        if not component_mapping:
+            return True  # If no mapping, accept all keys
+
+        # Walk through the path and check if each level is a registered bridge component
+        # For example, transformer.h.0.mlp.in.weight should be valid
+        # but transformer.h.0.mlp.c_fc.weight should be invalid (c_fc is nested HF component)
+
+        # Start from the root
+        current_component = None
+        idx = 0
+
+        # Find which top-level component this belongs to
+        for tl_name, component in component_mapping.items():
+            if component.name and hf_path.startswith(component.name + "."):
+                current_component = component
+                # Skip past the HF prefix
+                remaining_path = hf_path[len(component.name) + 1 :]
+                parts = remaining_path.split(".")
+                idx = 0
+                break
+
+        if current_component is None:
+            return True  # Path doesn't match any component, let it through
+
+        # Special handling for blocks
+        if hasattr(current_component, "is_list_item") and current_component.is_list_item:
+            # Skip the layer index
+            if idx < len(parts) and parts[idx].isdigit():
+                idx += 1
+
+        # Now validate the rest of the path against submodules
+        while idx < len(parts):
+            part = parts[idx]
+
+            # If we hit 'weight' or 'bias', we're at a parameter - this is valid
+            if part in ("weight", "bias"):
+                return True
+
+            # Check if this part is a registered submodule
+            if hasattr(current_component, "submodules") and current_component.submodules:
+                if part in current_component.submodules:
+                    current_component = current_component.submodules[part]
+                    idx += 1
+                    continue
+                else:
+                    # This part is not a registered bridge component
+                    # It's likely a nested HF component (like c_fc, c_proj, c_attn)
+                    return False
+            else:
+                # No submodules to check, but not at a parameter yet
+                # Check if next is weight/bias
+                if idx + 1 < len(parts) and parts[idx + 1] in ("weight", "bias"):
+                    return True
+                # Otherwise this is likely a nested HF component
+                return False
+
+            idx += 1
+
+        return True
+
+    def _normalize_bridge_key_to_hf(self, key: str) -> str:
+        """Normalize a key that uses bridge attribute names to use HF module names.
+
+        PyTorch's state_dict uses the Python attribute names (e.g., 'ln1')
+        but the conversion logic expects HF module names (e.g., 'ln_1'). This
+        function only replaces non-nested component names, leaving bridge
+        subcomponents (like 'in', 'out', 'q', 'k', 'v') unchanged since they're
+        handled by the component structure.
+
+        Args:
+            key: Key that may use bridge attribute names
+
+        Returns:
+            Key with attribute names replaced by module names where needed
+        """
+        component_mapping = self.adapter.component_mapping
+        if not component_mapping:
+            return key
+
+        # Build a mapping of only the direct module attribute names to HF names
+        # We only care about top-level and block-level component names, NOT subcomponents
+        attr_to_hf = {}
+
+        # Map top-level components
+        for tl_name, component in component_mapping.items():
+            if component.name and tl_name != "blocks":
+                # Skip if TL name is already a suffix of the HF path (avoids doubling).
+                if tl_name != component.name and not component.name.endswith("." + tl_name):
+                    attr_to_hf[tl_name] = component.name
+
+        # Map block-level components (ln1, ln2, attn, mlp)
+        blocks_component = component_mapping.get("blocks")
+        if blocks_component and hasattr(blocks_component, "submodules"):
+            for tl_subname, subcomponent in blocks_component.submodules.items():
+                if subcomponent.name:
+                    # Only map if the names differ (e.g., ln1 -> ln_1, but attn -> attn)
+                    if tl_subname != subcomponent.name:
+                        attr_to_hf[tl_subname] = subcomponent.name
+
+        # Replace only these specific attribute names in the key
+        # We need to be careful to only replace whole path components, not substrings
+        parts = key.split(".")
+        result_parts = []
+
+        for part in parts:
+            if part in attr_to_hf:
+                result_parts.append(attr_to_hf[part])
+            else:
+                result_parts.append(part)
+
+        return ".".join(result_parts)
+
+    def state_dict(self, destination=None, prefix="", keep_vars=False):
+        """Get state dict with TransformerLens format keys.
+
+        Converts HuggingFace format keys to TransformerLens format and filters out
+        _original_component references and nested HuggingFace components.
+
+        This returns a clean state dict with only bridge component paths converted to TL format,
+        excluding nested HF components (like c_fc, c_proj, c_attn) that exist inside
+        original_component modules.
+
+        Args:
+            destination: Optional dict to store state dict in
+            prefix: Optional prefix to add to all keys
+            keep_vars: Whether to keep variables as Variables instead of tensors
+
+        Returns:
+            Dict containing the state dict with TransformerLens format keys
+        """
+        if destination is not None:
+            raw_state_dict = self.original_model.state_dict(
+                destination=destination, prefix=prefix, keep_vars=keep_vars
+            )
+        else:
+            raw_state_dict = self.original_model.state_dict(prefix=prefix, keep_vars=keep_vars)
+
+        # Clean _original_component references and convert to TL format
+        # Also filter out nested HuggingFace components that are wrapped by bridge components
+        tl_state_dict = {}
+
+        for key, value in raw_state_dict.items():
+            # Skip _original_component keys
+            if key == "_original_component" or key.startswith("_original_component."):
+                continue
+
+            # Remove all _original_component from the key
+            clean_key = key.replace("._original_component", "")
+
+            # Check if this is a valid bridge path (not a nested HF component)
+            if not self._is_valid_bridge_path(clean_key):
+                continue
+
+            # Normalize bridge component names to HF names for conversion
+            # (e.g., 'ln1' -> 'ln_1', 'mlp.in' -> 'mlp.c_fc')
+            hf_key = self._normalize_bridge_key_to_hf(clean_key)
+
+            # Convert to TL format - this uses the adapter's component_mapping
+            tl_key = self.adapter.convert_hf_key_to_tl_key(hf_key)
+
+            # Only add if we haven't seen this TL key yet (handles duplicates)
+            if tl_key not in tl_state_dict:
+                tl_state_dict[tl_key] = value
+
+        return tl_state_dict
+
+    def load_state_dict(self, state_dict, strict=True, assign=False):
+        """Load state dict into the model, handling both clean keys and original keys with _original_component references.
+
+        Args:
+            state_dict: Dictionary containing a whole state of the module
+            strict: Whether to strictly enforce that the keys in state_dict match the keys returned by this module's state_dict() function
+            assign: Whether to assign items in the state dictionary to their corresponding keys in the module instead of copying them
+
+        Returns:
+            NamedTuple with missing_keys and unexpected_keys fields
+        """
+        current_state_dict = self.original_model.state_dict()
+        clean_to_actual = {}
+        actual_to_clean = {}
+        for actual_key in current_state_dict.keys():
+            if actual_key != "_original_component":
+                clean_key = actual_key.replace("._original_component", "")
+                clean_to_actual[clean_key] = actual_key
+                actual_to_clean[actual_key] = clean_key
+        mapped_state_dict = {}
+        for input_key, value in state_dict.items():
+            if input_key in current_state_dict:
+                mapped_state_dict[input_key] = value
+            else:
+                if input_key in clean_to_actual:
+                    actual_key = clean_to_actual[input_key]
+                    mapped_state_dict[actual_key] = value
+                else:
+                    mapped_state_dict[input_key] = value
+        effective_strict = strict and len(mapped_state_dict) == len(current_state_dict)
+        return self.original_model.load_state_dict(
+            mapped_state_dict, strict=effective_strict, assign=assign
+        )
+
+    def get_params(self):
+        """Access to model parameters in the format expected by SVDInterpreter.
+
+        For missing weights, returns zero tensors of appropriate shape instead of raising exceptions.
+        This ensures compatibility across different model architectures.
+
+        Returns:
+            dict: Dictionary of parameter tensors with TransformerLens naming convention
+
+        Raises:
+            ValueError: If configuration is inconsistent (e.g., cfg.n_layers != len(blocks))
+        """
+        return get_bridge_params(self)
+
+    # NOTE: list_supported_models and check_model_support are attached to this class
+    # dynamically by transformer_lens.model_bridge.sources.transformers module.
+    # These are HuggingFace-specific methods that belong in the transformers source module.

--- a/TransformerLens/transformer_lens/model_bridge/generalized_components/moe.py
+++ b/TransformerLens/transformer_lens/model_bridge/generalized_components/moe.py
@@ -1,0 +1,136 @@
+"""Mixture of Experts bridge component.
+
+This module contains the bridge component for Mixture of Experts layers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import torch
+
+from transformer_lens.hook_points import HookPoint
+from transformer_lens.model_bridge.generalized_components.base import (
+    GeneralizedComponent,
+)
+
+
+class MoEBridge(GeneralizedComponent):
+    """Bridge component for Mixture of Experts layers.
+
+    This component wraps a Mixture of Experts layer from a remote model and provides a consistent interface
+    for accessing its weights and performing MoE operations.
+
+    MoE models often return tuples of (hidden_states, router_scores). This bridge handles that pattern
+    and provides a hook for capturing router scores.
+    """
+
+    hook_aliases = {"hook_pre": "hook_in", "hook_post": "hook_out"}
+
+    def __init__(
+        self,
+        name: str,
+        config: Optional[Any] = None,
+        submodules: Optional[Dict[str, GeneralizedComponent]] = {},
+    ):
+        """Initialize the MoE bridge.
+
+        Args:
+            name: The name of the component in the model
+            config: Optional configuration (unused for MoEBridge)
+            submodules: Dictionary of GeneralizedComponent submodules to register
+        """
+        super().__init__(name, config, submodules=submodules)
+        self.hook_router_scores = HookPoint()
+
+    def get_random_inputs(
+        self,
+        batch_size: int = 2,
+        seq_len: int = 8,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> Dict[str, Any]:
+        """Generate random inputs for component testing.
+
+        Args:
+            batch_size: Batch size for generated inputs
+            seq_len: Sequence length for generated inputs
+            device: Device to place tensors on
+            dtype: Dtype for generated tensors (defaults to float32)
+
+        Returns:
+            Dictionary of input tensors matching the component's expected input signature
+        """
+        if device is None:
+            device = torch.device("cpu")
+        if dtype is None:
+            dtype = torch.float32
+        d_model = self.config.d_model if self.config and hasattr(self.config, "d_model") else 768
+        # Use positional args to avoid parameter name mismatches across MoE implementations
+        # (e.g., Mixtral uses "hidden_states", GraniteMoe uses "layer_input")
+        return {"args": (torch.randn(batch_size, seq_len, d_model, device=device, dtype=dtype),)}
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Forward pass through the MoE bridge.
+
+        Args:
+            *args: Input arguments
+            **kwargs: Input keyword arguments
+
+        Returns:
+            Same return type as original component (tuple or tensor).
+            For MoE models that return (hidden_states, router_scores), preserves the tuple.
+            Router scores are also captured via hook for inspection.
+        """
+        if self.original_component is None:
+            raise RuntimeError(
+                f"Original component not set for {self.name}. Call set_original_component() first."
+            )
+        target_dtype = None
+        try:
+            target_dtype = next(self.original_component.parameters()).dtype
+        except StopIteration:
+            pass
+        if len(args) > 0:
+            hooked = self.hook_in(args[0])
+            if (
+                target_dtype is not None
+                and isinstance(hooked, torch.Tensor)
+                and hooked.is_floating_point()
+            ):
+                hooked = hooked.to(dtype=target_dtype)
+            args = (hooked,) + args[1:]
+        elif "hidden_states" in kwargs:
+            hooked = self.hook_in(kwargs["hidden_states"])
+            if (
+                target_dtype is not None
+                and isinstance(hooked, torch.Tensor)
+                and hooked.is_floating_point()
+            ):
+                hooked = hooked.to(dtype=target_dtype)
+            kwargs = {**kwargs, "hidden_states": hooked}
+        output = self.original_component(*args, **kwargs)
+        if isinstance(output, tuple):
+            if not output:
+                raise TypeError(
+                    f"{self.name}: expected a non-empty tuple whose first "
+                    "element is a torch.Tensor from the wrapped MoE component, "
+                    "got an empty tuple."
+                )
+
+            hidden_states = output[0]
+            if not isinstance(hidden_states, torch.Tensor):
+                raise TypeError(
+                    f"{self.name}: expected the first tuple element from the "
+                    f"wrapped MoE component to be a torch.Tensor, got "
+                    f"{type(hidden_states).__name__}."
+                )
+            if len(output) > 1:
+                router_scores = output[1]
+                if isinstance(router_scores, torch.Tensor):
+                    self.hook_router_scores(router_scores)
+            hidden_states = self.hook_out(hidden_states)
+            return (hidden_states,) + output[1:]
+        else:
+            hidden_states = self.hook_out(output)
+            return hidden_states

--- a/TransformerLens/transformer_lens/model_bridge/supported_architectures/__init__.py
+++ b/TransformerLens/transformer_lens/model_bridge/supported_architectures/__init__.py
@@ -1,0 +1,280 @@
+"""Supported architecture adapters.
+
+This module contains all the supported architecture adapters for different model architectures.
+"""
+
+from transformer_lens.model_bridge.supported_architectures.apertus import (
+    ApertusArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.baichuan import (
+    BaichuanArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.bart import (
+    BartArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.bert import (
+    BertArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.bloom import (
+    BloomArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.codegen import (
+    CodeGenArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.cohere import (
+    CohereArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.deepseek_v2 import (
+    DeepSeekV2ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.deepseek_v3 import (
+    DeepSeekV3ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.falcon import (
+    FalconArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gemma1 import (
+    Gemma1ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gemma2 import (
+    Gemma2ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gemma3 import (
+    Gemma3ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gemma3_multimodal import (
+    Gemma3MultimodalArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gemma3n import (
+    Gemma3nArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gemma4 import (
+    Gemma4ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.glm4_moe import (
+    Glm4MoeArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gpt2 import (
+    GPT2ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gpt2_lm_head_custom import (
+    Gpt2LmHeadCustomArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gpt_bigcode import (
+    GPTBigCodeArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gpt_oss import (
+    GPTOSSArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.gptj import (
+    GptjArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.glm_moe_dsa import (
+    GlmMoeDsaArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.granite import (
+    GraniteArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.granite_moe import (
+    GraniteMoeArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.granite_moe_hybrid import (
+    GraniteMoeHybridArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.hubert import (
+    HubertArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.hunyuan_v1_dense import (
+    HunYuanDenseV1ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.internlm2 import (
+    InternLM2ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.lfm2_moe import (
+    Lfm2MoeArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.llama import (
+    LlamaArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.llava import (
+    LlavaArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.llava_next import (
+    LlavaNextArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.llava_onevision import (
+    LlavaOnevisionArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.mamba import (
+    MambaArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.mamba2 import (
+    Mamba2ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.mingpt import (
+    MingptArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.mistral import (
+    MistralArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.mixtral import (
+    MixtralArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.mpt import (
+    MPTArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.nanogpt import (
+    NanogptArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.native import (
+    NativeArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.neel_solu_old import (
+    NeelSoluOldArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.nemotron_h import (
+    NemotronHArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.neo import (
+    NeoArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.neox import (
+    NeoxArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.olmo import (
+    OlmoArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.olmo2 import (
+    Olmo2ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.olmo3 import (
+    Olmo3ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.olmoe import (
+    OlmoeArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.openelm import (
+    OpenElmArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.opt import (
+    OptArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.phi import (
+    PhiArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.phi3 import (
+    Phi3ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.phimoe import (
+    PhiMoEArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.pretrain import (
+    PretrainArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.qwen import (
+    QwenArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.qwen2 import (
+    Qwen2ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.qwen3 import (
+    Qwen3ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.qwen3_5 import (
+    Qwen3_5ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.qwen3_5_multimodal import (
+    Qwen3_5MultimodalArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.qwen3_moe import (
+    Qwen3MoeArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.qwen3_next import (
+    Qwen3NextArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.smollm3 import (
+    SmolLM3ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.stablelm import (
+    StableLmArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.t5 import (
+    T5ArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.t5gemma import (
+    T5GemmaArchitectureAdapter,
+)
+from transformer_lens.model_bridge.supported_architectures.xglm import (
+    XGLMArchitectureAdapter,
+)
+
+__all__ = [
+    "ApertusArchitectureAdapter",
+    "BaichuanArchitectureAdapter",
+    "BartArchitectureAdapter",
+    "BertArchitectureAdapter",
+    "BloomArchitectureAdapter",
+    "CodeGenArchitectureAdapter",
+    "CohereArchitectureAdapter",
+    "DeepSeekV2ArchitectureAdapter",
+    "DeepSeekV3ArchitectureAdapter",
+    "FalconArchitectureAdapter",
+    "Gemma1ArchitectureAdapter",
+    "Gemma2ArchitectureAdapter",
+    "Gemma3ArchitectureAdapter",
+    "Gemma3nArchitectureAdapter",
+    "Gemma3MultimodalArchitectureAdapter",
+    "Gemma4ArchitectureAdapter",
+    "GlmMoeDsaArchitectureAdapter",
+    "Glm4MoeArchitectureAdapter",
+    "GraniteArchitectureAdapter",
+    "GraniteMoeArchitectureAdapter",
+    "GraniteMoeHybridArchitectureAdapter",
+    "GPT2ArchitectureAdapter",
+    "GPTBigCodeArchitectureAdapter",
+    "GPTOSSArchitectureAdapter",
+    "Gpt2LmHeadCustomArchitectureAdapter",
+    "GptjArchitectureAdapter",
+    "HubertArchitectureAdapter",
+    "HunYuanDenseV1ArchitectureAdapter",
+    "InternLM2ArchitectureAdapter",
+    "LlamaArchitectureAdapter",
+    "LlavaArchitectureAdapter",
+    "LlavaNextArchitectureAdapter",
+    "LlavaOnevisionArchitectureAdapter",
+    "Lfm2MoeArchitectureAdapter",
+    "MambaArchitectureAdapter",
+    "Mamba2ArchitectureAdapter",
+    "MingptArchitectureAdapter",
+    "MistralArchitectureAdapter",
+    "MixtralArchitectureAdapter",
+    "MPTArchitectureAdapter",
+    "NanogptArchitectureAdapter",
+    "NativeArchitectureAdapter",
+    "NeelSoluOldArchitectureAdapter",
+    "NemotronHArchitectureAdapter",
+    "NeoArchitectureAdapter",
+    "NeoxArchitectureAdapter",
+    "OpenElmArchitectureAdapter",
+    "OlmoArchitectureAdapter",
+    "Olmo2ArchitectureAdapter",
+    "Olmo3ArchitectureAdapter",
+    "OlmoeArchitectureAdapter",
+    "OptArchitectureAdapter",
+    "PhiArchitectureAdapter",
+    "Phi3ArchitectureAdapter",
+    "PhiMoEArchitectureAdapter",
+    "PretrainArchitectureAdapter",
+    "QwenArchitectureAdapter",
+    "Qwen2ArchitectureAdapter",
+    "Qwen3ArchitectureAdapter",
+    "Qwen3MoeArchitectureAdapter",
+    "Qwen3NextArchitectureAdapter",
+    "Qwen3_5ArchitectureAdapter",
+    "Qwen3_5MultimodalArchitectureAdapter",
+    "SmolLM3ArchitectureAdapter",
+    "StableLmArchitectureAdapter",
+    "T5ArchitectureAdapter",
+    "T5GemmaArchitectureAdapter",
+    "XGLMArchitectureAdapter",
+]

--- a/TransformerLens/transformer_lens/model_bridge/supported_architectures/pretrain.py
+++ b/TransformerLens/transformer_lens/model_bridge/supported_architectures/pretrain.py
@@ -1,0 +1,442 @@
+"""Architecture adapter for a lightweight decoder-only pretraining model.
+
+Maps a decoder-only transformer using RoPE, RMSNorm, gated SwiGLU MLPs, and
+optional sparse mixture-of-experts feed-forward layers into
+TransformerBridge, by wrapping the source module and delegating to its own
+`forward` rather than translating parameters into a second implementation.
+
+Usage: `build_pretrain_bridge(model, cfg)` -- the public entry point.
+`PretrainModelContainer` and direct `build_bridge_from_module` use are
+internal/advanced details (see `PretrainModelContainer`'s docstring).
+
+Scope: maps a live module into TransformerBridge. Does not load
+checkpoints, merge tensor-parallel shards, or depend on a training
+framework.
+
+Required module protocol -- "lightweight decoder-only pretraining models"
+describes intent, not a generality guarantee. The wrapped model must
+expose:
+
+    model.embed                          (embedding lookup)
+    model.blocks[i].norm1                (pre-attention norm)
+    model.blocks[i].attn                 (called as attn(x, ...))
+    model.blocks[i].norm2                (pre-MLP norm)
+    model.blocks[i].mlp                  (gate/up/down, or router/experts)
+    model.norm_f                         (final norm)
+    model.lm_head                        (unembedding)
+
+`gate`/`up`/`down` and `router`/`experts` name the supported protocol.
+`DenseOrMoEFeedForwardBridge` checks these structurally -- attribute
+presence plus basic type (each is a module, `experts` is a registered
+module collection) -- and raises clearly on a mismatch, but that is
+structural validation only: it does not and cannot validate that a
+module satisfying the shape actually implements matching forward
+semantics. Blocks must take more than the bare hidden state (this target
+passes `cos`/`sin`) -- see `PretrainModelContainer`.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+from transformer_lens.model_bridge.bridge import TransformerBridge
+from transformer_lens.model_bridge.generalized_components import (
+    AttentionBridge,
+    DelegatedAttentionBlockBridge,
+    EmbeddingBridge,
+    GatedMLPBridge,
+    LinearBridge,
+    MoEBridge,
+    RMSNormalizationBridge,
+    UnembeddingBridge,
+)
+from transformer_lens.model_bridge.generalized_components.base import (
+    GeneralizedComponent,
+)
+
+ARCHITECTURE_NAME = "TransformerLensPretrain"
+
+# Reserved bridge kwargs removed before forwarding to the wrapped model.
+# Only known bridge-compatibility kwargs are stripped so genuine caller
+# mistakes (e.g. `target=` vs `targets=`) still raise naturally, and no
+# signature introspection is needed to support an arbitrary forward.
+_BRIDGE_COMPAT_KWARGS = frozenset({"output_attentions"})
+
+
+class DenseOrMoEFeedForwardBridge(GeneralizedComponent):
+    """Wraps either a dense SwiGLU MLP or a sparse MoE layer behind a
+    common interface. Dispatch is determined by structural inspection
+    (`router`/`experts` vs `gate`/`up`/`down`) rather than configuration,
+    so dense, MoE, and mixed architectures all use the same component
+    mapping. This identifies the supported protocol -- it does not
+    validate that a module merely sharing those attribute names actually
+    implements the matching forward behavior.
+
+    `hasattr` alone would let a module with, say, both `router`/`experts`
+    and `gate`/`up`/`down` (or `router`/`experts` of the wrong types) win
+    the MoE branch by attribute-name coincidence and fail later with a
+    confusing error from deep inside `MoEBridge`, or not fail until
+    forward time. `set_original_component` therefore also checks the
+    basic shape of whichever protocol wins: `router`/`gate`/`up`/`down`
+    must themselves be modules, and `experts` must be a *registered*
+    module collection (`nn.ModuleList`/`nn.ModuleDict`) -- a plain Python
+    list/tuple of `nn.Module` experts is rejected even though every
+    element is itself a valid module, because modules held in an
+    ordinary list aren't registered as children and would silently drop
+    out of `parameters()`/`state_dict()`/`.to(...)`/`train()`/`eval()`,
+    contradicting this adapter's lifecycle guarantees.
+    """
+
+    def __init__(self, name: str, config: Any):
+        super().__init__(name, config=config, submodules={})
+        self._delegate: GeneralizedComponent | None = None
+
+    def set_original_component(self, component: torch.nn.Module) -> None:
+        super().set_original_component(component)
+        # This subclass's own __init__ takes `name: str` (non-optional), so
+        # self.name is always a str here -- but the base GeneralizedComponent
+        # attribute is typed `str | None`, which is all mypy sees without this
+        # narrowing. MoEBridge/GatedMLPBridge both require a plain `str` name.
+        assert self.name is not None
+        if hasattr(component, "router") and hasattr(component, "experts"):
+            if not isinstance(component.router, torch.nn.Module):
+                raise TypeError(
+                    f"{type(component).__name__}.router must be an nn.Module; "
+                    f"got {type(component.router).__name__}."
+                )
+            if not isinstance(component.experts, (torch.nn.ModuleList, torch.nn.ModuleDict)):
+                raise TypeError(
+                    f"{type(component).__name__}.experts must be a registered "
+                    "module collection (nn.ModuleList or nn.ModuleDict); got "
+                    f"{type(component.experts).__name__}."
+                )
+            delegate: GeneralizedComponent = MoEBridge(
+                name=self.name,
+                config=self.config,
+                submodules={"gate": LinearBridge(name="router")},
+            )
+        elif hasattr(component, "gate") and hasattr(component, "up") and hasattr(component, "down"):
+            for field in ("gate", "up", "down"):
+                value = getattr(component, field)
+                if not isinstance(value, torch.nn.Module):
+                    raise TypeError(
+                        f"{type(component).__name__}.{field} must be an "
+                        f"nn.Module; got {type(value).__name__}."
+                    )
+            delegate = GatedMLPBridge(
+                name=self.name,
+                config=self.config,
+                submodules={
+                    "gate": LinearBridge(name="gate"),
+                    "in": LinearBridge(name="up"),
+                    "out": LinearBridge(name="down"),
+                },
+            )
+        else:
+            raise ValueError(
+                f"Block.mlp is a {type(component).__name__} with neither "
+                "an MoE layer's (router, experts) nor a gated MLP's "
+                "(gate, up, down) attributes -- this adapter doesn't know "
+                "how to wrap it."
+            )
+        delegate.set_original_component(component)
+        # Not `self._delegate = delegate`: normal registration would
+        # duplicate hook_in/hook_out under a nested `._delegate.` path,
+        # risking a broad hook selector firing twice.
+        # `_delegate` is an execution helper, absent from named_modules()
+        # -- safe since parameters/state_dict/dtype are read from the raw
+        # wrapped model (see PretrainModelContainer), not this tree.
+        object.__setattr__(self, "_delegate", delegate)
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        assert self._delegate is not None, f"{self.name}: original component not set"
+        if args:
+            args = (self.hook_in(args[0]),) + args[1:]
+        elif "hidden_states" in kwargs:
+            kwargs = {**kwargs, "hidden_states": self.hook_in(kwargs["hidden_states"])}
+        output = self._delegate(*args, **kwargs)
+
+        if isinstance(output, tuple):
+            if len(output) == 0:
+                raise TypeError(
+                    "DenseOrMoEFeedForwardBridge expected a non-empty tuple "
+                    "whose first element is a torch.Tensor"
+                )
+
+            first = output[0]
+
+            if not isinstance(first, torch.Tensor):
+                raise TypeError(
+                    "DenseOrMoEFeedForwardBridge expected the first tuple element "
+                    f"to be a torch.Tensor, got {type(first).__name__}"
+                )
+
+            hooked_first = self.hook_out(first)
+
+            # Preserve every auxiliary element without sending it through HookPoint.
+            return (hooked_first, *output[1:])
+
+        if not isinstance(output, torch.Tensor):
+            raise TypeError(
+                "DenseOrMoEFeedForwardBridge expected a torch.Tensor or a tuple "
+                f"whose first element is a torch.Tensor, got {type(output).__name__}"
+            )
+
+        return self.hook_out(output)
+
+
+class _LogitsAttrDict(dict):
+    """Makes a plain dict's keys accessible as attributes (`d.logits` reads
+    `d["logits"]`), so a source model's plain-dict forward output satisfies
+    the `hasattr(output, "logits")` contract `TransformerBridge` expects.
+    Behaves as a plain dict everywhere else (indexing, `.get`, `in`, ...).
+    """
+
+    def __getattr__(self, key: str) -> Any:
+        try:
+            return self[key]
+        except KeyError as e:
+            raise AttributeError(key) from e
+
+
+class PretrainModelContainer(torch.nn.Module):
+    """Internal detail -- `build_pretrain_bridge` applies this
+    automatically. Three responsibilities, all in this container's own
+    `forward`:
+
+    1. Avoids a `TransformerBridge.__getattr__` collision: a source
+       model's own `self.embed`/`self.blocks` clashes with identically
+       named component_mapping keys. Wrapping one level deeper
+       (`container.inner.embed`) fixes this without touching the source
+       model.
+    2. Normalizes the return value to the `.logits` contract
+       `TransformerBridge` expects: a plain `"logits"` dict (the target
+       architecture's actual shape) is wrapped in `_LogitsAttrDict`; a bare
+       tensor, tensor-first tuple, or object already exposing `.logits`
+       passes through after validating the tensor is present and is a
+       tensor; anything else raises immediately with a clear message.
+    3. Strips `_BRIDGE_COMPAT_KWARGS` from kwargs before calling the
+       wrapped model (see that constant's comment).
+
+    Also sidesteps a `BlockBridge` convention where a bare-tensor block
+    output gets wrapped in a 1-tuple for "standalone hidden_states calls":
+    since this target's blocks take `cos`/`sin` too, that path never
+    triggers, so the source forward loop needs no changes to be bridged.
+
+    `self.inner` is a regular registered submodule, so
+    `container.train()`/`.eval()` already recurse into it via the normal
+    `nn.Module` traversal -- no override needed here. The propagation gap
+    lives one level up, at `TransformerBridge` itself (see
+    `build_pretrain_bridge`), whose `.train()`/`.eval()` do not walk down
+    to `original_model`.
+    """
+
+    def __init__(self, model: torch.nn.Module) -> None:
+        super().__init__()
+        self.inner = model
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        filtered = {k: v for k, v in kwargs.items() if k not in _BRIDGE_COMPAT_KWARGS}
+        output = self.inner(*args, **filtered)
+
+        # Already-normalized or already-HF-style outputs pass through
+        # unchanged, but only after checking .logits is actually a tensor
+        # -- an object merely exposing the attribute isn't enough.
+        if isinstance(output, _LogitsAttrDict):
+            if "logits" not in output:
+                raise ValueError(
+                    f"{type(self.inner).__name__}.forward returned a "
+                    "_LogitsAttrDict without a 'logits' key."
+                )
+            if not isinstance(output["logits"], torch.Tensor):
+                raise TypeError(
+                    f"{type(self.inner).__name__}.forward returned a "
+                    f"_LogitsAttrDict with a non-tensor 'logits' value: "
+                    f"{type(output['logits']).__name__}."
+                )
+            return output
+
+        # try/except, not hasattr(): hasattr() would evaluate a
+        # property-backed .logits once, then a separate read would
+        # evaluate it again. This reads it exactly once.
+        try:
+            logits = output.logits
+        except AttributeError:
+            pass
+        else:
+            if not isinstance(logits, torch.Tensor):
+                raise TypeError(
+                    f"{type(self.inner).__name__}.forward returned a "
+                    f"{type(output).__name__} with a non-tensor .logits value: "
+                    f"{type(logits).__name__}."
+                )
+            return output
+
+        if isinstance(output, torch.Tensor):
+            return output
+
+        # TransformerBridge extracts output[0] as logits for tuple returns.
+        if isinstance(output, tuple):
+            if output and isinstance(output[0], torch.Tensor):
+                return output
+            raise TypeError(
+                f"{type(self.inner).__name__}.forward returned a tuple whose "
+                f"first element is a {type(output[0]).__name__ if output else 'empty tuple'}, "
+                "not a torch.Tensor -- TransformerBridge extracts output[0] as "
+                "logits for tuple returns, so it must be a tensor."
+            )
+
+        # The primary case: a plain dict, normalized into _LogitsAttrDict.
+        if isinstance(output, dict):
+            if "logits" not in output:
+                raise ValueError(
+                    f"{type(self.inner).__name__}.forward returned a dict with keys "
+                    # list(), not sorted(): sorted() raises TypeError on
+                    # heterogeneous keys, which would mask this error.
+                    f"{list(output.keys())}, but PretrainModelContainer requires a "
+                    "'logits' key -- without it, TransformerBridge's own "
+                    "hasattr(output, 'logits') check would silently fail the same "
+                    "way this container exists to prevent."
+                )
+            if not isinstance(output["logits"], torch.Tensor):
+                raise TypeError(
+                    f"{type(self.inner).__name__}.forward returned a dict whose "
+                    f"'logits' value is a {type(output['logits']).__name__}, not a "
+                    "torch.Tensor."
+                )
+            return _LogitsAttrDict(output)
+
+        raise TypeError(
+            f"{type(self.inner).__name__}.forward must return a torch.Tensor, a "
+            "tuple whose first element is a tensor, a dict containing a "
+            "tensor-valued 'logits' key, or an object with a tensor-valued "
+            f".logits attribute; got {type(output).__name__}."
+        )
+
+
+class NativeForwardAttentionBridge(AttentionBridge):
+    """Opaque attention bridge that delegates to the source attention.
+
+    This adapter intentionally exposes only input/output attention hooks.
+    It has no mapped Q/K/V/O projection components, so the standard
+    per-head aliases and weight aliases do not apply.
+    """
+
+    hook_aliases = {}
+    property_aliases = {}
+    supports_split_qkv_fork = False
+
+
+class PretrainArchitectureAdapter(ArchitectureAdapter):
+    """Adapter for a decoder-only transformer using RoPE, RMSNorm, gated
+    SwiGLU MLPs, and optional sparse MoE feed-forward layers.
+
+    Uses an opaque `NativeForwardAttentionBridge` with no attention
+    projection submodules, not `JointQKVAttentionBridge`/
+    `PositionEmbeddingsAttentionBridge`: those reimplement RoPE via HF's
+    rotate-half convention, wrong for a source model using the
+    adjacent-pair convention. The opaque bridge delegates unchanged to
+    `Attention.forward`, so RoPE runs as written -- at the cost of no
+    per-head hooks, only block-level
+    `resid_pre`/`resid_mid`/`resid_post`.
+
+    Blocks use `DelegatedAttentionBlockBridge` rather than plain
+    `BlockBridge`: that existing abstraction already exists for
+    architectures where attention is delegated wholesale and the
+    split-qkv-fork block-level aliases (`hook_attn_in`/`hook_q_input`/
+    `hook_k_input`/`hook_v_input`) don't apply. It complements
+    `NativeForwardAttentionBridge.supports_split_qkv_fork = False` (which
+    prevents the split-QKV-fork machinery and its associated HookPoints
+    from being exposed for this attention component) by also removing the
+    now-dangling block-level aliases that would otherwise point at them.
+    `hook_attn_out` is untouched by either change, since the attention
+    component still fires its own `hook_out` normally.
+
+    `self.cfg` is mutated in place, not copied (matches `nanogpt.py`'s
+    convention) -- callers holding another reference to the same config
+    will see these fields change.
+
+    Bridges built through `build_pretrain_bridge` are given a
+    mode-propagating subclass so `.train()`/`.eval()` reach the wrapped
+    source model (see that function's docstring) -- this adapter class
+    itself has no lifecycle behavior of its own.
+    """
+
+    def __init__(self, cfg: Any) -> None:
+        super().__init__(cfg)
+
+        self.cfg.normalization_type = "RMS"
+        self.cfg.positional_embedding_type = "rotary"
+        self.cfg.final_rms = True
+        self.cfg.gated_mlp = True
+        self.cfg.attn_only = False
+
+        self.component_mapping = {
+            # "inner." because this adapter expects the source model to
+            # arrive wrapped in `PretrainModelContainer` -- see that
+            # class's docstring for why.
+            "embed": EmbeddingBridge(name="inner.embed"),
+            "blocks": DelegatedAttentionBlockBridge(
+                name="inner.blocks",
+                config=self.cfg,
+                submodules={
+                    "ln1": RMSNormalizationBridge(name="norm1", config=self.cfg),
+                    "attn": NativeForwardAttentionBridge(
+                        name="attn",
+                        config=self.cfg,
+                        submodules={},  # opaque wrap -- see class docstring
+                    ),
+                    "ln2": RMSNormalizationBridge(name="norm2", config=self.cfg),
+                    "mlp": DenseOrMoEFeedForwardBridge(name="mlp", config=self.cfg),
+                },
+            ),
+            "ln_final": RMSNormalizationBridge(name="inner.norm_f", config=self.cfg),
+            "unembed": UnembeddingBridge(name="inner.lm_head"),
+        }
+
+
+def build_pretrain_bridge(
+    model: torch.nn.Module,
+    cfg: TransformerBridgeConfig,
+    *,
+    device: Any = None,
+    dtype: torch.dtype | None = None,
+    model_name: str | None = None,
+) -> TransformerBridge:
+    """Public entry point: wraps `model` in `PretrainModelContainer` and
+    builds a `TransformerBridge` around it. Prefer this over calling
+    `build_bridge_from_module` directly -- the container is easy to forget.
+
+    `device`/`dtype`/`model_name` forward to `build_bridge_from_module`
+    only when explicitly given.
+
+    `bridge.train()`/`.eval()` propagate to `model` via
+    `TransformerBridge.train()` itself, which sets mode on
+    `original_model` in addition to the registered module tree
+    (`original_model` is deliberately not a registered submodule, so
+    `nn.Module.train()`'s own recursion never reaches it). This adapter
+    needs nothing extra for mode propagation.
+
+    Setting mode on `model` directly still works too and stays in sync.
+    """
+    from transformer_lens.model_bridge.sources._bridge_builder import (
+        build_bridge_from_module,
+    )
+
+    kwargs: dict[str, Any] = {}
+    if device is not None:
+        kwargs["device"] = device
+    if dtype is not None:
+        kwargs["dtype"] = dtype
+    if model_name is not None:
+        kwargs["model_name"] = model_name
+
+    return build_bridge_from_module(
+        PretrainModelContainer(model),
+        architecture=ARCHITECTURE_NAME,
+        tl_config=cfg,
+        **kwargs,
+    )


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.
Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.
If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Summary

Adds an interoperability adapter for live model modules loaded from
lightweight decoder-only pretraining checkpoints (RoPE, RMSNorm, SwiGLU,
optional MoE), enabling mechanistic interpretability experiments on
models trained from scratch.

Rather than converting checkpoints into a separate TransformerLens
implementation, the adapter wraps the existing module and delegates
execution to its native `forward`, preserving the source model's semantics
(including RoPE conventions) while exposing the standard TransformerBridge
interface.

## Motivation

Interpretability research on small from-scratch models (circuit discovery,
induction heads, toy superposition models, controlled probing) needs
precise control over architecture, data, and checkpoints. This PR adds
that interoperability path: train a small decoder-only transformer, wrap
it with `build_pretrain_bridge`, confirm the wrapping is transparent (the
bridge delegates to and matches the source model's own forward exactly,
rather than running a separately reimplemented TransformerLens forward),
then use TransformerLens's caching, hooks, and patching. The goal is
architecture interoperability, not a general-purpose training framework.

## What changed

- **`PretrainArchitectureAdapter`**
  (`transformer_lens/model_bridge/supported_architectures/pretrain.py`)
  maps token embeddings, decoder blocks (RoPE attention, RMSNorm, gated
  SwiGLU MLP), final norm, and tied/untied unembedding.
- **`DenseOrMoEFeedForwardBridge`** dispatches each block's MLP
  structurally (`router` + `experts` versus `gate` + `up` + `down`), so
  dense, MoE, and mixed models use the same component mapping.
- The selected delegate is excluded from normal module registration to
  prevent duplicate named hook points. Structural validation requires
  projection/router fields to be modules and `experts` to be a registered
  `ModuleList` or `ModuleDict`, producing clear construction-time errors
  for unsupported module shapes.
- **`build_pretrain_bridge(model, cfg)`**: the public entry point. Wraps
  the source model, normalizes its output contract, and ensures bridge
  mode changes propagate to the source model (see Scope boundaries).
  Direct `build_bridge_from_module` use still works for advanced cases.
- Registered `"SwiGLUMoEForCausalLM"` in `SUPPORTED_ARCHITECTURES` and
  `INTENTIONAL_EXCLUDES` (no HF Hub checkpoint backs it).
- Config mutation: like `nanogpt.py`, the adapter mutates the passed-in
  `cfg` in place rather than copying it.
- Unit tests split by concern: `test_pretrain_adapter.py` (mapping,
  dispatch, tied embeddings) and `test_pretrain_model_container.py`
  (container, kwarg filtering, output normalization, hooks, train/eval,
  dtype, persistence -- see Scope boundaries), sharing mocks from
  `_pretrain_mocks.py`. Integration tests use a
  real reference model (`tests/mocks/tiny_pretrain_model.py`) with genuine
  adjacent-pair RoPE/RMSNorm math for logit and hook-placement parity
  (see the integration test module docstring for the caveat on what
  logit parity does and doesn't prove).
- **`MoEBridge` defensive validation:** added validation for tuple
  outputs -- rejecting empty tuples and non-tensor first elements with a
  clear `TypeError` (instead of a lower-level `HookPoint` type-check
  error), and guarding `hook_router_scores` so it is only invoked for
  tensor-valued router scores. Covered directly by new `MoEBridge` tests
  (empty tuple, non-tensor first element, non-tensor metadata preserved
  without firing the router hook, tensor router scores still firing it),
  not just indirectly through the pretrain adapter's tests. This is a
  small compatibility and error-reporting improvement discovered while
  integrating the pretrain adapter and does not change the behavior of
  standard `(hidden_states, router_scores)` MoE outputs.

## Supported behavior

`build_pretrain_bridge()` wraps the supplied model in place. Callers that
need a raw source-model checkpoint should capture its `state_dict()`
before bridge construction.

Requires a specific module protocol (documented in the adapter file's
docstring) rather than any decoder-only architecture generally. Within
that protocol:

- preserves the source model's rotary convention for native-forward
  execution, since the adapter delegates rather than reimplementing it —
  the tradeoff is that this adapter does not expose per-head attention
  hooks (`hook_q`/`hook_k`/`hook_v`/`hook_pattern`);
- RMS norm + gated SwiGLU MLP, dense/MoE/mixed, dispatched structurally;
- tied or untied embeddings; `forward` with or without a `**kwargs`
  catch-all (only `output_attentions` is stripped — anything else,
  including a caller typo, passes through and raises naturally);
- output as a `"logits"` dict, tensor, tensor-first tuple, or
  `.logits`-exposing object, all validated, with clear errors on
  malformed shapes.

## Container wrapping

`PretrainModelContainer` resolves attribute-name collisions with
`TransformerBridge` and normalizes output to the `.logits` contract
(raising immediately on missing/malformed output). Full mechanics are in
the class docstring. Kept local rather than generalizing
`TransformerBridge`'s output handling, to keep this PR architecture-scoped
— a candidate for later centralization, not addressed here.

The dense/MoE delegate is excluded from the public module tree to avoid
duplicate hook points; forward execution, gradients, dtype/device
conversion, `state_dict`-based reconstruction, hook lifecycle, and (via a
small generated subclass) train/eval mode all still reach the wrapped
source model — see Scope boundaries for why train/eval needed a
workaround here.

## Hook coverage

Block-level hooks only (`resid_pre`/`resid_mid`/`resid_post`, MLP
`hook_in`/`hook_out`) — no per-head `hook_q`/`hook_k`/`hook_v`/
`hook_pattern`. TransformerLens's HF-oriented attention bridges use
rotate-half RoPE, which does not match this adapter's adjacent-pair
convention and would break numerical equivalence, so it uses a plain
`AttentionBridge` delegating to the source model's own attention instead.
Per-head hooks would need a new attention bridge built for that
convention.

## Scope boundaries

No training loop, optimizers/schedules, dataset/tokenizer infrastructure,
experiment tracking, distributed training, or checkpoint-shard
reconstruction — those stay with the source framework. This PR only adds
the TransformerBridge mapping and its tests.

Worth flagging for discussion: `build_pretrain_bridge` reassigns
`bridge.__class__` to propagate train/eval mode (see code comments).
Reassigning `__class__` at runtime is unconventional; a
`TransformerBridge.train()` fix upstream would be cleaner if maintainers
are open to that scope.

Persistence is tested by saving the source model's pre-bridge
`state_dict`, reconstructing the source model and bridge from
configuration, and verifying output and mode-propagation equivalence.
Whole-object pickling is not asserted because it depends on unrelated
`TransformerBridge` internals, including locally defined attention
hook-conversion classes. A standardized `TransformerBridge` checkpoint
interface could provide a stable, versioned save/load contract,
improving usability and scalability without requiring whole-object
serialization.

## Testing

```bash
python -m pytest tests/unit/model_bridge/supported_architectures/test_pretrain_adapter.py -v
python -m pytest tests/unit/model_bridge/supported_architectures/test_pretrain_model_container.py -v
python -m pytest tests/integration/model_bridge/test_pretrain_adapter.py -v
python -m pytest tests/unit/model_bridge/generalized_components/test_moe_bridge_tuple_output.py -v
python -m pytest tests/unit/tools/test_model_registry.py -k TestRegistrySyncedWithFactory -v
```

Locally: 77 tests passed (26 adapter unit, 34 container unit, 9
integration, 4 generalized-component unit tests (MoEBridge tuple-output
validation), and 4 registry-sync tests). Covers: component
mapping and MLP dispatch (dense/MoE/mixed, checking actual
`run_with_cache` keys, not just `isinstance`, plus basic
type validation when an attribute name matches the MoE/gated-MLP protocol
but the value doesn't); logit and residual-stream parity; that
integration fixtures supply a `cfg` truthfully describing the model they
build (`build_pretrain_bridge` itself performs no cfg-vs-model
validation, so a mismatch silently reports wrong numbers on `bridge.cfg`
-- see `TestIntegrationFixturesSupplyATruthfulConfig`); activation
caching and hook interventions; kwarg filtering and output-normalization
edge cases; hook registration, gradients, dtype/device, `state_dict`-based
reconstruction; train/eval mode propagation (a cached generated subclass,
rather than per-instance method closures); malformed-architecture errors;
`MoEBridge`'s own tuple-output validation and router-score hook gating
(empty tuple, non-tensor first element, non-tensor metadata preserved
without firing the hook, tensor router scores still firing it).

Exact logit parity mainly demonstrates that wrapping does not alter the
delegated forward; it does not independently establish that the source
RoPE implementation is correct. The residual-stream decomposition and
hook-intervention tests provide the stronger evidence on hook placement.

Numerical parity is tested at float32 on CPU; float64 is tested for
preservation through construction only, not full parity at that dtype.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!--
Example:
| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |
To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it
For example,
- [x] I have done this task
- [ ] I have not done this task
-->
