### PR TITLE
refactor(train): relocate to tools/training.py for bridge compatibility

### DIFF
--- a/docs/source/content/migrating_to_v3.md
+++ b/docs/source/content/migrating_to_v3.md
@@ -239,6 +239,7 @@ Weight-matrix rows return **raw** HuggingFace weights by default. `HookedTransfo
 | `HookedTransformerConfig(...)` | `TransformerBridgeConfig(...)` | Construct the bridge config with the same core fields, then pass it to `TransformerBridge.boot_native(config)` for train-from-scratch or toy models. Do not pass a legacy config object to `boot_native`. |
 | `model.all_head_labels()` | `bridge.all_head_labels` | This is a property on the bridge, so omit the call parentheses. |
 | `model.set_tokenizer(tokenizer)` | `TransformerBridge.boot_transformers(name, tokenizer=tokenizer)` | A bridge's tokenizer is fixed when it boots. Reboot to change it; assigning `bridge.tokenizer` directly bypasses tokenizer/config wiring. |
+| `from transformer_lens.train import train, HookedTransformerTrainConfig` | `from transformer_lens.tools.training import train, TrainConfig` | The training loop moved to `tools.training` and `HookedTransformerTrainConfig` renamed to `TrainConfig`. The old imports still work but emit `DeprecationWarning`. |
 
 The loading, tokenization, generation, and basic hook calls listed under
 [APIs that are unchanged](#apis-that-are-unchanged) do not need wrappers. The

--- a/tests/integration/model_bridge/test_native_training.py
+++ b/tests/integration/model_bridge/test_native_training.py
@@ -12,6 +12,7 @@ import torch
 
 from transformer_lens.config import TransformerBridgeConfig
 from transformer_lens.model_bridge import TransformerBridge
+from transformer_lens.tools.training import TrainConfig, train
 
 
 def _induction_batch(batch_size: int, seq_len: int, vocab_size: int) -> torch.Tensor:
@@ -137,4 +138,51 @@ def test_native_bridge_induction_circuit_forms():
     assert max(rises) > 0.2, (
         f"No layer's coherence rose meaningfully. "
         f"Initial={coherence_initial}, final={coherence_final}, deltas={rises}"
+    )
+
+
+class InductionDataset(torch.utils.data.Dataset):
+    """Simple dataset wrapper for induction batches.
+
+    Returns single samples — DataLoader handles batching.
+    """
+
+    def __init__(self, num_samples: int, seq_len: int, vocab_size: int):
+        self.num_samples = num_samples
+        self.seq_len = seq_len
+        self.vocab_size = vocab_size
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        sample = _induction_batch(1, self.seq_len, self.vocab_size)
+        return {"tokens": sample.squeeze(0)}
+
+
+def test_train_loop_trains_bridge_via_train_config():
+    """train() function in tools.training trains a bridge via TrainConfig."""
+    torch.manual_seed(42)
+    cfg = _telemetry_cfg()
+    bridge = TransformerBridge.boot_native(cfg)
+
+    dataset = InductionDataset(
+        num_samples=16, seq_len=cfg.n_ctx, vocab_size=cfg.d_vocab
+    )
+    train_cfg = TrainConfig(
+        num_epochs=1,
+        batch_size=8,
+        lr=1e-3,
+        seed=42,
+        max_steps=10,
+    )
+
+    sample_batch = torch.stack([dataset[i]["tokens"] for i in range(8)])
+    initial_loss = bridge(sample_batch.to("cpu"), return_type="loss").item()
+
+    trained = train(bridge, train_cfg, dataset)
+
+    final_loss = trained(sample_batch.to("cpu"), return_type="loss").item()
+    assert final_loss < initial_loss, (
+        f"Training did not reduce loss: initial={initial_loss:.4f}, " f"final={final_loss:.4f}"
     )

--- a/tests/integration/model_bridge/test_native_training.py
+++ b/tests/integration/model_bridge/test_native_training.py
@@ -166,9 +166,7 @@ def test_train_loop_trains_bridge_via_train_config():
     cfg = _telemetry_cfg()
     bridge = TransformerBridge.boot_native(cfg)
 
-    dataset = InductionDataset(
-        num_samples=16, seq_len=cfg.n_ctx, vocab_size=cfg.d_vocab
-    )
+    dataset = InductionDataset(num_samples=16, seq_len=cfg.n_ctx, vocab_size=cfg.d_vocab)
     train_cfg = TrainConfig(
         num_epochs=1,
         batch_size=8,

--- a/tests/integration/model_bridge/test_native_training.py
+++ b/tests/integration/model_bridge/test_native_training.py
@@ -173,14 +173,15 @@ def test_train_loop_trains_bridge_via_train_config():
         lr=1e-3,
         seed=42,
         max_steps=10,
+        device="cpu",
     )
 
     sample_batch = torch.stack([dataset[i]["tokens"] for i in range(8)])
-    initial_loss = bridge(sample_batch.to("cpu"), return_type="loss").item()
+    initial_loss = bridge(sample_batch, return_type="loss").item()
 
     trained = train(bridge, train_cfg, dataset)
 
-    final_loss = trained(sample_batch.to("cpu"), return_type="loss").item()
+    final_loss = trained(sample_batch, return_type="loss").item()
     assert final_loss < initial_loss, (
         f"Training did not reduce loss: initial={initial_loss:.4f}, " f"final={final_loss:.4f}"
     )

--- a/transformer_lens/__init__.py
+++ b/transformer_lens/__init__.py
@@ -7,9 +7,9 @@ from . import (
     hook_points,
     patching,
     tools,
-    train,
     utilities,
 )
+from . import train
 from . import loading_from_pretrained as loading
 from . import supported_models
 from .ActivationCache import ActivationCache

--- a/transformer_lens/tools/__init__.py
+++ b/transformer_lens/tools/__init__.py
@@ -15,9 +15,9 @@ eager import here would create a cycle for core modules that consume
 import importlib
 from typing import Any
 
-_SUBMODULES = ("analysis", "model_registry")
+_SUBMODULES = ("analysis", "model_registry", "training")
 
-__all__ = ["analysis", "model_registry"]
+__all__ = ["analysis", "model_registry", "training"]
 
 
 def __getattr__(name: str) -> Any:

--- a/transformer_lens/tools/training.py
+++ b/transformer_lens/tools/training.py
@@ -1,0 +1,162 @@
+"""Train loop for TransformerLens models.
+
+Utilities for training models on autoregressive language modeling tasks.
+Typed against nn.Module so both HookedTransformer and TransformerBridge
+work through this loop.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader, Dataset
+from tqdm.auto import tqdm
+
+from transformer_lens import utilities as utils
+from transformer_lens.utilities.library_utils import is_library_available
+
+
+@dataclass
+class TrainConfig:
+    """Configuration class to store training hyperparameters for a training run.
+
+    Args:
+        num_epochs (int): Number of epochs to train for
+        batch_size (int): Size of batches to use for training
+        lr (float): Learning rate to use for training
+        seed (int): Random seed to use for training
+        momentum (float): Momentum to use for training
+        max_grad_norm (float, *optional*): Maximum gradient norm to use for
+        weight_decay (float, *optional*): Weight decay to use for training
+        optimizer_name (str): The name of the optimizer to use
+        device (str or torch.device, *optional*): Device to use for training
+        warmup_steps (int, *optional*): Number of warmup steps to use for training
+        save_every (int, *optional*): After how many batches should a checkpoint be saved
+        save_dir, (str, *optional*): Where to save checkpoints
+        wandb (bool): Whether to use Weights and Biases for logging
+        wandb_project (str, *optional*): Name of the Weights and Biases project to use
+        print_every (int, *optional*): Print the loss every n steps
+        max_steps (int, *optional*): Terminate the epoch after this many steps. Used for debugging.
+    """
+
+    num_epochs: int
+    batch_size: int
+    lr: float = 1e-3
+    seed: int = 0
+    momentum: float = 0.0
+    max_grad_norm: Optional[float] = None
+    weight_decay: Optional[float] = None
+    optimizer_name: str = "Adam"
+    device: Optional[Union[str, torch.device]] = None
+    warmup_steps: int = 0
+    save_every: Optional[int] = None
+    save_dir: Optional[str] = None
+    wandb: bool = False
+    wandb_project_name: Optional[str] = None
+    print_every: Optional[int] = 50
+    max_steps: Optional[int] = None
+
+
+def train(
+    model: nn.Module,
+    config: TrainConfig,
+    dataset: Dataset,
+) -> nn.Module:
+    """Train a model on an autoregressive language modeling task.
+
+    Args:
+        model: The model to train (must expose TrainableModel protocol surface)
+        config: The training configuration
+        dataset: The dataset to train on - assumed set up for autoregressive language modeling.
+
+    Returns:
+        The trained model
+    """
+
+    torch.manual_seed(config.seed)
+    model.train()
+
+    if config.wandb:
+        if not is_library_available("wandb"):
+            raise ImportError("Wandb is not available")
+
+        import wandb
+
+        if config.wandb_project_name is None:
+            config.wandb_project_name = "easy-transformer"
+        wandb.init(project=config.wandb_project_name, config=vars(config))
+
+    if config.device is None:
+        config.device = utils.get_device()
+
+    optimizer: Optimizer
+    if config.optimizer_name in ["Adam", "AdamW"]:
+        # Weight decay in Adam is implemented badly, so use AdamW instead (see PyTorch AdamW docs)
+        if config.weight_decay is not None:
+            optimizer = optim.AdamW(
+                model.parameters(),
+                lr=config.lr,
+                weight_decay=config.weight_decay,
+            )
+        else:
+            optimizer = optim.Adam(
+                model.parameters(),
+                lr=config.lr,
+            )
+    elif config.optimizer_name == "SGD":
+        optimizer = optim.SGD(
+            model.parameters(),
+            lr=config.lr,
+            weight_decay=(config.weight_decay if config.weight_decay is not None else 0.0),
+            momentum=config.momentum,
+        )
+    else:
+        raise ValueError(f"Optimizer {config.optimizer_name} not supported")
+
+    scheduler = None
+    if config.warmup_steps > 0:
+        scheduler = optim.lr_scheduler.LambdaLR(
+            optimizer,
+            lr_lambda=lambda step: min(1.0, step / config.warmup_steps),
+        )
+
+    dataloader = DataLoader(dataset, batch_size=config.batch_size, shuffle=True)
+
+    model.to(config.device)
+
+    for epoch in tqdm(range(1, config.num_epochs + 1)):
+        samples = 0
+        for step, batch in tqdm(enumerate(dataloader)):
+            tokens = batch["tokens"].to(config.device)
+            loss = model(tokens, return_type="loss")
+            loss.backward()
+            if config.max_grad_norm is not None:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), config.max_grad_norm)
+            optimizer.step()
+            if config.warmup_steps > 0:
+                assert scheduler is not None
+                scheduler.step()
+            optimizer.zero_grad()
+
+            samples += tokens.shape[0]
+
+            if config.wandb:
+                wandb.log({"train_loss": loss.item(), "samples": samples, "epoch": epoch})
+
+            if config.print_every is not None and step % config.print_every == 0:
+                print(f"Epoch {epoch} Samples {samples} Step {step} Loss {loss.item()}")
+
+            if (
+                config.save_every is not None
+                and step % config.save_every == 0
+                and config.save_dir is not None
+            ):
+                torch.save(model.state_dict(), f"{config.save_dir}/model_{step}.pt")
+
+            if config.max_steps is not None and step >= config.max_steps:
+                break
+
+    return model

--- a/transformer_lens/tools/training.py
+++ b/transformer_lens/tools/training.py
@@ -68,7 +68,7 @@ def train(
     """Train a model on an autoregressive language modeling task.
 
     Args:
-        model: The model to train (must expose TrainableModel protocol surface)
+        model: The model to train (nn.Module with __call__(tokens, return_type="loss"))
         config: The training configuration
         dataset: The dataset to train on - assumed set up for autoregressive language modeling.
 

--- a/transformer_lens/train.py
+++ b/transformer_lens/train.py
@@ -5,6 +5,9 @@ Use transformer_lens.tools.training instead.
 
 import warnings
 
+import torch.nn as nn
+from torch.utils.data import Dataset
+
 from transformer_lens.tools.training import TrainConfig as _TrainConfig
 from transformer_lens.tools.training import train as _train
 
@@ -19,10 +22,10 @@ class HookedTransformerTrainConfig(_TrainConfig):
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__(*args, **kwargs)  # type: ignore
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
 
 
-def train(model: object, config: object, dataset: object) -> object:
+def train(model: nn.Module, config: _TrainConfig, dataset: Dataset) -> nn.Module:
     """Deprecated. Use transformer_lens.tools.training.train instead."""
     warnings.warn(
         "transformer_lens.train is deprecated; use "
@@ -30,4 +33,4 @@ def train(model: object, config: object, dataset: object) -> object:
         DeprecationWarning,
         stacklevel=2,
     )
-    return _train(model, config, dataset)  # type: ignore
+    return _train(model, config, dataset)

--- a/transformer_lens/train.py
+++ b/transformer_lens/train.py
@@ -1,161 +1,33 @@
-"""Train.
+"""Deprecated: train.py moved to tools.training.
 
-Utilities for training :class:`transformer_lens.HookedTransformer` models on autoregressive language
-modeling tasks.
+Use transformer_lens.tools.training instead.
 """
 
-from dataclasses import dataclass
-from typing import Optional, Union
+import warnings
 
-import torch
-import torch.optim as optim
-from torch.optim import Optimizer
-from torch.utils.data import DataLoader, Dataset
-from tqdm.auto import tqdm
-
-from transformer_lens import utilities as utils
-from transformer_lens.HookedTransformer import HookedTransformer
-from transformer_lens.utilities.library_utils import is_library_available
+from transformer_lens.tools.training import TrainConfig as _TrainConfig
+from transformer_lens.tools.training import train as _train
 
 
-@dataclass
-class HookedTransformerTrainConfig:
-    """
-    Configuration class to store training hyperparameters for a training run of
-    an HookedTransformer model.
-    Args:
-        num_epochs (int): Number of epochs to train for
-        batch_size (int): Size of batches to use for training
-        lr (float): Learning rate to use for training
-        seed (int): Random seed to use for training
-        momentum (float): Momentum to use for training
-        max_grad_norm (float, *optional*): Maximum gradient norm to use for
-        weight_decay (float, *optional*): Weight decay to use for training
-        optimizer_name (str): The name of the optimizer to use
-        device (str or torch.device, *optional*): Device to use for training
-        warmup_steps (int, *optional*): Number of warmup steps to use for training
-        save_every (int, *optional*): After how many batches should a checkpoint be saved
-        save_dir, (str, *optional*): Where to save checkpoints
-        wandb (bool): Whether to use Weights and Biases for logging
-        wandb_project (str, *optional*): Name of the Weights and Biases project to use
-        print_every (int, *optional*): Print the loss every n steps
-        max_steps (int, *optional*): Terminate the epoch after this many steps. Used for debugging.
-    """
+class HookedTransformerTrainConfig(_TrainConfig):
+    """Deprecated alias for TrainConfig. Use transformer_lens.tools.training.TrainConfig instead."""
 
-    num_epochs: int
-    batch_size: int
-    lr: float = 1e-3
-    seed: int = 0
-    momentum: float = 0.0
-    max_grad_norm: Optional[float] = None
-    weight_decay: Optional[float] = None
-    optimizer_name: str = "Adam"
-    device: Optional[Union[str, torch.device]] = None
-    warmup_steps: int = 0
-    save_every: Optional[int] = None
-    save_dir: Optional[str] = None
-    wandb: bool = False
-    wandb_project_name: Optional[str] = None
-    print_every: Optional[int] = 50
-    max_steps: Optional[int] = None
-
-
-def train(
-    model: HookedTransformer,
-    config: HookedTransformerTrainConfig,
-    dataset: Dataset,
-) -> HookedTransformer:
-    """
-    Trains an HookedTransformer model on an autoregressive language modeling task.
-    Args:
-        model: The model to train
-        config: The training configuration
-        dataset: The dataset to train on - this function assumes the dataset is set up for autoregressive language modeling.
-    Returns:
-        The trained model
-    """
-
-    torch.manual_seed(config.seed)
-    model.train()
-
-    if config.wandb:
-        if not is_library_available("wandb"):
-            raise ImportError("Wandb is not available")
-
-        import wandb
-
-        if config.wandb_project_name is None:
-            config.wandb_project_name = "easy-transformer"
-        wandb.init(project=config.wandb_project_name, config=vars(config))
-
-    if config.device is None:
-        config.device = utils.get_device()
-
-    optimizer: Optimizer
-    if config.optimizer_name in ["Adam", "AdamW"]:
-        # Weight decay in Adam is implemented badly, so use AdamW instead (see PyTorch AdamW docs)
-        if config.weight_decay is not None:
-            optimizer = optim.AdamW(
-                model.parameters(),
-                lr=config.lr,
-                weight_decay=config.weight_decay,
-            )
-        else:
-            optimizer = optim.Adam(
-                model.parameters(),
-                lr=config.lr,
-            )
-    elif config.optimizer_name == "SGD":
-        optimizer = optim.SGD(
-            model.parameters(),
-            lr=config.lr,
-            weight_decay=(config.weight_decay if config.weight_decay is not None else 0.0),
-            momentum=config.momentum,
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        warnings.warn(
+            "HookedTransformerTrainConfig is deprecated; use "
+            "transformer_lens.tools.training.TrainConfig instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-    else:
-        raise ValueError(f"Optimizer {config.optimizer_name} not supported")
+        super().__init__(*args, **kwargs)  # type: ignore
 
-    scheduler = None
-    if config.warmup_steps > 0:
-        scheduler = optim.lr_scheduler.LambdaLR(
-            optimizer,
-            lr_lambda=lambda step: min(1.0, step / config.warmup_steps),
-        )
 
-    dataloader = DataLoader(dataset, batch_size=config.batch_size, shuffle=True)
-
-    model.to(config.device)
-
-    for epoch in tqdm(range(1, config.num_epochs + 1)):
-        samples = 0
-        for step, batch in tqdm(enumerate(dataloader)):
-            tokens = batch["tokens"].to(config.device)
-            loss = model(tokens, return_type="loss")
-            loss.backward()
-            if config.max_grad_norm is not None:
-                torch.nn.utils.clip_grad_norm_(model.parameters(), config.max_grad_norm)
-            optimizer.step()
-            if config.warmup_steps > 0:
-                assert scheduler is not None
-                scheduler.step()
-            optimizer.zero_grad()
-
-            samples += tokens.shape[0]
-
-            if config.wandb:
-                wandb.log({"train_loss": loss.item(), "samples": samples, "epoch": epoch})
-
-            if config.print_every is not None and step % config.print_every == 0:
-                print(f"Epoch {epoch} Samples {samples} Step {step} Loss {loss.item()}")
-
-            if (
-                config.save_every is not None
-                and step % config.save_every == 0
-                and config.save_dir is not None
-            ):
-                torch.save(model.state_dict(), f"{config.save_dir}/model_{step}.pt")
-
-            if config.max_steps is not None and step >= config.max_steps:
-                break
-
-    return model
+def train(model: object, config: object, dataset: object) -> object:
+    """Deprecated. Use transformer_lens.tools.training.train instead."""
+    warnings.warn(
+        "transformer_lens.train is deprecated; use "
+        "transformer_lens.tools.training.train instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _train(model, config, dataset)  # type: ignore


### PR DESCRIPTION
# Description

Relocate `train()` + `HookedTransformerTrainConfig` from `transformer_lens/train.py` to `transformer_lens/tools/training.py`, typed against `nn.Module` so `TransformerBridge` trains through it.

**Motivation:** `train.py:17` hard-imports `HookedTransformer` and is re-exported from `__init__.py:10`, so at 4.0 the package import breaks unless the loop leaves the HT namespace.

**Changes:**
- `transformer_lens/tools/training.py`: New home for `TrainConfig` (renamed from `HookedTransformerTrainConfig`) and `train()`, typed against `nn.Module`
- `transformer_lens/train.py`: Deprecation shim with `DeprecationWarning` on use
- `transformer_lens/tools/__init__.py`: Add `training` to lazy submodules
- `tests/integration/model_bridge/test_native_training.py`: Add `test_train_loop_trains_bridge_via_train_config`, fix `InductionDataset` to return single samples

**Acceptance:**
- [x] `tools/training.py` exists, no `HookedTransformer` import
- [x] `TransformerBridge` (via `boot_native`) trains through `train()`
- [x] `from transformer_lens import train` still imports, emits `DeprecationWarning`, delegates
- [x] Tests under `tests/integration/model_bridge/test_native_training.py`
- [x] `make unit-test` + `uv run mypy .` clean

Fixes #1589 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Screenshots
N/A

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility