### PR TITLE
Add native bridge state dict regression tests

### DIFF
--- a/tests/unit/model_bridge/test_boot_native.py
+++ b/tests/unit/model_bridge/test_boot_native.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 
+import pytest
 import torch
 
 from transformer_lens.config import TransformerBridgeConfig
@@ -69,6 +70,37 @@ def test_boot_native_returns_bridge_over_native_model():
     bridge = TransformerBridge.boot_native(_cfg())
     assert isinstance(bridge, TransformerBridge)
     assert isinstance(bridge.original_model, NativeModel)
+
+
+def test_native_state_dict_round_trip_restores_parameters():
+    bridge = TransformerBridge.boot_native(_cfg())
+
+    saved_state_dict = {key: value.detach().clone() for key, value in bridge.state_dict().items()}
+    original_parameters = {
+        name: parameter.detach().clone() for name, parameter in bridge.named_parameters()
+    }
+
+    with torch.no_grad():
+        for parameter in bridge.parameters():
+            parameter.zero_()
+
+    result = bridge.load_state_dict(saved_state_dict, strict=True)
+
+    assert result.missing_keys == []
+    assert result.unexpected_keys == []
+
+    for name, parameter in bridge.named_parameters():
+        torch.testing.assert_close(parameter, original_parameters[name])
+
+
+def test_native_state_dict_strict_rejects_unexpected_keys():
+    bridge = TransformerBridge.boot_native(_cfg())
+
+    with pytest.raises(RuntimeError, match="Unexpected key"):
+        bridge.load_state_dict(
+            {"not.a.real.weight": torch.zeros(1)},
+            strict=True,
+        )
 
 
 def test_boot_native_accepts_dict_config():

--- a/tests/unit/test_tracr_conversion.py
+++ b/tests/unit/test_tracr_conversion.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 import torch
 
+from transformer_lens.model_bridge import TransformerBridge
 from transformer_lens.utilities.tracr import (
     infer_tracr_output_label,
     make_tracr_categorical_unembed,
@@ -119,6 +120,17 @@ def test_bridge_config_matches_tracr_metadata():
     assert cfg.d_mlp == 6
     assert cfg.normalization_type is None
     assert cfg.attention_dir == "bidirectional"
+
+
+def test_bridge_state_dict_loads_into_native_bridge():
+    model = _fake_tracr_model()
+    bridge = TransformerBridge.boot_native(make_tracr_transformer_bridge_config(model))
+    state_dict = make_tracr_transformer_bridge_state_dict(model, output_label="reverse_1")
+
+    result = bridge.load_state_dict(state_dict, strict=False)
+
+    assert result.unexpected_keys == []
+    torch.testing.assert_close(bridge.state_dict()["embed.weight"], state_dict["tok_embed.weight"])
 
 
 def test_bridge_state_dict_transposes_tracr_weights_and_reconstructs_unembed():


### PR DESCRIPTION
# Description

Adds regression coverage for the native `TransformerBridge.state_dict()` / `load_state_dict()` round-trip behavior in #1587.

This PR intentionally contains tests only. It depends on #1598, which provides the production implementation selected by the maintainer. After #1598 is merged, these tests verify native round trips, strict handling of an unexpected key, and continued loading of Tracr-generated state dictionaries.

No new dependencies are required.

## Type of change

- [x] Bug-fix regression coverage

### Screenshots

Not applicable — no UI change.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes (depends on #1598)
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility