### PR TITLE
fix(bridge): remove dead _enable_ht_attention and its exclusive helpers

### DIFF
--- a/transformer_lens/model_bridge/architecture_adapter.py
+++ b/transformer_lens/model_bridge/architecture_adapter.py
@@ -4,7 +4,6 @@ This module contains the base class for architecture adapters that map between d
 """
 from typing import Any, Dict, Optional, cast
 
-import einops
 import torch
 
 from transformer_lens.config import TransformerBridgeConfig
@@ -1072,100 +1071,3 @@ class ArchitectureAdapter:
             template = None
         if template is not None and hasattr(template, "set_rotary_emb"):
             template.set_rotary_emb(rotary_emb)
-
-    def _enable_ht_attention(self, attn_bridge, hf_attn):
-        """Enable HT computation for attention (architecture-agnostic).
-
-        Detects the architecture by checking which weight attributes exist.
-        """
-        n_heads = getattr(
-            self.cfg,
-            "n_heads",
-            getattr(self.cfg, "n_head", getattr(self.cfg, "num_attention_heads", None)),
-        )
-        d_model = getattr(
-            self.cfg, "d_model", getattr(self.cfg, "n_embd", getattr(self.cfg, "hidden_size", None))
-        )
-        if n_heads is None or d_model is None:
-            raise RuntimeError(f"Could not determine n_heads or d_model from config: {self.cfg}")
-        d_head = d_model // n_heads
-        if hasattr(hf_attn, "c_attn"):
-            W_Q, W_K, W_V, b_Q, b_K, b_V = self._extract_qkv_gpt2_style(
-                hf_attn.c_attn, n_heads, d_model, d_head
-            )
-            W_O, b_O = self._extract_output_proj(hf_attn.c_proj, n_heads, d_head, d_model)
-        elif (
-            hasattr(hf_attn, "q_proj") and hasattr(hf_attn, "k_proj") and hasattr(hf_attn, "v_proj")
-        ):
-            W_Q, b_Q = self._extract_linear_ht_format(hf_attn.q_proj, n_heads, d_head, d_model)  # type: ignore[attr-defined]
-            W_K, b_K = self._extract_linear_ht_format(hf_attn.k_proj, n_heads, d_head, d_model)  # type: ignore[attr-defined]
-            W_V, b_V = self._extract_linear_ht_format(hf_attn.v_proj, n_heads, d_head, d_model)  # type: ignore[attr-defined]
-            out_proj = hf_attn.out_proj if hasattr(hf_attn, "out_proj") else hf_attn.o_proj
-            W_O, b_O = self._extract_output_proj(out_proj, n_heads, d_head, d_model)
-        elif hasattr(hf_attn, "query_key_value"):
-            W_Q, W_K, W_V, b_Q, b_K, b_V = self._extract_qkv_neox_style(  # type: ignore[attr-defined]
-                hf_attn.query_key_value, n_heads, d_model, d_head
-            )
-            W_O, b_O = self._extract_output_proj(hf_attn.dense, n_heads, d_head, d_model)
-        else:
-            raise ValueError(
-                f"Unsupported attention architecture. Module has attributes: {dir(hf_attn)}"
-            )
-        attn_bridge.set_processed_weights(
-            {
-                "W_Q": W_Q,
-                "W_K": W_K,
-                "W_V": W_V,
-                "W_O": W_O,
-                "b_Q": b_Q,
-                "b_K": b_K,
-                "b_V": b_V,
-                "b_O": b_O,
-            }
-        )
-        self._disable_hook_conversions(attn_bridge)
-
-    def _extract_qkv_gpt2_style(self, c_attn, n_heads, d_model, d_head):
-        """Extract Q, K, V weights from GPT-2 style combined c_attn.
-
-        GPT-2 uses Conv1D which stores weights as [in_features, out_features] = [d_model, 3*d_model].
-        We need to split and reshape to [n_heads, d_model, d_head] format for HookedTransformer.
-        """
-        W = c_attn.weight.data
-        W_Q, W_K, W_V = torch.tensor_split(W, 3, dim=1)
-        W_Q = einops.rearrange(W_Q, "m (i h)->i m h", i=n_heads)
-        W_K = einops.rearrange(W_K, "m (i h)->i m h", i=n_heads)
-        W_V = einops.rearrange(W_V, "m (i h)->i m h", i=n_heads)
-        qkv_bias = c_attn.bias.data
-        qkv_bias = einops.rearrange(
-            qkv_bias, "(qkv index head)->qkv index head", qkv=3, index=n_heads, head=d_head
-        )
-        b_Q = qkv_bias[0]
-        b_K = qkv_bias[1]
-        b_V = qkv_bias[2]
-        return (W_Q, W_K, W_V, b_Q, b_K, b_V)
-
-    def _extract_output_proj(self, out_proj, n_heads, d_head, d_model):
-        """Extract output projection weights in HT format.
-
-        Returns W_O in [n_heads, d_head, d_model] format for HookedTransformer compatibility.
-
-        For Conv1D (GPT-2), weight is stored as [d_model, d_model] = [nx, nf].
-        For Linear, weight is stored as [d_model, d_model] = [out_features, in_features].
-        """
-        weight = out_proj.weight.data
-        bias = out_proj.bias.data if hasattr(out_proj, "bias") else None
-        W_O = weight.view(n_heads, d_head, d_model).contiguous()
-        b_O = bias.contiguous() if bias is not None else None
-        return (W_O, b_O)
-
-    def _disable_hook_conversions(self, attn_bridge):
-        """Disable hook conversions for attention submodules.
-
-        Note: In no_processing mode, we DON'T disable conversions because Q/K/V hooks need
-        to convert from 3D [batch, seq, d_model] to 4D [batch, seq, n_heads, d_head].
-        We also preserve o.hook_in.hook_conversion (hook_z).
-
-        This method is kept for potential future use but currently does nothing in no_processing mode.
-        """
-        pass


### PR DESCRIPTION
# Description

Follow-up to #1602, as agreed in https://github.com/TransformerLensOrg/TransformerLens/issues/1601 - same defect pattern, same origin commit, separate PR.

`ArchitectureAdapter._enable_ht_attention` dispatched on three attention layouts, but two of the three branches called methods that do not exist anywhere in the tree:

| Branch | Attention layout | Helper called | Defined? |
|---|---|---|---|
| `c_attn` | GPT-2 | `_extract_qkv_gpt2_style` | yes |
| `q_proj` / `k_proj` / `v_proj` | Llama, Mistral, Qwen, Gemma, Phi, … | `_extract_linear_ht_format` | **no** |
| `query_key_value` | GPT-NeoX, Falcon | `_extract_qkv_neox_style` | **no** |

`3efbd6e` ("Cleanup (#1129)", 2025-11-15) deleted both helper definitions while keeping their call sites:

```
$ git show 3efbd6e -- transformer_lens/model_bridge/architecture_adapter.py | grep '^-.*def _extract'
-    def _extract_qkv_neox_style(self, query_key_value, n_heads, d_model, d_head):
-    def _extract_linear_ht_format(self, linear_module, n_heads, d_head, d_model):
```

Four `# type: ignore[attr-defined]` comments suppressed the resulting mypy errors, so CI stayed green. Only the GPT-2 branch could run; the other two raised `AttributeError` on entry.

**No user was affected.** The same commit also removed both callers (`architecture_adapter.py:1249` and `bridge.py:1144` as of `3efbd6e^`), leaving the method unreachable — verified by searching `*.py` / `*.ipynb` / `*.md` and checking for dynamic `getattr` dispatch. The risk was latent: the method advertises itself as "architecture-agnostic" in its docstring, so the next person wiring it into component testing would have hit an immediate crash on every architecture except GPT-2.

## What is removed

The whole unreachable cluster — 98 lines, the tail of the file:

- `_enable_ht_attention`
- `_extract_qkv_gpt2_style`, `_extract_output_proj`, `_disable_hook_conversions` — each called **only** from `_enable_ht_attention`, so they die with it. `_disable_hook_conversions` was already a no-op (`pass`, with a docstring saying it "currently does nothing in no_processing mode").
- the four `# type: ignore[attr-defined]` comments
- `import einops`, now unused (pruned by `make format`)

`setup_component_testing` and `_wire_rotary_for_testing` are untouched — they were never part of this path.

## If you would rather keep the capability

The opposite fix is equally available: restore `_extract_linear_ht_format` and `_extract_qkv_neox_style` from `3efbd6e^` and re-wire a caller. That is a feature with its own design questions (which call path owns it, how it relates to `setup_component_testing`), so I have not assumed it — happy to send that version instead if you prefer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas — this is a pure deletion; rationale is in the commit message and above
- [ ] I have made corresponding changes to the documentation — no documented behaviour changes; the removed code was unreachable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — nothing to test: the code is unreachable and removed. Dropping the `# type: ignore` comments leaves the CI `type-check` job as the guard against reintroduction.
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
