### PR TITLE
fix(model_bridge): raise clear TypeError for non-bridge config in boot_native (#1562)

### DIFF
--- a/tests/unit/model_bridge/test_boot_native.py
+++ b/tests/unit/model_bridge/test_boot_native.py
@@ -196,6 +196,22 @@ def test_boot_native_rejects_foreign_architecture_string():
     assert bridge.cfg.architecture == "TransformerLensNative"
 
 
+def test_boot_native_rejects_non_bridge_config_with_clear_typeerror():
+    """Passing a config that isn't a ``TransformerBridgeConfig`` or a dict (e.g.
+    the legacy ``HookedTransformerConfig``) used to fail deep inside ``boot``
+    with an opaque ``AttributeError`` ("...has no attribute 'architecture'").
+    Surface a clear ``TypeError`` that tells the caller what to construct
+    instead (regression for #1562)."""
+    import pytest
+
+    from transformer_lens import HookedTransformerConfig
+
+    ht_cfg = HookedTransformerConfig(n_layers=2, d_model=64, n_ctx=32, d_head=16, act_fn="gelu")
+    with pytest.raises(TypeError, match="TransformerBridgeConfig"):
+        TransformerBridge.boot_native(ht_cfg)
+
+
+
 def test_native_adapter_rejects_non_submodule_collisions():
     """The bridge's ``__getattr__`` fallback finds *any* attribute on the
     underlying model — buffers, plain tensors, properties — not just

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -336,10 +336,17 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
         cfg: TransformerBridgeConfig
         if isinstance(config, dict):
             cfg = _Cfg.from_dict(config)
-        else:
+        elif isinstance(config, _Cfg):
             # Deep-copy so NativeModel's default-resolution writes don't land
             # on the caller's config.
             cfg = _copy.deepcopy(config)
+        else:
+            raise TypeError(
+                f"boot_native expects a TransformerBridgeConfig or a plain dict, "
+                f"but got {type(config).__name__!r}. Construct a TransformerBridgeConfig "
+                f"(from transformer_lens.config) to build a TL-native model, or pass a "
+                f"dict of its fields."
+            )
 
         # Foreign architecture strings would dispatch to the wrong adapter and
         # crash deep in prepare_model. Refuse them with a pointing message.


### PR DESCRIPTION
Fixes #1562. boot_native raised an opaque AttributeError for non-bridge configs; now raises a clear TypeError.