### PR TITLE
Fix Gemma 4 gated MLP hook aliases

### DIFF
--- a/tests/integration/model_bridge/test_gemma4_bridge.py
+++ b/tests/integration/model_bridge/test_gemma4_bridge.py
@@ -98,3 +98,16 @@ def test_run_with_cache_text_only(bridge):
         logits, cache = bridge.run_with_cache(IDS)
     assert torch.isfinite(logits).all()
     assert len(cache) > 0
+
+
+def test_gated_mlp_hooks_are_available(bridge):
+    names = {
+        "blocks.0.mlp.hook_pre",
+        "blocks.0.mlp.hook_pre_linear",
+        "blocks.0.mlp.hook_post",
+    }
+    assert names <= bridge.hook_dict.keys()
+
+    with torch.no_grad():
+        _, cache = bridge.run_with_cache(IDS, names_filter=lambda name: name in names)
+    assert names == cache.keys()

--- a/tests/unit/model_bridge/supported_architectures/test_gemma4_adapter.py
+++ b/tests/unit/model_bridge/supported_architectures/test_gemma4_adapter.py
@@ -6,6 +6,7 @@ from transformer_lens.config import TransformerBridgeConfig
 from transformer_lens.model_bridge.generalized_components import (
     DelegatedAttentionBlockBridge,
     EmbeddingBridge,
+    GatedMLPBridge,
     LinearBridge,
     RotaryEmbeddingBridge,
     UnembeddingBridge,
@@ -161,6 +162,12 @@ def test_moe_submodules_are_optional():
 
 def test_gated_mlp_decomposition():
     mlp = _adapter().component_mapping["blocks"].submodules["mlp"]
+    assert isinstance(mlp, GatedMLPBridge)
     assert mlp.submodules["gate"].name == "gate_proj"
     assert mlp.submodules["in"].name == "up_proj"
     assert mlp.submodules["out"].name == "down_proj"
+    assert mlp.hook_aliases == {
+        "hook_pre": "gate.hook_out",
+        "hook_pre_linear": "in.hook_out",
+        "hook_post": "out.hook_in",
+    }

--- a/transformer_lens/model_bridge/supported_architectures/gemma4.py
+++ b/transformer_lens/model_bridge/supported_architectures/gemma4.py
@@ -145,14 +145,7 @@ class Gemma4ArchitectureAdapter(ArchitectureAdapter):
                             "v_norm": GeneralizedComponent(name="v_norm", optional=True),
                         },
                     ),
-                    "mlp": GeneralizedComponent(
-                        name="mlp",
-                        submodules={
-                            "gate": LinearBridge(name="gate_proj"),
-                            "in": LinearBridge(name="up_proj"),
-                            "out": LinearBridge(name="down_proj"),
-                        },
-                    ),
+                    "mlp": self._gated_mlp(),
                 },
             ),
             "ln_final": GeneralizedComponent(name="model.language_model.norm"),


### PR DESCRIPTION
# Description
Gemma 4 dense MLPs use the same gate/up/down projection structure as other gated MLP architectures, but the adapter mapped them as a bare GeneralizedComponent. This prevented the standard hook_pre, hook_pre_linear, and hook_post aliases from being registered.\n\nThis change uses the shared gated-MLP bridge for Gemma 4 and adds unit and integration coverage that verifies the aliases map to the expected projections and are available through run_with_cache across the PLE/KV-sharing, dense K=V, and MoE fixtures.\n\nFixes #1646\n\n## Type of change\n\n- [x] Bug fix (non-breaking change which fixes an issue)\n\n## Testing\n\n- Unit adapter test: 10 passed\n- Gemma 4 integration test: 15 passed\n- Full non-slow unit suite: 5266 passed, 56 skipped, 10 xfailed\n- Format check passed\n- mypy passed for 431 source files\n\n# Checklist\n\n- [x] The implementation is self-explanatory and does not require additional comments\n- [x] No documentation change is required for restoring the existing hook interface\n- [x] My changes generate no new warnings\n- [x] I have added tests that prove the fix is effective\n- [x] New and existing unit tests pass locally with my changes\n- [x] I have not rewritten tests relating to key interfaces