### PR TITLE
fix(bridge): add audio-specific guard for start_at_layer

### DIFF
--- a/tests/unit/model_bridge/test_audio_start_at_layer_guard.py
+++ b/tests/unit/model_bridge/test_audio_start_at_layer_guard.py
@@ -1,10 +1,17 @@
 """Tests for audio model start_at_layer guard."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from transformer_lens.config import TransformerBridgeConfig
 from transformer_lens.model_bridge import TransformerBridge
+
+
+class _NoParameterDriver:
+    def supports(self, name: str) -> bool:
+        return False
 
 
 class TestAudioStartAtLayerGuard:
@@ -40,17 +47,36 @@ class TestAudioStartAtLayerGuard:
             architecture="GPT2LMHeadModel",
         )
 
-    def test_audio_model_start_at_layer_raises_specific_error(self, audio_bridge_cfg):
-        """Test that start_at_layer on audio model raises audio-specific NotImplementedError."""
+    @pytest.fixture
+    def audio_bridge(self, audio_bridge_cfg: TransformerBridgeConfig) -> TransformerBridge:
         bridge = TransformerBridge.__new__(TransformerBridge)
         bridge.cfg = audio_bridge_cfg
+        bridge._hook_registry = {}
+        bridge._hook_registry_initialized = True
+        bridge.compatibility_mode = False
+        bridge.adapter = SimpleNamespace(supports_hf_output_attentions=False)
+        bridge._driver = _NoParameterDriver()
+        return bridge
 
-        resid = torch.zeros(1, 8, audio_bridge_cfg.d_model)
+    @pytest.mark.parametrize("runner", ["forward", "run_with_cache", "run_with_hooks"])
+    def test_audio_model_start_at_layer_raises_specific_error(
+        self,
+        audio_bridge: TransformerBridge,
+        runner: str,
+    ) -> None:
+        """Test that start_at_layer on audio model raises via public execution helpers."""
+        resid = torch.zeros(1, 8, audio_bridge.cfg.d_model)
 
-        with pytest.raises(NotImplementedError, match="not supported for audio models"):
-            bridge.forward(resid, start_at_layer=2)
+        with pytest.raises(
+            NotImplementedError,
+            match="not supported for audio models",
+        ):
+            getattr(audio_bridge, runner)(resid, start_at_layer=2)
 
-    def test_non_audio_model_start_at_layer_raises_blocks_error(self, non_audio_bridge_cfg):
+    def test_non_audio_model_start_at_layer_raises_blocks_error(
+        self,
+        non_audio_bridge_cfg: TransformerBridgeConfig,
+    ) -> None:
         """Test that start_at_layer on non-audio model raises the generic blocks error."""
         bridge = TransformerBridge.__new__(TransformerBridge)
         bridge.cfg = non_audio_bridge_cfg
@@ -60,22 +86,22 @@ class TestAudioStartAtLayerGuard:
         with pytest.raises(NotImplementedError, match="requires a 'blocks' stack"):
             bridge.forward(resid, start_at_layer=2)
 
-    def test_audio_error_message_mentions_convolutional(self, audio_bridge_cfg):
+    def test_audio_error_message_mentions_convolutional(
+        self,
+        audio_bridge: TransformerBridge,
+    ) -> None:
         """Test that the audio-specific error mentions convolutional feature extraction."""
-        bridge = TransformerBridge.__new__(TransformerBridge)
-        bridge.cfg = audio_bridge_cfg
-
-        resid = torch.zeros(1, 8, audio_bridge_cfg.d_model)
+        resid = torch.zeros(1, 8, audio_bridge.cfg.d_model)
 
         with pytest.raises(NotImplementedError, match="convolutional feature"):
-            bridge.forward(resid, start_at_layer=2)
+            audio_bridge.forward(resid, start_at_layer=2)
 
-    def test_audio_error_message_mentions_residual_injection(self, audio_bridge_cfg):
+    def test_audio_error_message_mentions_residual_injection(
+        self,
+        audio_bridge: TransformerBridge,
+    ) -> None:
         """Test that the audio-specific error mentions residual-stream injection."""
-        bridge = TransformerBridge.__new__(TransformerBridge)
-        bridge.cfg = audio_bridge_cfg
-
-        resid = torch.zeros(1, 8, audio_bridge_cfg.d_model)
+        resid = torch.zeros(1, 8, audio_bridge.cfg.d_model)
 
         with pytest.raises(NotImplementedError, match="residual-stream injection"):
-            bridge.forward(resid, start_at_layer=2)
+            audio_bridge.forward(resid, start_at_layer=2)

--- a/tests/unit/model_bridge/test_audio_start_at_layer_guard.py
+++ b/tests/unit/model_bridge/test_audio_start_at_layer_guard.py
@@ -1,0 +1,81 @@
+"""Tests for audio model start_at_layer guard."""
+
+import pytest
+import torch
+
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.model_bridge import TransformerBridge
+
+
+class TestAudioStartAtLayerGuard:
+    """Test that start_at_layer raises NotImplementedError for audio models."""
+
+    @pytest.fixture
+    def audio_bridge_cfg(self) -> TransformerBridgeConfig:
+        """Create a config with is_audio_model=True."""
+        return TransformerBridgeConfig(
+            d_model=768,
+            d_head=64,
+            n_layers=12,
+            n_ctx=1024,
+            d_vocab=1000,
+            d_mlp=3072,
+            n_heads=12,
+            is_audio_model=True,
+            architecture="HubertModel",
+        )
+
+    @pytest.fixture
+    def non_audio_bridge_cfg(self) -> TransformerBridgeConfig:
+        """Create a config with is_audio_model=False."""
+        return TransformerBridgeConfig(
+            d_model=768,
+            d_head=64,
+            n_layers=12,
+            n_ctx=1024,
+            d_vocab=1000,
+            d_mlp=3072,
+            n_heads=12,
+            is_audio_model=False,
+            architecture="GPT2LMHeadModel",
+        )
+
+    def test_audio_model_start_at_layer_raises_specific_error(self, audio_bridge_cfg):
+        """Test that start_at_layer on audio model raises audio-specific NotImplementedError."""
+        bridge = TransformerBridge.__new__(TransformerBridge)
+        bridge.cfg = audio_bridge_cfg
+
+        resid = torch.zeros(1, 8, audio_bridge_cfg.d_model)
+
+        with pytest.raises(NotImplementedError, match="not supported for audio models"):
+            bridge.forward(resid, start_at_layer=2)
+
+    def test_non_audio_model_start_at_layer_raises_blocks_error(self, non_audio_bridge_cfg):
+        """Test that start_at_layer on non-audio model raises the generic blocks error."""
+        bridge = TransformerBridge.__new__(TransformerBridge)
+        bridge.cfg = non_audio_bridge_cfg
+
+        resid = torch.zeros(1, 8, non_audio_bridge_cfg.d_model)
+
+        with pytest.raises(NotImplementedError, match="requires a 'blocks' stack"):
+            bridge.forward(resid, start_at_layer=2)
+
+    def test_audio_error_message_mentions_convolutional(self, audio_bridge_cfg):
+        """Test that the audio-specific error mentions convolutional feature extraction."""
+        bridge = TransformerBridge.__new__(TransformerBridge)
+        bridge.cfg = audio_bridge_cfg
+
+        resid = torch.zeros(1, 8, audio_bridge_cfg.d_model)
+
+        with pytest.raises(NotImplementedError, match="convolutional feature"):
+            bridge.forward(resid, start_at_layer=2)
+
+    def test_audio_error_message_mentions_residual_injection(self, audio_bridge_cfg):
+        """Test that the audio-specific error mentions residual-stream injection."""
+        bridge = TransformerBridge.__new__(TransformerBridge)
+        bridge.cfg = audio_bridge_cfg
+
+        resid = torch.zeros(1, 8, audio_bridge_cfg.d_model)
+
+        with pytest.raises(NotImplementedError, match="residual-stream injection"):
+            bridge.forward(resid, start_at_layer=2)

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -11,3 +11,4 @@ from transformer_lens.model_bridge.bridge_core import BridgeCore
 from transformer_lens.model_bridge.remote_bridge import RemoteBridge
 from transformer_lens.model_bridge.transformer_bridge import TransformerBridge
 
+__all__ = ["BridgeCore", "RemoteBridge", "TransformerBridge"]

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -11,4 +11,3 @@ from transformer_lens.model_bridge.bridge_core import BridgeCore
 from transformer_lens.model_bridge.remote_bridge import RemoteBridge
 from transformer_lens.model_bridge.transformer_bridge import TransformerBridge
 
-__all__ = ["BridgeCore", "RemoteBridge", "TransformerBridge"]

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -1454,7 +1454,13 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
                         "Audio models require tensor input (raw waveform), not text. "
                         "Pass a torch.Tensor or use the input_values parameter."
                     )
-                if getattr(self.cfg, "is_visual_model", False):
+        if getattr(self.cfg, "is_audio_model", False):
+            raise NotImplementedError(
+                "start_at_layer is not supported for audio models: audio encoders "
+                "process waveforms through convolutional feature extraction before "
+                "the transformer blocks, making residual-stream injection infeasible."
+            )
+        if getattr(self.cfg, "is_visual_model", False):
                     raise ValueError(
                         "Visual models require tensor input (pixel values), not text. "
                         "Pass a torch.Tensor or use the pixel_values parameter."

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -1454,13 +1454,7 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
                         "Audio models require tensor input (raw waveform), not text. "
                         "Pass a torch.Tensor or use the input_values parameter."
                     )
-        if getattr(self.cfg, "is_audio_model", False):
-            raise NotImplementedError(
-                "start_at_layer is not supported for audio models: audio encoders "
-                "process waveforms through convolutional feature extraction before "
-                "the transformer blocks, making residual-stream injection infeasible."
-            )
-        if getattr(self.cfg, "is_visual_model", False):
+                if getattr(self.cfg, "is_visual_model", False):
                     raise ValueError(
                         "Visual models require tensor input (pixel values), not text. "
                         "Pass a torch.Tensor or use the pixel_values parameter."
@@ -1671,6 +1665,12 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
             raise NotImplementedError(
                 "start_at_layer is not supported for vision models: the residual "
                 "re-entry path assumes token inputs_embeds."
+            )
+        if getattr(self.cfg, "is_audio_model", False):
+            raise NotImplementedError(
+                "start_at_layer is not supported for audio models: audio encoders "
+                "process waveforms through convolutional feature extraction before "
+                "the transformer blocks, making residual-stream injection infeasible."
             )
         for alt in ("encoder_blocks", "decoder_blocks", "L_blocks", "H_blocks"):
             if hasattr(self, alt):


### PR DESCRIPTION
# Description

On audio models (HuBERT, wav2vec2), `start_at_layer` would hit the generic TransformerBridge guard, but the error message didn't explain *why* audio models specifically can't use this feature. Users passing a residual tensor to an audio bridge got a confusing error about HuggingFace internals instead of an actionable explanation.

This PR adds an audio-specific guard that fires before the generic one, with a message explaining that audio encoders process waveforms through convolutional feature extraction before the transformer blocks, making residual-stream injection infeasible

Fixes #1555 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

N/A - error message improvement

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
