### PR TITLE
Expose BERT token-type embeddings through TransformerBridge

### DIFF
--- a/tests/unit/model_bridge/supported_architectures/test_bert_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_bert_adapter.py
@@ -74,6 +74,7 @@ class TestBertComponentMapping:
     def test_top_level_keys(self, adapter: BertArchitectureAdapter) -> None:
         assert set(adapter.component_mapping.keys()) == {
             "embed",
+            "token_type_embed",
             "pos_embed",
             "blocks",
             "ln_final",
@@ -83,6 +84,7 @@ class TestBertComponentMapping:
     def test_bridge_types(self, adapter: BertArchitectureAdapter) -> None:
         mapping = adapter.component_mapping
         assert isinstance(mapping["embed"], EmbeddingBridge)
+        assert isinstance(mapping["token_type_embed"], EmbeddingBridge)
         assert isinstance(mapping["pos_embed"], PosEmbedBridge)
         assert isinstance(mapping["blocks"], BlockBridge)
         assert isinstance(mapping["ln_final"], NormalizationBridge)
@@ -91,10 +93,41 @@ class TestBertComponentMapping:
     def test_top_level_hf_paths(self, adapter: BertArchitectureAdapter) -> None:
         mapping = adapter.component_mapping
         assert mapping["embed"].name == "bert.embeddings.word_embeddings"
+        assert mapping["token_type_embed"].name == "bert.embeddings.token_type_embeddings"
         assert mapping["pos_embed"].name == "bert.embeddings.position_embeddings"
         assert mapping["blocks"].name == "bert.encoder.layer"
         assert mapping["ln_final"].name == "cls.predictions.transform.LayerNorm"
         assert mapping["unembed"].name == "cls.predictions.decoder"
+
+    def test_token_type_embedding_is_cached_with_hf_output(self) -> None:
+        import torch
+        from transformers import BertForMaskedLM
+
+        from transformer_lens.model_bridge.sources import build_bridge_from_module
+
+        hf_model = BertForMaskedLM.from_pretrained("bert-base-cased").eval()
+        input_ids = torch.tensor([[101, 7592, 102, 2088, 102]])
+        token_type_ids = torch.tensor([[0, 0, 0, 1, 1]])
+        with torch.no_grad():
+            expected = hf_model.bert.embeddings.token_type_embeddings(token_type_ids).clone()
+
+        bridge = build_bridge_from_module(
+            hf_model,
+            "BertForMaskedLM",
+            hf_config=hf_model.config,
+            dtype=torch.float32,
+            device="cpu",
+            model_name="bert-base-cased",
+        )
+        with torch.no_grad():
+            _, cache = bridge.run_with_cache(
+                input_ids,
+                token_type_ids=token_type_ids,
+                names_filter=["token_type_embed.hook_out"],
+            )
+
+        assert "token_type_embed.hook_out" in cache
+        torch.testing.assert_close(cache["token_type_embed.hook_out"], expected)
 
     def test_block_submodule_keys(self, adapter: BertArchitectureAdapter) -> None:
         assert set(adapter.component_mapping["blocks"].submodules.keys()) == {

--- a/transformer_lens/model_bridge/supported_architectures/bert.py
+++ b/transformer_lens/model_bridge/supported_architectures/bert.py
@@ -87,6 +87,7 @@ class BertArchitectureAdapter(ArchitectureAdapter):
         # MLM defaults; prepare_model() adjusts for other task heads (e.g., NSP).
         self.component_mapping = {
             "embed": EmbeddingBridge(name="bert.embeddings.word_embeddings"),
+            "token_type_embed": EmbeddingBridge(name="bert.embeddings.token_type_embeddings"),
             "pos_embed": PosEmbedBridge(name="bert.embeddings.position_embeddings"),
             "blocks": BlockBridge(
                 name="bert.encoder.layer",


### PR DESCRIPTION
# Description

Expose BERT token-type (segment) embeddings as the bridge-native `token_type_embed.hook_out` hook.

The BERT adapter now maps `bert.embeddings.token_type_embeddings` through an `EmbeddingBridge`. The regression test boots `bert-base-cased`, captures the new hook with `run_with_cache`, and compares it directly with Hugging Face's token-type embedding output.

Fixes #1662

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Validation

- `uv run pytest tests/unit/model_bridge/supported_architectures/test_bert_adapter.py -q --tb=short -o addopts=`: 22 passed
- `make unit-test`: 5,260 passed, 56 skipped, 54 deselected, 10 xfailed
- `make check-format`: passed
- `uv run mypy .`: no issues in 431 source files
- `make docstring-test`: 17 passed, 24 skipped
- `make acceptance-test`: 199 passed, 72 skipped, 11 deselected
- `make integration-test`: 1,016 passed; the two `google/gemma-2-2b-it` cases could not run locally because this machine is not authenticated for that gated Hugging Face model (401)

# Checklist

- [x] The change is self-explanatory and does not need additional inline comments
- [x] No documentation change is needed for this bridge-native hook mapping
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
