### PR TITLE
fix(release): publish with uv instead of twine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Build
         run: uv build
       - name: Publish
-        run: |
-          uv pip install twine
-          uv run twine upload --non-interactive -u __token__ -p "$PYPI_TOKEN_PYPI" dist/*
+        # uv-native publish: no twine, so no ad-hoc install for `uv run` to
+        # re-sync back to locked (older) dependency versions mid-publish.
+        run: uv publish --token "$PYPI_TOKEN_PYPI"
         env:
           PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN_PYPI }}


### PR DESCRIPTION
The Publish step installed twine ad hoc, then `uv run` re-synced the project env to uv.lock, downgrading packaging below twine 7's floor and crashing on `from packaging import errors` (v3.6.0 release run). uv publish uses the dists from `uv build` directly, with no extra installs for the implicit sync to revert.