### PR TITLE
Remove dead _last_input_before_norm write in NormalizationBridge

### DIFF
--- a/transformer_lens/model_bridge/generalized_components/normalization.py
+++ b/transformer_lens/model_bridge/generalized_components/normalization.py
@@ -77,7 +77,6 @@ class NormalizationBridge(GeneralizedComponent):
             )
         assert self.config is not None
         hidden_states = self.hook_in(hidden_states)
-        self._last_input_before_norm = hidden_states
         if self.use_native_layernorm_autograd:
             result = self._hf_autograd_forward_with_hooks(hidden_states)
         elif hasattr(self.config, "layer_norm_folding") and self.config.layer_norm_folding:


### PR DESCRIPTION
# Description

Dead-code cleanup split out of #1526 per maintainer request there (the bug fix itself is #1527, based on `main`).

`NormalizationBridge.forward` wrote `self._last_input_before_norm = hidden_states` on every call, but nothing in the repo has read that attribute since the #1129 cleanup. The write pins one `[batch, seq, d_model]` activation per norm module between forwards, and when the input has `requires_grad=True` it also keeps the upstream autograd graph alive, which is real memory overhead for anyone training through the bridge.

One-line deletion; a repo-wide grep confirms no remaining references. Note for merge ordering: #1527 touches the surrounding lines on `main`, so whichever lands second may need a trivial rebase when `main` syncs into `dev`. Happy to handle that.

The second observation from #1526 (the `layer_norm_folding` config flag is never set `True` anywhere, so its branch in `forward` appears unreachable) is deliberately NOT touched here: removing a public config field or its branch is a design decision I'd rather leave to maintainers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

Notes on the checklist:
- *Tests*: none added; this deletes an attribute that nothing reads, so there is no behavior to pin. `tests/unit/model_bridge/generalized_components/` passes locally (161 passed).
- *Docs*: the attribute was never documented.

*Drafted with the assistance of Claude (Anthropic's AI assistant), working under my direction.*
