### PR TITLE
fix(bridge): remove orphaned convert_weights override from nanogpt adapter

### DIFF
--- a/transformer_lens/model_bridge/supported_architectures/nanogpt.py
+++ b/transformer_lens/model_bridge/supported_architectures/nanogpt.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-import torch
-
 from transformer_lens.conversion_utils.conversion_steps import RearrangeTensorConversion
 from transformer_lens.conversion_utils.param_processing_conversion import (
     ParamProcessingConversion,
@@ -88,16 +86,3 @@ class NanogptArchitectureAdapter(ArchitectureAdapter):
             ),  # Final layer norm
             "unembed": UnembeddingBridge(name="lm_head"),
         }
-
-    def convert_weights(self, remote_module: Any) -> dict[str, torch.Tensor]:
-        # Nanogpt models saved after torch.compile() have this unwanted prefix
-        # This is a simple way to remove it
-        unwanted_prefix = "_orig_mod."
-        state_dict: dict[str, torch.Tensor] = (
-            remote_module.state_dict() if hasattr(remote_module, "state_dict") else remote_module
-        )
-        for k, v in list(state_dict.items()):
-            if k.startswith(unwanted_prefix):
-                state_dict[k[len(unwanted_prefix) :]] = state_dict.pop(k)
-
-        return super().convert_weights(remote_module)  # type: ignore[misc]


### PR DESCRIPTION
# Description

`NanogptArchitectureAdapter.convert_weights` ended in `return super().convert_weights(remote_module)`, but `ArchitectureAdapter` has had no `convert_weights` method since `3efbd6e` ("Cleanup (#1129)", 2025-11-15). Every call therefore raised `AttributeError: 'super' object has no attribute 'convert_weights'`.

The defect was invisible to CI because of the `# type: ignore[misc]` on that line. With the ignore removed, `uv run mypy .` reports it directly:

```
transformer_lens/model_bridge/supported_architectures/nanogpt.py:103: error: "convert_weights" undefined in superclass  [misc]
```

This PR deletes the orphaned override together with its ignore, and drops the now-unused `torch` import.

**Why removal rather than repair:**

- The method had no callers. A search over `*.py` / `*.ipynb` / `*.md`, plus a check for dynamic `getattr` dispatch, finds only two definitions of `convert_weights` in the tree — this one and `bd3lm.py:208` (a different signature returning `{}`, likewise never called). Both are orphans from the base-class removal.
- Its `_orig_mod.` prefix strip was a no-op regardless. `nn.Module.state_dict()` returns a fresh dict, so the `pop`/reassign loop mutated a throwaway copy and then passed the original `remote_module` to `super()`.
- Removal cannot regress behaviour, because every path through the method already raised.

**Deliberately not re-homed into `preprocess_weights`.** That hook runs on `self.state_dict()` inside `process_weights` (`transformer_bridge.py:608`) — after loading, with TL-renamed keys — so it would never observe `_orig_mod.`-prefixed checkpoint keys. Moving the logic there would look like a fix while doing nothing.

**Regression guard:** with the `# type: ignore` gone, the CI `type-check` job fails if the override is reintroduced.

**Adjacent gap, not addressed here:** `TransformerBridge` consequently has no `_orig_mod.` handling for `torch.compile()`'d nanoGPT checkpoints, while the HookedTransformer path does (`transformer_lens/pretrained/weight_conversions/nanogpt.py:14`). That is HT→Bridge drift, but adding it is a feature with its own design question (which load path should own the strip), so it is out of scope for a dead-code removal. Happy to file it separately.

**On unit coverage:** `nanogpt` sits in `_COVERAGE_EXEMPT_MODULES` (`tests/unit/model_bridge/supported_architectures/test_thin_subclass_adapters.py:94`) as an internal-only adapter, so no test file accompanies this change. I have a structural unit suite for the adapter ready if you want it — note that adding it also requires dropping `"nanogpt"` from that exemption set, since `test_coverage_exemptions_are_still_uncovered` is self-cleaning. That is a policy call on an intentionally-exempt adapter, so I did not make it unilaterally.

Fixes #1601

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas — the change is a deletion; the rationale is in the commit message and above
- [ ] I have made corresponding changes to the documentation — no documented behaviour changes; the removed method was unreachable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — see "On unit coverage" above: `nanogpt` is an exempt module, and the `# type: ignore` removal makes the CI `type-check` job the regression guard. A structural unit suite is ready if you want the exemption retired.
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility