### PR TITLE
fix(bridge): restore native stop_at_layer and input_to_embed

### DIFF
--- a/tests/unit/model_bridge/test_boot_native.py
+++ b/tests/unit/model_bridge/test_boot_native.py
@@ -75,6 +75,42 @@ def test_boot_native_returns_bridge_over_native_model():
     assert isinstance(bridge.original_model, NativeModel)
 
 
+@pytest.mark.parametrize("stop_at_layer", [0, 2, -1])
+def test_boot_native_direct_stop_matches_cached_stop(stop_at_layer: int):
+    bridge = TransformerBridge.boot_native(_cfg(n_layers=3))
+    bridge.eval()
+    tokens = torch.tensor([[1, 2, 3]])
+
+    with torch.no_grad():
+        expected, _ = bridge.run_with_cache(tokens, stop_at_layer=stop_at_layer)
+        actual = bridge(tokens, stop_at_layer=stop_at_layer)
+
+    assert actual.shape == (1, 3, bridge.cfg.d_model)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_boot_native_input_to_embed_round_trip():
+    bridge = TransformerBridge.boot_native(_cfg(n_layers=3))
+    bridge.eval()
+    tokens = torch.tensor([[1, 2, 3]])
+
+    with torch.no_grad():
+        expected = bridge(tokens)
+        residual, returned_tokens, shortformer_pos_embed, attention_mask = bridge.input_to_embed(
+            tokens
+        )
+        actual = bridge(
+            residual,
+            start_at_layer=0,
+            attention_mask=attention_mask,
+        )
+
+    assert residual.shape == (1, 3, bridge.cfg.d_model)
+    assert torch.equal(returned_tokens, tokens)
+    assert shortformer_pos_embed is None
+    torch.testing.assert_close(actual, expected)
+
+
 def test_native_state_dict_round_trip_restores_parameters():
     bridge = TransformerBridge.boot_native(_cfg())
 

--- a/transformer_lens/model_bridge/generalized_components/block.py
+++ b/transformer_lens/model_bridge/generalized_components/block.py
@@ -261,11 +261,7 @@ class BlockBridge(GeneralizedComponent):
         """Parse this block's layer index from its name (TL/GPT-2/LLaMA patterns)."""
         if self.name is None:
             return None
-        match = (
-            re.search(r"blocks\.(\d+)", self.name)
-            or re.search(r"\.h\.(\d+)", self.name)
-            or re.search(r"\.layers\.(\d+)", self.name)
-        )
+        match = re.search(r"(?:^|\.)(?:blocks|h|layers)\.(\d+)", self.name)
         return int(match.group(1)) if match else None
 
     def _check_stop_at_layer(self, *args: Any, **kwargs: Any) -> None:

--- a/transformer_lens/model_bridge/sources/native/model.py
+++ b/transformer_lens/model_bridge/sources/native/model.py
@@ -487,15 +487,27 @@ class NativeModel(nn.Module):
 
     def forward(
         self,
-        input_ids: torch.Tensor,
+        input_ids: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         """Returns logits directly."""
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("Exactly one of input_ids or inputs_embeds must be provided.")
+        if input_ids is not None:
+            model_input = input_ids
+            hidden_states = self.tok_embed(input_ids)
+        elif inputs_embeds is not None:
+            model_input = inputs_embeds
+            hidden_states = inputs_embeds
+        else:
+            raise ValueError("Exactly one of input_ids or inputs_embeds must be provided.")
+
         # Bounds check up front so both absolute and rotary paths produce a
         # self-explanatory error rather than IndexError / shape mismatch.
-        seq_len = input_ids.shape[-1]
+        seq_len = model_input.shape[1]
         if seq_len > self.cfg.n_ctx:
             raise ValueError(
                 f"input length {seq_len} exceeds n_ctx={self.cfg.n_ctx}; "
@@ -504,11 +516,12 @@ class NativeModel(nn.Module):
 
         # Resolve position_ids before the block loop so rotary sees the caller's
         # positions, not the dense default.
-        batch, seq = input_ids.shape
+        batch, seq = model_input.shape[:2]
         if position_ids is None:
-            position_ids = torch.arange(seq, device=input_ids.device).unsqueeze(0).expand(batch, -1)
+            position_ids = (
+                torch.arange(seq, device=model_input.device).unsqueeze(0).expand(batch, -1)
+            )
 
-        hidden_states = self.tok_embed(input_ids)
         if self.pos is not None:
             hidden_states = hidden_states + self.pos(position_ids)
 

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -1648,8 +1648,11 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
                     "The bridge only supports stop_at_layer on 'blocks'."
                 )
             if hasattr(self, "blocks"):
+                effective_stop_at_layer = (
+                    len(self.blocks) + stop_at_layer if stop_at_layer < 0 else stop_at_layer
+                )
                 for block in self.blocks:
-                    block._stop_at_layer_idx = stop_at_layer
+                    block._stop_at_layer_idx = effective_stop_at_layer
 
         # Map HookedEncoderDecoder-style kwargs to HF-compatible names
         if "decoder_input" in kwargs:


### PR DESCRIPTION
# Description

Fixes #1632.

Native `TransformerBridge` blocks are named `layers.N`, but the block layer-index parser only recognized `layers.N` when it had a preceding dot. As a result, direct `forward(..., stop_at_layer=...)` calls never stopped and `input_to_embed()` returned final vocabulary logits instead of the residual stream entering block 0.

This change:

- makes the layer-name parser boundary-aware for `blocks.N`, `h.N`, and `layers.N`, including top-level native names;
- normalizes negative `stop_at_layer` indices before passing the stop point to blocks;
- lets the native model accept `inputs_embeds`, which is required to resume a residual with `start_at_layer`;
- adds direct stopping and `input_to_embed()` round-trip regression coverage for an offline `boot_native()` model.

No new dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Not applicable.

# Verification

- Before the fix, the four new regression cases failed: direct stops returned logits with the `d_vocab` dimension, and residual re-entry raised because the native model required `input_ids`.
- `uv run pytest tests/unit/model_bridge/test_boot_native.py` — 35 passed
- Focused direct-stop and round-trip regression selection — 4 passed, 31 deselected
- `uv run pytest tests/integration/model_bridge/test_bridge_input_to_embed.py tests/integration/model_bridge/test_bridge_stop_at_layer.py::test_manual_hooks_stop_at_layer_compat_with_processing` — 5 passed
- `uv run mypy .` — success, 424 source files
- `pycln`, `isort`, and `black` checks on the four changed files — passed
- `git diff --check` — passed

The complete unit-test suite was not rerun; only the affected unit and integration surface was run locally.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not applicable; behavior now matches the documented API contract)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (only the affected test surface was run)
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
