### PR TITLE
Test Hooked from_pretrained deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@
         filterwarnings=[
             "ignore:distutils Version classes are deprecated:DeprecationWarning",
             "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+            "ignore:Hooked(Transformer|EncoderDecoder|AudioEncoder)\\.from_pretrained is deprecated:DeprecationWarning",
         ]
         markers=[
             "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/tests/unit/test_from_pretrained_deprecations.py
+++ b/tests/unit/test_from_pretrained_deprecations.py
@@ -1,0 +1,49 @@
+import pytest
+
+import transformer_lens.loading_from_pretrained as loading
+from transformer_lens import HookedAudioEncoder, HookedEncoderDecoder, HookedTransformer
+
+
+class _StopLoading(Exception):
+    pass
+
+
+def _stop_model_lookup(_: str) -> str:
+    raise _StopLoading
+
+
+def test_hooked_transformer_from_pretrained_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(loading, "get_official_model_name", _stop_model_lookup)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"HookedTransformer\.from_pretrained is deprecated.*"
+        r"TransformerBridge\.boot_transformers",
+    ), pytest.raises(_StopLoading):
+        HookedTransformer.from_pretrained("test-model")
+
+
+def test_hooked_encoder_decoder_from_pretrained_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(loading, "get_official_model_name", _stop_model_lookup)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"HookedEncoderDecoder\.from_pretrained is deprecated.*"
+        r"TransformerBridge\.boot_transformers",
+    ), pytest.raises(_StopLoading):
+        HookedEncoderDecoder.from_pretrained("test-model")
+
+
+def test_hooked_audio_encoder_from_pretrained_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(loading, "get_official_model_name", _stop_model_lookup)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"HookedAudioEncoder\.from_pretrained is deprecated.*"
+        r"TransformerBridge\.boot_transformers",
+    ), pytest.raises(_StopLoading):
+        HookedAudioEncoder.from_pretrained("test-model")


### PR DESCRIPTION
# Description

Adds regression tests for the three deprecated `Hooked*.from_pretrained`
paths and a narrowly scoped pytest warning filter for internal uses. Each
test still captures its warning and verifies that the message names the
legacy class and directs users to `TransformerBridge.boot_transformers`.

Fixes #1564

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- `uv run pytest tests/unit/test_from_pretrained_deprecations.py -q` — 3 passed
- `uv run pytest tests/unit -m "not slow" --reruns 2 --reruns-delay 5` — 5,143 passed
- `uv run mypy .` — no issues in 421 source files
- `uv run pytest transformer_lens/ --reruns 2 --reruns-delay 5` — 17 passed
- `uv run pytest tests/acceptance -m "not slow" --reruns 2 --reruns-delay 5` — 154 passed
- `uv build` — source distribution and wheel built successfully

# Checklist:

- [x] No hard-to-understand code requires additional comments
- [x] No documentation change is required
- [x] My changes generate no new warnings
- [x] I have added tests that prove the change works
- [x] New and existing unit tests pass locally
- [x] I have not rewritten tests relating to key interfaces