### PR TITLE
Fix Tracr demo output_label: compiled labels are auto-numbered

### DIFF
--- a/demos/Tracr_to_Transformer_Lens_Demo.ipynb
+++ b/demos/Tracr_to_Transformer_Lens_Demo.ipynb
@@ -147,7 +147,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Extract the state dict. The helper reconstructs Tracr's categorical unembed from the output basis labels, so it still works when the final RASP expression is explicitly named and its residual coordinates are not first."
+    "Extract the state dict. The helper reconstructs Tracr's categorical unembed from the output basis labels, so it still works when the final RASP expression is explicitly named and its residual coordinates are not first.\n",
+    "\n",
+    "Note that Tracr suffixes every label with a unique id — the expression named `reverse` compiles to residual labels like `reverse_1:1` — so we pass `reverse.label` rather than hardcoding the name. (Omitting `output_label` entirely also works: the helper infers it from the output encoder's value set.)"
    ]
   },
   {
@@ -157,7 +159,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "sd = make_tracr_transformer_bridge_state_dict(model, output_label=\"reverse\")\n",
+    "sd = make_tracr_transformer_bridge_state_dict(model, output_label=reverse.label)\n",
     "print(sd.keys())"
    ]
   },

--- a/tests/unit/test_tracr_conversion.py
+++ b/tests/unit/test_tracr_conversion.py
@@ -74,9 +74,9 @@ def _fake_tracr_model() -> SimpleNamespace:
             "aggregate_1:2",
             "aggregate_1:3",
             "indices:0",
-            "reverse:1",
-            "reverse:2",
-            "reverse:3",
+            "reverse_1:1",
+            "reverse_1:2",
+            "reverse_1:3",
             "tokens:BOS",
         ],
         output_encoder=_CategoricalEncoder({1: 0, 2: 1, 3: 2}),
@@ -94,7 +94,7 @@ def _fake_tracr_model() -> SimpleNamespace:
 def test_categorical_unembed_uses_named_output_basis():
     model = _fake_tracr_model()
 
-    unembed = make_tracr_categorical_unembed(model, output_label="reverse")
+    unembed = make_tracr_categorical_unembed(model, output_label="reverse_1")
 
     assert unembed.shape == (8, 3)
     np.testing.assert_array_equal(unembed[:4], np.zeros((4, 3)))
@@ -125,7 +125,7 @@ def test_bridge_state_dict_transposes_tracr_weights_and_reconstructs_unembed():
     model = _fake_tracr_model()
 
     state_dict = make_tracr_transformer_bridge_state_dict(
-        model, output_label="reverse", dtype=torch.float64
+        model, output_label="reverse_1", dtype=torch.float64
     )
 
     assert state_dict["tok_embed.weight"].shape == (5, 8)
@@ -161,4 +161,4 @@ def test_bridge_state_dict_rejects_layer_norm_tracr_models():
     model.model_config.layer_norm = True
 
     with pytest.raises(NotImplementedError, match="layer_norm=True"):
-        make_tracr_transformer_bridge_state_dict(model, output_label="reverse")
+        make_tracr_transformer_bridge_state_dict(model, output_label="reverse_1")

--- a/transformer_lens/utilities/tracr.py
+++ b/transformer_lens/utilities/tracr.py
@@ -19,7 +19,7 @@ from transformer_lens.config.transformer_bridge_config import TransformerBridgeC
 def infer_tracr_output_label(model: Any) -> str:
     """Infer the RASP output label used in ``model.residual_labels``.
 
-    Tracr stores residual basis labels as strings like ``"reverse:3"`` while
+    Tracr stores residual basis labels as strings like ``"reverse_1:3"`` while
     its categorical output encoder stores only values and output-column ids.
     The output label is the unique residual-label prefix whose value set exactly
     matches the output encoder's categorical value set.


### PR DESCRIPTION
# Description

The Tracr demo as shipped fails at its state-dict cell. Cell 11 passes `output_label="reverse"`, but Tracr builds labels as `f"{name}_{unique_id}"`, so the compiled expression's residual labels are `reverse_1:*` and `make_tracr_transformer_bridge_state_dict` raises:

```
ValueError: Could not find output basis label 'reverse:1' in model.residual_labels. Pass the final RASP expression label as output_label.
```

This is a follow-up to #1460 (the TransformerBridge port addressing #481): the conversion helpers there are correct, but the demo call site — and the unit-test fixture — assume the un-numbered label. The fixture in `tests/unit/test_tracr_conversion.py` hand-writes `residual_labels` containing `"reverse:1"` etc., a shape real Tracr never emits, which is why the tests pass while the demo doesn't run.

Three small changes, one concept (Tracr labels are auto-numbered; ask the expression for its label instead of hardcoding its name):

1. **Demo cell 11**: `output_label="reverse"` → `output_label=reverse.label`, plus a sentence in the preceding markdown cell explaining the auto-numbering (and that omitting `output_label` also works via `infer_tracr_output_label`).
2. **Test fixture**: `"reverse:*"` → `"reverse_1:*"` in `_fake_tracr_model()` and the matching `output_label` call sites, so the mock matches what the compiler actually produces. The ambiguity test still has two candidate prefixes (`aggregate_1`, `reverse_1`) and all positional assertions are unchanged.
3. **Docstring**: the `infer_tracr_output_label` example `"reverse:3"` → `"reverse_1:3"`.

Fixes #481.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

Run locally against this branch (Python 3.12, torch CPU, real `tracr` from `google-deepmind/tracr` — note the Tracr stack needs `jax<0.11`, since dm-haiku still references the removed `jax.core.DropVar`):

- `pytest tests/unit/test_tracr_conversion.py` — 5 passed.
- The demo's code path executed end-to-end as a script (compile the demo's RASP program → `TransformerBridge.boot_native` → load state dict → run): with `output_label="reverse"` it raises as above; with `output_label=reverse.label` **and** with `output_label` omitted, the Bridge decoding matches Tracr (`['BOS', 3, 2, 1]`) and every layer's attn/MLP `hook_out` matches Tracr's `layer_outputs` (`np.isclose(...).all()` per layer).

Prepared with AI assistance and human-reviewed; all validation runs above are real runs on the contributor's machine.
