### PR TITLE
Allow running heterogeneous Gemma4 models on transformer v5.15.0

### DIFF
--- a/tests/unit/model_bridge/test_config_mapping.py
+++ b/tests/unit/model_bridge/test_config_mapping.py
@@ -6,9 +6,16 @@ SimpleNamespace HF-config stand-ins, no network access.
 
 from types import SimpleNamespace
 
+import torch
+
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.model_bridge.sources._bridge_builder import (
+    build_bridge_config_from_hf,
+)
 from transformer_lens.model_bridge.sources.transformers import (
     map_default_transformer_lens_config,
 )
+from transformer_lens.utilities.heterogeneous_config import majority_value
 
 
 def _hf_config(**overrides: object) -> SimpleNamespace:
@@ -39,3 +46,220 @@ def test_d_head_falls_back_to_derived_when_head_dim_is_none() -> None:
     """HF configs may carry head_dim=None; treat it the same as absent."""
     mapped = map_default_transformer_lens_config(_hf_config(head_dim=None))
     assert mapped.d_head == 16 // 4
+
+
+class _AmbiguousAccessError(Exception):
+    """Stand-in for transformers>=5.15 AmbiguousGlobalPerLayerAttributeError.
+
+    Deliberately not an AttributeError: neither hasattr() nor getattr(..., default)
+    suppresses the real exception, which is the crash mode of issue #1647.
+    """
+
+
+class _HeterogeneousConfig:
+    """Minimal transformers>=5.15 heterogeneous-config contract.
+
+    Exposes ``is_heterogeneous`` / ``per_layer_attributes`` / ``per_layer_config``
+    and raises a non-AttributeError on any global read of a registered per-layer
+    attribute, proving the mapping never performs the forbidden access.
+    """
+
+    def __init__(self, per_layer: dict, **global_fields: object) -> None:
+        object.__setattr__(self, "_per_layer", per_layer)
+        for key, value in global_fields.items():
+            object.__setattr__(self, key, value)
+
+    def __getattribute__(self, name: str):
+        # __dict__ lookup keeps deepcopy working: it reconstructs instances
+        # attribute-by-attribute, probing before _per_layer exists.
+        per_layer = object.__getattribute__(self, "__dict__").get("_per_layer", {})
+        if name in per_layer:
+            raise _AmbiguousAccessError(f"'{name}' is a per-layer attribute")
+        return object.__getattribute__(self, name)
+
+    @property
+    def is_heterogeneous(self) -> bool:
+        return True
+
+    @property
+    def per_layer_attributes(self) -> set:
+        return set(self._per_layer)
+
+    @property
+    def per_layer_config(self) -> list:
+        return [
+            SimpleNamespace(**{key: values[i] for key, values in self._per_layer.items()})
+            for i in range(self.num_hidden_layers)
+        ]
+
+
+_GEMMA4_GLOBALS: dict[str, object] = {
+    "hidden_size": 16,
+    "num_hidden_layers": 6,
+    "vocab_size": 32,
+    "max_position_embeddings": 64,
+    "intermediate_size": 32,
+    "sliding_window": 8,
+}
+
+
+def test_heterogeneous_head_dim_does_not_read_global() -> None:
+    """Gemma-4-E2B shape: per-layer head_dim (sliding 256 / full-attention 512)."""
+    config = _HeterogeneousConfig(
+        per_layer={"head_dim": [256, 256, 256, 256, 256, 512]},
+        num_attention_heads=8,
+        num_key_value_heads=1,
+        **_GEMMA4_GLOBALS,
+    )
+    mapped = map_default_transformer_lens_config(config)
+    assert mapped.d_head == 256  # majority-layer value, matching pre-5.15 behavior
+    assert mapped.per_layer_head_dim == [256, 256, 256, 256, 256, 512]
+    assert mapped.n_key_value_heads == 1  # uniform, still read globally
+
+
+def test_heterogeneous_kv_heads_does_not_read_global() -> None:
+    """Gemma-4-31B shape: head_dim and num_key_value_heads both vary per layer."""
+    config = _HeterogeneousConfig(
+        per_layer={
+            "head_dim": [256, 256, 256, 256, 256, 512],
+            "num_key_value_heads": [16, 16, 16, 16, 16, 4],
+        },
+        num_attention_heads=32,
+        **_GEMMA4_GLOBALS,
+    )
+    mapped = map_default_transformer_lens_config(config)
+    assert mapped.d_head == 256
+    assert mapped.n_key_value_heads == 16
+    assert mapped.per_layer_head_dim == [256, 256, 256, 256, 256, 512]
+    assert mapped.per_layer_num_key_value_heads == [16, 16, 16, 16, 16, 4]
+
+
+def test_legacy_global_fields_reconstruct_per_layer_geometry() -> None:
+    """Pre-5.15 Gemma 4: <field> holds the sliding value, global_<field> the
+    full-attention value; the per-layer view is rebuilt from layer_types."""
+    layer_types = ["sliding_attention"] * 5 + ["full_attention"]
+    mapped = map_default_transformer_lens_config(
+        _hf_config(
+            num_attention_heads=32,
+            head_dim=256,
+            global_head_dim=512,
+            num_key_value_heads=16,
+            num_global_key_value_heads=4,
+            layer_types=layer_types,
+            num_hidden_layers=6,
+        )
+    )
+    assert mapped.d_head == 256  # unchanged from the pre-fix scalar
+    assert mapped.n_key_value_heads == 16
+    assert mapped.per_layer_head_dim == [256] * 5 + [512]
+    assert mapped.per_layer_num_key_value_heads == [16] * 5 + [4]
+
+
+def test_legacy_kv_reconstruction_gated_on_attention_k_eq_v() -> None:
+    """HF applies num_global_key_value_heads only when attention_k_eq_v is set;
+    with it False, every layer runs the base KV-head count."""
+    mapped = map_default_transformer_lens_config(
+        _hf_config(
+            num_attention_heads=32,
+            head_dim=256,
+            global_head_dim=512,
+            num_key_value_heads=16,
+            num_global_key_value_heads=4,
+            attention_k_eq_v=False,
+            layer_types=["sliding_attention"] * 5 + ["full_attention"],
+            num_hidden_layers=6,
+        )
+    )
+    assert not hasattr(mapped, "per_layer_num_key_value_heads")
+    assert mapped.n_key_value_heads == 16
+    # head_dim reconstruction is ungated — global_head_dim applies regardless.
+    assert mapped.per_layer_head_dim == [256] * 5 + [512]
+
+
+def test_unanticipated_per_layer_field_resolves_to_majority() -> None:
+    """Any registered per-layer field — not just the ones Gemma 4 registers today —
+    must resolve to its majority value instead of crashing the probe."""
+    config = _HeterogeneousConfig(
+        per_layer={"sliding_window": [8, 8, 16, 8]},
+        num_attention_heads=4,
+        hidden_size=16,
+        num_hidden_layers=4,
+        vocab_size=32,
+        max_position_embeddings=64,
+        intermediate_size=32,
+    )
+    mapped = map_default_transformer_lens_config(config)
+    # Read via __dict__: boot consumes the mapped config that way, and attribute
+    # access on the (copied) heterogeneous config itself still raises.
+    assert mapped.__dict__["sliding_window"] == 8
+
+
+def test_legacy_global_field_equal_to_base_stays_scalar() -> None:
+    """No per-layer view when the global_* value matches the base field."""
+    mapped = map_default_transformer_lens_config(
+        _hf_config(
+            head_dim=8,
+            global_head_dim=8,
+            layer_types=["sliding_attention", "full_attention"],
+        )
+    )
+    assert mapped.d_head == 8
+    assert not hasattr(mapped, "per_layer_head_dim")
+
+
+def test_homogeneous_config_gets_no_per_layer_fields() -> None:
+    mapped = map_default_transformer_lens_config(_hf_config(head_dim=8))
+    assert not hasattr(mapped, "per_layer_head_dim")
+    assert not hasattr(mapped, "per_layer_num_key_value_heads")
+
+
+def test_majority_value_semantics() -> None:
+    """The scalar collapse is the most-common value — not first, min, or max."""
+    assert majority_value([512, 256, 256]) == 256  # majority beats first element
+    assert majority_value([64, 32, 64]) == 64  # majority beats min
+    assert majority_value([512, 256, 512, 256]) == 512  # tie breaks to earliest layer
+
+
+def test_heterogeneous_config_through_bridge_config_build() -> None:
+    """Full boot pipeline (map → from_dict → passthrough) on a heterogeneous config.
+
+    intermediate_size is both per-layer here and in _HF_PASSTHROUGH_ATTRS, so the
+    passthrough loop must skip it rather than perform the raising global read.
+    """
+    config = _HeterogeneousConfig(
+        per_layer={
+            "head_dim": [32, 32, 32, 64],
+            "intermediate_size": [128, 64, 64, 64],
+            "num_attention_heads": [8, 8, 8, 4],
+        },
+        num_key_value_heads=2,
+        hidden_size=16,
+        num_hidden_layers=4,
+        vocab_size=32,
+        max_position_embeddings=64,
+    )
+    bridge_config = build_bridge_config_from_hf(config, "TestArch", "test-model", torch.float32)
+    assert bridge_config.n_heads == 8  # majority of per-layer num_attention_heads
+    assert bridge_config.d_head == 32
+    assert bridge_config.per_layer_head_dim == [32, 32, 32, 64]
+    assert bridge_config.n_key_value_heads == 2  # uniform, still read globally
+    assert bridge_config.d_mlp == 128  # per-layer intermediate_size collapses to max
+    # The passthrough loop must skip the per-layer-registered attr, not copy it.
+    assert not hasattr(bridge_config, "intermediate_size")
+
+
+def test_bridge_config_retains_per_layer_fields() -> None:
+    """from_dict filters to signature params; the per-layer fields must survive."""
+    bridge_config = TransformerBridgeConfig.from_dict(
+        {
+            "d_model": 16,
+            "d_head": 256,
+            "n_layers": 6,
+            "n_ctx": 64,
+            "n_heads": 8,
+            "per_layer_head_dim": [256] * 5 + [512],
+            "per_layer_num_key_value_heads": [16] * 5 + [4],
+        }
+    )
+    assert bridge_config.per_layer_head_dim == [256] * 5 + [512]
+    assert bridge_config.per_layer_num_key_value_heads == [16] * 5 + [4]

--- a/transformer_lens/config/transformer_bridge_config.py
+++ b/transformer_lens/config/transformer_bridge_config.py
@@ -74,6 +74,11 @@ class TransformerBridgeConfig(TransformerLensConfig):
         num_experts: Optional[int] = None,
         experts_per_token: Optional[int] = None,
         n_key_value_heads: Optional[int] = None,
+        # Heterogeneous attention geometry (e.g. Gemma 4): per-layer values when
+        # they vary across layers; d_head / n_key_value_heads then hold the
+        # majority-layer scalar and attention math is delegated to HF.
+        per_layer_head_dim: Optional[list] = None,
+        per_layer_num_key_value_heads: Optional[list] = None,
         relative_attention_max_distance: Optional[int] = None,
         relative_attention_num_buckets: Optional[int] = None,
         decoder_start_token_id: Optional[int] = None,
@@ -169,6 +174,8 @@ class TransformerBridgeConfig(TransformerLensConfig):
         self.num_experts = num_experts
         self.experts_per_token = experts_per_token
         self.n_key_value_heads = n_key_value_heads
+        self.per_layer_head_dim = per_layer_head_dim
+        self.per_layer_num_key_value_heads = per_layer_num_key_value_heads
         self.relative_attention_max_distance = relative_attention_max_distance
         self.relative_attention_num_buckets = relative_attention_num_buckets
         self.decoder_start_token_id = decoder_start_token_id

--- a/transformer_lens/model_bridge/generalized_components/position_embeddings_attention.py
+++ b/transformer_lens/model_bridge/generalized_components/position_embeddings_attention.py
@@ -22,6 +22,7 @@ from transformer_lens.model_bridge.generalized_components.attention import (
 from transformer_lens.model_bridge.generalized_components.position_embedding_hooks_mixin import (
     PositionEmbeddingHooksMixin,
 )
+from transformer_lens.utilities.heterogeneous_config import safe_config_get
 from transformer_lens.utilities.hf_utils import get_rotary_pct_from_config
 
 # Global registry mapping HF attention modules to their bridge instances
@@ -669,12 +670,8 @@ class PositionEmbeddingsAttentionBridge(PositionEmbeddingHooksMixin, AttentionBr
         inputs: Dict[str, Any] = {
             "hidden_states": torch.randn(batch_size, seq_len, d_model, device=device, dtype=dtype)
         }
-        num_heads = (
-            self.config.num_attention_heads
-            if self.config and hasattr(self.config, "num_attention_heads")
-            else 4
-        )
-        head_dim = self.config.head_dim if self.config and hasattr(self.config, "head_dim") else 256
+        num_heads = safe_config_get(self.config, "num_attention_heads", 4) if self.config else 4
+        head_dim = safe_config_get(self.config, "head_dim", 256) if self.config else 256
         dummy_qk = torch.randn(1, seq_len, num_heads, head_dim, device=device, dtype=dtype)
         position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
         if self._rotary_emb is not None:

--- a/transformer_lens/model_bridge/generalized_components/rotary_embedding.py
+++ b/transformer_lens/model_bridge/generalized_components/rotary_embedding.py
@@ -10,6 +10,7 @@ from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge.generalized_components.base import (
     GeneralizedComponent,
 )
+from transformer_lens.utilities.heterogeneous_config import safe_config_get
 
 
 class RotaryEmbeddingBridge(GeneralizedComponent):
@@ -62,14 +63,8 @@ class RotaryEmbeddingBridge(GeneralizedComponent):
             device = torch.device("cpu")
         if dtype is None:
             dtype = torch.float32
-        if self.config and hasattr(self.config, "num_attention_heads"):
-            num_heads = self.config.num_attention_heads
-        else:
-            num_heads = 4
-        if self.config and hasattr(self.config, "head_dim"):
-            head_dim = self.config.head_dim
-        else:
-            head_dim = 256
+        num_heads = safe_config_get(self.config, "num_attention_heads", 4) if self.config else 4
+        head_dim = safe_config_get(self.config, "head_dim", 256) if self.config else 256
         x = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
         position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
         args: tuple = (x, position_ids)

--- a/transformer_lens/model_bridge/sources/_bridge_builder.py
+++ b/transformer_lens/model_bridge/sources/_bridge_builder.py
@@ -13,6 +13,7 @@ from transformer_lens.factories.architecture_adapter_factory import (
 )
 from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
 from transformer_lens.model_bridge.bridge import TransformerBridge
+from transformer_lens.utilities.heterogeneous_config import per_layer_attr_names
 
 # Architecture-agnostic; do not extend per-architecture.
 _HF_PASSTHROUGH_ATTRS = [
@@ -180,7 +181,11 @@ def build_bridge_config_from_hf(
     bridge_config.dtype = dtype
 
     effective_config = get_effective_text_config(hf_config)
+    # Per-layer-registered attrs would raise on global access (transformers>=5.15).
+    _het_attrs = per_layer_attr_names(effective_config) | per_layer_attr_names(hf_config)
     for attr in _HF_PASSTHROUGH_ATTRS:
+        if attr in _het_attrs:
+            continue
         val = getattr(effective_config, attr, None)
         if val is None and effective_config is not hf_config:
             val = getattr(hf_config, attr, None)

--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -28,6 +28,12 @@ from transformer_lens.model_bridge.bridge import TransformerBridge
 from transformer_lens.model_bridge.sources._bridge_builder import _HF_PASSTHROUGH_ATTRS
 from transformer_lens.supported_models import MODEL_ALIASES
 from transformer_lens.utilities import get_device, get_tokenizer_with_bos
+from transformer_lens.utilities.heterogeneous_config import (
+    het_safe_view,
+    majority_value,
+    per_layer_attr_names,
+    per_layer_values,
+)
 
 # Suppress transformers warnings that go to stderr
 # This prevents notebook tests from failing due to unexpected stderr output
@@ -62,9 +68,31 @@ def map_default_transformer_lens_config(hf_config):
         A copy of hf_config with additional TransformerLens fields
     """
     # Extract language model config from text_config for multimodal models
-    source_config = get_effective_text_config(hf_config)
+    raw_source_config = get_effective_text_config(hf_config)
 
     tl_config = copy.deepcopy(hf_config)
+
+    # transformers>=5.15 heterogeneous configs (e.g. Gemma 4) refuse global reads of
+    # registered per-layer attributes — the raise is not an AttributeError, so hasattr()
+    # does not suppress it. The view resolves any registered field to its majority-layer
+    # value, keeping every probe below safe regardless of which fields a future
+    # architecture registers; geometry fields needing full per-layer detail are
+    # handled explicitly first.
+    het_attrs = per_layer_attr_names(raw_source_config)
+    source_config = het_safe_view(raw_source_config)
+
+    def legacy_per_layer(base_name: str, global_name: str) -> Any:
+        """Pre-5.15 Gemma 4 split geometry across <field> (sliding-attention layers)
+        and global_<field> (full-attention layers); rebuild the per-layer view."""
+        if base_name in het_attrs or "layer_types" in het_attrs:
+            return None
+        base = getattr(source_config, base_name, None)
+        full = getattr(source_config, global_name, None)
+        layer_types = getattr(source_config, "layer_types", None)
+        if base is None or full is None or full == base or not layer_types:
+            return None
+        return [full if t == "full_attention" else base for t in layer_types]
+
     if hasattr(source_config, "n_embd"):
         tl_config.d_model = source_config.n_embd
     elif hasattr(source_config, "hidden_size"):
@@ -90,7 +118,29 @@ def map_default_transformer_lens_config(hf_config):
         source_config.num_query_heads, list
     ):
         tl_config.n_heads = max(source_config.num_query_heads)
-    if (
+    if "num_key_value_heads" in het_attrs:
+        per_layer_kv = per_layer_values(source_config, "num_key_value_heads")
+    elif getattr(source_config, "attention_k_eq_v", True):
+        # HF applies num_global_key_value_heads only on attention_k_eq_v models;
+        # the 5.15 per-layer migration gates identically, defaulting True when absent.
+        per_layer_kv = legacy_per_layer("num_key_value_heads", "num_global_key_value_heads")
+    else:
+        per_layer_kv = None
+    kv_values = [v for v in per_layer_kv if v is not None] if per_layer_kv else []
+    if kv_values:
+        # Heterogeneous KV geometry (e.g. Gemma 4 31B: 16 KV heads on sliding layers,
+        # 4 on full-attention layers). The scalar keeps the majority-layer value —
+        # attention math is delegated to HF for these architectures — and the
+        # per-layer truth is preserved alongside it.
+        tl_config.per_layer_num_key_value_heads = per_layer_kv
+        try:
+            num_kv_heads = int(majority_value(kv_values))
+            num_heads = int(getattr(tl_config, "n_heads", 0))
+            if num_kv_heads != num_heads:
+                tl_config.n_key_value_heads = num_kv_heads
+        except (TypeError, ValueError):
+            pass
+    elif (
         hasattr(source_config, "num_key_value_heads")
         and source_config.num_key_value_heads is not None
     ):
@@ -178,6 +228,10 @@ def map_default_transformer_lens_config(hf_config):
         tl_config.n_ctx = 2048
     if hasattr(source_config, "n_inner"):
         tl_config.d_mlp = source_config.n_inner
+    elif "intermediate_size" in het_attrs:
+        # Same max collapse as the per-layer-list case below.
+        mlp_values = [v for v in per_layer_values(source_config, "intermediate_size") if v]
+        tl_config.d_mlp = max(mlp_values) if mlp_values else None
     elif hasattr(source_config, "intermediate_size"):
         intermediate_size = source_config.intermediate_size
         # Gemma 3n exposes a per-layer intermediate_size list (the MatFormer design permits
@@ -191,7 +245,18 @@ def map_default_transformer_lens_config(hf_config):
         tl_config.d_mlp = source_config.mlp_hidden_size
     elif hasattr(tl_config, "d_model"):
         tl_config.d_mlp = getattr(source_config, "n_inner", 4 * tl_config.d_model)
-    if hasattr(source_config, "head_dim") and source_config.head_dim is not None:
+    if "head_dim" in het_attrs:
+        per_layer_hd = per_layer_values(source_config, "head_dim")
+    else:
+        per_layer_hd = legacy_per_layer("head_dim", "global_head_dim")
+    hd_values = [v for v in per_layer_hd if v is not None] if per_layer_hd else []
+    if hd_values:
+        # Heterogeneous head_dim (e.g. Gemma 4: 256 on sliding layers, 512 on
+        # full-attention layers). Scalar d_head keeps the majority-layer value;
+        # the per-layer truth is preserved alongside it.
+        tl_config.per_layer_head_dim = per_layer_hd
+        tl_config.d_head = majority_value(hd_values)
+    elif hasattr(source_config, "head_dim") and source_config.head_dim is not None:
         tl_config.d_head = source_config.head_dim
     elif hasattr(tl_config, "d_model") and hasattr(tl_config, "n_heads"):
         tl_config.d_head = tl_config.d_model // tl_config.n_heads
@@ -624,7 +689,11 @@ def boot(
     # Propagate HF-specific config attributes that adapters may need.
     # Canonical list lives in sources/_bridge_builder.py (architecture-agnostic).
     effective_config = get_effective_text_config(hf_config)
+    # Per-layer-registered attrs would raise on global access (transformers>=5.15).
+    _het_attrs = per_layer_attr_names(effective_config) | per_layer_attr_names(hf_config)
     for attr in _HF_PASSTHROUGH_ATTRS:
+        if attr in _het_attrs:
+            continue
         val = getattr(effective_config, attr, None)
         if val is None and effective_config is not hf_config:
             val = getattr(hf_config, attr, None)

--- a/transformer_lens/tools/model_registry/verify_models.py
+++ b/transformer_lens/tools/model_registry/verify_models.py
@@ -35,6 +35,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from transformer_lens.utilities.heterogeneous_config import het_safe_view
+
 # Exit code used for graceful interrupts (Ctrl+C).  The wrapper script
 # recognises this and stops without marking the in-flight model as failed.
 _EXIT_GRACEFUL_INTERRUPT = 42
@@ -269,6 +271,10 @@ def estimate_model_params(model_id: str) -> int:
             ):
                 lang_config = _subcfg
                 break
+
+    # Heterogeneous configs (transformers>=5.15 Gemma 4) raise on global reads of
+    # per-layer fields like head_dim; the view resolves them to majority values.
+    lang_config = het_safe_view(lang_config)
 
     # Extract dimensions from config (different models use different attribute names)
     d_model = (

--- a/transformer_lens/utilities/heterogeneous_config.py
+++ b/transformer_lens/utilities/heterogeneous_config.py
@@ -1,0 +1,71 @@
+"""Safe attribute access for transformers>=5.15 heterogeneous configs.
+
+Configs whose attention geometry varies across layers (e.g. Gemma 4) register
+those fields as per-layer: reading one on the global config raises
+``AmbiguousGlobalPerLayerAttributeError`` from ``__getattribute__``, which
+neither ``hasattr()`` nor ``getattr(..., default)`` suppresses. These helpers
+let config-probing code stay safe on any transformers version — the per-layer
+machinery is simply absent pre-5.15, where every helper degrades to plain
+attribute access.
+"""
+
+from typing import Any
+
+
+def per_layer_attr_names(config: Any) -> frozenset:
+    """Fields a heterogeneous config refuses to serve globally.
+
+    Empty for homogeneous configs and pre-5.15 transformers.
+    """
+    if not getattr(config, "is_heterogeneous", False):
+        return frozenset()
+    return frozenset(getattr(config, "per_layer_attributes", None) or ())
+
+
+def per_layer_values(config: Any, name: str) -> list:
+    """Collect a per-layer attribute from a heterogeneous config's layer configs."""
+    per_layer_config = config.per_layer_config
+    return [getattr(per_layer_config[i], name, None) for i in range(len(per_layer_config))]
+
+
+def majority_value(values: list) -> Any:
+    """Most common value in a per-layer list; ties break toward the earliest layer."""
+    counts: dict = {}
+    for v in values:
+        counts[v] = counts.get(v, 0) + 1
+    return max(counts, key=lambda v: (counts[v], -values.index(v)))
+
+
+def safe_config_get(config: Any, name: str, default: Any = None) -> Any:
+    """getattr that resolves per-layer-registered fields to their majority value."""
+    if name in per_layer_attr_names(config):
+        values = [v for v in per_layer_values(config, name) if v is not None]
+        return majority_value(values) if values else default
+    return getattr(config, name, default)
+
+
+class HetSafeConfigView:
+    """Read-only getattr proxy: per-layer-registered fields resolve to their
+    majority-layer value instead of raising; everything else passes through.
+
+    Wrap a config once and downstream ``hasattr``/``getattr`` probes need no
+    per-field awareness of heterogeneity.
+    """
+
+    def __init__(self, config: Any) -> None:
+        object.__setattr__(self, "_config", config)
+        object.__setattr__(self, "_het_attrs", per_layer_attr_names(config))
+
+    def __getattr__(self, name: str) -> Any:
+        config = object.__getattribute__(self, "_config")
+        if name in object.__getattribute__(self, "_het_attrs"):
+            values = [v for v in per_layer_values(config, name) if v is not None]
+            if not values:
+                raise AttributeError(name)
+            return majority_value(values)
+        return getattr(config, name)
+
+
+def het_safe_view(config: Any) -> Any:
+    """Wrap heterogeneous configs in a :class:`HetSafeConfigView`; pass others through."""
+    return HetSafeConfigView(config) if per_layer_attr_names(config) else config


### PR DESCRIPTION
# Description

Resolves issue with running heterogeneous Gemma4 models when on `transformers` v5.15.0 or later

Fixes #1647 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
