### PR TITLE
docs: add boot_native train-from-scratch recipe to migration guide

### DIFF
--- a/docs/source/content/migrating_to_v3.md
+++ b/docs/source/content/migrating_to_v3.md
@@ -335,3 +335,50 @@ def cache_activations(model: TransformerLensModel, text: str):
 
 Use `TransformerLensModelWithWeights` instead when the helper also needs the
 weight-processing surface used by advanced `ActivationCache` operations.
+
+
+### Build a TL-native model from scratch
+
+For toy models and interpretability-research training loops, the bridge
+replaces `HookedTransformerConfig + HookedTransformer(cfg)` with
+`TransformerBridgeConfig + TransformerBridge.boot_native(cfg)`:
+
+```python
+# Before
+from transformer_lens import HookedTransformer, HookedTransformerConfig
+
+cfg = HookedTransformerConfig(
+    d_model=64,
+    d_head=8,
+    n_heads=8,
+    n_layers=2,
+    n_ctx=256,
+    d_vocab=50257,
+    act_fn="gelu_new",
+    seed=42,
+)
+model = HookedTransformer(cfg)
+
+# After
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.model_bridge import TransformerBridge
+
+cfg = TransformerBridgeConfig(
+    d_model=64,
+    d_head=8,
+    n_heads=8,
+    n_layers=2,
+    n_ctx=256,
+    d_vocab=50257,
+    act_fn="gelu_new",
+    seed=42,               # optional: makes initialisation reproducible
+)
+bridge = TransformerBridge.boot_native(cfg, device="cpu")
+```
+
+`boot_native` makes no HuggingFace Hub call and requires no `transformers`
+import. `cfg.seed` seeds the weight initialiser; omitting it lets the
+global RNG advance normally. Passing a `HookedTransformerConfig` (or any
+other legacy config object) to `boot_native` raises `TypeError` — construct
+a `TransformerBridgeConfig` directly. To re-randomise weights after
+construction, call `bridge.init_weights()`.

--- a/docs/source/content/migrating_to_v3.md
+++ b/docs/source/content/migrating_to_v3.md
@@ -380,5 +380,9 @@ bridge = TransformerBridge.boot_native(cfg, device="cpu")
 import. `cfg.seed` seeds the weight initialiser; omitting it lets the
 global RNG advance normally. Passing a `HookedTransformerConfig` (or any
 other legacy config object) to `boot_native` raises `TypeError` — construct
-a `TransformerBridgeConfig` directly. To re-randomise weights after
-construction, call `bridge.init_weights()`.
+a `TransformerBridgeConfig` directly. To reinitialize weights in place, call `bridge.init_weights()` — if `cfg.seed` is set,
+`init_weights()` rebuilds from that same seed and produces identical weights; clear or
+change `cfg.seed` first for a genuinely fresh draw. Unlike `HookedTransformer.init_weights()`,
+which calls `torch.manual_seed(cfg.seed)` globally, `boot_native` forks the RNG — training
+loops ported verbatim that rely on global seed state for data shuffling will silently
+lose reproducibility.


### PR DESCRIPTION
Closes #1557

The `migrating_to_v3.md` on `dev-4.x` already has 13 API migration table rows and 4 runnable prose recipes, but `boot_native` / `TransformerBridgeConfig` only appeared as a table row with no runnable before/after snippet.

This PR adds the missing `### Build a TL-native model from scratch` recipe, showing the direct replacement for `HookedTransformerConfig + HookedTransformer(cfg)`. Notes included: no HF Hub call, `cfg.seed` reproducibility, `TypeError` on legacy config objects, and `bridge.init_weights()` for re-randomisation.

Base branch: `dev-4.x` (targets the v4 preview line where the rest of the migration API section lives).