### PR TITLE
Fix BLOOM residual branch hook semantics

### DIFF
--- a/tests/integration/model_bridge/test_bloom_hook_semantics.py
+++ b/tests/integration/model_bridge/test_bloom_hook_semantics.py
@@ -1,0 +1,43 @@
+"""Integration tests for BLOOM residual-branch hook semantics."""
+
+import pytest
+import torch
+
+from transformer_lens.model_bridge import TransformerBridge
+
+MODEL = "trl-internal-testing/tiny-BloomForCausalLM"
+
+
+@pytest.fixture(scope="module")
+def bloom_bridge() -> TransformerBridge:
+    return TransformerBridge.boot_transformers(MODEL, device="cpu", dtype=torch.float32)
+
+
+def test_residual_branch_hooks_decompose_stream(bloom_bridge: TransformerBridge) -> None:
+    tokens = bloom_bridge.to_tokens("The capital of France is Paris.")
+
+    with torch.no_grad():
+        _, cache = bloom_bridge.run_with_cache(tokens)
+
+    for layer in range(bloom_bridge.cfg.n_layers):
+        torch.testing.assert_close(
+            cache[f"blocks.{layer}.hook_resid_mid"],
+            cache[f"blocks.{layer}.hook_resid_pre"] + cache[f"blocks.{layer}.hook_attn_out"],
+        )
+        torch.testing.assert_close(
+            cache[f"blocks.{layer}.hook_resid_post"],
+            cache[f"blocks.{layer}.hook_resid_mid"] + cache[f"blocks.{layer}.hook_mlp_out"],
+        )
+
+
+def test_residual_branch_hooks_are_writable(bloom_bridge: TransformerBridge) -> None:
+    tokens = bloom_bridge.to_tokens("The capital of France is Paris.")
+
+    with torch.no_grad():
+        baseline = bloom_bridge(tokens)
+        ablated = bloom_bridge.run_with_hooks(
+            tokens,
+            fwd_hooks=[("blocks.0.hook_attn_out", lambda tensor, hook: torch.zeros_like(tensor))],
+        )
+
+    assert not torch.equal(ablated, baseline)

--- a/tests/unit/model_bridge/supported_architectures/test_bloom_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_bloom_adapter.py
@@ -103,6 +103,11 @@ class TestBloomAdapterComponentMapping:
         assert isinstance(mapping["blocks"], BloomBlockBridge)
         assert mapping["blocks"].name == "transformer.h"
 
+    def test_residual_branch_hook_aliases(self, adapter: BloomArchitectureAdapter) -> None:
+        blocks = self._mapping(adapter)["blocks"]
+        assert blocks.hook_aliases["hook_attn_out"] == "attn.o.hook_out"
+        assert blocks.hook_aliases["hook_mlp_out"] == "mlp.out.hook_out"
+
     def test_ln_final_type_and_name(self, adapter: BloomArchitectureAdapter) -> None:
         mapping = self._mapping(adapter)
         assert isinstance(mapping["ln_final"], NormalizationBridge)

--- a/transformer_lens/model_bridge/supported_architectures/bloom.py
+++ b/transformer_lens/model_bridge/supported_architectures/bloom.py
@@ -69,6 +69,10 @@ class BloomArchitectureAdapter(ArchitectureAdapter):
             "blocks": BloomBlockBridge(
                 name="transformer.h",
                 config=self.cfg,
+                hook_alias_overrides={
+                    "hook_attn_out": "attn.o.hook_out",
+                    "hook_mlp_out": "mlp.out.hook_out",
+                },
                 submodules={
                     "ln1": NormalizationBridge(name="input_layernorm", config=self.cfg),
                     "ln2": NormalizationBridge(name="post_attention_layernorm", config=self.cfg),


### PR DESCRIPTION
# Description

Fixes #1639.

BLOOM's Hugging Face attention and MLP modules return states after adding the residual stream, so the default block aliases made `hook_attn_out` and `hook_mlp_out` point at accumulated residual states. This breaks the HookedTransformer-compatible decomposition identities and makes interventions target the wrong tensors.

This change overrides those two aliases to use BLOOM's existing output-projection hooks, which sit immediately before each residual addition and remain writable. The integration coverage uses the tiny BLOOM fixture to verify both residual identities on every layer and confirms that an attention-output ablation changes the model output.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Validation

- `uv run pytest tests/unit/model_bridge/supported_architectures/test_bloom_adapter.py tests/integration/model_bridge/test_bloom_hook_semantics.py` — 31 passed
- `uv run pytest tests/unit/model_bridge/test_hook_alias_resolution.py tests/unit/model_bridge/test_component_hooks_fire.py tests/integration/model_bridge/test_pretrain_adapter.py` — 212 passed, 3 skipped, 10 xfailed
- `make format`
- `uv run mypy transformer_lens/model_bridge/supported_architectures/bloom.py tests/unit/model_bridge/supported_architectures/test_bloom_adapter.py tests/integration/model_bridge/test_bloom_hook_semantics.py`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas (no new comments were needed for the alias mapping)
- [x] I have made corresponding changes to the documentation (not applicable; behavior is covered by tests)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing targeted tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
