### PR TITLE
Fix run_with_cache BOS handling for string inputs

### DIFF
--- a/tests/unit/model_bridge/test_boot_native.py
+++ b/tests/unit/model_bridge/test_boot_native.py
@@ -367,6 +367,35 @@ def test_boot_native_forward_and_cache():
     assert "blocks.0.attn.hook_pattern" in cache
 
 
+@pytest.mark.parametrize("prepend_bos", [True, False])
+def test_run_with_cache_forwards_prepend_bos_for_string_input(monkeypatch, prepend_bos):
+    cfg = _cfg()
+    bridge = TransformerBridge.boot_native(cfg)
+    bridge._tokenizer = object()
+    tokenization_calls = []
+
+    def to_tokens(input, prepend_bos=None, padding_side=None):
+        tokenization_calls.append((input, prepend_bos, padding_side))
+        if prepend_bos is None:
+            prepend_bos = bridge.cfg.default_prepend_bos
+        tokens = [0, 7] if prepend_bos else [7]
+        return torch.tensor([tokens])
+
+    monkeypatch.setattr(bridge, "to_tokens", to_tokens)
+    bridge.eval()
+
+    with torch.no_grad():
+        direct_logits = bridge("hello", prepend_bos=prepend_bos)
+        cached_logits, cache = bridge.run_with_cache("hello", prepend_bos=prepend_bos)
+
+    assert tokenization_calls == [
+        ("hello", prepend_bos, None),
+        ("hello", prepend_bos, None),
+    ]
+    torch.testing.assert_close(cached_logits, direct_logits)
+    assert cache["hook_embed"].shape[1] == direct_logits.shape[1]
+
+
 def test_boot_native_does_not_load_transformers_runtime():
     # Sanity that the native path doesn't depend on HuggingFace's `transformers`
     # for the runtime work — we check that calling boot_native doesn't trigger

--- a/transformer_lens/model_bridge/bridge_core.py
+++ b/transformer_lens/model_bridge/bridge_core.py
@@ -1293,14 +1293,16 @@ class BridgeCore:
         target_device = self._input_device()
         if processed_args and isinstance(processed_args[0], str):
             assert self.tokenizer is not None, "Tokenizer must be set to pass string input."
-            input_ids = self.to_tokens(processed_args[0])
+            prepend_bos = kwargs.pop("prepend_bos", None)
+            input_ids = self.to_tokens(processed_args[0], prepend_bos=prepend_bos)
             if target_device is not None:
                 input_ids = input_ids.to(target_device)
             kwargs["input_ids"] = input_ids
             processed_args = processed_args[1:]
         elif "input" in kwargs and isinstance(kwargs["input"], str):
             assert self.tokenizer is not None, "Tokenizer must be set to pass string input."
-            input_ids = self.to_tokens(kwargs["input"])
+            prepend_bos = kwargs.pop("prepend_bos", None)
+            input_ids = self.to_tokens(kwargs["input"], prepend_bos=prepend_bos)
             if target_device is not None:
                 input_ids = input_ids.to(target_device)
             kwargs["input_ids"] = input_ids


### PR DESCRIPTION
# Description

## Summary

- Preserve an explicit `prepend_bos` value when `BridgeCore.run_with_cache()` eagerly tokenizes a scalar string input.
- Consume the tokenization option before forwarding the resulting token tensor, rather than leaving an ineffective `prepend_bos` argument on the tensor forward.
- Add offline native-Bridge regression coverage for direct-vs-cached parity with both `prepend_bos=True` and `False`.

## Root cause and impact

`run_with_cache()` converts scalar string inputs with `self.to_tokens(input)` before calling `forward()`, but did not pass the caller's `prepend_bos` value. `to_tokens()` therefore fell back to `cfg.default_prepend_bos`, typically `True`. Although the original argument was subsequently forwarded, the input was already a token tensor and could no longer be retokenized.

As a result, `bridge(text, prepend_bos=False)` and `bridge.run_with_cache(text, prepend_bos=False)` could run on different token sequences. The cached path silently included an extra BOS position, shifting logits and position-indexed activations used for attention analysis, attribution, and activation patching.

The fix lives in `BridgeCore`, so it preserves the shared local/remote cache contract while leaving tensor/list inputs and driver-aware device placement unchanged. This PR intentionally does not broaden into `padding_side`, whose tokenization support differs between `TransformerBridge` and `RemoteBridge` and is not required to fix the demonstrated bug.

No documentation change is required because the existing `prepend_bos` contract is already documented; this change makes `run_with_cache()` conform to it.

Fixes #1624

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

N/A — code-only behavior fix.

## Validation

- Target regression: `2 passed`.
- Full affected files (`test_boot_native.py` and `test_remote_bridge.py`): `62 passed`.
- Related model-bridge unit surface selected by `run_with_cache`, tokenizer, and `prepend_bos`: `68 passed, 6 skipped`.
- Offline tiny native Bridge parity: direct logits, cached logits, and `hook_embed` all have shape `(1, 1, 8)` with `prepend_bos=False`; maximum direct-vs-cached logit difference is `0.0`.
- `mypy .`: no issues in 424 source files.
- pycln, isort, Black, and `git diff --check`: passed for the changed files.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (no change required; existing docs already specify this behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (the affected unit-test surface passed; the complete suite was not rerun locally)
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
