### PR TITLE
Honor native bridge weight initialization config

### DIFF
--- a/docs/source/content/migrating_to_v3.md
+++ b/docs/source/content/migrating_to_v3.md
@@ -237,6 +237,7 @@ Weight-matrix rows return **raw** HuggingFace weights by default. `HookedTransfo
 | `model.reset_hooks(...)` | `bridge.reset_hooks(clear_contexts=..., direction=..., including_permanent=..., level=...)` | The bridge supports the same scoped hook cleanup controls. |
 | A helper typed as `HookedTransformer` | Type it as `TransformerLensModel` or `TransformerLensModelWithWeights` from `transformer_lens.model_protocol` | Use the narrower structural protocol unless the helper reads weights or advanced `ActivationCache` helpers. |
 | `HookedTransformerConfig(...)` | `TransformerBridgeConfig(...)` | Construct the bridge config with the same core fields, then pass it to `TransformerBridge.boot_native(config)` for train-from-scratch or toy models. Do not pass a legacy config object to `boot_native`. |
+| `cfg.init_weights` | `bridge.init_weights()` | `boot_native()` honors the config flag during construction; call `init_weights()` to reinitialize a TL-native bridge in place. |
 | `model.all_head_labels()` | `bridge.all_head_labels` | This is a property on the bridge, so omit the call parentheses. |
 | `model.set_tokenizer(tokenizer)` | `TransformerBridge.boot_transformers(name, tokenizer=tokenizer)` | A bridge's tokenizer is fixed when it boots. Reboot to change it; assigning `bridge.tokenizer` directly bypasses tokenizer/config wiring. |
 

--- a/tests/unit/model_bridge/test_boot_native.py
+++ b/tests/unit/model_bridge/test_boot_native.py
@@ -264,10 +264,14 @@ def test_boot_native_skips_custom_init_when_disabled(monkeypatch):
     def fail_if_called(*_args, **_kwargs):
         pytest.fail("initialize_native_model was called with init_weights=False")
 
+    def fail_if_forked(*_args, **_kwargs):
+        pytest.fail("fork_rng was called with init_weights=False")
+
     monkeypatch.setattr(
         "transformer_lens.model_bridge.sources.native.initialize_native_model",
         fail_if_called,
     )
+    monkeypatch.setattr(torch.random, "fork_rng", fail_if_forked)
     bridge = TransformerBridge.boot_native(_cfg(init_weights=False))
 
     assert isinstance(bridge.original_model, NativeModel)
@@ -281,7 +285,7 @@ def test_native_bridge_init_weights_reinitializes_in_place_and_honors_seed():
 
     with torch.no_grad():
         for param in model.parameters():
-            param.zero_()
+            param.fill_(42)
 
     bridge.init_weights()
 

--- a/tests/unit/model_bridge/test_boot_native.py
+++ b/tests/unit/model_bridge/test_boot_native.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 
 import sys
 
+import pytest
 import torch
+import torch.nn as nn
 
 from transformer_lens.config import TransformerBridgeConfig
 from transformer_lens.model_bridge import TransformerBridge
+from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
+from transformer_lens.model_bridge.generalized_components import LinearBridge
 from transformer_lens.model_bridge.sources.native import NativeModel
 
 
@@ -256,8 +260,64 @@ def test_boot_native_rmspre_forward():
     expected = (x_fp32 * rms_inv).to(x.dtype)
 
     assert torch.allclose(out, expected, atol=1e-6)
+def test_boot_native_skips_custom_init_when_disabled(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        pytest.fail("initialize_native_model was called with init_weights=False")
+
+    monkeypatch.setattr(
+        "transformer_lens.model_bridge.sources.native.initialize_native_model",
+        fail_if_called,
+    )
+    bridge = TransformerBridge.boot_native(_cfg(init_weights=False))
+
+    assert isinstance(bridge.original_model, NativeModel)
+    assert torch.count_nonzero(bridge.original_model.layers[0].attn.q.bias) > 0
 
 
+def test_native_bridge_init_weights_reinitializes_in_place_and_honors_seed():
+    bridge = TransformerBridge.boot_native(_cfg(seed=123))
+    model = bridge.original_model
+    expected = {name: param.detach().clone() for name, param in model.named_parameters()}
+
+    with torch.no_grad():
+        for param in model.parameters():
+            param.zero_()
+
+    bridge.init_weights()
+
+    assert bridge.original_model is model
+    for name, param in model.named_parameters():
+        assert torch.equal(param, expected[name]), f"Seed mismatch on {name}"
+
+
+def test_native_bridge_init_weights_does_not_perturb_global_rng():
+    bridge = TransformerBridge.boot_native(_cfg(seed=42))
+    torch.manual_seed(0)
+    expected_after = torch.randn(5)
+
+    torch.manual_seed(0)
+    bridge.init_weights()
+    actual_after = torch.randn(5)
+
+    assert torch.equal(actual_after, expected_after)
+
+
+def test_init_weights_rejects_non_native_bridge():
+    class StubModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.proj = nn.Linear(4, 4)
+
+    class StubAdapter(ArchitectureAdapter):
+        def __init__(self, cfg):
+            super().__init__(cfg)
+            self.component_mapping = {"stub_proj": LinearBridge(name="proj")}
+
+    cfg = _cfg(architecture="StubForTest")
+    bridge = TransformerBridge(StubModel(), StubAdapter(cfg), tokenizer=None)
+
+    with pytest.raises(RuntimeError, match=r"boot_native.*StubModel"):
+        bridge.init_weights()
 def test_boot_native_forward_and_cache():
     cfg = _cfg()
     bridge = TransformerBridge.boot_native(cfg)

--- a/tests/unit/model_bridge/test_boot_native.py
+++ b/tests/unit/model_bridge/test_boot_native.py
@@ -260,6 +260,8 @@ def test_boot_native_rmspre_forward():
     expected = (x_fp32 * rms_inv).to(x.dtype)
 
     assert torch.allclose(out, expected, atol=1e-6)
+
+
 def test_boot_native_skips_custom_init_when_disabled(monkeypatch):
     def fail_if_called(*_args, **_kwargs):
         pytest.fail("initialize_native_model was called with init_weights=False")
@@ -322,6 +324,8 @@ def test_init_weights_rejects_non_native_bridge():
 
     with pytest.raises(RuntimeError, match=r"boot_native.*StubModel"):
         bridge.init_weights()
+
+
 def test_boot_native_forward_and_cache():
     cfg = _cfg()
     bridge = TransformerBridge.boot_native(cfg)

--- a/transformer_lens/model_bridge/sources/native/__init__.py
+++ b/transformer_lens/model_bridge/sources/native/__init__.py
@@ -8,7 +8,9 @@ import torch
 
 from transformer_lens.config import TransformerBridgeConfig
 from transformer_lens.model_bridge.bridge import TransformerBridge
-from transformer_lens.model_bridge.sources._bridge_builder import build_bridge_from_module
+from transformer_lens.model_bridge.sources._bridge_builder import (
+    build_bridge_from_module,
+)
 from transformer_lens.model_bridge.sources.native.init import initialize_native_model
 from transformer_lens.model_bridge.sources.native.model import (
     NativeAttention,
@@ -86,10 +88,12 @@ def boot(
     if cfg.seed is not None:
         with torch.random.fork_rng(devices=[]):
             model = NativeModel(cfg)
-            initialize_native_model(model, cfg)
+            if cfg.init_weights:
+                initialize_native_model(model, cfg)
     else:
         model = NativeModel(cfg)
-        initialize_native_model(model, cfg)
+        if cfg.init_weights:
+            initialize_native_model(model, cfg)
 
     if device is not None:
         model = model.to(device)

--- a/transformer_lens/model_bridge/sources/native/__init__.py
+++ b/transformer_lens/model_bridge/sources/native/__init__.py
@@ -84,12 +84,12 @@ def boot(
 
     # Fork RNG around construction + init when seeded so neither nn.Linear's
     # default reset_parameters nor our scoped init perturb the caller's RNG.
-    # Unseeded calls let global RNG advance normally.
-    if cfg.seed is not None:
+    # When custom init is disabled, construction keeps PyTorch's normal global
+    # RNG semantics and cfg.seed has no initialization work to control.
+    if cfg.init_weights and cfg.seed is not None:
         with torch.random.fork_rng(devices=[]):
             model = NativeModel(cfg)
-            if cfg.init_weights:
-                initialize_native_model(model, cfg)
+            initialize_native_model(model, cfg)
     else:
         model = NativeModel(cfg)
         if cfg.init_weights:

--- a/transformer_lens/model_bridge/sources/native/init.py
+++ b/transformer_lens/model_bridge/sources/native/init.py
@@ -43,6 +43,12 @@ _NON_RESIDUAL_MODES: dict[str, _NonResidualInit] = {
 _SUPPORTED_MODES = frozenset({"gpt2", *_NON_RESIDUAL_MODES})
 
 
+def _unwrap_component(module: nn.Module) -> nn.Module:
+    """Return the native module stored behind a bridge wrapper, if present."""
+    original = getattr(module, "original_component", None)
+    return original if isinstance(original, nn.Module) else module
+
+
 def initialize_native_model(
     model: NativeModel, cfg: TransformerBridgeConfig, seed: int | None = None
 ) -> None:
@@ -85,19 +91,24 @@ def initialize_native_model(
         weight_init = lambda t: fn(t, generator)  # noqa: E731
         output_init = weight_init
 
-    weight_init(model.tok_embed.weight)
+    tok_embed = cast(nn.Embedding, _unwrap_component(model.tok_embed))
+    weight_init(tok_embed.weight)
     if model.pos is not None:
-        weight_init(model.pos.weight)
+        pos = cast(nn.Embedding, _unwrap_component(model.pos))
+        weight_init(pos.weight)
     # Rotary has only registered buffers (cos/sin), no parameters to init.
 
     for block in model.layers:
-        _init_block(block, weight_init=weight_init, output_init=output_init)
+        native_block = cast(NativeBlock, _unwrap_component(block))
+        _init_block(native_block, weight_init=weight_init, output_init=output_init)
 
     _init_norm(model.ln_out)
-    weight_init(model.head.weight)
+    head = cast(nn.Linear, _unwrap_component(model.head))
+    weight_init(head.weight)
 
 
 def _init_norm(norm: nn.Module) -> None:
+    norm = _unwrap_component(norm)
     if isinstance(norm, NativeRMSNorm):
         nn.init.ones_(norm.weight)
     elif isinstance(norm, (NativeRMSNormPre, NativeLayerNormPre)):
@@ -118,13 +129,19 @@ def _init_block(
     output_init: Callable[[torch.Tensor], torch.Tensor],
 ) -> None:
     _init_norm(block.ln1)
-    _init_attention(block.attn, weight_init=weight_init, output_init=output_init)
+    attn = cast(NativeAttention, _unwrap_component(block.attn))
+    _init_attention(attn, weight_init=weight_init, output_init=output_init)
     if not block.cfg.attn_only:
         _init_norm(block.ln2)
-        if isinstance(block.mlp, NativeGatedMLP):
-            _init_gated_mlp(block.mlp, weight_init=weight_init, output_init=output_init)
+        mlp = _unwrap_component(block.mlp)
+        if isinstance(mlp, NativeGatedMLP):
+            _init_gated_mlp(mlp, weight_init=weight_init, output_init=output_init)
         else:
-            _init_mlp(block.mlp, weight_init=weight_init, output_init=output_init)
+            _init_mlp(
+                cast(NativeMLP, mlp),
+                weight_init=weight_init,
+                output_init=output_init,
+            )
 
 
 def _init_attention(
@@ -133,13 +150,15 @@ def _init_attention(
     weight_init: Callable[[torch.Tensor], torch.Tensor],
     output_init: Callable[[torch.Tensor], torch.Tensor],
 ) -> None:
-    for linear in (attn.q, attn.k, attn.v):
+    for component in (attn.q, attn.k, attn.v):
+        linear = cast(nn.Linear, _unwrap_component(component))
         weight_init(linear.weight)
         if linear.bias is not None:
             nn.init.zeros_(linear.bias)
-    output_init(attn.o.weight)
-    if attn.o.bias is not None:
-        nn.init.zeros_(attn.o.bias)
+    output = cast(nn.Linear, _unwrap_component(attn.o))
+    output_init(output.weight)
+    if output.bias is not None:
+        nn.init.zeros_(output.bias)
 
 
 def _init_mlp(
@@ -148,10 +167,12 @@ def _init_mlp(
     weight_init: Callable[[torch.Tensor], torch.Tensor],
     output_init: Callable[[torch.Tensor], torch.Tensor],
 ) -> None:
-    weight_init(mlp.fc_in.weight)
-    nn.init.zeros_(mlp.fc_in.bias)
-    output_init(mlp.fc_out.weight)
-    nn.init.zeros_(mlp.fc_out.bias)
+    fc_in = cast(nn.Linear, _unwrap_component(mlp.fc_in))
+    fc_out = cast(nn.Linear, _unwrap_component(mlp.fc_out))
+    weight_init(fc_in.weight)
+    nn.init.zeros_(fc_in.bias)
+    output_init(fc_out.weight)
+    nn.init.zeros_(fc_out.bias)
 
 
 def _init_gated_mlp(
@@ -160,8 +181,10 @@ def _init_gated_mlp(
     weight_init: Callable[[torch.Tensor], torch.Tensor],
     output_init: Callable[[torch.Tensor], torch.Tensor],
 ) -> None:
-    weight_init(mlp.gate.weight)
+    gate = cast(nn.Linear, _unwrap_component(mlp.gate))
+    weight_init(gate.weight)
     # ``in`` is registered via add_module; getattr resolves it from _modules.
-    in_proj = cast(nn.Linear, getattr(mlp, "in"))
+    in_proj = cast(nn.Linear, _unwrap_component(getattr(mlp, "in")))
+    out_proj = cast(nn.Linear, _unwrap_component(mlp.out))
     weight_init(in_proj.weight)
-    output_init(mlp.out.weight)
+    output_init(out_proj.weight)

--- a/transformer_lens/model_bridge/sources/native/init.py
+++ b/transformer_lens/model_bridge/sources/native/init.py
@@ -105,6 +105,8 @@ def initialize_native_model(
     _init_norm(model.ln_out)
     head = cast(nn.Linear, _unwrap_component(model.head))
     weight_init(head.weight)
+    if head.bias is not None:
+        nn.init.zeros_(head.bias)
 
 
 def _init_norm(norm: nn.Module) -> None:

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -193,6 +193,22 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
         if callable(setter):
             setter(value)
 
+    def init_weights(self) -> None:
+        """Reinitialize a TL-native model in place using the bridge config."""
+        from transformer_lens.model_bridge.sources.native.init import (
+            initialize_native_model,
+        )
+        from transformer_lens.model_bridge.sources.native.model import NativeModel
+
+        model = self.original_model
+        if not isinstance(model, NativeModel):
+            raise RuntimeError(
+                "TransformerBridge.init_weights() is only supported for TL-native "
+                "bridges created with TransformerBridge.boot_native(...); this bridge "
+                f"wraps {type(model).__name__}."
+            )
+        initialize_native_model(model, self.cfg)
+
     def _set_processed_weight_attributes(self) -> None:
         """Create 3D processed weight attributes for attention components.
 


### PR DESCRIPTION
# Description

Honors `cfg.init_weights=False` in `TransformerBridge.boot_native()` and adds a public `TransformerBridge.init_weights()` method for deterministic, in-place reinitialization of TL-native bridges.

Bridge construction replaces native submodules with generalized component wrappers, so the native initializer now unwraps those components before resetting the original parameters. Calling `init_weights()` on a non-native bridge raises an actionable error pointing to `boot_native()`.

Fixes #1566

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Validation

- `pytest tests/unit/model_bridge/test_boot_native.py tests/unit/model_bridge/test_build_bridge_from_module.py tests/unit/model_bridge/test_native_features.py -q`: 78 passed
- `mypy .`: Success, no issues found in 421 source files
- Full `pytest tests/unit -m "not slow" -q`: 5142 passed; the only two failures were existing UTF-8 test files read with the Windows GBK locale, and both pass with `PYTHONUTF8=1`
- Black, isort, pycln, and `git diff --check`

Development note: AI-assisted implementation; I manually traced bridge component replacement, reviewed the patch, and ran the focused and repository-wide validation above.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility