### PR TITLE
fix(bridge): validate boot_native config type

### DIFF
--- a/tests/unit/model_bridge/test_boot_native.py
+++ b/tests/unit/model_bridge/test_boot_native.py
@@ -88,6 +88,30 @@ def test_boot_native_accepts_dict_config():
     assert bridge.cfg.architecture == "TransformerLensNative"
 
 
+def test_boot_native_rejects_legacy_config_with_actionable_error():
+    import pytest
+
+    from transformer_lens import HookedTransformerConfig
+
+    legacy_config = HookedTransformerConfig(
+        n_layers=1,
+        d_model=32,
+        n_ctx=8,
+        d_head=16,
+        n_heads=2,
+        d_vocab=16,
+        act_fn="gelu",
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "boot_native expected a TransformerBridgeConfig or dict, " "got HookedTransformerConfig"
+        ),
+    ):
+        TransformerBridge.boot_native(legacy_config)
+
+
 def test_boot_native_does_not_perturb_global_rng():
     """``boot_native(seed=...)`` must use a scoped torch.Generator instead of
     ``torch.manual_seed``. Otherwise a user calling boot_native then

--- a/transformer_lens/model_bridge/sources/native/__init__.py
+++ b/transformer_lens/model_bridge/sources/native/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import copy as _copy
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, overload
 
 import torch
 
@@ -18,8 +18,30 @@ from transformer_lens.model_bridge.sources.native.model import (
 )
 
 
+@overload
 def boot(
-    config: Union[TransformerBridgeConfig, dict],
+    config: TransformerBridgeConfig,
+    tokenizer: Optional[Any] = None,
+    device: Optional[Union[str, torch.device]] = None,
+    dtype: Optional[torch.dtype] = None,
+    model_name: str = "native",
+) -> TransformerBridge:
+    ...
+
+
+@overload
+def boot(
+    config: dict[str, Any],
+    tokenizer: Optional[Any] = None,
+    device: Optional[Union[str, torch.device]] = None,
+    dtype: Optional[torch.dtype] = None,
+    model_name: str = "native",
+) -> TransformerBridge:
+    ...
+
+
+def boot(
+    config: Any,
     tokenizer: Optional[Any] = None,
     device: Optional[Union[str, torch.device]] = None,
     dtype: Optional[torch.dtype] = None,
@@ -30,6 +52,14 @@ def boot(
     No HuggingFace Hub call, no ``transformers`` import. ``config.init_mode``
     and ``config.seed`` control reproducibility.
     """
+    if not isinstance(config, (TransformerBridgeConfig, dict)):
+        raise TypeError(
+            "boot_native expected a TransformerBridgeConfig or dict, "
+            f"got {type(config).__name__}. Construct a TransformerBridgeConfig "
+            "with the same fields; legacy config classes are deprecated and "
+            "are not accepted."
+        )
+
     cfg: TransformerBridgeConfig
     if isinstance(config, dict):
         cfg = TransformerBridgeConfig.from_dict(config)


### PR DESCRIPTION
# Description

`TransformerBridge.boot_native` now validates its configuration object at the entry point and raises an actionable `TypeError` for unsupported objects.

The implementation keeps precise overloads for the supported `TransformerBridgeConfig` and dictionary inputs while allowing the function body to perform explicit runtime validation. Existing bridge-config and dictionary behavior is unchanged.

Fixes #1562

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `uv run pytest tests/unit/model_bridge/test_boot_native.py -q` (`17 passed`)
- `make unit-test` (`5140 passed`, `61 skipped`, `44 deselected`, `10 xfailed`)
- `uv run mypy .`
- `make check-format`
- `git diff --check`

# Checklist

- [x] The error message identifies the unsupported type and points users to `TransformerBridgeConfig`
- [x] No documentation changes are required for this error-handling fix
- [x] My changes generate no new warnings
- [x] I have added a regression test that proves the fix is effective
- [x] New and existing unit tests pass locally
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
