### PR TITLE
fix(tokenizer): do not prepend a BOS token the tokenizer does not have

### DIFF
--- a/tests/unit/utilities/test_get_input_with_manually_prepended_bos.py
+++ b/tests/unit/utilities/test_get_input_with_manually_prepended_bos.py
@@ -1,0 +1,70 @@
+"""Tests for get_input_with_manually_prepended_bos when the tokenizer has no BOS token.
+
+``to_tokens`` reaches this helper whenever the caller wants a BOS that the tokenizer
+will not add on its own — ``prepend_bos and not cfg.tokenizer_prepends_bos``. For a
+tokenizer with no BOS token that condition is *correctly* true rather than stale:
+``detect_tokenizer_bos_eos`` requires a ``bos_token_id``, so it reports False for
+BERT and T5, and ``prepend_bos`` defaults to True. The helper then evaluated
+``None + input`` and raised ``TypeError: unsupported operand type(s) for +:
+'NoneType' and 'str'``, naming neither the tokenizer nor the flag.
+
+This is the prepend-side counterpart of #1628, which covers the removal side.
+"""
+
+from __future__ import annotations
+
+import pytest
+from transformers import AutoTokenizer
+
+from transformer_lens.utilities.tokenize_utils import (
+    get_input_with_manually_prepended_bos,
+)
+
+
+@pytest.fixture(
+    scope="module",
+    params=["google-bert/bert-base-cased", "google-t5/t5-small"],
+)
+def no_bos_tokenizer(request):
+    """BERT opens with [CLS] and T5 with nothing, so bos_token is None for both."""
+    tokenizer = AutoTokenizer.from_pretrained(request.param)
+    assert tokenizer.bos_token is None
+    return tokenizer
+
+
+@pytest.fixture(scope="module")
+def bos_tokenizer():
+    tokenizer = AutoTokenizer.from_pretrained("distilgpt2")
+    assert tokenizer.bos_token is not None
+    return tokenizer
+
+
+def test_no_bos_token_returns_string_unchanged(no_bos_tokenizer) -> None:
+    """There is no BOS to prepend, so the string must come back untouched."""
+    assert get_input_with_manually_prepended_bos(no_bos_tokenizer.bos_token, "hello world") == (
+        "hello world"
+    )
+
+
+def test_no_bos_token_returns_list_unchanged(no_bos_tokenizer) -> None:
+    """Same for the batched form — and no partially-prepended list."""
+    inputs = ["hello world", "second string"]
+
+    result = get_input_with_manually_prepended_bos(no_bos_tokenizer.bos_token, inputs)
+
+    assert result == ["hello world", "second string"]
+
+
+def test_a_real_bos_is_still_prepended_to_a_string(bos_tokenizer) -> None:
+    """The guard must not disturb the case the helper exists for."""
+    result = get_input_with_manually_prepended_bos(bos_tokenizer.bos_token, "hello world")
+
+    assert result == bos_tokenizer.bos_token + "hello world"
+
+
+def test_a_real_bos_is_still_prepended_to_a_list(bos_tokenizer) -> None:
+    bos = bos_tokenizer.bos_token
+
+    result = get_input_with_manually_prepended_bos(bos, ["hello world", "second string"])
+
+    assert result == [bos + "hello world", bos + "second string"]

--- a/transformer_lens/utilities/tokenize_utils.py
+++ b/transformer_lens/utilities/tokenize_utils.py
@@ -183,18 +183,27 @@ def get_tokenizer_with_bos(tokenizer: PreTrainedTokenizerBase) -> PreTrainedToke
 
 
 def get_input_with_manually_prepended_bos(
-    bos_token: str, input: str | list[str]
+    bos_token: Optional[str], input: str | list[str]
 ) -> str | list[str]:
     """
     Manually prepends the bos token to the input.
 
     Args:
-        bos_token (str): The BOS token to prepend.
+        bos_token (Optional[str]): The BOS token to prepend, or None for a tokenizer
+            that has none (e.g. BERT, T5).
         input (str | list[str]): The input to prepend the bos token to.
 
     Returns:
-        str | list[str]: The input with the bos token manually prepended.
+        str | list[str]: The input with the bos token manually prepended, or unchanged
+            when there is no BOS token to prepend.
     """
+    if bos_token is None:
+        # Nothing to prepend. Callers reach this when prepend_bos is asked for and
+        # cfg.tokenizer_prepends_bos is False — correctly so for a BOS-less tokenizer,
+        # since detect_tokenizer_bos_eos() requires a bos_token_id. Concatenating
+        # would raise a TypeError naming neither the tokenizer nor the flag.
+        return input
+
     if isinstance(input, str):
         input = bos_token + input
     else:


### PR DESCRIPTION
# Description

Follow-up to #1628. That issue fixed the removal side (`get_tokens_with_bos_removed`, #1629) and deliberately left the prepend side alone, noting that the root-cause fix "needs the prepend path hardened first". This is that hardening.

`get_input_with_manually_prepended_bos` concatenates `bos_token + input`. With no BOS token that is `None + str`:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

With no BOS token there is nothing to prepend, so the helper now returns the input unchanged — the same shape of fix #1629 applied to the mirror-image helper.

## How it is reached

Both normal paths are safe today. `setup_tokenizer` (`_hf_format.py:376`) and `HookedTransformer.set_tokenizer` (`HookedTransformer.py:801`) each backfill `bos_token = eos_token`, so a booted model never hands `None` to this helper.

The gap is the one #1628 identified. A bridge built via `build_bridge_from_module(tokenizer=None)` and given a tokenizer afterwards takes the initial-assignment branch at `bridge_core.py:113`, so `configure_tokenizer` — and with it that backfill — never runs, and `bos_token` stays `None`. The stale `tokenizer_prepends_bos=True` currently keeps `to_tokens` out of the prepend branch. Correcting that flag, which is exactly what fixing #1628's root cause does, routes `to_tokens(prepend_bos=True)` straight into this helper.

```python
from transformers import AutoModelForCausalLM, AutoTokenizer
from transformer_lens.model_bridge.sources._bridge_builder import build_bridge_from_module

model = AutoModelForCausalLM.from_pretrained("roneneldan/TinyStories-1M")
bridge = build_bridge_from_module(
    model, architecture="GPTNeoForCausalLM", hf_config=model.config, tokenizer=None
)

# Initial assignment per bridge_core.py:113 -> configure_tokenizer is skipped.
bridge.tokenizer = AutoTokenizer.from_pretrained("google-bert/bert-base-cased")
assert bridge.tokenizer.bos_token is None

# What fixing the root cause would set, since detection correctly reports False here.
bridge.cfg.tokenizer_prepends_bos = False

bridge.to_tokens("hello world")
```

Before: `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'`.
After: `[[101, 19082, 1362, 102]]` — `[CLS] hello world [SEP]`, with `[CLS]` intact.

So this unblocks the `bridge_core.py:113` fix rather than competing with it.

## Scope

The guard lives in the shared helper, so all three call sites are covered in one place: `transformer_bridge.py:717`, `HookedTransformer.py:850`, and `remote_bridge.py:216`. The HT-to-Bridge mirroring rule in AGENTS.md is satisfied by construction.

`bos_token` is now typed `Optional[str]`. That part is load-bearing, not cosmetic: the repo's beartype instrumentation rejects `None` against the old `str` annotation, so the runtime guard alone would still fail under test.

Related to #1628 — this does not close it, since #1629 covers the removal side. I asked on the issue whether this warranted its own issue or a PR referencing that one; opening it here as the latter, happy to move it if a maintainer prefers.

Based on `dev-4.x` to match #1628 and #1629. Happy to retarget to `dev` if that is preferred — the only difference is that `Optional` is not yet imported in `tokenize_utils.py` there.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
