### PR TITLE
fix(bridge): gate batched-list position_ids on the target model

### DIFF
--- a/tests/integration/model_bridge/test_batched_generate_position_ids.py
+++ b/tests/integration/model_bridge/test_batched_generate_position_ids.py
@@ -1,0 +1,133 @@
+"""position_ids handling during batched-list generation.
+
+Batched list input is left-padded internally, so each row's real tokens start at
+a different offset. The bridge derives position_ids for that, but only models
+that neither reject the kwarg nor derive positions themselves may receive them
+(#1626).
+
+The cached decoding path needs the same gate as the prompt path. Every branch
+there supplies position_ids, including a ``total_len - 1`` fallback that counts
+pad slots, so gating only the prompt derivation diverts a refused model into the
+fallback instead of leaving it alone.
+
+OPT is the vehicle for the refused case: ``OPTLearnedPositionalEmbedding``
+consumes the attention mask and derives its own positions, so the gate declines
+it, while its forward would happily accept the kwarg and use it.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import pytest
+import torch
+
+GREEDY = dict(max_new_tokens=4, do_sample=False, verbose=False)
+PROMPTS = ["The capital of France is the city of", "Hi"]
+
+
+@pytest.fixture(scope="module")
+def opt_bridge():
+    """A model the gate refuses. Its positional embedding reads the mask."""
+    from transformer_lens.model_bridge import TransformerBridge
+
+    bridge = TransformerBridge.boot_transformers(
+        "hf-internal-testing/tiny-random-OPTForCausalLM", device="cpu", dtype=torch.float32
+    )
+    bridge.eval()
+    return bridge
+
+
+def _stack_logits(output) -> torch.Tensor:
+    logits = output.logits
+    return torch.stack(list(logits)) if isinstance(logits, (list, tuple)) else logits
+
+
+def _position_ids_per_step(bridge, use_past_kv_cache: bool) -> list:
+    """The position_ids each forward actually received, one entry per step."""
+    seen: list = []
+    original = bridge.original_model.forward
+
+    # functools.wraps so the gate still sees the real signature; a bare
+    # (*args, **kwargs) spy would look like it accepts position_ids.
+    @functools.wraps(original)
+    def _spy(*args, **kwargs):
+        supplied = kwargs.get("position_ids")
+        seen.append(None if supplied is None else supplied.tolist())
+        return original(*args, **kwargs)
+
+    bridge.original_model.forward = _spy
+    try:
+        bridge.generate(list(PROMPTS), use_past_kv_cache=use_past_kv_cache, **GREEDY)
+    finally:
+        bridge.original_model.forward = original
+    return seen
+
+
+def test_gate_refuses_opt(opt_bridge) -> None:
+    """Guards the premise of the tests below: OPT must be the refused case."""
+    assert opt_bridge._accepts_derived_position_ids() is False
+
+
+def test_refused_model_generates_identically_with_and_without_cache(opt_bridge) -> None:
+    """Cached decoding must not change the answer.
+
+    Compared on logits rather than decoded text on purpose: greedy argmax
+    absorbs the drift and the strings match even when the positions are wrong.
+    """
+    cached = opt_bridge.generate(
+        list(PROMPTS), use_past_kv_cache=True, output_logits=True, **GREEDY
+    )
+    uncached = opt_bridge.generate(
+        list(PROMPTS), use_past_kv_cache=False, output_logits=True, **GREEDY
+    )
+
+    torch.testing.assert_close(_stack_logits(cached), _stack_logits(uncached), rtol=0, atol=1e-5)
+
+
+def test_refused_model_receives_no_position_ids_on_cached_steps(opt_bridge) -> None:
+    """The mechanism, not just the symptom.
+
+    The fallback supplies a per-batch constant, so a coarser check can miss it;
+    assert the kwarg never reaches a model that derives positions itself.
+    """
+    assert _position_ids_per_step(opt_bridge, use_past_kv_cache=True) == [None] * (
+        GREEDY["max_new_tokens"]
+    )
+
+
+def test_accepted_model_still_receives_per_row_position_ids(distilgpt2_bridge) -> None:
+    """The gate must not disarm the models it was never meant to exclude."""
+    if distilgpt2_bridge.tokenizer.pad_token_id is None:
+        distilgpt2_bridge.tokenizer.pad_token = distilgpt2_bridge.tokenizer.eos_token
+
+    seen = _position_ids_per_step(distilgpt2_bridge, use_past_kv_cache=True)
+
+    assert seen[0] is not None, "prompt step must still receive derived positions"
+    cached_steps = [step for step in seen[1:] if step is not None]
+    assert len(cached_steps) == len(seen) - 1, "cached steps must still be supplied"
+    # Row 1 ("Hi") is left-padded, so its position must be strictly lower than
+    # row 0's. A pad-counting fallback would give both rows the same value.
+    first_cached = cached_steps[0]
+    assert first_cached[1][0] < first_cached[0][0], first_cached
+
+
+def test_accepted_model_generates_identically_with_and_without_cache(distilgpt2_bridge) -> None:
+    """Control for the parity property on a model the gate allows.
+
+    Looser than the OPT case at 1e-3. Cached decoding and full recompute sum in
+    different orders, which on distilgpt2's logit scale of ~132 shows as 1.4e-04,
+    or 1e-06 relative. The regression this guards moves logits by ~0.3, so the
+    margin is still more than two orders of magnitude.
+    """
+    if distilgpt2_bridge.tokenizer.pad_token_id is None:
+        distilgpt2_bridge.tokenizer.pad_token = distilgpt2_bridge.tokenizer.eos_token
+
+    cached = distilgpt2_bridge.generate(
+        list(PROMPTS), use_past_kv_cache=True, output_logits=True, **GREEDY
+    )
+    uncached = distilgpt2_bridge.generate(
+        list(PROMPTS), use_past_kv_cache=False, output_logits=True, **GREEDY
+    )
+
+    torch.testing.assert_close(_stack_logits(cached), _stack_logits(uncached), rtol=0, atol=1e-3)

--- a/tests/integration/model_bridge/test_llada_adapter.py
+++ b/tests/integration/model_bridge/test_llada_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import functools
 import gc
 import math
 import weakref
@@ -661,6 +662,54 @@ def test_left_padding_does_not_inject_unsupported_position_ids(models: TinyModel
         reference_logits = models.reference(tokens, attention_mask=attention_mask).logits
         bridge_logits = models.bridge(tokens, attention_mask=attention_mask)
     torch.testing.assert_close(bridge_logits, reference_logits, rtol=1e-5, atol=1e-6)
+
+
+def test_batched_list_input_does_not_inject_unsupported_position_ids() -> None:
+    """Batched list input builds its own attention_mask and position_ids so pad
+    tokens don't contaminate the forward (#1626). The mask is safe for any model;
+    the position_ids are not, and this forward takes neither them nor **kwargs.
+
+    A local bridge rather than the module fixture: this needs a tokenizer, and
+    attaching one to the shared instance would leak into the other tests. The
+    tokenizer is given a BOS so the path under test is reached independently of
+    BOS handling elsewhere.
+    """
+    local = _build_models()
+    tokenizer = _offline_tokenizer()
+    tokenizer.bos_token = "<bos>"
+    local.bridge.tokenizer = tokenizer
+
+    seen: dict = {}
+    original = local.bridge.original_model.forward
+
+    # functools.wraps so inspect.signature() still resolves to the real forward:
+    # the gate reads that signature, and a bare (*args, **kwargs) spy would look
+    # like it accepts position_ids and defeat the check under test.
+    @functools.wraps(original)
+    def _spy(*args, **kwargs):
+        seen.clear()
+        seen.update(kwargs)
+        return original(*args, **kwargs)
+
+    local.bridge.original_model.forward = _spy
+    try:
+        with torch.inference_mode():
+            logits = local.bridge(["token_5 token_7 token_9", "token_5"], return_type="logits")
+        batched = dict(seen)
+        with torch.inference_mode():
+            local.bridge("token_5 token_7 token_9", return_type="logits")
+        unbatched = dict(seen)
+    finally:
+        local.bridge.original_model.forward = original
+
+    assert logits.shape[0] == 2
+    assert "position_ids" not in batched
+    # The mask is still supplied — withholding it would reintroduce the padding
+    # contamination this branch exists to prevent.
+    assert "attention_mask" in batched
+    # Control: a single unbatched string never reached this branch, so the gate
+    # must not have changed anything for it either.
+    assert "position_ids" not in unbatched
 
 
 def test_run_with_cache_exposes_hooks_without_hf_output_attentions(

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -2248,24 +2248,32 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
                                     dtype=torch.long,
                                     device=device,
                                 )
-                            if "position_ids" in forward_kwargs:
-                                forward_kwargs["position_ids"] = forward_kwargs["position_ids"][
-                                    :, -1:
-                                ]
-                            elif running_attention_mask is not None:
-                                # total_len - 1 counts pad slots, so it is wrong
-                                # for a left-padded prompt. Derive the new token's
-                                # position from the mask instead.
-                                forward_kwargs["position_ids"] = utils.get_offset_position_ids(
-                                    0, running_attention_mask.long()
-                                )[:, -1:]
-                            else:
-                                forward_kwargs["position_ids"] = torch.full(
-                                    (batch_size, 1),
-                                    total_len - 1,
-                                    dtype=torch.long,
-                                    device=device,
-                                )
+                            # Gated as a whole (#1626): every branch below supplies
+                            # position_ids, so gating only the prompt derivation
+                            # above would divert a refused model into the
+                            # total_len - 1 fallback, which counts pad slots and is
+                            # wrong per row for a left-padded batch. A model that
+                            # owns its position derivation gets the mask alone,
+                            # matching the uncached path.
+                            if self._accepts_derived_position_ids():
+                                if "position_ids" in forward_kwargs:
+                                    forward_kwargs["position_ids"] = forward_kwargs["position_ids"][
+                                        :, -1:
+                                    ]
+                                elif running_attention_mask is not None:
+                                    # total_len - 1 counts pad slots, so it is wrong
+                                    # for a left-padded prompt. Derive the new token's
+                                    # position from the mask instead.
+                                    forward_kwargs["position_ids"] = utils.get_offset_position_ids(
+                                        0, running_attention_mask.long()
+                                    )[:, -1:]
+                                else:
+                                    forward_kwargs["position_ids"] = torch.full(
+                                        (batch_size, 1),
+                                        total_len - 1,
+                                        dtype=torch.long,
+                                        device=device,
+                                    )
                             logits = self(
                                 current_tokens[:, -1:],
                                 return_type="logits",

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -1777,7 +1777,11 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
                     ).to(self.cfg.device)
                 finally:
                     self.tokenizer.padding_side = _prev_side
-                if "position_ids" not in kwargs:
+                # Gated on the target for the same reason the derivation below is:
+                # a fixed-signature forward raises TypeError on the kwarg, and a
+                # model that owns its own position derivation is overridden by it
+                # (#1626).
+                if "position_ids" not in kwargs and self._accepts_derived_position_ids():
                     position_ids = attention_mask.long().cumsum(-1) - 1
                     position_ids.masked_fill_(attention_mask == 0, 1)
                     kwargs["position_ids"] = position_ids
@@ -2185,9 +2189,12 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
                         ).to(self.cfg.device)
                         self.tokenizer.padding_side = _prev_side
                         forward_kwargs["attention_mask"] = attn_mask
-                        position_ids = attn_mask.long().cumsum(-1) - 1
-                        position_ids.masked_fill_(attn_mask == 0, 1)
-                        forward_kwargs["position_ids"] = position_ids
+                        # Same target gate as the forward() path: the mask is safe
+                        # for every model, the derived positions are not (#1626).
+                        if self._accepts_derived_position_ids():
+                            position_ids = attn_mask.long().cumsum(-1) - 1
+                            position_ids.masked_fill_(attn_mask == 0, 1)
+                            forward_kwargs["position_ids"] = position_ids
                     if gen_step_idx == 0:
                         if pixel_values is not None:
                             forward_kwargs["pixel_values"] = pixel_values


### PR DESCRIPTION
Fixes #1626.

Batched list input builds an `attention_mask` and `position_ids` itself so pad tokens don't contaminate the forward. The mask is safe for any model, but the `position_ids` were handed over unchecked — a forward taking neither `position_ids` nor `**kwargs` raises `TypeError` where it would otherwise have returned logits.

This is the gap that was raised while reviewing #1610. That PR added `_accepts_derived_position_ids()` and gated the main `forward()` derivation, but we left these two sites for a follow-up because I couldn't produce a model that demonstrably failed there. The LLaDA test harness builds a fixed-signature forward in-process, which reproduces it:

```
TypeError: TinyLLaDAModelLM.forward() got an unexpected keyword argument 'position_ids'
kwargs attempted: ['attention_mask', 'position_ids']
```

## What I changed

Both sites now call the same `_accepts_derived_position_ids()` helper, so there's no new predicate. The `attention_mask` stays unconditional -it's safe for every model, and withholding it would reintroduce the padding contamination the branch exists to prevent.

## Verification

One regression test in the LLaDA suite, red on `dev-4.x` with the `TypeError` above and green with the fix. It asserts both halves: no `position_ids` reaches the model, and the `attention_mask` still does. A single unbatched string was never affected and is covered as a control.

Full unit + integration + acceptance: **6594 passed, 1 failed**. The failure is `test_bridge_hooked_parity_multi_step_optimization`, which fails identically on unmodified code and is `--ignore`d on the macOS CI job. mypy clean.

