### PR TITLE
Fix TransformerBridge loss with explicit labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ logits, activations = bridge.run_with_cache("Hello World")
 
 > Gated models (Llama, Mistral, Gemma, ...) require `HF_TOKEN` in your environment. See [Environment Variables](https://TransformerLensOrg.github.io/TransformerLens/content/getting_started.html#environment-variables) for the full list.
 
-`TransformerBridge` is the recommended 3.0 path and supports 15,000+ models across 140+ architecture families (see [`supported_models.json`](transformer_lens/tools/model_registry/data/supported_models.json) for the full inventory). By default it preserves raw HuggingFace weights – logits and activations match HF, *not* legacy `HookedTransformer` (which folds LayerNorm and centers weights by default). Call `bridge.enable_compatibility_mode()` after booting for HookedTransformer-equivalent numerics. The legacy `HookedTransformer.from_pretrained` API is still available but deprecated — see the [Migrating to TransformerLens 3](https://TransformerLensOrg.github.io/TransformerLens/content/migrating_to_v3.html) guide.
+`TransformerBridge` is the recommended path and supports 15,000+ models across 140+ architecture families (see [`supported_models.json`](transformer_lens/tools/model_registry/data/supported_models.json) for the full inventory). By default it preserves raw HuggingFace weights – logits and activations match HF, *not* legacy `HookedTransformer` (which folds LayerNorm and centers weights by default). Call `bridge.enable_compatibility_mode()` after booting for HookedTransformer-equivalent numerics. The legacy `HookedTransformer.from_pretrained` API is still available but deprecated — see the [Migrating to TransformerLens 3](https://TransformerLensOrg.github.io/TransformerLens/content/migrating_to_v3.html) guide.
 
 ## Key Tutorials
 

--- a/tests/integration/model_bridge/test_seq2seq_loss.py
+++ b/tests/integration/model_bridge/test_seq2seq_loss.py
@@ -1,0 +1,281 @@
+"""Regression tests for TransformerBridge explicit-label loss semantics."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+from transformers import (
+    BartConfig,
+    BartForConditionalGeneration,
+    GPT2Config,
+    GPT2LMHeadModel,
+    T5Config,
+    T5ForConditionalGeneration,
+)
+
+from tests.integration.model_bridge.helpers import make_tiny_pair
+from transformer_lens.model_bridge import TransformerBridge
+
+
+@pytest.fixture(scope="module")
+def tiny_gpt2_pair() -> tuple[TransformerBridge, torch.nn.Module]:
+    config = GPT2Config(
+        vocab_size=32,
+        n_embd=16,
+        n_layer=1,
+        n_head=2,
+        n_positions=16,
+        n_ctx=16,
+        bos_token_id=1,
+        eos_token_id=2,
+        pad_token_id=0,
+    )
+    return make_tiny_pair(config, "GPT2LMHeadModel", loader=GPT2LMHeadModel)
+
+
+@pytest.fixture(scope="module", params=("bart", "t5"))
+def tiny_seq2seq_pair(request) -> tuple[TransformerBridge, torch.nn.Module]:
+    if request.param == "bart":
+        config = BartConfig(
+            vocab_size=32,
+            d_model=16,
+            encoder_layers=1,
+            decoder_layers=1,
+            encoder_attention_heads=2,
+            decoder_attention_heads=2,
+            encoder_ffn_dim=32,
+            decoder_ffn_dim=32,
+            max_position_embeddings=32,
+            pad_token_id=0,
+            bos_token_id=1,
+            eos_token_id=2,
+            decoder_start_token_id=2,
+        )
+        return make_tiny_pair(
+            config,
+            "BartForConditionalGeneration",
+            loader=BartForConditionalGeneration,
+        )
+
+    config = T5Config(
+        vocab_size=32,
+        d_model=16,
+        d_kv=8,
+        d_ff=32,
+        num_layers=1,
+        num_decoder_layers=1,
+        num_heads=2,
+        pad_token_id=0,
+        eos_token_id=1,
+        decoder_start_token_id=0,
+    )
+    return make_tiny_pair(
+        config,
+        "T5ForConditionalGeneration",
+        loader=T5ForConditionalGeneration,
+    )
+
+
+def test_seq2seq_loss_and_logits_follow_labels(
+    tiny_seq2seq_pair: tuple[TransformerBridge, torch.nn.Module],
+) -> None:
+    bridge, reference = tiny_seq2seq_pair
+    source = torch.tensor([[4, 5, 6, 7, 2]])
+    label_batches = (
+        torch.tensor([[8, 9, 10, 2, -100]]),
+        torch.tensor([[11, 12, 13, 2, -100]]),
+    )
+
+    bridge_losses = []
+    bridge_logits = []
+    for labels in label_batches:
+        with torch.no_grad():
+            loss = bridge(source, labels=labels, return_type="loss")
+            logits = bridge(source, labels=labels, return_type="logits")
+            reference_output = reference(input_ids=source, labels=labels)
+
+        torch.testing.assert_close(loss, reference_output.loss)
+        torch.testing.assert_close(logits, reference_output.logits)
+        bridge_losses.append(loss)
+        bridge_logits.append(logits)
+
+    assert not torch.allclose(bridge_losses[0], bridge_losses[1])
+    assert not torch.allclose(bridge_logits[0], bridge_logits[1])
+
+
+def test_seq2seq_both_allows_shorter_target(
+    tiny_seq2seq_pair: tuple[TransformerBridge, torch.nn.Module],
+) -> None:
+    bridge, reference = tiny_seq2seq_pair
+    source = torch.tensor([[4, 5, 6, 7, 2]])
+    labels = torch.tensor([[14, 15, 2]])
+
+    with torch.no_grad():
+        logits, loss = bridge(source, labels=labels, return_type="both")
+        reference_output = reference(input_ids=source, labels=labels)
+
+    assert logits.shape[:2] == labels.shape
+    torch.testing.assert_close(logits, reference_output.logits)
+    torch.testing.assert_close(loss, reference_output.loss)
+
+
+def test_seq2seq_loss_supports_hf_tuple_output(
+    tiny_seq2seq_pair: tuple[TransformerBridge, torch.nn.Module],
+) -> None:
+    bridge, reference = tiny_seq2seq_pair
+    source = torch.tensor([[4, 5, 6, 7, 2]])
+    labels = torch.tensor([[14, 15, 2]])
+
+    with torch.no_grad():
+        logits, loss = bridge(
+            source,
+            labels=labels,
+            return_type="both",
+            return_dict=False,
+        )
+        reference_loss, reference_logits, *_ = reference(
+            input_ids=source,
+            labels=labels,
+            return_dict=False,
+        )
+
+    torch.testing.assert_close(logits, reference_logits)
+    torch.testing.assert_close(loss, reference_loss)
+
+
+@pytest.mark.parametrize("return_type", ("loss", "both"))
+def test_seq2seq_per_token_loss_matches_unshifted_labels(
+    tiny_seq2seq_pair: tuple[TransformerBridge, torch.nn.Module],
+    return_type: str,
+) -> None:
+    bridge, reference = tiny_seq2seq_pair
+    source = torch.tensor([[4, 5, 6, 7, 2]])
+    labels = torch.tensor([[14, 15, 2, -100]])
+
+    with torch.no_grad():
+        output = bridge(
+            source,
+            labels=labels,
+            return_type=return_type,
+            loss_per_token=True,
+        )
+        reference_logits = reference(input_ids=source, labels=labels).logits
+
+    loss = output[1] if isinstance(output, tuple) else output
+    expected = F.cross_entropy(
+        reference_logits.flatten(0, 1),
+        labels.flatten(),
+        reduction="none",
+        ignore_index=-100,
+    ).view_as(labels)
+
+    assert loss.shape == labels.shape
+    assert loss[0, -1] == 0
+    torch.testing.assert_close(loss, expected)
+
+
+@pytest.mark.parametrize("return_type", ("loss", "both"))
+def test_seq2seq_loss_requires_labels(
+    tiny_seq2seq_pair: tuple[TransformerBridge, torch.nn.Module],
+    return_type: str,
+) -> None:
+    bridge, _ = tiny_seq2seq_pair
+    source = torch.tensor([[4, 5, 6, 7, 2]])
+
+    with pytest.raises(ValueError, match="labels are required"):
+        bridge(source, return_type=return_type)
+
+
+def test_causal_loss_uses_explicit_labels(
+    tiny_gpt2_pair: tuple[TransformerBridge, torch.nn.Module],
+) -> None:
+    bridge, reference = tiny_gpt2_pair
+    input_ids = torch.tensor([[4, 5, 6, 7, 2]])
+    labels = torch.full_like(input_ids, 9)
+
+    with torch.no_grad():
+        default_loss = bridge(input_ids, return_type="loss")
+        logits, labeled_loss = bridge(input_ids, labels=labels, return_type="both")
+        reference_output = reference(input_ids=input_ids, labels=labels)
+
+    assert not torch.allclose(labeled_loss, default_loss)
+    torch.testing.assert_close(logits, reference_output.logits)
+    torch.testing.assert_close(labeled_loss, reference_output.loss)
+
+
+def test_causal_labels_support_hf_tuple_output(
+    tiny_gpt2_pair: tuple[TransformerBridge, torch.nn.Module],
+) -> None:
+    bridge, reference = tiny_gpt2_pair
+    input_ids = torch.tensor([[4, 5, 6, 7, 2]])
+    labels = torch.full_like(input_ids, 9)
+
+    with torch.no_grad():
+        logits, loss = bridge(
+            input_ids,
+            labels=labels,
+            return_type="both",
+            return_dict=False,
+        )
+        reference_loss, reference_logits, *_ = reference(
+            input_ids=input_ids,
+            labels=labels,
+            return_dict=False,
+        )
+
+    torch.testing.assert_close(logits, reference_logits)
+    torch.testing.assert_close(loss, reference_loss)
+
+
+def test_causal_per_token_loss_uses_labels_and_ignore_index(
+    tiny_gpt2_pair: tuple[TransformerBridge, torch.nn.Module],
+) -> None:
+    bridge, reference = tiny_gpt2_pair
+    input_ids = torch.tensor([[4, 5, 6, 7, 2]])
+    labels = torch.tensor([[9, 8, 7, -100, -100]])
+
+    with torch.no_grad():
+        loss = bridge(
+            input_ids,
+            labels=labels,
+            return_type="loss",
+            loss_per_token=True,
+        )
+        reference_logits = reference(input_ids=input_ids).logits
+
+    expected = F.cross_entropy(
+        reference_logits[:, :-1].flatten(0, 1),
+        labels[:, 1:].flatten(),
+        reduction="none",
+        ignore_index=-100,
+    ).view_as(labels[:, 1:])
+
+    assert loss.shape == labels[:, 1:].shape
+    assert torch.count_nonzero(loss[:, 2:]) == 0
+    torch.testing.assert_close(loss, expected)
+
+
+def test_causal_explicit_labels_preserve_attention_mask_contract(
+    tiny_gpt2_pair: tuple[TransformerBridge, torch.nn.Module],
+) -> None:
+    bridge, _ = tiny_gpt2_pair
+    input_ids = torch.tensor([[4, 5, 6, 0, 0]])
+    labels = torch.tensor([[9, 8, 7, 6, 5]])
+    attention_mask = torch.tensor([[1, 1, 1, 0, 0]])
+
+    with torch.no_grad():
+        logits = bridge(input_ids, attention_mask=attention_mask, return_type="logits")
+        loss = bridge(
+            input_ids,
+            labels=labels,
+            attention_mask=attention_mask,
+            return_type="loss",
+        )
+
+    transition_mask = attention_mask[:, :-1].bool() & attention_mask[:, 1:].bool()
+    expected = F.cross_entropy(
+        logits[:, :-1][transition_mask],
+        labels[:, 1:][transition_mask],
+    )
+    torch.testing.assert_close(loss, expected)

--- a/tests/unit/benchmarks/test_forward_pass_loss.py
+++ b/tests/unit/benchmarks/test_forward_pass_loss.py
@@ -1,0 +1,36 @@
+"""Loss benchmarks must follow the explicit-label Bridge contract."""
+
+from typing import Any
+
+import pytest
+import torch
+
+from transformer_lens.benchmarks.forward_pass import benchmark_loss_equivalence
+from transformer_lens.model_bridge import TransformerBridge
+
+
+def test_benchmark_loss_equivalence_supplies_tokenized_self_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = object.__new__(TransformerBridge)
+    torch.nn.Module.__init__(bridge)
+    labels = torch.tensor([[1, 2, 3]])
+    forward_kwargs: dict[str, Any] = {}
+
+    def to_tokens(text: str, **kwargs: Any) -> torch.Tensor:
+        assert text == "benchmark text"
+        return labels
+
+    def forward(input: str, **kwargs: Any) -> torch.Tensor:
+        assert input == "benchmark text"
+        forward_kwargs.update(kwargs)
+        return torch.tensor(1.25)
+
+    monkeypatch.setattr(bridge, "to_tokens", to_tokens)
+    monkeypatch.setattr(bridge, "forward", forward)
+
+    result = benchmark_loss_equivalence(bridge, "benchmark text", reference_loss=1.25)
+
+    assert result.passed
+    assert forward_kwargs["labels"] is labels
+    assert forward_kwargs["return_type"] == "loss"

--- a/tests/unit/model_bridge/test_remote_bridge.py
+++ b/tests/unit/model_bridge/test_remote_bridge.py
@@ -220,6 +220,44 @@ class TestRemoteBridgeForward:
         loss = bridge.forward(torch.tensor([[1, 2, 3]]), return_type="loss")
         assert isinstance(loss, torch.Tensor) and loss.dim() == 0
 
+    def test_forward_loss_uses_explicit_labels(self):
+        import torch
+        import torch.nn.functional as F
+
+        logits = torch.zeros(1, 3, 16)
+        logits[0, 0, 9] = 2.0
+        logits[0, 1, 8] = 2.0
+
+        class LogitsDriver(DriverBase):
+            supported_hook_points = frozenset({"x"})
+            _supported_features = frozenset()
+
+            def __init__(self):
+                super().__init__(_cfg(), tokenizer=None)
+
+            def forward(
+                self,
+                input_ids=None,
+                *,
+                capture=(),
+                intervene=None,
+                max_new_tokens=1,
+                return_logits=True,
+                **kw,
+            ):
+                return ForwardResult(logits=logits, captured={})
+
+        bridge = RemoteBridge(_stub_adapter(), tokenizer=None, driver=LogitsDriver())
+        labels = torch.tensor([[7, 9, 8]])
+        loss = bridge.forward(
+            torch.tensor([[1, 2, 3]]),
+            labels=labels,
+            return_type="loss",
+        )
+
+        expected = F.cross_entropy(logits[:, :-1].flatten(0, 1), labels[:, 1:].flatten())
+        torch.testing.assert_close(loss, expected)
+
     def test_forward_loss_uses_scored_window_of_cached_attention_mask(self):
         import torch
         import torch.nn.functional as F

--- a/transformer_lens/benchmarks/forward_pass.py
+++ b/transformer_lens/benchmarks/forward_pass.py
@@ -13,6 +13,12 @@ from transformer_lens.benchmarks.utils import (
 from transformer_lens.model_bridge import TransformerBridge
 
 
+def _compute_self_target_loss(bridge: TransformerBridge, test_text: str) -> torch.Tensor:
+    """Compute loss with the tokenized input supplied as explicit labels."""
+    labels = bridge.to_tokens(test_text)
+    return bridge(test_text, labels=labels, return_type="loss")
+
+
 def _is_encoder_decoder(model: torch.nn.Module) -> bool:
     """Check if a model is an encoder-decoder architecture."""
     config = getattr(model, "config", None)
@@ -188,7 +194,7 @@ def benchmark_loss_equivalence(
         BenchmarkResult with comparison details
     """
     try:
-        bridge_loss = bridge(test_text, return_type="loss")
+        bridge_loss = _compute_self_target_loss(bridge, test_text)
 
         if reference_loss is None:
             # No reference - just verify loss is valid

--- a/transformer_lens/benchmarks/main_benchmark.py
+++ b/transformer_lens/benchmarks/main_benchmark.py
@@ -35,6 +35,7 @@ from transformer_lens.benchmarks.backward_gradients import (
 )
 from transformer_lens.benchmarks.component_benchmark import benchmark_all_components
 from transformer_lens.benchmarks.forward_pass import (
+    _compute_self_target_loss,
     benchmark_forward_pass,
     benchmark_loss_equivalence,
 )
@@ -1038,7 +1039,7 @@ def run_benchmark_suite(
                 with torch.no_grad():
                     bridge_logits = bridge_unprocessed(test_text, return_type="logits")
                     phase1_reference.hf_logits = bridge_logits.detach().cpu().clone()
-                    bridge_loss = bridge_unprocessed(test_text, return_type="loss")
+                    bridge_loss = _compute_self_target_loss(bridge_unprocessed, test_text)
                     phase1_reference.hf_loss = bridge_loss.item()
                     phase1_reference.test_text = test_text
                 if needs_upcast:

--- a/transformer_lens/model_bridge/bridge_core.py
+++ b/transformer_lens/model_bridge/bridge_core.py
@@ -23,6 +23,7 @@ from typing import (
 )
 
 import torch
+from torch.nn import functional as F
 
 from transformer_lens.ActivationCache import ActivationCache
 from transformer_lens.hook_points import HookPoint
@@ -351,6 +352,37 @@ class BridgeCore:
             attention_mask = self._prepare_loss_attention_mask(attention_mask, tokens)
         return lm_cross_entropy_loss(logits, tokens, attention_mask, per_token)
 
+    def _causal_labels_loss(
+        self,
+        logits: torch.Tensor,
+        labels: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        per_token: bool = False,
+    ) -> torch.Tensor:
+        """Compute shifted causal loss against explicit labels, ignoring ``-100``."""
+        if labels.device != logits.device:
+            labels = labels.to(logits.device)
+        if labels.shape != logits.shape[:-1]:
+            raise ValueError(
+                "causal labels must match the logits batch and position dimensions, "
+                f"got labels {tuple(labels.shape)} and logits {tuple(logits.shape)}"
+            )
+
+        losses = F.cross_entropy(
+            logits[:, :-1].flatten(0, 1),
+            labels[:, 1:].flatten(),
+            reduction="none",
+            ignore_index=-100,
+        ).view_as(labels[:, 1:])
+        valid_targets = labels[:, 1:] != -100
+        if attention_mask is not None:
+            if attention_mask.device != logits.device:
+                attention_mask = attention_mask.to(logits.device)
+            token_mask = self._prepare_loss_attention_mask(attention_mask, labels)
+            valid_targets &= token_mask[:, :-1] & token_mask[:, 1:]
+        losses = losses.masked_fill(~valid_targets, 0.0)
+        return losses if per_token else losses.sum() / valid_targets.sum()
+
     @staticmethod
     def _prepare_loss_attention_mask(
         attention_mask: torch.Tensor, tokens: torch.Tensor
@@ -417,6 +449,7 @@ class BridgeCore:
         input_ids: Optional[torch.Tensor],
         *,
         attention_mask: Optional[torch.Tensor] = None,
+        labels: Optional[torch.Tensor] = None,
         is_audio_model: bool = False,
         is_visual_model: bool = False,
         inputs_embeds_was_used: bool = False,
@@ -442,11 +475,18 @@ class BridgeCore:
                     "yourself from the returned logits, or use hf_generate()-style "
                     "direct access to self.original_model for HF's own loss."
                 )
-            if inputs_embeds_was_used:
+            if inputs_embeds_was_used and labels is None:
                 raise ValueError(
                     "Cannot compute loss with inputs_embeds — token IDs required for labels."
                 )
             assert isinstance(logits, torch.Tensor), f"Expected logits tensor, got {type(logits)}"
+            if labels is not None:
+                return self._causal_labels_loss(
+                    logits,
+                    labels,
+                    attention_mask=attention_mask,
+                    per_token=loss_per_token,
+                )
             assert input_ids is not None, "input_ids required for return_type='loss'"
             return self.loss_fn(
                 logits,
@@ -467,18 +507,26 @@ class BridgeCore:
                     "classification). Compute cross-entropy against `labels` "
                     "yourself from the returned logits."
                 )
-            if inputs_embeds_was_used:
+            if inputs_embeds_was_used and labels is None:
                 raise ValueError(
                     "Cannot compute loss with inputs_embeds — token IDs required for labels."
                 )
             assert isinstance(logits, torch.Tensor), f"Expected logits tensor, got {type(logits)}"
-            assert input_ids is not None, "input_ids required for return_type='both'"
-            loss = self.loss_fn(
-                logits,
-                input_ids,
-                attention_mask=attention_mask,
-                per_token=loss_per_token,
-            )
+            if labels is not None:
+                loss = self._causal_labels_loss(
+                    logits,
+                    labels,
+                    attention_mask=attention_mask,
+                    per_token=loss_per_token,
+                )
+            else:
+                assert input_ids is not None, "input_ids required for return_type='both'"
+                loss = self.loss_fn(
+                    logits,
+                    input_ids,
+                    attention_mask=attention_mask,
+                    per_token=loss_per_token,
+                )
             return (logits, loss)
         if return_type == "predictions":
             assert self.tokenizer is not None, "Tokenizer required for return_type='predictions'"

--- a/transformer_lens/model_bridge/remote_bridge.py
+++ b/transformer_lens/model_bridge/remote_bridge.py
@@ -78,7 +78,11 @@ class RemoteBridge(BridgeCore, HookIntrospectionMixin):
         labels: Any = None,
         **kwargs: Any,
     ) -> Any:
-        """Tokenize → driver.forward → replay captures → finalize per return_type."""
+        """Tokenize → driver.forward → replay captures → finalize per return_type.
+
+        Explicit ``labels`` use shifted causal loss; remote encoder-decoder loss
+        is unsupported.
+        """
         # Early copy of _finalize_return's gate — fail before the wasted remote forward.
         self._check_loss_supported(return_type)
         self._reject_stop_at_layer(kwargs.pop("stop_at_layer", None))

--- a/transformer_lens/model_bridge/remote_bridge.py
+++ b/transformer_lens/model_bridge/remote_bridge.py
@@ -75,6 +75,7 @@ class RemoteBridge(BridgeCore, HookIntrospectionMixin):
         *,
         return_type: str | None = "logits",
         loss_per_token: bool = False,
+        labels: Any = None,
         **kwargs: Any,
     ) -> Any:
         """Tokenize → driver.forward → replay captures → finalize per return_type."""
@@ -109,12 +110,17 @@ class RemoteBridge(BridgeCore, HookIntrospectionMixin):
             return logits  # weird shape — let caller handle
         if logits is not None:
             logits = to_torch(logits)
+        if labels is not None:
+            if not isinstance(labels, TensorLike):
+                raise TypeError(f"labels must be tensor-like, got {type(labels).__name__}")
+            labels = to_torch(labels)
 
         return self._finalize_return(
             return_type,
             logits,
             kwargs.get("input_ids"),
             attention_mask=kwargs.get("attention_mask"),
+            labels=labels,
             is_audio_model=getattr(self.cfg, "is_audio_model", False),
             is_visual_model=getattr(self.cfg, "is_visual_model", False),
             loss_per_token=loss_per_token,

--- a/transformer_lens/model_bridge/sources/transformers_driver.py
+++ b/transformer_lens/model_bridge/sources/transformers_driver.py
@@ -66,7 +66,8 @@ class TransformersDriver(DriverBase):
             if hasattr(raw, "logits"):
                 logits = raw.logits
             elif isinstance(raw, tuple) and len(raw) > 0:
-                logits = raw[0]
+                # HF tuple outputs prepend loss when labels are supplied.
+                logits = raw[1] if kwargs.get("labels") is not None and len(raw) > 1 else raw[0]
             elif hasattr(raw, "last_hidden_state"):
                 # Bare encoder models (ViTModel, DeiTModel, BertModel, etc. without
                 # a task head) return e.g. BaseModelOutput/BaseModelOutputWithPooling,

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -28,6 +28,7 @@ import numpy as np
 import torch
 import tqdm
 from torch import nn
+from torch.nn import functional as F
 
 from transformer_lens import utilities as utils
 from transformer_lens.ActivationCache import ActivationCache
@@ -1459,6 +1460,51 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
         self.__dict__["_derived_position_ids_ok"] = (underlying, accepts)
         return accepts
 
+    @staticmethod
+    def _seq2seq_loss(
+        logits: torch.Tensor,
+        labels: torch.Tensor,
+        native_loss: Any,
+        *,
+        per_token: bool,
+    ) -> torch.Tensor:
+        """Return encoder-decoder loss without the causal LM token shift."""
+        if labels.device != logits.device:
+            labels = labels.to(logits.device)
+        if labels.shape != logits.shape[:-1]:
+            raise ValueError(
+                "seq2seq labels must match the decoder logits batch and position "
+                f"dimensions, got labels {tuple(labels.shape)} and logits "
+                f"{tuple(logits.shape)}"
+            )
+        if not per_token and isinstance(native_loss, torch.Tensor):
+            return native_loss
+
+        losses = F.cross_entropy(
+            logits.flatten(0, 1),
+            labels.flatten(),
+            reduction="none" if per_token else "mean",
+            ignore_index=-100,
+        )
+        return losses.view_as(labels) if per_token else losses
+
+    def _finalize_seq2seq_return(
+        self,
+        return_type: str,
+        logits: torch.Tensor,
+        labels: torch.Tensor,
+        native_output: Any,
+        *,
+        loss_per_token: bool,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        loss = self._seq2seq_loss(
+            logits,
+            labels,
+            getattr(native_output, "loss", None),
+            per_token=loss_per_token,
+        )
+        return (logits, loss) if return_type == "both" else loss
+
     def forward(
         self,
         input: Union[str, List[str], torch.Tensor],
@@ -1467,6 +1513,7 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
         prepend_bos: Optional[bool] = None,
         padding_side: Optional[str] = None,
         attention_mask: Optional[torch.Tensor] = None,
+        labels: Optional[torch.Tensor] = None,
         start_at_layer: Optional[int] = None,
         stop_at_layer: Optional[int] = None,
         pixel_values: Optional[torch.Tensor] = None,
@@ -1485,6 +1532,8 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
             loss_per_token: Whether to return loss per token
             prepend_bos: Whether to prepend BOS token
             padding_side: Which side to pad on
+            labels: Explicit language-model targets. Encoder-decoder models require
+                labels for loss; decoder-only models fall back to input IDs when omitted.
             past_key_values: HuggingFace KV cache from a prior ``use_cache=True`` step
                 (e.g. the second element of a ``return_type='logits_and_cache'`` return).
                 When provided, KV caching is enabled automatically and only the new
@@ -1511,13 +1560,29 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
             Model output based on return_type
         """
 
-        if return_type in ("loss", "both") and not self.adapter.supports_causal_loss:
+        underlying_model = getattr(getattr(self, "_driver", None), "underlying_model", None)
+        model_config = getattr(underlying_model, "config", None)
+        is_encoder_decoder = bool(getattr(model_config, "is_encoder_decoder", False))
+        if return_type in ("loss", "both"):
+            if is_encoder_decoder and labels is None:
+                raise ValueError(
+                    "labels are required for seq2seq return_type='loss' or 'both'; "
+                    "encoder input_ids are not decoder targets"
+                )
+        if (
+            return_type in ("loss", "both")
+            and not is_encoder_decoder
+            and not self.adapter.supports_causal_loss
+        ):
             architecture = self.cfg.architecture or type(self.adapter).__name__
             raise NotImplementedError(
                 f"{architecture} does not support TransformerBridge's shifted causal "
                 "loss. Request return_type='logits' and compute the architecture-specific "
                 "masked-token objective explicitly."
             )
+
+        if labels is not None:
+            kwargs["labels"] = labels
 
         if start_at_layer is not None:
             input = self._setup_start_at_layer(input, start_at_layer)
@@ -1673,11 +1738,7 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
             if kwargs.pop("use_past_kv_cache", False) or kwargs.get("use_cache", False):
                 kwargs["use_cache"] = True
             # Auto-generate decoder_input_ids for encoder-decoder models
-            if (
-                "decoder_input_ids" not in kwargs
-                and hasattr(self.original_model, "config")
-                and getattr(self.original_model.config, "is_encoder_decoder", False)
-            ):
+            if "decoder_input_ids" not in kwargs and labels is None and is_encoder_decoder:
                 decoder_start_token_id = getattr(
                     self.original_model.config, "decoder_start_token_id", None
                 )
@@ -1766,11 +1827,24 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
             if return_type == "logits_and_cache":
                 past_key_values = getattr(output, "past_key_values", None)
                 return (logits, past_key_values)
+            if is_encoder_decoder and return_type in ("loss", "both"):
+                assert isinstance(
+                    logits, torch.Tensor
+                ), f"Expected seq2seq logits tensor, got {type(logits)}"
+                assert isinstance(labels, torch.Tensor)
+                return self._finalize_seq2seq_return(
+                    return_type,
+                    logits,
+                    labels,
+                    output,
+                    loss_per_token=loss_per_token,
+                )
             return self._finalize_return(
                 return_type,
                 logits,
                 input_ids,
                 attention_mask=attention_mask,
+                labels=labels,
                 is_audio_model=getattr(self.cfg, "is_audio_model", False),
                 is_visual_model=getattr(self.cfg, "is_visual_model", False),
                 inputs_embeds_was_used=_is_inputs_embeds,


### PR DESCRIPTION
# Description

## Summary

- Add an explicit seq2seq loss path that preserves Hugging Face label-driven decoder input construction and computes loss against unshifted decoder labels.
- Honor explicit `labels` for decoder-only causal loss, including `-100`, per-token loss, and the existing attention-mask transition semantics.
- Require `labels` for encoder-decoder `return_type="loss"` and `"both"` instead of silently treating encoder inputs as decoder targets.
- Handle Hugging Face tuple outputs correctly when `labels` prepend a native loss value.
- Keep `RemoteBridge` explicit-label causal loss consistent with the local bridge.

## Root cause and impact

`TransformerBridge` forwarded `labels` to Hugging Face but discarded the native label-driven loss during finalization. It then reused the shifted causal loss helper with encoder `input_ids`, so seq2seq losses ignored decoder targets and failed when source and target lengths differed. Decoder-only models had the related issue that explicit labels were ignored in favor of input IDs.

This change makes both paths follow their intended contracts while preserving the input-ID fallback for decoder-only callers that omit labels. It also safely detects encoder-decoder models through the optional driver model so lightweight and non-torch test bridges continue to reach their architecture-specific validation paths.

Fixes #1611

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

- Full non-slow unit suite: `5140 passed, 55 skipped, 54 deselected, 10 xfailed`.
- Tiny BART, T5, and GPT-2 label-loss regression suite: `18 passed`.
- Lightweight Bridge compatibility regressions covering diffusion and audio stubs: `9 passed`.
- `uv run mypy .`: no issues found in 422 source files.
- Full pycln, isort, Black, and `git diff --check` completed successfully.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
