### PR TITLE
Fix Gemma 4 MLP hook aliases

### DIFF
--- a/tests/unit/model_bridge/supported_architectures/test_gemma4_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_gemma4_adapter.py
@@ -6,6 +6,7 @@ from transformer_lens.config import TransformerBridgeConfig
 from transformer_lens.model_bridge.generalized_components import (
     DelegatedAttentionBlockBridge,
     EmbeddingBridge,
+    GatedMLPBridge,
     LinearBridge,
     RotaryEmbeddingBridge,
     UnembeddingBridge,
@@ -161,6 +162,12 @@ def test_moe_submodules_are_optional():
 
 def test_gated_mlp_decomposition():
     mlp = _adapter().component_mapping["blocks"].submodules["mlp"]
+    assert isinstance(mlp, GatedMLPBridge)
     assert mlp.submodules["gate"].name == "gate_proj"
     assert mlp.submodules["in"].name == "up_proj"
     assert mlp.submodules["out"].name == "down_proj"
+    assert mlp.hook_aliases == {
+        "hook_pre": "gate.hook_out",
+        "hook_pre_linear": "in.hook_out",
+        "hook_post": "out.hook_in",
+    }

--- a/transformer_lens/model_bridge/supported_architectures/gemma4.py
+++ b/transformer_lens/model_bridge/supported_architectures/gemma4.py
@@ -145,14 +145,7 @@ class Gemma4ArchitectureAdapter(ArchitectureAdapter):
                             "v_norm": GeneralizedComponent(name="v_norm", optional=True),
                         },
                     ),
-                    "mlp": GeneralizedComponent(
-                        name="mlp",
-                        submodules={
-                            "gate": LinearBridge(name="gate_proj"),
-                            "in": LinearBridge(name="up_proj"),
-                            "out": LinearBridge(name="down_proj"),
-                        },
-                    ),
+                    "mlp": self._gated_mlp(),
                 },
             ),
             "ln_final": GeneralizedComponent(name="model.language_model.norm"),


### PR DESCRIPTION
# Description

Fixes #1646.

## Problem

The Gemma 4 adapter decomposes its dense MLP into `gate_proj`, `up_proj`, and `down_proj`, but wraps them in a plain `GeneralizedComponent`. The standard gated-MLP aliases (`hook_pre`, `hook_pre_linear`, and `hook_post`) are therefore missing even though the underlying module has the same projection structure as other supported gated MLPs.

## Fix

Use the adapter's existing `_gated_mlp()` helper for Gemma 4. This preserves the same projection paths while installing the standard hook aliases. The unit test now checks both the bridge type and the exact alias mapping.

## Test

- `uv run pytest tests/unit/model_bridge/supported_architectures/test_gemma4_adapter.py -q` (10 passed)
- `uv run pytest tests/integration/model_bridge/test_gemma4_bridge.py -q` (12 passed across PLE/KV-shared, dense K=V, and MoE fixtures)
- `uv run mypy transformer_lens/model_bridge/supported_architectures/gemma4.py`
- `make check-format`
- `git diff --check`

## Risk

Low. The component retains the same `mlp` path and gate/up/down projection names. Gemma 4's delegated blocks still execute the Hugging Face forward path, and the three existing architecture fixtures retain logit parity. The change only adds the gated-MLP compatibility interface around the already-decomposed projections.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing focused tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
