### PR TITLE
Stabilize Bridge numerical CI tests

### DIFF
--- a/tests/integration/model_bridge/test_left_padding_positions.py
+++ b/tests/integration/model_bridge/test_left_padding_positions.py
@@ -180,22 +180,23 @@ def test_unshifted_rows_keep_default_positions(distilgpt2_bridge, tokens) -> Non
 
 
 def test_one_left_padded_row_does_not_perturb_its_neighbours(distilgpt2_bridge, tokens) -> None:
-    """A whole-batch predicate would hand derived positions to every row; the
-    rows that needed no correction must come out bit-identical to running alone."""
+    """Derived positions for one row must not change its unshifted neighbours."""
     n_pad = 3
     batch, mask, (right, m_right), (plain, m_plain) = _mixed_batch(tokens, n_pad)
+    control_batch = torch.cat([right, right, plain], dim=0)
+    control_mask = torch.cat([m_right, m_right, m_plain], dim=0)
 
     with torch.no_grad():
         mixed = distilgpt2_bridge(batch, attention_mask=mask, return_type="logits")
-        alone_right = distilgpt2_bridge(right, attention_mask=m_right, return_type="logits")
-        alone_plain = distilgpt2_bridge(plain, attention_mask=m_plain, return_type="logits")
+        control = distilgpt2_bridge(
+            control_batch, attention_mask=control_mask, return_type="logits"
+        )
         unpadded = distilgpt2_bridge(tokens, return_type="logits")
 
-    # Not exact equality: batching alone perturbs float accumulation order. The
-    # regression this guards was 8e-01, so 1e-6 separates them decisively while
-    # staying above anything a different BLAS could introduce.
-    torch.testing.assert_close(mixed[0:1], alone_right, rtol=0, atol=1e-6)
-    torch.testing.assert_close(mixed[2:3], alone_plain, rtol=0, atol=1e-6)
+    # Matching batch shapes isolate derived-position handling from BLAS kernel
+    # changes caused by comparing batched and single-row matrix multiplications.
+    torch.testing.assert_close(mixed[0:1], control[0:1], rtol=0, atol=1e-6)
+    torch.testing.assert_close(mixed[2:3], control[2:3], rtol=0, atol=1e-6)
     # ...while the row that did need correcting still gets it.
     torch.testing.assert_close(mixed[1:2, n_pad:], unpadded, rtol=1e-3, atol=1e-3)
 

--- a/tests/integration/model_bridge/test_optimizer_compatibility.py
+++ b/tests/integration/model_bridge/test_optimizer_compatibility.py
@@ -134,7 +134,8 @@ def test_bridge_hooked_parity_multi_step_optimization():
         StepThresholds(
             step=1,
             initial_fwd=StageThresholds(logits_max=1e-3, logits_mean=1e-4, loss_relative=1e-6),
-            post_update_fwd=StageThresholds(logits_max=2.0, logits_mean=1e-3, loss_relative=1e-5),
+            # GitHub CPU runners repeatedly produce a 1.032e-3 mean difference here.
+            post_update_fwd=StageThresholds(logits_max=2.0, logits_mean=2e-3, loss_relative=1e-5),
             param_update=StageThresholds(params_max=1e-2, params_mean=1e-6),
         ),
         StepThresholds(


### PR DESCRIPTION
# Description

Stabilize two TransformerBridge integration assertions that cross the numerical envelope of different GitHub-hosted CPU runners. This is independent of the Qwen gated-query change in #1653; that PR exposed the existing baseline failures through its full-coverage run.

The left-padding neighbour test previously compared a three-row batch against separate one-row forwards. Those different matrix shapes can select different CPU/BLAS kernels and produced a `9.1552734375e-05` maximum absolute difference despite equivalent position handling. The test now compares two equal-shaped batches that differ only in whether the middle row requires derived positions, isolating the behaviour the regression test is intended to protect.

The optimizer parity test used a step-1 post-update mean-logit threshold of `1e-3`. Multiple GitHub CPU runners reproducibly report `0.0010319872526451945`, so this one empirical threshold is recalibrated to `2e-3`; the initial-forward, maximum-logit, loss, parameter-update, and step-10 thresholds remain unchanged.

The exact pair of failures appeared in these unrelated `dev-4.x` runs:

- https://github.com/TransformerLensOrg/TransformerLens/actions/runs/31398580334
- https://github.com/TransformerLensOrg/TransformerLens/actions/runs/31395356122
- https://github.com/TransformerLensOrg/TransformerLens/actions/runs/31233076384

The current #1653 failure is:

- https://github.com/TransformerLensOrg/TransformerLens/actions/runs/31577290649

The same base SHA also completed successfully in:

- https://github.com/TransformerLensOrg/TransformerLens/actions/runs/31517217634

No production code or dependencies are changed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Not applicable.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

The documentation change is limited to the affected test docstring and explanatory comment; no user-facing API documentation changes are needed. The full unit suite was not rerun because this PR changes only two integration tests.

## Validation

- Exact two previously failing tests: `2 passed`
- Both complete integration test files with CI-style `-n 2 --dist loadscope`, `OMP_NUM_THREADS=1`, and `MKL_NUM_THREADS=1`: `31 passed`
- Full-repository pycln, isort, and Black checks pass
- `uv run mypy .`: `Success: no issues found in 431 source files`
- `git diff --check` passes
