### PR TITLE
fix(bridge): derive position_ids from attention_mask for left-padded input

### DIFF
--- a/tests/integration/model_bridge/test_left_padding_positions.py
+++ b/tests/integration/model_bridge/test_left_padding_positions.py
@@ -1,0 +1,168 @@
+"""Regression tests for left-padding position handling in TransformerBridge.
+
+A causal LM's logits at a sequence's real token positions must not depend on how
+that sequence is padded, provided the caller supplies the matching attention_mask.
+Left padding shifts every real token's absolute position, so position_ids have to
+be derived from the mask; without that the bridge silently returns wrong logits
+and a wrong loss. See #1609.
+
+Right padding is included as a control: causality already protects it, so it was
+never affected and must stay that way.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from transformer_lens import utilities as utils
+
+PAD_ID = 0
+
+
+def _pad(tokens: torch.Tensor, n_pad: int, side: str) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pad `tokens` on `side`, returning (padded_tokens, attention_mask)."""
+    pads = torch.full((tokens.shape[0], n_pad), PAD_ID, dtype=tokens.dtype)
+    ones = torch.ones(tokens.shape, dtype=torch.long)
+    zeros = torch.zeros((tokens.shape[0], n_pad), dtype=torch.long)
+    if side == "left":
+        return torch.cat([pads, tokens], dim=1), torch.cat([zeros, ones], dim=1)
+    return torch.cat([tokens, pads], dim=1), torch.cat([ones, zeros], dim=1)
+
+
+@pytest.fixture(scope="module")
+def tokens(distilgpt2_bridge) -> torch.Tensor:
+    return distilgpt2_bridge.to_tokens("The capital of France is")
+
+
+@pytest.mark.parametrize("side", ["left", "right"])
+@pytest.mark.parametrize("n_pad", [1, 3, 5])
+def test_logits_are_invariant_to_padding(distilgpt2_bridge, tokens, side, n_pad) -> None:
+    """Padding must not change the logits at a sequence's real positions."""
+    padded, mask = _pad(tokens, n_pad, side)
+    real = slice(n_pad, None) if side == "left" else slice(None, tokens.shape[1])
+
+    with torch.no_grad():
+        baseline = distilgpt2_bridge(tokens, return_type="logits")
+        actual = distilgpt2_bridge(padded, attention_mask=mask, return_type="logits")[:, real]
+
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual, baseline, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_compat_mode_logits_are_invariant_to_padding(distilgpt2_bridge_compat, side: str) -> None:
+    """enable_compatibility_mode() promises HookedTransformer-equivalent numerics,
+    which this property is part of."""
+    tokens = distilgpt2_bridge_compat.to_tokens("The capital of France is")
+    n_pad = 3
+    padded, mask = _pad(tokens, n_pad, side)
+    real = slice(n_pad, None) if side == "left" else slice(None, tokens.shape[1])
+
+    with torch.no_grad():
+        baseline = distilgpt2_bridge_compat(tokens, return_type="logits")
+        actual = distilgpt2_bridge_compat(padded, attention_mask=mask, return_type="logits")[
+            :, real
+        ]
+
+    torch.testing.assert_close(actual, baseline, rtol=1e-3, atol=1e-3)
+
+
+def test_derived_position_ids_match_hooked_transformer(distilgpt2_bridge, tokens) -> None:
+    """The derived positions must be the ones HookedTransformer would use, i.e. the
+    shared get_offset_position_ids helper rather than a parallel derivation."""
+    n_pad = 3
+    padded, mask = _pad(tokens, n_pad, "left")
+    expected = utils.get_offset_position_ids(0, mask)
+
+    with torch.no_grad():
+        derived = distilgpt2_bridge(padded, attention_mask=mask, return_type="logits")
+        supplied = distilgpt2_bridge(
+            padded, attention_mask=mask, position_ids=expected, return_type="logits"
+        )
+
+    torch.testing.assert_close(derived, supplied, rtol=1e-5, atol=1e-5)
+
+
+def test_explicit_position_ids_take_precedence(distilgpt2_bridge, tokens) -> None:
+    """A caller-supplied position_ids must not be overwritten by the derivation."""
+    n_pad = 3
+    padded, mask = _pad(tokens, n_pad, "left")
+    derived_positions = utils.get_offset_position_ids(0, mask)
+    shifted = derived_positions + 1  # deliberately different, but still in range
+
+    with torch.no_grad():
+        default = distilgpt2_bridge(padded, attention_mask=mask, return_type="logits")
+        overridden = distilgpt2_bridge(
+            padded, attention_mask=mask, position_ids=shifted, return_type="logits"
+        )
+
+    assert not torch.allclose(default, overridden, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("gap", [slice(3, 5), slice(1, 2)])
+def test_interior_mask_gap_uses_derived_positions(distilgpt2_bridge, tokens, gap) -> None:
+    """A mask gap that is not leading padding still shifts later positions, so the
+    derivation must fire for any mask, not only ones starting with a pad."""
+    mask = torch.ones(tokens.shape, dtype=torch.long)
+    mask[0, gap] = 0
+    gapped = tokens.clone()
+    gapped[0, gap] = PAD_ID
+    expected = utils.get_offset_position_ids(0, mask)
+
+    with torch.no_grad():
+        derived = distilgpt2_bridge(gapped, attention_mask=mask, return_type="logits")
+        supplied = distilgpt2_bridge(
+            gapped, attention_mask=mask, position_ids=expected, return_type="logits"
+        )
+
+    torch.testing.assert_close(derived, supplied, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("mask_kind", ["all_ones", "right_padded"])
+def test_no_position_ids_injected_when_unnecessary(distilgpt2_bridge, tokens, mask_kind) -> None:
+    """Masks whose attended tokens already sit at their default positions must not
+    get position_ids injected: it is a no-op at best, and models whose forward does
+    not accept position_ids would raise.
+    """
+    if mask_kind == "all_ones":
+        passed, mask = tokens, torch.ones(tokens.shape, dtype=torch.long)
+    else:
+        passed, mask = _pad(tokens, 3, "right")
+
+    seen: dict[str, object] = {}
+    original = distilgpt2_bridge.original_model.forward
+
+    def _spy(*args, **kwargs):
+        seen["position_ids"] = kwargs.get("position_ids")
+        return original(*args, **kwargs)
+
+    distilgpt2_bridge.original_model.forward = _spy
+    try:
+        with torch.no_grad():
+            distilgpt2_bridge(passed, attention_mask=mask, return_type="logits")
+    finally:
+        distilgpt2_bridge.original_model.forward = original
+
+    assert seen["position_ids"] is None
+
+
+def test_cached_step_with_left_padding(distilgpt2_bridge, tokens) -> None:
+    """With a KV cache the mask spans past+new while input_ids is only the new
+    token, so the derivation must be offset back to the tokens being passed."""
+    n_pad = 3
+    padded, mask = _pad(tokens, n_pad, "left")
+
+    with torch.no_grad():
+        prefill = distilgpt2_bridge.original_model(padded, attention_mask=mask, use_cache=True)
+        new_token = tokens[:, -1:].clone()
+        extended = torch.cat([mask, torch.ones(1, 1, dtype=torch.long)], dim=1)
+        step = distilgpt2_bridge(
+            new_token,
+            attention_mask=extended,
+            past_key_values=prefill.past_key_values,
+            return_type="logits",
+        )
+
+    assert step.shape[:2] == (1, 1)
+    assert torch.isfinite(step).all()

--- a/tests/integration/model_bridge/test_left_padding_positions.py
+++ b/tests/integration/model_bridge/test_left_padding_positions.py
@@ -30,6 +30,38 @@ def _pad(tokens: torch.Tensor, n_pad: int, side: str) -> tuple[torch.Tensor, tor
     return torch.cat([tokens, pads], dim=1), torch.cat([ones, zeros], dim=1)
 
 
+def _mixed_batch(
+    tokens: torch.Tensor, n_pad: int
+) -> tuple[torch.Tensor, torch.Tensor, tuple, tuple]:
+    """A batch of one right-padded, one left-padded and one unpadded row."""
+    width = tokens.shape[1] + n_pad
+    right, m_right = _pad(tokens, n_pad, "right")
+    left, m_left = _pad(tokens, n_pad, "left")
+    plain = torch.arange(20, 20 + width, dtype=tokens.dtype).unsqueeze(0)
+    m_plain = torch.ones(1, width, dtype=torch.long)
+    batch = torch.cat([right, left, plain], dim=0)
+    mask = torch.cat([m_right, m_left, m_plain], dim=0)
+    return batch, mask, (right, m_right), (plain, m_plain)
+
+
+def _spy_on_position_ids(bridge, tokens_in: torch.Tensor, mask: torch.Tensor):
+    """Run a forward, returning the position_ids the wrapped model actually saw."""
+    seen: dict[str, object] = {}
+    original = bridge.original_model.forward
+
+    def _spy(*args, **kwargs):
+        seen["position_ids"] = kwargs.get("position_ids")
+        return original(*args, **kwargs)
+
+    bridge.original_model.forward = _spy
+    try:
+        with torch.no_grad():
+            bridge(tokens_in, attention_mask=mask, return_type="logits")
+    finally:
+        bridge.original_model.forward = original
+    return seen["position_ids"]
+
+
 @pytest.fixture(scope="module")
 def tokens(distilgpt2_bridge) -> torch.Tensor:
     return distilgpt2_bridge.to_tokens("The capital of France is")
@@ -130,39 +162,205 @@ def test_no_position_ids_injected_when_unnecessary(distilgpt2_bridge, tokens, ma
     else:
         passed, mask = _pad(tokens, 3, "right")
 
-    seen: dict[str, object] = {}
-    original = distilgpt2_bridge.original_model.forward
-
-    def _spy(*args, **kwargs):
-        seen["position_ids"] = kwargs.get("position_ids")
-        return original(*args, **kwargs)
-
-    distilgpt2_bridge.original_model.forward = _spy
-    try:
-        with torch.no_grad():
-            distilgpt2_bridge(passed, attention_mask=mask, return_type="logits")
-    finally:
-        distilgpt2_bridge.original_model.forward = original
-
-    assert seen["position_ids"] is None
+    assert _spy_on_position_ids(distilgpt2_bridge, passed, mask) is None
 
 
-def test_cached_step_with_left_padding(distilgpt2_bridge, tokens) -> None:
-    """With a KV cache the mask spans past+new while input_ids is only the new
-    token, so the derivation must be offset back to the tokens being passed."""
+def test_unshifted_rows_keep_default_positions(distilgpt2_bridge, tokens) -> None:
+    """The decision is per row, not per batch: only rows whose mask moves an
+    attended token get derived positions, so the others stay on plain arange."""
+    n_pad = 3
+    batch, mask, _, _ = _mixed_batch(tokens, n_pad)
+    seen = _spy_on_position_ids(distilgpt2_bridge, batch, mask)
+
+    assert seen is not None
+    arange = torch.arange(batch.shape[1])
+    torch.testing.assert_close(seen[0], arange)  # right-padded
+    torch.testing.assert_close(seen[2], arange)  # unpadded
+    torch.testing.assert_close(seen[1], utils.get_offset_position_ids(0, mask)[1])  # left-padded
+
+
+def test_one_left_padded_row_does_not_perturb_its_neighbours(distilgpt2_bridge, tokens) -> None:
+    """A whole-batch predicate would hand derived positions to every row; the
+    rows that needed no correction must come out bit-identical to running alone."""
+    n_pad = 3
+    batch, mask, (right, m_right), (plain, m_plain) = _mixed_batch(tokens, n_pad)
+
+    with torch.no_grad():
+        mixed = distilgpt2_bridge(batch, attention_mask=mask, return_type="logits")
+        alone_right = distilgpt2_bridge(right, attention_mask=m_right, return_type="logits")
+        alone_plain = distilgpt2_bridge(plain, attention_mask=m_plain, return_type="logits")
+        unpadded = distilgpt2_bridge(tokens, return_type="logits")
+
+    # Not exact equality: batching alone perturbs float accumulation order. The
+    # regression this guards was 8e-01, so 1e-6 separates them decisively while
+    # staying above anything a different BLAS could introduce.
+    torch.testing.assert_close(mixed[0:1], alone_right, rtol=0, atol=1e-6)
+    torch.testing.assert_close(mixed[2:3], alone_plain, rtol=0, atol=1e-6)
+    # ...while the row that did need correcting still gets it.
+    torch.testing.assert_close(mixed[1:2, n_pad:], unpadded, rtol=1e-3, atol=1e-3)
+
+
+def test_float_attention_mask_is_accepted(distilgpt2_bridge, tokens) -> None:
+    """Derived positions index an embedding table, so a float 0/1 mask must not
+    produce float position_ids."""
     n_pad = 3
     padded, mask = _pad(tokens, n_pad, "left")
 
     with torch.no_grad():
-        prefill = distilgpt2_bridge.original_model(padded, attention_mask=mask, use_cache=True)
-        new_token = tokens[:, -1:].clone()
-        extended = torch.cat([mask, torch.ones(1, 1, dtype=torch.long)], dim=1)
+        baseline = distilgpt2_bridge(tokens, return_type="logits")
+        actual = distilgpt2_bridge(padded, attention_mask=mask.float(), return_type="logits")
+
+    torch.testing.assert_close(actual[:, n_pad:], baseline, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "mask_row",
+    [
+        pytest.param([0, 0, 0, 0, 0, 0], id="all_masked"),
+        pytest.param([0, 0, 0, 0, 0, 1], id="single_real_token"),
+        pytest.param([1, 0, 1, 0, 1, 1], id="two_interior_gaps"),
+        pytest.param([0, 1, 1, 1, 1, 0], id="padded_both_ends"),
+    ],
+)
+def test_degenerate_masks_do_not_crash(distilgpt2_bridge, tokens, mask_row) -> None:
+    """Shapes the happy path never reaches. An all-masked row in particular must
+    not inject anything: every position is a pad, so nothing is displaced."""
+    mask = torch.tensor([mask_row[: tokens.shape[1]]], dtype=torch.long)
+    positions = _spy_on_position_ids(distilgpt2_bridge, tokens, mask)
+
+    if mask.sum() == 0:
+        assert positions is None
+    else:
+        expected = utils.get_offset_position_ids(0, mask)
+        torch.testing.assert_close(positions, expected)
+
+
+def test_four_dimensional_mask_is_left_alone(distilgpt2_bridge, tokens) -> None:
+    """A 4-D mask is an additive attention bias, not a 0/1 padding mask, so the
+    cumsum derivation is meaningless on it."""
+    seq = tokens.shape[1]
+    mask = torch.ones(1, 1, seq, seq)
+    assert _spy_on_position_ids(distilgpt2_bridge, tokens, mask) is None
+
+
+def test_inputs_embeds_are_left_alone(distilgpt2_bridge, tokens) -> None:
+    """Float input is pre-computed embeddings; there are no token positions to
+    derive and the batch/seq layout is not guaranteed to match the mask."""
+    embeds = distilgpt2_bridge.original_model.get_input_embeddings()(tokens)
+    _, mask = _pad(tokens[:, :-2], 2, "left")
+    assert _spy_on_position_ids(distilgpt2_bridge, embeds, mask) is None
+
+
+def test_gradients_flow_through_a_left_padded_forward(distilgpt2_bridge, tokens) -> None:
+    """The derivation must not detach the graph or poison the loss with pads."""
+    n_pad = 3
+    padded, mask = _pad(tokens, n_pad, "left")
+
+    loss = distilgpt2_bridge(padded, attention_mask=mask, return_type="loss")
+    loss.backward()
+    grad = distilgpt2_bridge.original_model.get_input_embeddings().weight.grad
+    try:
+        assert torch.isfinite(loss)
+        assert grad is not None and torch.isfinite(grad).all() and (grad != 0).any()
+    finally:
+        distilgpt2_bridge.zero_grad(set_to_none=True)
+
+
+def test_run_with_cache_matches_forward_under_left_padding(distilgpt2_bridge, tokens) -> None:
+    """run_with_cache routes through a different kwarg-filtering path, so the
+    injection has to survive it identically."""
+    n_pad = 3
+    padded, mask = _pad(tokens, n_pad, "left")
+
+    with torch.no_grad():
+        direct = distilgpt2_bridge(padded, attention_mask=mask, return_type="logits")
+        cached, activations = distilgpt2_bridge.run_with_cache(padded, attention_mask=mask)
+
+    torch.testing.assert_close(direct, cached, rtol=0, atol=1e-6)
+    assert len(activations) > 0
+
+
+@pytest.fixture(scope="module")
+def opt_bridge():
+    """OPT is the one supported architecture whose positional embedding consumes
+    the attention mask, so it must be left to derive positions for itself."""
+    from transformer_lens.model_bridge import TransformerBridge
+
+    bridge = TransformerBridge.boot_transformers(
+        "hf-internal-testing/tiny-random-OPTForCausalLM", device="cpu", dtype=torch.float32
+    )
+    bridge.eval()
+    return bridge
+
+
+def test_self_deriving_model_is_left_alone(opt_bridge) -> None:
+    """OPTLearnedPositionalEmbedding derives from the mask already, and uses its
+    own convention (-1) for padded slots. Overriding it buys no correctness and
+    silently changes the padded slots, so the bridge must stay out of the way.
+    """
+    ids = torch.arange(20, 26).unsqueeze(0)
+    n_pad = 3
+    padded, mask = _pad(ids, n_pad, "left")
+
+    assert opt_bridge._accepts_derived_position_ids() is False
+    assert _spy_on_position_ids(opt_bridge, padded, mask) is None
+
+    with torch.no_grad():
+        bridge_out = opt_bridge(padded, attention_mask=mask, return_type="logits")
+        hf_out = opt_bridge.original_model(input_ids=padded, attention_mask=mask).logits
+        unpadded = opt_bridge(ids, attention_mask=torch.ones_like(ids), return_type="logits")
+
+    # Deferring to OPT keeps the bridge exactly on HF, and OPT's own derivation
+    # already delivers the padding-invariance this module is about.
+    torch.testing.assert_close(bridge_out, hf_out, rtol=0, atol=1e-6)
+    torch.testing.assert_close(bridge_out[:, n_pad:], unpadded, rtol=1e-4, atol=1e-4)
+
+
+def test_cached_step_with_left_padding(distilgpt2_bridge, tokens) -> None:
+    """With a KV cache the mask spans past+new while input_ids is only the new
+    token, so the derivation must be offset back to the tokens being passed.
+
+    Prefill goes through the bridge (return_type="logits_and_cache") so the
+    cached keys and values are built under the same position convention the step
+    uses. Stepping off a cache prefilled by raw HF mixes two conventions and is
+    not equivalent to anything.
+    """
+    n_pad = 3
+    padded, mask = _pad(tokens, n_pad, "left")
+    new_token = torch.tensor([[318]])
+    extended = torch.cat([mask, torch.ones(1, 1, dtype=torch.long)], dim=1)
+
+    with torch.no_grad():
+        _, cache = distilgpt2_bridge(padded, attention_mask=mask, return_type="logits_and_cache")
         step = distilgpt2_bridge(
-            new_token,
-            attention_mask=extended,
-            past_key_values=prefill.past_key_values,
-            return_type="logits",
+            new_token, attention_mask=extended, past_key_values=cache, return_type="logits"
         )
+        # Ground truth: the same prompt and token with no padding at all.
+        unpadded = distilgpt2_bridge(torch.cat([tokens, new_token], dim=1), return_type="logits")
 
     assert step.shape[:2] == (1, 1)
-    assert torch.isfinite(step).all()
+    torch.testing.assert_close(step, unpadded[:, -1:], rtol=1e-3, atol=1e-3)
+
+
+def test_cached_decoding_with_left_padding_matches_full_recompute(
+    distilgpt2_bridge, tokens
+) -> None:
+    """Several cached steps in a row: each must land on what recomputing the
+    whole left-padded sequence would give, or the offset drifts with the cache."""
+    n_pad = 3
+    padded, mask = _pad(tokens, n_pad, "left")
+
+    with torch.no_grad():
+        _, cache = distilgpt2_bridge(padded, attention_mask=mask, return_type="logits_and_cache")
+        sequence, grown = padded, mask
+        for _ in range(4):
+            logits = distilgpt2_bridge(sequence, attention_mask=grown, return_type="logits")
+            next_token = logits[:, -1].argmax(dim=-1, keepdim=True)
+            sequence = torch.cat([sequence, next_token], dim=1)
+            grown = torch.cat([grown, torch.ones(1, 1, dtype=torch.long)], dim=1)
+
+            stepped = distilgpt2_bridge(
+                next_token, attention_mask=grown, past_key_values=cache, return_type="logits"
+            )
+            full = distilgpt2_bridge(sequence, attention_mask=grown, return_type="logits")
+            torch.testing.assert_close(stepped, full[:, -1:], rtol=1e-3, atol=1e-3)

--- a/tests/integration/model_bridge/test_llada_adapter.py
+++ b/tests/integration/model_bridge/test_llada_adapter.py
@@ -649,6 +649,20 @@ def test_padding_mask_blocks_keys_without_becoming_causal(models: TinyModels) ->
     )
 
 
+def test_left_padding_does_not_inject_unsupported_position_ids(models: TinyModels) -> None:
+    """The bridge derives position_ids from attention_mask for left-padded input
+    (#1609), but this forward takes neither position_ids nor **kwargs — as the
+    released LLaDA remote code does not — so the kwarg would raise TypeError
+    where the model used to return logits.
+    """
+    tokens = torch.tensor([[63, 63, 5, 7, 9]])
+    attention_mask = torch.tensor([[0, 0, 1, 1, 1]])
+    with torch.inference_mode():
+        reference_logits = models.reference(tokens, attention_mask=attention_mask).logits
+        bridge_logits = models.bridge(tokens, attention_mask=attention_mask)
+    torch.testing.assert_close(bridge_logits, reference_logits, rtol=1e-5, atol=1e-6)
+
+
 def test_run_with_cache_exposes_hooks_without_hf_output_attentions(
     models: TinyModels,
 ) -> None:

--- a/tests/integration/model_bridge/test_qwen2_5_vl_adapter.py
+++ b/tests/integration/model_bridge/test_qwen2_5_vl_adapter.py
@@ -68,6 +68,52 @@ class TestQwen2_5_VLForwardEquivalence:
         max_diff = (bridge_out - hf_out).abs().max().item()
         assert max_diff < 1e-5, f"Bridge vs fresh HF max diff = {max_diff}"
 
+    def test_left_padded_multimodal_forward_matches_fresh_hf(self, bridge):
+        """The bridge derives position_ids from attention_mask for left-padded
+        input (#1609), but mRoPE models build their own 3-D index in
+        get_rope_index and only while position_ids is None — a supplied 2-D
+        tensor is silently broadcast across all three streams instead. Their
+        derivation already scatters positions onto attended slots only, so left
+        padding must be left entirely to HF here.
+        """
+        from PIL import Image
+        from transformers import AutoModelForImageTextToText, AutoProcessor
+
+        fresh = AutoModelForImageTextToText.from_pretrained(
+            MODEL, dtype=torch.float32, attn_implementation="eager"
+        )
+        fresh.eval()
+        proc = AutoProcessor.from_pretrained(MODEL)
+        img = Image.new("RGB", (56, 56), "red")
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "image"}, {"type": "text", "text": "Describe"}],
+            }
+        ]
+        text = proc.apply_chat_template(messages, add_generation_prompt=True)
+        inputs = proc(text=[text], images=[img], return_tensors="pt")
+
+        n_pad = 4
+        ids = inputs["input_ids"]
+        padded = {k: v for k, v in inputs.items() if k != "input_ids"}
+        padded["attention_mask"] = torch.cat(
+            [torch.zeros(1, n_pad, dtype=torch.long), torch.ones_like(ids)], dim=1
+        )
+        # Per-token tensors have to grow with the padding or HF's own rope index
+        # rejects the mask outright.
+        token_type_ids = inputs["mm_token_type_ids"]
+        padded["mm_token_type_ids"] = torch.cat(
+            [torch.zeros(1, n_pad, dtype=token_type_ids.dtype), token_type_ids], dim=1
+        )
+        padded_ids = torch.cat([torch.zeros(1, n_pad, dtype=ids.dtype), ids], dim=1)
+
+        with torch.no_grad():
+            bridge_out = bridge(padded_ids, **padded)
+            hf_out = fresh(input_ids=padded_ids, **padded).logits
+        max_diff = (bridge_out - hf_out).abs().max().item()
+        assert max_diff < 1e-5, f"Bridge vs fresh HF max diff = {max_diff}"
+
 
 class TestQwen2_5_VLHooks:
     def test_hooks_fire(self, bridge, sample_tokens):

--- a/tests/unit/model_bridge/test_position_ids_injection_gate.py
+++ b/tests/unit/model_bridge/test_position_ids_injection_gate.py
@@ -1,0 +1,160 @@
+"""Unit tests for the target gate on mask-derived ``position_ids`` injection.
+
+``TransformerBridge.forward`` derives ``position_ids`` from ``attention_mask``
+so left-padded input gets the right absolute positions (see #1609). That kwarg
+is only safe for models that both accept it and do not derive positions
+themselves, so the injection is gated the same way ``output_attentions`` is in
+``run_with_cache``. The gate is exercised directly here with stand-in modules:
+the models it exists to protect (fixed-signature remote code, mRoPE) are either
+never loaded in CI or belong to the integration tier.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+
+from transformer_lens.model_bridge import TransformerBridge
+
+# Unbound so it can run against a stand-in that owns only ``_driver``; the gate
+# reads nothing else off the bridge.
+gate = TransformerBridge._accepts_derived_position_ids
+
+
+def _bridge_over(model: Optional[nn.Module]) -> Any:
+    return SimpleNamespace(_driver=SimpleNamespace(underlying_model=model))
+
+
+class _FixedSignature(nn.Module):
+    """Mirrors ``LLaDAModelLM.forward``: no ``position_ids``, no ``**kwargs``."""
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        use_cache: bool = False,
+    ) -> torch.Tensor:
+        return input_ids
+
+
+class _AcceptsPositionIds(nn.Module):
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        return input_ids
+
+
+class _AcceptsKwargs(nn.Module):
+    def forward(self, input_ids: torch.Tensor, **kwargs: Any) -> torch.Tensor:
+        return input_ids
+
+
+class _MaskConsumingEmbedding(nn.Embedding):
+    """Mirrors ``OPTLearnedPositionalEmbedding``: positions come from the mask."""
+
+    def forward(  # type: ignore[override]
+        self,
+        attention_mask: torch.Tensor,
+        past_key_values_length: int = 0,
+        position_ids: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if position_ids is None:
+            position_ids = (attention_mask.cumsum(1) * attention_mask - 1).long()
+        return super().forward(position_ids)
+
+
+class _OwnsPositions(_AcceptsPositionIds):
+    """mRoPE models compute a 3-D index here, but only while position_ids is None."""
+
+    def get_rope_index(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+class TestSignatureGate:
+    def test_refuses_model_that_cannot_take_position_ids(self) -> None:
+        """Injecting into a fixed-signature remote-code forward raises TypeError
+        where the model previously returned logits."""
+        assert gate(_bridge_over(_FixedSignature())) is False
+
+    def test_allows_explicit_position_ids_parameter(self) -> None:
+        assert gate(_bridge_over(_AcceptsPositionIds())) is True
+
+    def test_allows_var_keyword_forward(self) -> None:
+        """**kwargs forwards pass the kwarg through to the inner model."""
+        assert gate(_bridge_over(_AcceptsKwargs())) is True
+
+
+class TestOwnsPositionsGate:
+    def test_refuses_model_defining_get_rope_index(self) -> None:
+        assert gate(_bridge_over(_OwnsPositions())) is False
+
+    def test_refuses_wrapper_whose_inner_model_owns_positions(self) -> None:
+        """get_rope_index lives on the inner text model, while original_model is
+        usually the ForConditionalGeneration wrapper around it."""
+        wrapper = _AcceptsPositionIds()
+        wrapper.model = _OwnsPositions()
+        assert gate(_bridge_over(wrapper)) is False
+
+    def test_refuses_wrapper_whose_language_model_owns_positions(self) -> None:
+        wrapper = _AcceptsPositionIds()
+        wrapper.language_model = _OwnsPositions()
+        assert gate(_bridge_over(wrapper)) is False
+
+    def test_refuses_mrope_section_in_config(self) -> None:
+        """Config-level backstop: the section list is what makes positions 3-D."""
+        model = _AcceptsPositionIds()
+        model.config = SimpleNamespace(  # type: ignore[assignment]
+            rope_scaling={"mrope_section": [1, 1, 2], "rope_type": "default"}
+        )
+        assert gate(_bridge_over(model)) is False
+
+    def test_refuses_mrope_section_in_text_config(self) -> None:
+        """Multimodal configs nest the text model's rope_scaling one level down."""
+        model = _AcceptsPositionIds()
+        model.config = SimpleNamespace(  # type: ignore[assignment]
+            rope_scaling=None,
+            text_config=SimpleNamespace(rope_scaling={"mrope_section": [1, 1, 2]}),
+        )
+        assert gate(_bridge_over(model)) is False
+
+    def test_refuses_mask_consuming_positional_embedding(self) -> None:
+        """OPT's OPTLearnedPositionalEmbedding takes the mask and derives its own
+        positions, including its own convention for the padded slots."""
+        model = _AcceptsPositionIds()
+        model.embed_positions = _MaskConsumingEmbedding(8, 4)
+        assert gate(_bridge_over(model)) is False
+
+    def test_ordinary_embeddings_do_not_trip_the_scan(self) -> None:
+        """nn.Embedding takes only indices, so the common case stays injectable."""
+        model = _AcceptsPositionIds()
+        model.wte = nn.Embedding(8, 4)
+        model.wpe = nn.Embedding(8, 4)
+        assert gate(_bridge_over(model)) is True
+
+    def test_plain_rope_scaling_is_not_treated_as_mrope(self) -> None:
+        """Only mrope_section means a multi-stream index; yarn/linear do not."""
+        model = _AcceptsPositionIds()
+        model.config = SimpleNamespace(  # type: ignore[assignment]
+            rope_scaling={"rope_type": "yarn", "factor": 8.0}
+        )
+        assert gate(_bridge_over(model)) is True
+
+
+class TestDriverAndCaching:
+    def test_refuses_driver_without_a_local_module(self) -> None:
+        """vLLM/Inspect expose no module to introspect and own positions internally."""
+        assert gate(_bridge_over(None)) is False
+
+    def test_recomputes_when_the_underlying_model_is_swapped(self) -> None:
+        """Weight processing replaces original_model, so a cached verdict keyed on
+        the old module must not survive."""
+        bridge = _bridge_over(_AcceptsPositionIds())
+        assert gate(bridge) is True
+        bridge._driver.underlying_model = _FixedSignature()
+        assert gate(bridge) is False

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -1551,6 +1551,37 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
                     position_ids.masked_fill_(attention_mask == 0, 1)
                     kwargs["position_ids"] = position_ids
 
+            # Any masked-out token shifts the absolute position of every real token
+            # after it, so positions must be derived from the mask rather than left
+            # to HF's default arange. This is the same derivation HookedTransformer
+            # applies in pos_embed; without it the bridge silently returns wrong
+            # logits. An all-ones mask reduces to arange, so this is a no-op there.
+            #
+            # The mask spans any cached prefix as well as the new tokens, so it is
+            # offset back to just the tokens actually being passed — matching how
+            # AbstractAttention/PosEmbed use past_kv_pos_offset.
+            if (
+                attention_mask is not None
+                and "position_ids" not in kwargs
+                and not _is_inputs_embeds
+                and attention_mask.ndim == 2
+                and isinstance(input_ids, torch.Tensor)
+                and input_ids.ndim == 2
+                and attention_mask.shape[1] >= input_ids.shape[1]
+            ):
+                _derived = utils.get_offset_position_ids(0, attention_mask)
+                _arange = torch.arange(attention_mask.shape[1], device=_derived.device)
+                # Only intervene when the mask actually moves an attended token off
+                # its default position — i.e. some masked token precedes a real one
+                # (left padding, or an interior gap). Pure right padding and an
+                # all-ones mask already agree with arange, and injecting position_ids
+                # there would be a no-op at best and unsupported by models whose
+                # forward does not take them at worst.
+                if bool(((_derived != _arange) & (attention_mask != 0)).any()):
+                    kwargs["position_ids"] = _derived[
+                        :, attention_mask.shape[1] - input_ids.shape[1] :
+                    ]
+
             if attention_mask is not None:
                 kwargs["attention_mask"] = attention_mask
             if past_key_values is not None:

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -1383,6 +1383,82 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
         residual = self.forward(tokens, stop_at_layer=0, attention_mask=attention_mask)
         return residual, tokens, None, attention_mask
 
+    def _accepts_derived_position_ids(self) -> bool:
+        """Whether it is safe to hand the wrapped model a mask-derived ``position_ids``.
+
+        Two families of model must be left alone, so the injection below is
+        gated on the target the same way ``output_attentions`` is in
+        :meth:`BridgeCore.run_with_cache`:
+
+        * **Fixed-signature models.** Remote-code forwards such as
+          ``LLaDAModelLM.forward`` take neither ``position_ids`` nor
+          ``**kwargs``, so passing it raises ``TypeError`` where the model
+          previously returned logits.
+        * **Models that own their position derivation.** mRoPE architectures
+          (Qwen2-VL, Qwen2.5-VL, Qwen3-VL, GLM-4V) build a 3-D temporal /
+          height / width index in ``get_rope_index``, and only while
+          ``position_ids is None``; a supplied 2-D tensor is silently expanded
+          across all three streams instead. Their derivation already scatters
+          positions onto attended slots only, so it handles left padding
+          correctly on its own and needs no help from us.
+        * **Mask-consuming positional embeddings.** OPT's
+          ``OPTLearnedPositionalEmbedding.forward`` takes the mask and derives
+          the same positions we would, so injection buys nothing — but it does
+          replace the model's own padding-slot convention with ours, which
+          shows up as a whole-tensor diff.
+
+        Non-torch drivers (vLLM, Inspect) expose no module to introspect and
+        manage positions internally, so they are excluded as well.
+        """
+        underlying = getattr(self._driver, "underlying_model", None)
+        if underlying is None:
+            return False
+
+        cached = self.__dict__.get("_derived_position_ids_ok")
+        if cached is not None and cached[0] is underlying:
+            return bool(cached[1])
+
+        def verdict() -> bool:
+            fwd_params = inspect.signature(underlying.forward).parameters
+            if "position_ids" not in fwd_params and not any(
+                p.kind is inspect.Parameter.VAR_KEYWORD for p in fwd_params.values()
+            ):
+                return False
+
+            # ``get_rope_index`` lives on the inner text model, not the
+            # ForConditionalGeneration wrapper that is usually original_model.
+            for module in (
+                underlying,
+                getattr(underlying, "model", None),
+                getattr(underlying, "language_model", None),
+            ):
+                if module is not None and hasattr(module, "get_rope_index"):
+                    return False
+
+            # Config-level backstop for mRoPE models that spell the derivation
+            # differently; the section list is what makes positions 3-D.
+            config = getattr(underlying, "config", None)
+            for candidate in (config, getattr(config, "text_config", None)):
+                scaling = getattr(candidate, "rope_scaling", None)
+                if isinstance(scaling, dict) and "mrope_section" in scaling:
+                    return False
+
+            # A positional embedding that takes the mask derives positions for
+            # itself. Only embeddings that override nn.Embedding.forward are
+            # worth inspecting, which keeps this to a handful per model.
+            for module in underlying.modules():
+                if not isinstance(module, nn.Embedding):
+                    continue
+                if type(module).forward is nn.Embedding.forward:
+                    continue
+                if "attention_mask" in inspect.signature(module.forward).parameters:
+                    return False
+            return True
+
+        accepts = verdict()
+        self.__dict__["_derived_position_ids_ok"] = (underlying, accepts)
+        return accepts
+
     def forward(
         self,
         input: Union[str, List[str], torch.Tensor],
@@ -1568,17 +1644,22 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
                 and isinstance(input_ids, torch.Tensor)
                 and input_ids.ndim == 2
                 and attention_mask.shape[1] >= input_ids.shape[1]
+                and self._accepts_derived_position_ids()
             ):
-                _derived = utils.get_offset_position_ids(0, attention_mask)
+                # .long() because callers may hand in a float 0/1 mask, and
+                # positions index an embedding table.
+                _derived = utils.get_offset_position_ids(0, attention_mask.long())
                 _arange = torch.arange(attention_mask.shape[1], device=_derived.device)
-                # Only intervene when the mask actually moves an attended token off
-                # its default position — i.e. some masked token precedes a real one
-                # (left padding, or an interior gap). Pure right padding and an
-                # all-ones mask already agree with arange, and injecting position_ids
-                # there would be a no-op at best and unsupported by models whose
-                # forward does not take them at worst.
-                if bool(((_derived != _arange) & (attention_mask != 0)).any()):
-                    kwargs["position_ids"] = _derived[
+                # Decide per row, not per batch. A row only needs the derived
+                # positions when its mask actually moves one of its attended
+                # tokens off the default position — i.e. a masked token precedes
+                # a real one (left padding, or an interior gap). Rows that are
+                # unpadded or purely right-padded keep arange verbatim, so one
+                # left-padded row in a batch cannot perturb its neighbours.
+                _needs = ((_derived != _arange) & (attention_mask != 0)).any(dim=1, keepdim=True)
+                if bool(_needs.any()):
+                    _positions = torch.where(_needs, _derived, _arange.expand_as(_derived))
+                    kwargs["position_ids"] = _positions[
                         :, attention_mask.shape[1] - input_ids.shape[1] :
                     ]
 


### PR DESCRIPTION
## Description

Fixes #1609.

`TransformerBridge.forward()` did not derive `position_ids` from a supplied `attention_mask`, so left-padded input silently got the wrong absolute positions — no error, no NaN, just wrong logits and a wrong loss.

On gpt2, one prompt, mask supplied:

| n_pad | HT loss | Bridge loss (before) | HT drift | Bridge drift |
|---|---|---|---|---|
| 0 | 4.503170 | 4.503170 | — | — |
| 1 | 4.503169 | 13.594296 | 1.4e-06 | **9.09** |
| 3 | 4.503169 | 11.154946 | 9.5e-07 | **6.65** |
| 8 | 4.503169 | 10.787075 | 1.4e-06 | **6.28** |

Right padding was never affected (drift ≤ 9.5e-07) — causality already protects it.

`transformer_bridge.py` derived `position_ids` only for batched *list* input, so pre-tokenized tensors fell through to HF's plain `arange` and the padding offset was never removed. This extends the same correction that branch already applies. An explicitly supplied `position_ids` still wins.

Two consequences this also fixes:

- The bridge was inconsistent with itself — the same batch gave different logits depending on whether it was passed as strings or token IDs (max |logit diff| `4.142e+01`).
- `enable_compatibility_mode()`, which documents "HookedTransformer-equivalent numerics", matched HT exactly on unpadded input (`0.000e+00`) but diverged on left-padded input.

### Tests

Adds `tests/integration/model_bridge/test_left_padding_positions.py`: logit invariance under both padding sides, the same property in compatibility mode, and agreement between the derived and an explicitly supplied `position_ids`.

Red-before / green-after: **9 passed** with the fix, **5 failed** without it. The right-padding cases are controls — they pass in both states, so the tests are specific to the bug rather than to padding in general.

These sit in the integration tier rather than the unit tier deliberately: left padding produces a fully masked query row, which the Native attention path turns into `NaN` until the masked-softmax fix in #1608 lands, so `boot_native` cannot express the property yet.

### Verification

- New tests: 9 passed / 5 failed without the fix
- `tests/unit/model_bridge` + `tests/unit/test_tokenizer_padding_side.py`: 3955 passed, 27 skipped, 10 xfailed
- `pycln` / `isort` / `black` clean; `mypy` clean

### Relationship to #1607 / #1608

Independent bugs on the same path that compound. This is measured across four states (gpt2, aggregate loss on a left-padded batch; HT reference `4.814578`):

| state | batch loss | max \|logit diff\| |
|---|---|---|
| `dev-4.x` | 7.254170 | 1.361e+02 |
| #1608 alone | 7.411356 | 1.361e+02 |
| this PR alone | 6.688155 | **9.918e-05** |
| both | **4.814578** | **9.918e-05** |

This PR fixes the **logits**; #1608 fixes the **loss aggregation**. Batched loss is only correct with both, so reviewing this one in isolation will still show a wrong aggregate. No file overlap, so they merge in either order.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility