### PR TITLE
docs: clarify gradient support during v3 migration

### DIFF
--- a/docs/source/content/drivers.md
+++ b/docs/source/content/drivers.md
@@ -100,6 +100,7 @@ From the [`boot_inspect` docstring](../../../transformer_lens/model_bridge/sourc
 
 ---
 
+(drivers-fundamental-limits)=
 ## Fundamental limits
 
 Serving engines are not autograd engines. On the vLLM backend (and any future serving backend):

--- a/docs/source/content/migrating_to_v3.md
+++ b/docs/source/content/migrating_to_v3.md
@@ -140,6 +140,12 @@ These work identically on `TransformerBridge` and need no migration:
 - `cfg.*` — the bridge exposes a `.cfg` with the same fields (`n_layers`, `n_heads`, `d_model`, `d_vocab`, `n_ctx`, ...)
 - `W_Q`, `W_K`, `W_V`, `W_O`, `b_Q`, `b_K`, `b_V`, `b_O` — attention weights are exposed with the same `[n_heads, d_model, d_head]` shape conventions
 
+> **Gradients require the transformers driver.** `run_with_cache(incl_bwd=True)`,
+> backward hooks, attribution patching, and other gradient-based analyses need
+> local autograd, so load the model with `TransformerBridge.boot_transformers(...)`.
+> Serving and remote drivers do not expose gradients; see
+> {ref}`Fundamental limits <drivers-fundamental-limits>`.
+
 If your code only touches these APIs, the migration is genuinely just the loading call and (optionally) `enable_compatibility_mode`.
 
 ### BERT Next Sentence Prediction


### PR DESCRIPTION
## Description

Clarifies that gradient-based analyses require the local transformers driver during migration to v3. The migration guide now calls out `run_with_cache(incl_bwd=True)`, backward hooks, and attribution patching, and links to the driver limitations documentation.

Adds an explicit MyST target for the existing Fundamental limits section so the cross-reference resolves without warnings.

Fixes #1559

## Type of change

- [x] This change requires a documentation update

## Verification

- [x] `make format`
- [x] `uv run mypy .`
- [x] `make unit-test` (5,204 selected tests)
- [x] `uv run build-docs`

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

Not applicable: code comments and new tests, because this is a documentation-only clarification.