### PR TITLE
feat(jacobian_lens): add artifact registry + short-name resolution in from_pretrained

### DIFF
--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -990,9 +990,9 @@ class TestRegistry:
                 continue
             assert "repo_id" in entry, f"Missing repo_id in entry '{key}'"
             assert "filename" in entry, f"Missing filename in entry '{key}'"
-            assert entry["filename"].endswith(".pt"), (
-                f"filename in '{key}' does not end with .pt: {entry['filename']}"
-            )
+            assert entry["filename"].endswith(
+                ".pt"
+            ), f"filename in '{key}' does not end with .pt: {entry['filename']}"
             assert "aliases" in entry, f"Missing aliases list in entry '{key}'"
 
     def test_resolve_registry_entry_by_short_name(self) -> None:
@@ -1152,7 +1152,5 @@ class TestRegistry:
         for name in ("gpt2-small", "gpt2", "openai-community/gpt2"):
             JacobianLens.from_pretrained(name)
 
-        assert len(set(filenames)) == 1, (
-            "All three aliases should resolve to the same filename"
-        )
+        assert len(set(filenames)) == 1, "All three aliases should resolve to the same filename"
         assert filenames[0].endswith("gpt2_jacobian_lens.pt")

--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -945,3 +945,208 @@ def test_exports() -> None:
 
     assert analysis.JacobianLens is JacobianLens
     assert hasattr(analysis, "JacobianLensReadout")
+
+
+# ---------------------------------------------------------------------------
+# Registry / from_pretrained short-name resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    """Tests for the bundled jacobian_lens_registry.json and its resolution helpers."""
+
+    def test_registry_is_valid_json_and_nonempty(self) -> None:
+        import json
+        import pathlib
+
+        path = (
+            pathlib.Path(__file__).parents[3]
+            / "transformer_lens"
+            / "tools"
+            / "analysis"
+            / "jacobian_lens_registry.json"
+        )
+        assert path.is_file(), f"Registry not found at {path}"
+        with path.open() as fh:
+            registry = json.load(fh)
+        model_entries = {k: v for k, v in registry.items() if not k.startswith("_")}
+        assert len(model_entries) >= 30, "Expected at least 30 model entries"
+
+    def test_registry_entries_have_required_fields(self) -> None:
+        import json
+        import pathlib
+
+        path = (
+            pathlib.Path(__file__).parents[3]
+            / "transformer_lens"
+            / "tools"
+            / "analysis"
+            / "jacobian_lens_registry.json"
+        )
+        with path.open() as fh:
+            registry = json.load(fh)
+        for key, entry in registry.items():
+            if key.startswith("_"):
+                continue
+            assert "repo_id" in entry, f"Missing repo_id in entry '{key}'"
+            assert "filename" in entry, f"Missing filename in entry '{key}'"
+            assert entry["filename"].endswith(".pt"), (
+                f"filename in '{key}' does not end with .pt: {entry['filename']}"
+            )
+            assert "aliases" in entry, f"Missing aliases list in entry '{key}'"
+
+    def test_resolve_registry_entry_by_short_name(self) -> None:
+        from transformer_lens.tools.analysis.jacobian_lens import _resolve_registry_entry
+
+        result = _resolve_registry_entry("gemma-2-2b")
+        assert result is not None
+        repo_id, filename = result
+        assert repo_id == "neuronpedia/jacobian-lens"
+        assert "gemma-2-2b" in filename
+        assert filename.endswith(".pt")
+
+    def test_resolve_registry_entry_by_hf_model_id(self) -> None:
+        from transformer_lens.tools.analysis.jacobian_lens import _resolve_registry_entry
+
+        result = _resolve_registry_entry("google/gemma-2-2b")
+        assert result is not None
+        repo_id, filename = result
+        assert repo_id == "neuronpedia/jacobian-lens"
+        assert "gemma-2-2b" in filename
+
+    def test_resolve_registry_entry_unknown_returns_none(self) -> None:
+        from transformer_lens.tools.analysis.jacobian_lens import _resolve_registry_entry
+
+        assert _resolve_registry_entry("not-a-real-model") is None
+        assert _resolve_registry_entry("some/unknown-repo") is None
+
+    def test_from_pretrained_resolves_short_name_via_registry(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """Short model name resolves to the registry's repo_id and filename."""
+        import huggingface_hub
+
+        path = tmp_path / "lens.pt"
+        _lens().save(str(path))
+        calls: dict[str, Any] = {}
+
+        def fake_download(**kwargs: Any) -> str:
+            raise AssertionError("Must use retry wrapper")
+
+        def fake_retry(function: Any, **kwargs: Any) -> str:
+            calls["kwargs"] = kwargs
+            return str(path)
+
+        monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake_download)
+        monkeypatch.setattr(jacobian_lens_module, "call_hf_with_retry", fake_retry)
+
+        JacobianLens.from_pretrained("gemma-2-2b")
+
+        assert calls["kwargs"]["repo_id"] == "neuronpedia/jacobian-lens"
+        assert "gemma-2-2b" in calls["kwargs"]["filename"]
+        assert calls["kwargs"]["filename"].endswith(".pt")
+
+    def test_from_pretrained_resolves_hf_model_id_via_registry(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """HF model ID alias resolves to the same artifact as the short name."""
+        import huggingface_hub
+
+        path = tmp_path / "lens.pt"
+        _lens().save(str(path))
+
+        short_calls: dict[str, Any] = {}
+        alias_calls: dict[str, Any] = {}
+
+        def make_fake_retry(store: dict[str, Any]):
+            def fake_retry(function: Any, **kwargs: Any) -> str:
+                store["kwargs"] = kwargs
+                return str(path)
+
+            return fake_retry
+
+        monkeypatch.setattr(huggingface_hub, "hf_hub_download", lambda **kw: None)
+
+        monkeypatch.setattr(
+            jacobian_lens_module, "call_hf_with_retry", make_fake_retry(short_calls)
+        )
+        JacobianLens.from_pretrained("gemma-2-2b")
+
+        monkeypatch.setattr(
+            jacobian_lens_module, "call_hf_with_retry", make_fake_retry(alias_calls)
+        )
+        JacobianLens.from_pretrained("google/gemma-2-2b")
+
+        assert short_calls["kwargs"]["filename"] == alias_calls["kwargs"]["filename"]
+        assert short_calls["kwargs"]["repo_id"] == alias_calls["kwargs"]["repo_id"]
+
+    def test_from_pretrained_unknown_name_falls_through_to_hub(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """An unrecognised name is forwarded to Hub as the repo_id (backward compat)."""
+        import huggingface_hub
+
+        path = tmp_path / "lens.pt"
+        _lens().save(str(path))
+        calls: dict[str, Any] = {}
+
+        def fake_retry(function: Any, **kwargs: Any) -> str:
+            calls["kwargs"] = kwargs
+            return str(path)
+
+        monkeypatch.setattr(huggingface_hub, "hf_hub_download", lambda **kw: None)
+        monkeypatch.setattr(jacobian_lens_module, "call_hf_with_retry", fake_retry)
+
+        custom_filename = "custom/path/lens.pt"
+        JacobianLens.from_pretrained("my-org/my-repo", filename=custom_filename)
+
+        assert calls["kwargs"]["repo_id"] == "my-org/my-repo"
+        assert calls["kwargs"]["filename"] == custom_filename
+
+    def test_from_pretrained_registry_ignores_explicit_filename_kwarg(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """When the registry resolves a name, the registry filename wins over the kwarg."""
+        import huggingface_hub
+
+        path = tmp_path / "lens.pt"
+        _lens().save(str(path))
+        calls: dict[str, Any] = {}
+
+        def fake_retry(function: Any, **kwargs: Any) -> str:
+            calls["kwargs"] = kwargs
+            return str(path)
+
+        monkeypatch.setattr(huggingface_hub, "hf_hub_download", lambda **kw: None)
+        monkeypatch.setattr(jacobian_lens_module, "call_hf_with_retry", fake_retry)
+
+        JacobianLens.from_pretrained("gemma-2-2b", filename="should-be-ignored.pt")
+
+        assert calls["kwargs"]["filename"] != "should-be-ignored.pt"
+        assert "gemma-2-2b" in calls["kwargs"]["filename"]
+
+    def test_gpt2_small_alias_resolves(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """Both 'gpt2' and 'openai-community/gpt2' are aliases for gpt2-small."""
+        import huggingface_hub
+
+        path = tmp_path / "lens.pt"
+        _lens().save(str(path))
+
+        filenames: list[str] = []
+
+        def fake_retry(function: Any, **kwargs: Any) -> str:
+            filenames.append(kwargs["filename"])
+            return str(path)
+
+        monkeypatch.setattr(huggingface_hub, "hf_hub_download", lambda **kw: None)
+        monkeypatch.setattr(jacobian_lens_module, "call_hf_with_retry", fake_retry)
+
+        for name in ("gpt2-small", "gpt2", "openai-community/gpt2"):
+            JacobianLens.from_pretrained(name)
+
+        assert len(set(filenames)) == 1, (
+            "All three aliases should resolve to the same filename"
+        )
+        assert filenames[0].endswith("gpt2_jacobian_lens.pt")

--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -996,7 +996,9 @@ class TestRegistry:
             assert "aliases" in entry, f"Missing aliases list in entry '{key}'"
 
     def test_resolve_registry_entry_by_short_name(self) -> None:
-        from transformer_lens.tools.analysis.jacobian_lens import _resolve_registry_entry
+        from transformer_lens.tools.analysis.jacobian_lens import (
+            _resolve_registry_entry,
+        )
 
         result = _resolve_registry_entry("gemma-2-2b")
         assert result is not None
@@ -1006,7 +1008,9 @@ class TestRegistry:
         assert filename.endswith(".pt")
 
     def test_resolve_registry_entry_by_hf_model_id(self) -> None:
-        from transformer_lens.tools.analysis.jacobian_lens import _resolve_registry_entry
+        from transformer_lens.tools.analysis.jacobian_lens import (
+            _resolve_registry_entry,
+        )
 
         result = _resolve_registry_entry("google/gemma-2-2b")
         assert result is not None
@@ -1015,7 +1019,9 @@ class TestRegistry:
         assert "gemma-2-2b" in filename
 
     def test_resolve_registry_entry_unknown_returns_none(self) -> None:
-        from transformer_lens.tools.analysis.jacobian_lens import _resolve_registry_entry
+        from transformer_lens.tools.analysis.jacobian_lens import (
+            _resolve_registry_entry,
+        )
 
         assert _resolve_registry_entry("not-a-real-model") is None
         assert _resolve_registry_entry("some/unknown-repo") is None

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -74,6 +74,45 @@ from transformer_lens.utilities.hf_utils import call_hf_with_retry
 
 TokenInput = Union[str, int]
 
+# ---------------------------------------------------------------------------
+# Registry helpers
+# ---------------------------------------------------------------------------
+
+_REGISTRY_CACHE: Optional[Dict[str, Any]] = None
+
+
+def _load_registry() -> Dict[str, Any]:
+    """Return the bundled artifact registry, loading it once on first call."""
+    global _REGISTRY_CACHE
+    if _REGISTRY_CACHE is None:
+        import json
+        import pathlib
+
+        registry_path = pathlib.Path(__file__).with_name("jacobian_lens_registry.json")
+        with registry_path.open() as fh:
+            _REGISTRY_CACHE = json.load(fh)
+    return _REGISTRY_CACHE
+
+
+def _resolve_registry_entry(name_or_path: str) -> Optional[Tuple[str, str]]:
+    """Return ``(repo_id, filename)`` if *name_or_path* matches the registry.
+
+    Matching is tried in two passes:
+    1. Direct key match against short model names (e.g. ``"gemma-2-2b"``).
+    2. Alias match against Hugging Face model IDs (e.g. ``"google/gemma-2-2b"``).
+
+    Returns ``None`` when there is no match so callers can fall through to the
+    generic Hub download path.
+    """
+    registry = _load_registry()
+    if name_or_path in registry:
+        entry = registry[name_or_path]
+        return entry["repo_id"], entry["filename"]
+    for entry in registry.values():
+        if isinstance(entry, dict) and name_or_path in entry.get("aliases", []):
+            return entry["repo_id"], entry["filename"]
+    return None
+
 # Fitting excludes early positions (attention sinks with atypical residual statistics)
 # and the final position (no next-token target), matching the reference implementation.
 DEFAULT_SKIP_FIRST_POSITIONS = 16
@@ -257,15 +296,33 @@ class JacobianLens:
         revision: Optional[str] = None,
         model: Any = None,
     ) -> "JacobianLens":
-        """Load a lens from a local path or a Hugging Face Hub repository.
+        """Load a lens from a local path, a short model name, or a Hub repo.
+
+        Resolution order
+        ----------------
+        1. **Local file** — if *name_or_path* is an existing ``.pt`` file,
+           load it directly.
+        2. **Local directory** — if *name_or_path* is a directory, load
+           ``<name_or_path>/<filename>``.
+        3. **Registry short name or HF model ID** — if *name_or_path* matches
+           a key or alias in the bundled ``jacobian_lens_registry.json`` (e.g.
+           ``"gemma-2-2b"`` or ``"google/gemma-2-2b"``), the corresponding
+           artifact in ``neuronpedia/jacobian-lens`` is fetched automatically.
+           The *filename* argument is ignored in this case because the registry
+           already encodes the correct subpath.
+        4. **Explicit Hub repo** — otherwise *name_or_path* is treated as a Hub
+           repo id and *filename* is used as-is, preserving full backward
+           compatibility (e.g. ``from_pretrained("neuronpedia/jacobian-lens",
+           filename="gpt2-small/jlens/...")``).
 
         Args:
-            name_or_path: A local ``.pt`` file, a local directory containing
-                ``filename``, or a Hub repo id such as
-                ``"neuronpedia/jacobian-lens"``.
-            filename: File (or subpath) inside the directory / Hub repo. Hub
-                repos host lenses for many models, e.g.
-                ``"gpt2-small/jlens/Salesforce-wikitext/gpt2_jacobian_lens.pt"``.
+            name_or_path: A local ``.pt`` file, a local directory, a short
+                model name such as ``"gemma-2-2b"`` or ``"llama3.1-8b"``, a
+                Hugging Face model ID such as ``"google/gemma-2-2b"``, or an
+                explicit Hub repo id paired with *filename*.
+            filename: File (or subpath) inside a local directory or an explicit
+                Hub repo.  Ignored when *name_or_path* resolves via the
+                registry.
             revision: Optional Hub revision (branch, tag, or commit) to pin.
                 When omitted, the Hub repository's mutable default branch is
                 followed; pin a commit hash for reproducible analyses.
@@ -274,6 +331,21 @@ class JacobianLens:
 
         Returns:
             The loaded (and, if ``model`` was given, validated) lens.
+
+        Examples::
+
+            # Short model name — no need to remember the HF subpath
+            lens = JacobianLens.from_pretrained("gemma-2-2b", model=model)
+
+            # HF model ID also works
+            lens = JacobianLens.from_pretrained("google/gemma-2-2b", model=model)
+
+            # Explicit Hub repo + subpath (backward-compatible)
+            lens = JacobianLens.from_pretrained(
+                "neuronpedia/jacobian-lens",
+                filename="gpt2-small/jlens/Salesforce-wikitext/gpt2_jacobian_lens.pt",
+                model=model,
+            )
         """
         import os
 
@@ -284,10 +356,16 @@ class JacobianLens:
         else:
             from huggingface_hub import hf_hub_download
 
+            resolved = _resolve_registry_entry(name_or_path)
+            if resolved is not None:
+                repo_id, resolved_filename = resolved
+            else:
+                repo_id, resolved_filename = name_or_path, filename
+
             local_path = call_hf_with_retry(
                 hf_hub_download,
-                repo_id=name_or_path,
-                filename=filename,
+                repo_id=repo_id,
+                filename=resolved_filename,
                 revision=revision,
             )
             lens = cls.load(local_path)

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -113,6 +113,7 @@ def _resolve_registry_entry(name_or_path: str) -> Optional[Tuple[str, str]]:
             return entry["repo_id"], entry["filename"]
     return None
 
+
 # Fitting excludes early positions (attention sinks with atypical residual statistics)
 # and the final position (no next-token target), matching the reference implementation.
 DEFAULT_SKIP_FIRST_POSITIONS = 16

--- a/transformer_lens/tools/analysis/jacobian_lens_registry.json
+++ b/transformer_lens/tools/analysis/jacobian_lens_registry.json
@@ -1,0 +1,225 @@
+{
+  "_comment": "Artifact registry for pre-fitted Jacobian Lens checkpoints hosted on neuronpedia/jacobian-lens (https://huggingface.co/neuronpedia/jacobian-lens). Keys are short model names accepted by JacobianLens.from_pretrained(); aliases lists the canonical Hugging Face model IDs that also resolve to the same entry. Generated from the repository's sibling list on 2026-07-23.",
+  "gemma-2-2b": {
+    "aliases": ["google/gemma-2-2b"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-2-2b/jlens/Salesforce-wikitext/gemma-2-2b_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-2-2b-it": {
+    "aliases": ["google/gemma-2-2b-it"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-2-2b-it/jlens/Salesforce-wikitext/gemma-2-2b-it_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-2-9b": {
+    "aliases": ["google/gemma-2-9b"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-2-9b/jlens/Salesforce-wikitext/gemma-2-9b_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-2-9b-it": {
+    "aliases": ["google/gemma-2-9b-it"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-2-9b-it/jlens/Salesforce-wikitext/gemma-2-9b-it_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-2-27b": {
+    "aliases": ["google/gemma-2-27b"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-2-27b/jlens/Salesforce-wikitext/gemma-2-27b_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-270m": {
+    "aliases": [],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-270m/jlens/Salesforce-wikitext/gemma-3-270m_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-270m-it": {
+    "aliases": [],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-270m-it/jlens/Salesforce-wikitext/gemma-3-270m-it_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-1b": {
+    "aliases": ["google/gemma-3-1b-pt"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-1b/jlens/Salesforce-wikitext/gemma-3-1b-pt_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-1b-it": {
+    "aliases": ["google/gemma-3-1b-it"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-1b-it/jlens/Salesforce-wikitext/gemma-3-1b-it_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-4b": {
+    "aliases": ["google/gemma-3-4b-pt"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-4b/jlens/Salesforce-wikitext/gemma-3-4b-pt_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-4b-it": {
+    "aliases": ["google/gemma-3-4b-it"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-4b-it/jlens/Salesforce-wikitext/gemma-3-4b-it_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-12b": {
+    "aliases": ["google/gemma-3-12b-pt"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-12b/jlens/Salesforce-wikitext/gemma-3-12b-pt_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-12b-it": {
+    "aliases": ["google/gemma-3-12b-it"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-12b-it/jlens/Salesforce-wikitext/gemma-3-12b-it_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-27b": {
+    "aliases": ["google/gemma-3-27b-pt"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-27b/jlens/Salesforce-wikitext/gemma-3-27b-pt_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-3-27b-it": {
+    "aliases": ["google/gemma-3-27b-it"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-3-27b-it/jlens/Salesforce-wikitext/gemma-3-27b-it_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-4-31b": {
+    "aliases": ["google/gemma-4-31b"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-4-31b/jlens/Salesforce-wikitext/gemma-4-31B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-4-e2b": {
+    "aliases": ["google/gemma-4-e2b"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-4-e2b/jlens/Salesforce-wikitext/gemma-4-E2B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gemma-4-e4b": {
+    "aliases": ["google/gemma-4-e4b"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gemma-4-e4b/jlens/Salesforce-wikitext/gemma-4-E4B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gpt2-small": {
+    "aliases": ["gpt2", "openai-community/gpt2"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gpt2-small/jlens/Salesforce-wikitext/gpt2_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "gpt-oss-20b": {
+    "aliases": [],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "gpt-oss-20b/jlens/Salesforce-wikitext/gpt-oss-20b_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "llama3.1-8b": {
+    "aliases": ["meta-llama/Llama-3.1-8B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "llama3.1-8b/jlens/Salesforce-wikitext/Llama-3.1-8B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "llama3.1-8b-it": {
+    "aliases": ["meta-llama/Llama-3.1-8B-Instruct"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "llama3.1-8b-it/jlens/Salesforce-wikitext/Llama-3.1-8B-Instruct_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "llama3.3-70b-it": {
+    "aliases": ["meta-llama/Llama-3.3-70B-Instruct"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "llama3.3-70b-it/jlens/Salesforce-wikitext/Llama-3.3-70B-Instruct_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "olmo-3-1025-7b": {
+    "aliases": ["allenai/OLMo-3-1025-7B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "olmo-3-1025-7b/jlens/Salesforce-wikitext/Olmo-3-1025-7B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "olmo-3-1125-32b": {
+    "aliases": ["allenai/OLMo-3-1125-32B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "olmo-3-1125-32b/jlens/Salesforce-wikitext/Olmo-3-1125-32B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "pythia-70m-deduped": {
+    "aliases": ["EleutherAI/pythia-70m-deduped"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "pythia-70m-deduped/jlens/Salesforce-wikitext/pythia-70m-deduped_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen2.5-7b-it": {
+    "aliases": ["Qwen/Qwen2.5-7B-Instruct"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen2.5-7b-it/jlens/Salesforce-wikitext/Qwen2.5-7B-Instruct_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3-1.7b": {
+    "aliases": ["Qwen/Qwen3-1.7B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3-1.7b/jlens/Salesforce-wikitext/Qwen3-1.7B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3-4b": {
+    "aliases": ["Qwen/Qwen3-4B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3-4b/jlens/Salesforce-wikitext/Qwen3-4B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3-8b": {
+    "aliases": ["Qwen/Qwen3-8B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3-8b/jlens/Salesforce-wikitext/Qwen3-8B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3-14b": {
+    "aliases": ["Qwen/Qwen3-14B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3-14b/jlens/Salesforce-wikitext/Qwen3-14B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3-32b": {
+    "aliases": ["Qwen/Qwen3-32B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3-32b/jlens/Salesforce-wikitext/Qwen3-32B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3.5-0.8b": {
+    "aliases": ["Qwen/Qwen3.5-0.8B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3.5-0.8b/jlens/Salesforce-wikitext/Qwen3.5-0.8B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3.5-2b-pt": {
+    "aliases": ["Qwen/Qwen3.5-2B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3.5-2b-pt/jlens/Salesforce-wikitext/Qwen3.5-2B-Base_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3.5-4b": {
+    "aliases": ["Qwen/Qwen3.5-4B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3.5-4b/jlens/Salesforce-wikitext/Qwen3.5-4B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3.5-9b-pt": {
+    "aliases": ["Qwen/Qwen3.5-9B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3.5-9b-pt/jlens/Salesforce-wikitext/Qwen3.5-9B-Base_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  },
+  "qwen3.5-27b": {
+    "aliases": ["Qwen/Qwen3.5-27B"],
+    "repo_id": "neuronpedia/jacobian-lens",
+    "filename": "qwen3.5-27b/jlens/Salesforce-wikitext/Qwen3.5-27B_jacobian_lens.pt",
+    "corpus": "Salesforce-wikitext"
+  }
+}


### PR DESCRIPTION
Closes #1536.

## What

Adds `jacobian_lens_registry.json` bundling 37 pre-fitted J-lens artifacts from `neuronpedia/jacobian-lens`, and teaches `JacobianLens.from_pretrained` to resolve short model names and Hugging Face model IDs automatically.

**Before** (users had to know the full Hub subpath):
```python
JacobianLens.from_pretrained(
    "neuronpedia/jacobian-lens",
    filename="gemma-2-2b/jlens/Salesforce-wikitext/gemma-2-2b_jacobian_lens.pt",
)
```

**After** (both of these work):
```python
JacobianLens.from_pretrained("gemma-2-2b")
JacobianLens.from_pretrained("google/gemma-2-2b")
```

## Resolution order

1. Local `.pt` file — unchanged
2. Local directory — unchanged
3. Registry short name or HF model ID alias — resolved to `neuronpedia/jacobian-lens` + exact subpath
4. Explicit Hub repo + `filename` kwarg — unchanged (fully backward-compatible)

## Registry coverage (37 models)

- Gemma 2 (2b / 9b / 27b, base + instruct)
- Gemma 3 (270m / 1b / 4b / 12b / 27b, base + instruct)
- Gemma 4 (31b / e2b / e4b)
- GPT-2 Small (aliases: `gpt2`, `openai-community/gpt2`), GPT-OSS 20B
- Llama 3.1 (8b base + instruct), Llama 3.3 (70b instruct)
- OLMo 3 (7b / 32b), Pythia 70M-deduped
- Qwen 2.5 (7b-it), Qwen 3 (1.7b / 4b / 8b / 14b / 32b), Qwen 3.5 (0.8b / 2b / 4b / 9b / 27b)

The registry JSON is generated from `neuronpedia/jacobian-lens` sibling list and includes the exact filenames (including the naming irregularities in Gemma 3 base `-pt` suffix and Gemma 4 uppercase size suffix).

## Tests

9 new unit tests in `TestRegistry`:
- Registry JSON validity and required-field checks
- `_resolve_registry_entry` by short name and by HF model ID alias
- Unknown model returns `None` (passthrough to explicit Hub path)
- `from_pretrained` short-name resolution end-to-end
- `from_pretrained` HF alias → same artifact as short name
- Unknown name forwards repo_id + filename kwargs unchanged (backward compat)
- Registry filename wins over explicit `filename` kwarg when name resolves
- GPT-2's three entry points (`gpt2-small` / `gpt2` / `openai-community/gpt2`) all resolve to the same file