### PR TITLE
fix(bridge): make tokenizer assignment re-run wiring logic

### DIFF
--- a/tests/unit/model_bridge/test_tokenizer_reassignment.py
+++ b/tests/unit/model_bridge/test_tokenizer_reassignment.py
@@ -4,8 +4,8 @@ import pytest
 from transformers import AutoTokenizer
 
 from transformer_lens.config import TransformerBridgeConfig
-from transformer_lens.model_bridge.bridge_core import BridgeCore
 from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+from transformer_lens.model_bridge.bridge_core import BridgeCore
 
 
 class MockAdapter(ArchitectureAdapter):

--- a/tests/unit/model_bridge/test_tokenizer_reassignment.py
+++ b/tests/unit/model_bridge/test_tokenizer_reassignment.py
@@ -1,0 +1,120 @@
+"""Tests for tokenizer reassignment wiring."""
+
+import pytest
+from transformers import AutoTokenizer
+
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.model_bridge.bridge_core import BridgeCore
+from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+
+
+class MockAdapter(ArchitectureAdapter):
+    """Minimal adapter for testing."""
+
+    def __init__(self, cfg: TransformerBridgeConfig):
+        super().__init__(cfg)
+        self.component_mapping = {"embed": None}
+
+
+class MockDriver:
+    """Minimal driver for testing."""
+
+    pass
+
+
+class ConcreteBridgeCore(BridgeCore):
+    """Concrete implementation of BridgeCore for testing."""
+
+    def _scan_existing_hooks(self, module, prefix: str = "") -> None:
+        pass
+
+
+class TestTokenizerReassignment:
+    """Test that tokenizer reassignment re-runs wiring logic."""
+
+    @pytest.fixture
+    def base_cfg(self) -> TransformerBridgeConfig:
+        return TransformerBridgeConfig(
+            d_model=768,
+            d_head=64,
+            n_layers=12,
+            n_ctx=1024,
+            d_vocab=-1,  # Will be inferred from tokenizer
+            d_mlp=3072,
+            n_heads=12,
+        )
+
+    @pytest.fixture
+    def gpt2_tokenizer(self):
+        """GPT-2 tokenizer (does not prepend BOS by default)."""
+        return AutoTokenizer.from_pretrained("gpt2")
+
+    @pytest.fixture
+    def llama_style_tokenizer(self):
+        """A tokenizer that prepends BOS (using gpt-neox as example)."""
+        tok = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
+        return tok
+
+    def test_initial_tokenizer_sets_d_vocab(self, base_cfg, gpt2_tokenizer):
+        """Test that initial tokenizer assignment sets d_vocab."""
+        adapter = MockAdapter(base_cfg)
+        bridge = ConcreteBridgeCore(adapter, gpt2_tokenizer, MockDriver())
+
+        # GPT-2 vocab size is 50257
+        assert bridge.cfg.d_vocab == 50257
+        assert bridge.cfg.d_vocab_out == 50257
+
+    def test_reassignment_updates_d_vocab(self, base_cfg, gpt2_tokenizer, llama_style_tokenizer):
+        """Test that reassigning tokenizer updates d_vocab."""
+        adapter = MockAdapter(base_cfg)
+        bridge = ConcreteBridgeCore(adapter, gpt2_tokenizer, MockDriver())
+
+        old_d_vocab = bridge.cfg.d_vocab
+
+        bridge.tokenizer = llama_style_tokenizer
+
+        # GPT-NeoX has a different vocab size than GPT-2
+        assert bridge.cfg.d_vocab != old_d_vocab
+        assert bridge.cfg.d_vocab_out == bridge.cfg.d_vocab
+
+    def test_reassignment_updates_bos_flag(self, base_cfg, gpt2_tokenizer, llama_style_tokenizer):
+        """Test that reassigning tokenizer updates tokenizer_prepends_bos."""
+        adapter = MockAdapter(base_cfg)
+        bridge = ConcreteBridgeCore(adapter, gpt2_tokenizer, MockDriver())
+
+        gpt2_bos = bridge.cfg.tokenizer_prepends_bos
+
+        bridge.tokenizer = llama_style_tokenizer
+
+        neox_bos = bridge.cfg.tokenizer_prepends_bos
+        # The flags should be properly detected (actual values depend on tokenizer behavior)
+        assert isinstance(neox_bos, bool)
+
+    def test_reassignment_to_none_preserves_config(self, base_cfg, gpt2_tokenizer):
+        """Test that setting tokenizer to None doesn't crash."""
+        adapter = MockAdapter(base_cfg)
+        bridge = ConcreteBridgeCore(adapter, gpt2_tokenizer, MockDriver())
+
+        old_d_vocab = bridge.cfg.d_vocab
+
+        bridge.tokenizer = None
+
+        assert bridge.tokenizer is None
+        assert bridge.cfg.d_vocab == old_d_vocab  # Preserved from previous tokenizer
+
+    def test_tokenizer_property_returns_tokenizer(self, base_cfg, gpt2_tokenizer):
+        """Test that the tokenizer property returns the stored tokenizer."""
+        adapter = MockAdapter(base_cfg)
+        bridge = ConcreteBridgeCore(adapter, gpt2_tokenizer, MockDriver())
+
+        assert bridge.tokenizer is not None
+        assert hasattr(bridge.tokenizer, "encode")
+
+    def test_no_tokenizer_at_init(self, base_cfg):
+        """Test that bridge can be created without tokenizer."""
+        base_cfg.d_vocab = 50257  # Set explicitly since no tokenizer
+        adapter = MockAdapter(base_cfg)
+        bridge = ConcreteBridgeCore(adapter, None, MockDriver())
+
+        assert bridge.tokenizer is None
+        assert bridge.cfg.d_vocab == 50257

--- a/transformer_lens/model_bridge/bridge_core.py
+++ b/transformer_lens/model_bridge/bridge_core.py
@@ -75,16 +75,10 @@ class BridgeCore:
         then do framework-specific setup."""
         self.adapter = adapter
         self.cfg = adapter.cfg
-        self.tokenizer = tokenizer
-        if self.cfg.d_vocab == -1 and self.tokenizer is not None:
-            if hasattr(self.tokenizer, "get_vocab"):
-                vocab = self.tokenizer.get_vocab()
-                self.cfg.d_vocab = max(vocab.values()) + 1
-            elif hasattr(self.tokenizer, "vocab"):
-                self.cfg.d_vocab = max(self.tokenizer.vocab.values()) + 1
-            else:
-                self.cfg.d_vocab = getattr(self.tokenizer, "vocab_size", 50257)
-        if self.cfg.d_vocab_out == -1:
+        self._tokenizer = None
+        if tokenizer is not None:
+            self.tokenizer = tokenizer  # Use the property setter
+        elif self.cfg.d_vocab_out == -1:
             self.cfg.d_vocab_out = self.cfg.d_vocab
         self.compatibility_mode = False
         self._weights_processed = False
@@ -96,6 +90,32 @@ class BridgeCore:
         self._driver = driver
         if not hasattr(adapter, "component_mapping") or adapter.component_mapping is None:
             raise ValueError("Adapter must have a component_mapping attribute")
+
+    # ---- tokenizer property ----
+
+    @property
+    def tokenizer(self) -> Any:
+        """The tokenizer used for encoding/decoding text."""
+        return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: Any) -> None:
+        """Set tokenizer and re-run wiring (d_vocab, BOS/EOS detection, padding)."""
+        if value is not None:
+            from transformer_lens.model_bridge.sources._bridge_builder import (
+                configure_tokenizer,
+            )
+
+            value = configure_tokenizer(value, self.cfg)
+            if hasattr(value, "get_vocab"):
+                vocab = value.get_vocab()
+                self.cfg.d_vocab = max(vocab.values()) + 1
+            elif hasattr(value, "vocab"):
+                self.cfg.d_vocab = max(value.vocab.values()) + 1
+            else:
+                self.cfg.d_vocab = getattr(value, "vocab_size", 50257)
+            self.cfg.d_vocab_out = self.cfg.d_vocab
+        self._tokenizer = value
 
     # ---- hook registry ----
 

--- a/transformer_lens/model_bridge/bridge_core.py
+++ b/transformer_lens/model_bridge/bridge_core.py
@@ -107,14 +107,19 @@ class BridgeCore:
             )
 
             value = configure_tokenizer(value, self.cfg)
-            if hasattr(value, "get_vocab"):
-                vocab = value.get_vocab()
-                self.cfg.d_vocab = max(vocab.values()) + 1
-            elif hasattr(value, "vocab"):
-                self.cfg.d_vocab = max(value.vocab.values()) + 1
-            else:
-                self.cfg.d_vocab = getattr(value, "vocab_size", 50257)
-            self.cfg.d_vocab_out = self.cfg.d_vocab
+            # Only infer d_vocab from tokenizer if not already set from model config.
+            # This preserves the original behavior where d_vocab=-1 triggers inference.
+            # On reassignment, always update since user explicitly changed tokenizer.
+            if self.cfg.d_vocab == -1 or self._tokenizer is not None:
+                if hasattr(value, "get_vocab"):
+                    vocab = value.get_vocab()
+                    self.cfg.d_vocab = max(vocab.values()) + 1
+                elif hasattr(value, "vocab"):
+                    self.cfg.d_vocab = max(value.vocab.values()) + 1
+                else:
+                    self.cfg.d_vocab = getattr(value, "vocab_size", 50257)
+                if self.cfg.d_vocab_out == -1 or self._tokenizer is not None:
+                    self.cfg.d_vocab_out = self.cfg.d_vocab
         self._tokenizer = value
 
     # ---- hook registry ----

--- a/transformer_lens/model_bridge/bridge_core.py
+++ b/transformer_lens/model_bridge/bridge_core.py
@@ -78,7 +78,7 @@ class BridgeCore:
         self._tokenizer = None
         if tokenizer is not None:
             self.tokenizer = tokenizer  # Use the property setter
-        elif self.cfg.d_vocab_out == -1:
+        if self.cfg.d_vocab_out == -1:
             self.cfg.d_vocab_out = self.cfg.d_vocab
         self.compatibility_mode = False
         self._weights_processed = False
@@ -100,26 +100,40 @@ class BridgeCore:
 
     @tokenizer.setter
     def tokenizer(self, value: Any) -> None:
-        """Set tokenizer and re-run wiring (d_vocab, BOS/EOS detection, padding)."""
-        if value is not None:
-            from transformer_lens.model_bridge.sources._bridge_builder import (
-                configure_tokenizer,
-            )
+        """Set tokenizer and re-run wiring (d_vocab, BOS/EOS detection, padding).
 
-            value = configure_tokenizer(value, self.cfg)
-            # Only infer d_vocab from tokenizer if not already set from model config.
-            # This preserves the original behavior where d_vocab=-1 triggers inference.
-            # On reassignment, always update since user explicitly changed tokenizer.
-            if self.cfg.d_vocab == -1 or self._tokenizer is not None:
+        On initial assignment (during __init__), the boot path has already called
+        configure_tokenizer, so we skip calling it again. However, we still infer
+        d_vocab if it wasn't set from the model config (d_vocab == -1).
+
+        On reassignment, we re-run configure_tokenizer and update d_vocab to keep
+        cfg in sync with the new tokenizer.
+        """
+        is_reassignment = getattr(self, "_tokenizer", None) is not None
+        cfg = getattr(self, "cfg", None)
+        if value is not None and cfg is not None:
+            if is_reassignment:
+                from transformer_lens.model_bridge.sources._bridge_builder import (
+                    configure_tokenizer,
+                )
+
+                value = configure_tokenizer(value, cfg)
+
+            # Infer d_vocab: on initial assignment only if not set (-1),
+            # on reassignment always update to match new tokenizer.
+            # Use getattr for cfg attributes since tests may use SimpleNamespace.
+            d_vocab = getattr(cfg, "d_vocab", None)
+            if d_vocab == -1 or is_reassignment:
                 if hasattr(value, "get_vocab"):
                     vocab = value.get_vocab()
-                    self.cfg.d_vocab = max(vocab.values()) + 1
+                    cfg.d_vocab = max(vocab.values()) + 1
                 elif hasattr(value, "vocab"):
-                    self.cfg.d_vocab = max(value.vocab.values()) + 1
+                    cfg.d_vocab = max(value.vocab.values()) + 1
                 else:
-                    self.cfg.d_vocab = getattr(value, "vocab_size", 50257)
-                if self.cfg.d_vocab_out == -1 or self._tokenizer is not None:
-                    self.cfg.d_vocab_out = self.cfg.d_vocab
+                    cfg.d_vocab = getattr(value, "vocab_size", 50257)
+            d_vocab_out = getattr(cfg, "d_vocab_out", None)
+            if d_vocab_out == -1 or is_reassignment:
+                cfg.d_vocab_out = getattr(cfg, "d_vocab", d_vocab_out)
         self._tokenizer = value
 
     # ---- hook registry ----


### PR DESCRIPTION
# Description

`bridge.tokenizer` was a plain mutable attribute, but the bridge derives state from it at construction:
- `d_vocab`/`d_vocab_out` inferred from tokenizer (bridge_core.py:79-88)
- BOS/EOS/pad behavior configured via `configure_tokenizer()` 

Assigning `bridge.tokenizer = other_tokenizer` after boot silently bypassed all wiring, leaving `cfg.d_vocab`, `tokenizer_prepends_bos`, `tokenizer_appends_eos`, and padding-side stale.

This PR converts `tokenizer` to a property with a setter that re-runs `configure_tokenizer()` and re-infers vocab size, following the existing `original_model` property pattern.

**Before:**
```python
bridge = TransformerBridge.boot_transformers("gpt2")
bridge.tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
# cfg.d_vocab still 50257 (gpt2) — silent state corruption
```
**After:**

```python
bridge = TransformerBridge.boot_transformers("gpt2")
bridge.tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
# cfg.d_vocab correctly updated to 50277 (gpt-neox)
```
Fixes #1561 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility