### PR TITLE
fix(bridge): expand grouped K/V heads in QK/OV and composition circuits on GQA models

### DIFF
--- a/tests/integration/model_bridge/test_attention_weight_accessors.py
+++ b/tests/integration/model_bridge/test_attention_weight_accessors.py
@@ -126,3 +126,59 @@ class TestConv1DAccessorParity:
         expected = c_proj(z.reshape(2, 64))
         actual = torch.einsum("bhd,hdm->bm", z, w_o) + attn.b_O
         assert torch.allclose(actual, expected, atol=1e-5)
+
+
+class TestWeightCircuitsGQA:
+    """QK/OV/composition circuits expand grouped K/V to n_heads (issue #1553).
+
+    Pre-fix, every property below raised at FactoredMatrix construction on GQA
+    models because the grouped [n_kv_heads] axis cannot broadcast against the
+    per-query-head [n_heads] axis.
+    """
+
+    def test_qk_factors_align_to_query_heads(self, llama_bridge):
+        bridge, _ = llama_bridge
+        QK = bridge.QK
+        assert QK.A.shape == (2, 4, 64, 16)
+        assert QK.B.shape == (2, 4, 16, 64)
+        # Query head h reads kv head h // (n_heads // n_kv_heads).
+        for h in range(4):
+            assert torch.equal(QK.B[0, h], bridge.blocks[0].attn.W_K[h // 2].T)
+
+    def test_ov_factors_align_to_query_heads(self, llama_bridge):
+        bridge, _ = llama_bridge
+        OV = bridge.OV
+        assert OV.A.shape == (2, 4, 64, 16)
+        assert OV.B.shape == (2, 4, 16, 64)
+        for h in range(4):
+            assert torch.equal(OV.A[1, h], bridge.blocks[1].attn.W_V[h // 2])
+
+    def test_for_attn_layers_variants_align(self, llama_bridge):
+        bridge, _ = llama_bridge
+        indices, QK = bridge.QK_for_attn_layers()
+        assert indices == [0, 1]
+        assert QK.A.shape == (2, 4, 64, 16)
+        assert QK.B.shape == (2, 4, 16, 64)
+        _, OV = bridge.OV_for_attn_layers()
+        assert OV.A.shape == (2, 4, 64, 16)
+        assert OV.B.shape == (2, 4, 16, 64)
+
+    @pytest.mark.parametrize("mode", ["Q", "K", "V"])
+    def test_composition_scores_cover_all_query_heads(self, llama_bridge, mode):
+        bridge, _ = llama_bridge
+        result = bridge.all_composition_scores(mode)
+        assert result.scores.shape == (2, 4, 2, 4)
+        assert len(result.head_labels) == 8
+
+    def test_raw_kv_stacks_stay_grouped(self, llama_bridge):
+        bridge, _ = llama_bridge
+        assert bridge.W_K.shape == (2, 2, 64, 16)
+        assert bridge.W_V.shape == (2, 2, 64, 16)
+
+    def test_mha_circuits_untouched(self, tiny_gpt2_bridge):
+        bridge, _ = tiny_gpt2_bridge
+        QK, OV = bridge.QK, bridge.OV
+        assert torch.equal(QK.A, bridge.W_Q)
+        assert torch.equal(QK.B, bridge.W_K.transpose(-2, -1))
+        assert torch.equal(OV.A, bridge.W_V)
+        assert torch.equal(OV.B, bridge.W_O)

--- a/tests/integration/model_bridge/test_bridge_qk_ov_vs_hooked_gqa.py
+++ b/tests/integration/model_bridge/test_bridge_qk_ov_vs_hooked_gqa.py
@@ -1,0 +1,54 @@
+"""GQA weight-circuit parity between TransformerBridge and HookedTransformer.
+
+Acceptance for https://github.com/TransformerLensOrg/TransformerLens/issues/1553:
+bridge.QK/OV on a GQA model must match HookedTransformer.QK/OV (whose
+GroupedQueryAttention repeat_interleaves grouped K/V) within fp tolerance.
+Qwen2-0.5B (14 query heads, 2 kv heads) is a small ungated GQA model both
+systems support; it is not CI-cached, hence @pytest.mark.slow.
+"""
+
+import pytest
+import torch
+
+from transformer_lens import HookedTransformer
+from transformer_lens.model_bridge.bridge import TransformerBridge
+
+MODEL = "Qwen/Qwen2-0.5B"
+
+
+@pytest.mark.slow
+class TestGQAWeightCircuitParity:
+    @pytest.fixture(scope="class")
+    def bridge_and_hooked(self):
+        bridge = TransformerBridge.boot_transformers(MODEL, device="cpu")
+        hooked = HookedTransformer.from_pretrained_no_processing(MODEL, device="cpu")
+        return bridge, hooked
+
+    def test_model_is_gqa(self, bridge_and_hooked):
+        bridge, _ = bridge_and_hooked
+        assert bridge.cfg.n_key_value_heads is not None
+        assert bridge.cfg.n_key_value_heads < bridge.cfg.n_heads
+
+    def test_qk_factors_match_hooked(self, bridge_and_hooked):
+        bridge, hooked = bridge_and_hooked
+        torch.testing.assert_close(bridge.QK.A, hooked.QK.A)
+        torch.testing.assert_close(bridge.QK.B, hooked.QK.B)
+
+    def test_ov_factors_match_hooked(self, bridge_and_hooked):
+        bridge, hooked = bridge_and_hooked
+        torch.testing.assert_close(bridge.OV.A, hooked.OV.A)
+        torch.testing.assert_close(bridge.OV.B, hooked.OV.B)
+
+    def test_qk_product_matches_hooked(self, bridge_and_hooked):
+        bridge, hooked = bridge_and_hooked
+        torch.testing.assert_close(bridge.QK.A[0] @ bridge.QK.B[0], hooked.QK.A[0] @ hooked.QK.B[0])
+
+    def test_for_attn_layers_match_hooked(self, bridge_and_hooked):
+        bridge, hooked = bridge_and_hooked
+        indices, QK = bridge.QK_for_attn_layers()
+        assert indices == list(range(bridge.cfg.n_layers))
+        torch.testing.assert_close(QK.A, hooked.QK.A)
+        torch.testing.assert_close(QK.B, hooked.QK.B)
+        _, OV = bridge.OV_for_attn_layers()
+        torch.testing.assert_close(OV.A, hooked.OV.A)
+        torch.testing.assert_close(OV.B, hooked.OV.B)

--- a/tests/unit/model_bridge/test_expand_kv_heads.py
+++ b/tests/unit/model_bridge/test_expand_kv_heads.py
@@ -1,0 +1,56 @@
+"""Unit tests for TransformerBridge._expand_kv_heads.
+
+Regression for https://github.com/TransformerLensOrg/TransformerLens/issues/1553:
+weight circuits on GQA models must expand the grouped K/V head axis to n_heads
+(repeat_interleave, matching HookedTransformer's GroupedQueryAttention layout)
+before factoring, while MHA weights pass through untouched.
+"""
+
+import pytest
+import torch
+
+from transformer_lens.config.transformer_bridge_config import TransformerBridgeConfig
+from transformer_lens.model_bridge.transformer_bridge import TransformerBridge
+
+
+def _bridge_stub(n_heads: int) -> TransformerBridge:
+    """Uninitialized bridge carrying only the cfg that _expand_kv_heads reads."""
+    bridge = TransformerBridge.__new__(TransformerBridge)
+    bridge.cfg = TransformerBridgeConfig(
+        d_model=8,
+        d_head=2,
+        n_heads=n_heads,
+        n_layers=2,
+        n_ctx=8,
+        d_vocab=16,
+    )
+    return bridge
+
+
+class TestExpandKvHeads:
+    def test_grouped_kv_expands_by_repeat_interleave(self):
+        bridge = _bridge_stub(n_heads=4)
+        grouped = torch.arange(2 * 2 * 3 * 2, dtype=torch.float32).reshape(2, 2, 3, 2)
+
+        expanded = bridge._expand_kv_heads(grouped)
+
+        assert expanded.shape == (2, 4, 3, 2)
+        # Query head h must read kv head h // (n_heads // n_kv_heads).
+        for h in range(4):
+            assert torch.equal(expanded[:, h], grouped[:, h // 2])
+
+    def test_mha_weights_pass_through_untouched(self):
+        bridge = _bridge_stub(n_heads=4)
+        mha = torch.randn(2, 4, 3, 2)
+        assert bridge._expand_kv_heads(mha) is mha
+
+    def test_non_4d_input_passes_through_untouched(self):
+        bridge = _bridge_stub(n_heads=4)
+        bias_stack = torch.randn(2, 2, 2)
+        assert bridge._expand_kv_heads(bias_stack) is bias_stack
+
+    def test_indivisible_head_counts_raise(self):
+        bridge = _bridge_stub(n_heads=4)
+        grouped = torch.randn(2, 3, 3, 2)
+        with pytest.raises(ValueError, match="multiple of n_kv_heads"):
+            bridge._expand_kv_heads(grouped)

--- a/transformer_lens/config/transformer_bridge_config.py
+++ b/transformer_lens/config/transformer_bridge_config.py
@@ -40,7 +40,6 @@ class TransformerBridgeConfig(TransformerLensConfig):
         use_attn_in: bool = False,
         use_qk_norm: bool = False,
         use_local_attn: bool = False,
-        ungroup_grouped_query_attention: bool = False,
         original_architecture: Optional[str] = None,
         from_checkpoint: bool = False,
         checkpoint_index: Optional[int] = None,
@@ -135,7 +134,6 @@ class TransformerBridgeConfig(TransformerLensConfig):
         self.use_attn_in = use_attn_in
         self.use_qk_norm = use_qk_norm
         self.use_local_attn = use_local_attn
-        self.ungroup_grouped_query_attention = ungroup_grouped_query_attention
         self.original_architecture = original_architecture
         self.from_checkpoint = from_checkpoint
         self.checkpoint_index = checkpoint_index

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -948,6 +948,26 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
             return w.reshape(self.cfg.n_heads, d_head, self.cfg.d_model)
         return w
 
+    def _expand_kv_heads(self, w: torch.Tensor) -> torch.Tensor:
+        """Expand stacked grouped K/V weights along the head axis to n_heads.
+
+        GQA models store one K/V projection per key-value head while W_Q/W_O are
+        per-query-head, so weight circuits must repeat the grouped K/V up to
+        n_heads before factoring: query head h reads kv head
+        h // (n_heads // n_kv_heads), i.e. repeat_interleave — the same layout
+        GroupedQueryAttention.W_K/W_V expose on HookedTransformer. No-op for MHA,
+        where the head axes already match.
+        """
+        if w.ndim != 4 or w.shape[1] == self.cfg.n_heads:
+            return w
+        n_kv_heads = w.shape[1]
+        if self.cfg.n_heads % n_kv_heads != 0:
+            raise ValueError(
+                f"Cannot expand {n_kv_heads} key-value heads to {self.cfg.n_heads} "
+                f"query heads: n_heads must be a multiple of n_kv_heads."
+            )
+        return w.repeat_interleave(self.cfg.n_heads // n_kv_heads, dim=1)
+
     @property
     def W_K(self) -> torch.Tensor:
         """Stack the key weights across all layers."""
@@ -1033,24 +1053,24 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
     @property
     def QK(self):
         """QK circuit. On hybrids, returns attn layers only (with warning). See QK_for_attn_layers()."""
-        return FactoredMatrix(self.W_Q, self.W_K.transpose(-2, -1))
+        return FactoredMatrix(self.W_Q, self._expand_kv_heads(self.W_K).transpose(-2, -1))
 
     @property
     def OV(self):
         """OV circuit. On hybrids, returns attn layers only (with warning). See OV_for_attn_layers()."""
-        return FactoredMatrix(self.W_V, self.W_O)
+        return FactoredMatrix(self._expand_kv_heads(self.W_V), self.W_O)
 
     def QK_for_attn_layers(self) -> Tuple[List[int], FactoredMatrix]:
         """QK circuit for attention layers only. Returns (layer_indices, FactoredMatrix)."""
         q_indices, W_Q = self.stack_params_for("attn", "attn.W_Q", self._reshape_qkv)
         _, W_K = self.stack_params_for("attn", "attn.W_K", self._reshape_qkv)
-        return q_indices, FactoredMatrix(W_Q, W_K.transpose(-2, -1))
+        return q_indices, FactoredMatrix(W_Q, self._expand_kv_heads(W_K).transpose(-2, -1))
 
     def OV_for_attn_layers(self) -> Tuple[List[int], FactoredMatrix]:
         """OV circuit for attention layers only. Returns (layer_indices, FactoredMatrix)."""
         v_indices, W_V = self.stack_params_for("attn", "attn.W_V", self._reshape_qkv)
         _, W_O = self.stack_params_for("attn", "attn.W_O", self._reshape_o)
-        return v_indices, FactoredMatrix(W_V, W_O)
+        return v_indices, FactoredMatrix(self._expand_kv_heads(W_V), W_O)
 
     # ------------------------------------------------------------------
     # Mechanistic interpretability analysis methods
@@ -1177,17 +1197,17 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
                 weights = [w.to(target_device) for w in weights]
             return torch.stack(weights, dim=0)
 
-        W_V = _stack("attn.W_V", self._reshape_qkv)
+        W_V = self._expand_kv_heads(_stack("attn.W_V", self._reshape_qkv))
         W_O = _stack("attn.W_O", self._reshape_o)
         left = FactoredMatrix(W_V, W_O)
 
         if mode == "Q":
             W_Q = _stack("attn.W_Q", self._reshape_qkv)
-            W_K = _stack("attn.W_K", self._reshape_qkv)
+            W_K = self._expand_kv_heads(_stack("attn.W_K", self._reshape_qkv))
             right = FactoredMatrix(W_Q, W_K.transpose(-2, -1))
         elif mode == "K":
             W_Q = _stack("attn.W_Q", self._reshape_qkv)
-            W_K = _stack("attn.W_K", self._reshape_qkv)
+            W_K = self._expand_kv_heads(_stack("attn.W_K", self._reshape_qkv))
             right = FactoredMatrix(W_Q, W_K.transpose(-2, -1)).T
         elif mode == "V":
             right = left


### PR DESCRIPTION
## What this fixes

`bridge.QK`, `bridge.OV`, and `bridge.all_composition_scores()` crash on every GQA model (Llama, Qwen, Gemma, Mistral, most MoE). The bridge stacks `W_Q`/`W_O` per query head (`[n_layers, n_heads, ...]`) but keeps `W_K`/`W_V` grouped (`[n_layers, n_kv_heads, ...]`), so `FactoredMatrix` hits a broadcast error on the leading head axes before any analysis can run. `HookedTransformer` already expands grouped K/V in its weight properties; the bridge never did.

Fixes #1553.

## Changes

- New `_expand_kv_heads()` in `transformer_bridge.py`: `repeat_interleave`s a stacked grouped K/V head axis up to `n_heads`. Query head `h` reads kv head `h // (n_heads // n_kv_heads)` — the same layout `GroupedQueryAttention.W_K`/`W_V` expose on HT, and the same routing HF uses at runtime. No-op for MHA and non-4D tensors; raises `ValueError` if `n_heads` isn't a multiple of `n_kv_heads` rather than silently mis-expanding.
- Applied at all seven grouped `FactoredMatrix` sites: `QK`, `OV`, `QK_for_attn_layers()`, `OV_for_attn_layers()`, and the three inside `all_composition_scores()`. The issue lists the first four; composition scores have the identical mismatch (their head labels already assume `n_heads` per layer), so I fixed them in the same pass rather than leaving GQA composition scores broken.
- Raw `bridge.W_K`/`W_V` stacks and per-block weights stay grouped — only the circuit views expand.
- Removed the inert `ungroup_grouped_query_attention` kwarg from `TransformerBridgeConfig`. No bridge code reads it, and the only tests exercising the flag build `HookedTransformer` objects; HT's flag and `set_ungroup_grouped_query_attention` are untouched.

## Tests

- `tests/unit/model_bridge/test_expand_kv_heads.py` (new, synthetic): the head mapping itself, MHA/non-4D pass-through as the identical tensor, indivisible-count `ValueError`.
- `tests/integration/model_bridge/test_attention_weight_accessors.py` (extended, reuses the file's tiny random GQA Llama fixture — no Hub access): QK/OV factors align per query head against the per-block grouped weights, both `*_for_attn_layers` variants, composition scores in all three modes, raw storage stays grouped, and an MHA bit-identity control on tiny GPT-2.
- `tests/integration/model_bridge/test_bridge_qk_ov_vs_hooked_gqa.py` (new, `@pytest.mark.slow` since Qwen2-0.5B isn't CI-cached): bridge QK/OV factors, the layer-0 `AB` product, and the `*_for_attn_layers` variants match `HookedTransformer.from_pretrained_no_processing` via `torch.testing.assert_close`.

## Acceptance criteria from #1553

- [x] `bridge.QK`/`OV` match `HookedTransformer.QK`/`OV` within fp tolerance on a small GQA model — exact on Qwen2-0.5B locally (max |Δ| = 0.0 on all four factors)
- [x] `QK_for_attn_layers`/`OV_for_attn_layers` return the same ungrouped alignment
- [x] Grouped-storage tests unchanged (raw grouped storage additionally asserted in the new tests)
- [x] Regression test asserts non-GQA (MHA) QK/OV unchanged
- [x] `rg ungroup transformer_lens/model_bridge/ transformer_lens/config/transformer_bridge_config.py` returns zero hits
- [x] `uv run mypy .` clean (421 files); `make format` applied; `patching.py` untouched
- [x] `make unit-test`: 5097 passed / 0 failed / 59 skipped / 10 xfailed locally, with one caveat below

Local caveat: five generation-exercising unit test files SIGBUS on my macOS-arm64 machine. That's pre-existing, not from this diff — it reproduces identically on the clean `dev-4.x` base under both torch 2.7.1 and 2.11.0, and matches the "Upstream PyTorch/HF on M-series Macs" quarantines in `tests/QUARANTINES.md`. The 5097 figure is the tier with those five files excluded; CI should be treated as authoritative for the full tier. I also ran `test_analysis_methods.py` (22 passed) and `test_attention_weight_accessors.py` (13 passed) directly as regressions for the touched surfaces.

## Relation to #1584

Overlaps — I was assigned on the issue and had this in flight. Beyond the overlap, this PR also fixes the three broken sites in `all_composition_scores()`, adds the HookedTransformer-parity test from the acceptance list, keeps the `rg ungroup` check at zero hits, and guards indivisible head counts.
