### PR TITLE
fix(tokenizer): do not strip a BOS token the tokenizer does not have

### DIFF
--- a/tests/unit/utilities/test_get_tokens_with_bos_removed.py
+++ b/tests/unit/utilities/test_get_tokens_with_bos_removed.py
@@ -1,0 +1,82 @@
+"""Tests for get_tokens_with_bos_removed when the tokenizer has no BOS token.
+
+Callers gate this helper on ``cfg.tokenizer_prepends_bos``. That flag is set by
+``detect_tokenizer_bos_eos``, which requires a ``bos_token_id`` — so a tokenizer
+with none should never reach here. It does when the flag is stale: a bridge built
+via ``build_bridge_from_module(tokenizer=None)`` keeps the config default of True,
+and the tokenizer setter only re-runs detection on *re*-assignment.
+
+Trusting a stale flag is not harmless. Under right padding the helper drops the
+first token unconditionally, which silently removes ``[CLS]`` from a BERT
+tokenizer's output; under left padding it compares tokens against ``None`` and
+raises an ``AttributeError`` naming neither the tokenizer nor the flag.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from transformers import AutoTokenizer
+
+from transformer_lens.utilities.tokenize_utils import get_tokens_with_bos_removed
+
+
+@pytest.fixture(scope="module")
+def no_bos_tokenizer():
+    """BERT uses [CLS] rather than a BOS token, so bos_token_id is None."""
+    tokenizer = AutoTokenizer.from_pretrained("google-bert/bert-base-cased")
+    assert tokenizer.bos_token_id is None
+    return tokenizer
+
+
+@pytest.fixture(scope="module")
+def bos_tokenizer():
+    tokenizer = AutoTokenizer.from_pretrained("distilgpt2")
+    assert tokenizer.bos_token_id is not None
+    return tokenizer
+
+
+@pytest.mark.parametrize("padding_side", ["left", "right"])
+def test_no_bos_token_returns_tokens_unchanged(no_bos_tokenizer, padding_side) -> None:
+    """There is no BOS to remove, so the tokens must come back untouched."""
+    no_bos_tokenizer.padding_side = padding_side
+    tokens = torch.tensor([[101, 19082, 1362, 102]])
+
+    result = get_tokens_with_bos_removed(no_bos_tokenizer, tokens)
+
+    torch.testing.assert_close(result, tokens)
+
+
+def test_no_bos_token_does_not_drop_cls_under_right_padding(no_bos_tokenizer) -> None:
+    """The damaging case: [CLS] is not a BOS token, and dropping it changes what
+    the model is asked to encode."""
+    no_bos_tokenizer.padding_side = "right"
+    tokens = no_bos_tokenizer("hello world", return_tensors="pt")["input_ids"]
+
+    result = get_tokens_with_bos_removed(no_bos_tokenizer, tokens)
+
+    assert result.shape == tokens.shape
+    assert result[0, 0].item() == no_bos_tokenizer.cls_token_id
+
+
+def test_no_bos_token_does_not_raise_under_left_padding(no_bos_tokenizer) -> None:
+    """Previously `(tokens == None).int()` — a Python bool, not a tensor."""
+    no_bos_tokenizer.padding_side = "left"
+    tokens = torch.tensor([[101, 19082, 1362, 102]])
+
+    result = get_tokens_with_bos_removed(no_bos_tokenizer, tokens)
+
+    assert result.shape == tokens.shape
+
+
+@pytest.mark.parametrize("padding_side", ["left", "right"])
+def test_a_real_bos_is_still_removed(bos_tokenizer, padding_side) -> None:
+    """The guard must not disturb the case the helper exists for."""
+    bos_tokenizer.padding_side = padding_side
+    bos = bos_tokenizer.bos_token_id
+    tokens = torch.tensor([[bos, 15496, 995]])
+
+    result = get_tokens_with_bos_removed(bos_tokenizer, tokens)
+
+    assert result.shape[-1] == tokens.shape[-1] - 1
+    assert bos not in result[0].tolist()

--- a/transformer_lens/utilities/tokenize_utils.py
+++ b/transformer_lens/utilities/tokenize_utils.py
@@ -216,6 +216,14 @@ def get_tokens_with_bos_removed(
     Returns:
         torch.Tensor: The tokenized input with the bos token removed.
     """
+    if tokenizer.bos_token_id is None:
+        # Nothing to remove (#1628). Callers reach this when cfg.tokenizer_prepends_bos
+        # says the tokenizer prepends a BOS but the tokenizer has none — a stale
+        # flag, since detect_tokenizer_bos_eos() requires a bos_token_id. Trusting
+        # it here would drop a real first token under right padding ([CLS] for a
+        # BERT tokenizer), and compare tokens against None under left padding.
+        return tokens
+
     if tokenizer.padding_side == "right":
         return tokens[..., 1:]
 


### PR DESCRIPTION
`get_tokens_with_bos_removed` assumed the tokenizer has a `bos_token_id`. When `cfg.tokenizer_prepends_bos` goes stale the helper is reached anyway, and it then does damage in two directions.

Under right padding, which is the default, it drops the first token unconditionally. For a BERT tokenizer that silently removes `[CLS]` and returns a plausible looking wrong result. Under left padding it evaluates `(tokens == None).int()`, which is a Python bool rather than a tensor, and raises `AttributeError: 'bool' object has no attribute 'int'`.

## What I changed

With no `bos_token_id` there is nothing to remove, so the helper returns the tokens unchanged. This is correct however the config got out of sync, it fixes both symptoms, and it leaves the `boot_transformers` path untouched.

## What I did not change and why

The root cause is the reassignment test at `bridge_core.py:113`. I left it alone, and not only because it alters build and attach semantics. Correcting the flag would route `to_tokens(prepend_bos=True)` into the manual prepend branch at `transformer_bridge.py:716`, which calls `get_input_with_manually_prepended_bos(tokenizer.bos_token, ...)` and raises `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'` when there is no BOS token. The stale flag is currently masking that, so the root cause fix needs the prepend path hardened first. Happy to take that on as a follow up if you want it.

## Verification

Six unit tests, four of which are red on `dev-4.x`. The two that pass either way are controls confirming a real BOS is still removed for `distilgpt2` on both padding sides.

Reproduced with two off the shelf tokenizers, `google-bert/bert-base-cased` and `google-t5/t5-small`, both of which have `bos_token_id` set to `None`.