### PR TITLE
feat(jacobian_lens): add occupancy and fraction-of-variance

### DIFF
--- a/docs/source/content/jacobian_lens_fitting.md
+++ b/docs/source/content/jacobian_lens_fitting.md
@@ -348,6 +348,8 @@ records `||j_space_component||^2 / ||activation||^2` — the `selected_support` 
 matching the paper's appendix operationalization, **not** the nonnegative `reconstruction`. Per
 layer it reports the `median` of those fractions and the `pooled` ratio
 `sum(||j_space||^2) / sum(||activation||^2)`.
+Each token tensor must represent one prompt and have shape `[1, seq]`; `skip_first` must be
+non-negative even when explicit `positions` override its sampling behavior.
 
 ```python
 profile = lens.fraction_of_variance(model, prompts, layers=[3, 6], k=8)

--- a/docs/source/content/jacobian_lens_fitting.md
+++ b/docs/source/content/jacobian_lens_fitting.md
@@ -320,16 +320,20 @@ exact values will not necessarily transfer.
 
 ### Occupancy and fraction of variance
 
-Two statistics turn the honesty bullets above into numbers you can measure. Both build on the same
-greedy selection as `decompose`.
+Two statistics turn the honesty bullets above into numbers you can measure. Both build on J-lens
+vector dictionaries and sparse supports, but occupancy uses its own projection-residual recurrence.
 
 `occupancy` estimates **how many J-lens vectors are meaningfully active** in a single activation —
-the quantity behind the paper's `k <= 25`. It runs the greedy selection up to `max_atoms`, records
-the per-step captured variance `||Pi_S x||^2 / ||x||^2`, and compares that curve against the same
-greedy run on `num_control_dictionaries` random unit-norm dictionaries. The occupancy is the step
-of **maximum separation** between the real and averaged-control *cumulative* captured variance — the
-point past which further vectors add no more than random directions would. It is deterministic given
-`seed` and needs no threshold.
+the quantity behind the paper's `k <= 25`. At each step it admits the unused atom with the greatest
+signed, norm-normalized correlation with the current residual, projects the activation onto the full
+selected span, and sets the next residual to `x - Pi_S x`. This is the same per-step correlation
+*rule* as `decompose`, but `decompose` recurses on a nonnegative coefficient-fit residual and may
+stop early, whereas occupancy selects exactly `max_atoms` atoms, so their supports need not match.
+Occupancy records the per-step captured variance `||Pi_S x||^2 / ||x||^2` and compares that curve
+against the same occupancy recurrence on `num_control_dictionaries` random unit-norm dictionaries.
+The occupancy is the step of **maximum separation** between the real and averaged-control
+*cumulative* captured variance — the point past which further vectors add no more than random
+directions would. It is deterministic given `seed` and needs no threshold.
 
 ```python
 occ = lens.occupancy(model, "The Eiffel Tower is in the city of", layer=6, position=-1)

--- a/docs/source/content/jacobian_lens_fitting.md
+++ b/docs/source/content/jacobian_lens_fitting.md
@@ -318,6 +318,43 @@ exact values will not necessarily transfer.
   time." Here `k` is an **upper bound**: `support` returns *at most* `k` active vectors (often
   fewer), never `k` padded with zero-coefficient slots.
 
+### Occupancy and fraction of variance
+
+Two statistics turn the honesty bullets above into numbers you can measure. Both build on the same
+greedy selection as `decompose`.
+
+`occupancy` estimates **how many J-lens vectors are meaningfully active** in a single activation —
+the quantity behind the paper's `k <= 25`. It runs the greedy selection up to `max_atoms`, records
+the per-step captured variance `||Pi_S x||^2 / ||x||^2`, and compares that curve against the same
+greedy run on `num_control_dictionaries` random unit-norm dictionaries. The occupancy is the step
+of **maximum separation** between the real and averaged-control *cumulative* captured variance — the
+point past which further vectors add no more than random directions would. It is deterministic given
+`seed` and needs no threshold.
+
+```python
+occ = lens.occupancy(model, "The Eiffel Tower is in the city of", layer=6, position=-1)
+occ.occupancy                    # int: meaningfully-active vector count (a small positive integer)
+occ.marginal_captured_variance   # [max_atoms] real per-step captured-variance gains (for plotting)
+occ.control_captured_variance    # [max_atoms] averaged random-control gains
+```
+
+`fraction_of_variance` profiles the **J-space share of activation variance over a prompt corpus**.
+For each `(layer, position)` at or past `skip_first` (mirroring the fit's early-position skip) it
+records `||j_space_component||^2 / ||activation||^2` — the `selected_support` span projection,
+matching the paper's appendix operationalization, **not** the nonnegative `reconstruction`. Per
+layer it reports the `median` of those fractions and the `pooled` ratio
+`sum(||j_space||^2) / sum(||activation||^2)`.
+
+```python
+profile = lens.fraction_of_variance(model, prompts, layers=[3, 6], k=8)
+profile.median   # {layer: median fraction}   -- the paper's "median 6-7%" quantity
+profile.pooled   # {layer: pooled ratio in [0, 1]}
+```
+
+Both are **shape** claims on open weights: expect a small occupancy and a small variance fraction,
+but do not expect the paper's closed-model figures (see *Interpreting the numbers honestly* above)
+to transfer numerically.
+
 The full-vocabulary dictionary is cached on the model's device and is vocabulary-sized
 (gigabytes for large models); release it with `lens.clear_device_cache()`.
 

--- a/tests/integration/test_jacobian_lens.py
+++ b/tests/integration/test_jacobian_lens.py
@@ -464,6 +464,74 @@ def test_decompose_gpt2_activation_reconstructs_and_is_orthogonal(published_gpt2
         assert cosine.abs().item() < 1e-3
 
 
+def test_occupancy_gpt2_activation_is_a_small_positive_integer(published_gpt2_lens, gpt2_bridge):
+    """occupancy on a real GPT-2 activation returns a positive integer within ``[1, max_atoms]``,
+    with per-step real and control captured-variance curves of the right shape. We assert shape and
+    bounds -- not the paper's closed-model count (an open-weight observation, recorded on failure).
+    A reduced control count keeps CI fast."""
+    layer, max_atoms = 6, 12
+    result = published_gpt2_lens.occupancy(
+        gpt2_bridge,
+        PROMPT,
+        layer=layer,
+        position=-1,
+        max_atoms=max_atoms,
+        num_control_dictionaries=8,
+    )
+
+    assert isinstance(result.occupancy, int)
+    assert 1 <= result.occupancy <= max_atoms, f"occupancy={result.occupancy} max_atoms={max_atoms}"
+    assert result.marginal_captured_variance.shape == (max_atoms,)
+    assert result.control_captured_variance.shape == (max_atoms,)
+    assert result.support.shape == (max_atoms,)
+    assert (result.support >= 0).all() and (result.support < gpt2_bridge.cfg.d_vocab).all()
+
+    # Cumulative captured variance is a projection ratio: non-decreasing and bounded to [0, 1].
+    real_cumulative = result.marginal_captured_variance.cumsum(0)
+    assert (result.marginal_captured_variance >= -1e-4).all()
+    assert (real_cumulative >= -1e-4).all() and (real_cumulative <= 1.0 + 1e-4).all()
+
+    # Deterministic given the seed: an identical call reproduces the count and both curves exactly.
+    repeat = published_gpt2_lens.occupancy(
+        gpt2_bridge,
+        PROMPT,
+        layer=layer,
+        position=-1,
+        max_atoms=max_atoms,
+        num_control_dictionaries=8,
+    )
+    assert repeat.occupancy == result.occupancy
+    assert torch.equal(repeat.marginal_captured_variance, result.marginal_captured_variance)
+    assert torch.equal(repeat.control_captured_variance, result.control_captured_variance)
+
+
+def test_fraction_of_variance_gpt2_is_a_small_ratio(published_gpt2_lens, gpt2_bridge):
+    """fraction_of_variance over a small corpus: each layer's median and pooled ratio land in
+    ``[0, 1]`` with samples recorded, consistent with the paper's "J-space is a small fraction of
+    total variance" (an open-weight observation, not a numeric match to the closed-model figures).
+    FIT_PROMPTS are long enough to clear the default 16-position skip."""
+    layers = [3, 6]
+    profile = published_gpt2_lens.fraction_of_variance(gpt2_bridge, FIT_PROMPTS, layers=layers, k=8)
+
+    assert profile.layers == layers
+    for layer in layers:
+        per_position = profile.per_position[layer]
+        assert per_position.numel() > 0
+        # Each fraction is ||projection||^2 / ||activation||^2, a variance ratio in [0, 1].
+        assert (per_position >= 0.0).all() and (per_position <= 1.0).all()
+        assert 0.0 <= profile.median[layer] <= 1.0
+        assert 0.0 <= profile.pooled[layer] <= 1.0
+
+    # positions= overrides the skip_first sweep: one explicit position per prompt over the
+    # two-prompt corpus exercises the override path and cross-prompt pooling (one sample each).
+    pinned = published_gpt2_lens.fraction_of_variance(
+        gpt2_bridge, FIT_PROMPTS, layers=layers, k=8, positions=[-1]
+    )
+    for layer in layers:
+        assert pinned.per_position[layer].numel() == len(FIT_PROMPTS)
+        assert 0.0 <= pinned.pooled[layer] <= 1.0
+
+
 @pytest.mark.slow
 def test_decompose_gemma_activation_is_valid():
     """Decompose a real gemma-2-2b-it activation via its published lens (slow: real download)."""

--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from enum import IntEnum
 from inspect import Parameter, signature
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Optional, Sequence
 
 import numpy as np
 import pytest
@@ -1451,6 +1451,37 @@ def test_fraction_of_variance_rejects_empty_corpus(
 ) -> None:
     with pytest.raises(ValueError):
         fitted_lens.fraction_of_variance(toy_model, [])
+
+
+@pytest.mark.parametrize(
+    "tokens",
+    [
+        torch.zeros(4, dtype=torch.long),
+        torch.zeros((2, 4), dtype=torch.long),
+        torch.zeros((1, 1, 4), dtype=torch.long),
+    ],
+    ids=["missing-batch-dimension", "multiple-prompts", "extra-dimension"],
+)
+def test_fraction_of_variance_rejects_invalid_token_shape(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens, tokens: torch.Tensor
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"fraction_of_variance expects each tokenized prompt to have shape \[1, seq\]",
+    ):
+        fitted_lens.fraction_of_variance(toy_model, tokens, k=3, skip_first=0)
+
+
+@pytest.mark.parametrize("positions", [None, [0]], ids=["default-sampling", "explicit-positions"])
+def test_fraction_of_variance_rejects_negative_skip_first(
+    toy_model: _ToyBridge,
+    fitted_lens: JacobianLens,
+    positions: Optional[Sequence[int]],
+) -> None:
+    with pytest.raises(ValueError, match="skip_first must be non-negative"):
+        fitted_lens.fraction_of_variance(
+            toy_model, "a toy prompt", k=3, skip_first=-1, positions=positions
+        )
 
 
 def test_fraction_of_variance_yields_nan_when_no_positions_are_sampled(

--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -21,6 +21,8 @@ from transformer_lens.model_bridge.supported_architectures.deepseek_v4 import (
 from transformer_lens.tools.analysis import (
     JacobianLens,
     JSpaceDecomposition,
+    JSpaceOccupancy,
+    JSpaceVarianceProfile,
     get_sparse_decomposition,
 )
 from transformer_lens.utilities.activation_functions import apply_softcap
@@ -1391,3 +1393,76 @@ def test_decompose_rejects_unfitted_layer(toy_model: _ToyBridge, fitted_lens: Ja
         fitted_lens.decompose(
             toy_model, torch.randn(toy_model.cfg.d_model), layer=N_LAYERS - 1, k=3
         )
+
+
+def test_occupancy_on_toy_model_raw_activation(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    """occupancy on a raw activation returns a JSpaceOccupancy with a count in [1, max_atoms]."""
+    layer = fitted_lens.source_layers[0]
+    activation = torch.randn(toy_model.cfg.d_model)
+    result = fitted_lens.occupancy(toy_model, activation, layer, max_atoms=5, seed=0)
+    assert isinstance(result, JSpaceOccupancy)
+    assert 1 <= result.occupancy <= 5
+    assert result.support.numel() == 5
+    assert result.marginal_captured_variance.shape == result.control_captured_variance.shape
+
+
+def test_occupancy_prompt_path_runs(toy_model: _ToyBridge, fitted_lens: JacobianLens) -> None:
+    """occupancy accepts a prompt plus position, running the model to fetch the activation."""
+    layer = fitted_lens.source_layers[0]
+    result = fitted_lens.occupancy(
+        toy_model, "a toy prompt", layer, position=-1, max_atoms=5, seed=0
+    )
+    assert isinstance(result, JSpaceOccupancy)
+    assert 1 <= result.occupancy <= 5
+
+
+def test_occupancy_rejects_unfitted_layer(toy_model: _ToyBridge, fitted_lens: JacobianLens) -> None:
+    """occupancy shares decompose's validation: an unfitted layer raises."""
+    with pytest.raises(ValueError):
+        fitted_lens.occupancy(toy_model, torch.randn(toy_model.cfg.d_model), layer=N_LAYERS - 1)
+
+
+def test_fraction_of_variance_on_toy_model(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    """fraction_of_variance returns per-layer median and pooled ratios in [0, 1] over a corpus."""
+    profile = fitted_lens.fraction_of_variance(
+        toy_model, ["a toy prompt here", "another toy prompt goes here"], k=3, skip_first=0
+    )
+    assert isinstance(profile, JSpaceVarianceProfile)
+    assert profile.layers == list(fitted_lens.source_layers)
+    for layer in profile.layers:
+        assert 0.0 <= profile.median[layer] <= 1.0
+        assert 0.0 <= profile.pooled[layer] <= 1.0
+        assert profile.per_position[layer].numel() > 0
+
+
+def test_fraction_of_variance_rejects_unfitted_layer(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    with pytest.raises(ValueError):
+        fitted_lens.fraction_of_variance(toy_model, "a toy prompt", layers=[N_LAYERS - 1])
+
+
+def test_fraction_of_variance_rejects_empty_corpus(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    with pytest.raises(ValueError):
+        fitted_lens.fraction_of_variance(toy_model, [])
+
+
+def test_fraction_of_variance_yields_nan_when_no_positions_are_sampled(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    """When ``skip_first`` exceeds every prompt's length no position is sampled, so each layer's
+    ``median`` and ``pooled`` are NaN and ``per_position`` is empty (the documented contract)."""
+    import math
+
+    profile = fitted_lens.fraction_of_variance(toy_model, "a toy prompt", k=3, skip_first=999)
+    assert profile.layers == list(fitted_lens.source_layers)
+    for layer in profile.layers:
+        assert math.isnan(profile.median[layer])
+        assert math.isnan(profile.pooled[layer])
+        assert profile.per_position[layer].numel() == 0

--- a/tests/unit/tools/test_jacobian_lens_decomposition.py
+++ b/tests/unit/tools/test_jacobian_lens_decomposition.py
@@ -813,17 +813,63 @@ def test_occupancy_is_deterministic():
 
 def test_occupancy_rejects_invalid_inputs():
     dictionary = torch.eye(6)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="max_atoms must be between"):
         estimate_occupancy(torch.ones(6), dictionary, max_atoms=0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="max_atoms must be between"):
         estimate_occupancy(torch.ones(6), dictionary, max_atoms=99)
-    with pytest.raises(ValueError):
-        estimate_occupancy(torch.ones(6), dictionary, num_control_dictionaries=0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="num_control_dictionaries must be at least 1"):
+        estimate_occupancy(torch.ones(6), dictionary, max_atoms=6, num_control_dictionaries=0)
+    with pytest.raises(ValueError, match="x must be 1-D of length"):
         estimate_occupancy(torch.ones(5), dictionary)  # target length != d_model
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="x must be 1-D of length"):
         estimate_occupancy(torch.ones(2, 6), dictionary)  # non-1-D target
     zero_norm_dictionary = torch.eye(6)
     zero_norm_dictionary[2] = 0.0
-    with pytest.raises(ValueError):
-        estimate_occupancy(torch.ones(6), zero_norm_dictionary)
+    with pytest.raises(ValueError, match="dictionary contains a non-finite or zero-norm atom"):
+        estimate_occupancy(torch.ones(6), zero_norm_dictionary, max_atoms=6)
+
+
+@pytest.mark.parametrize("invalid_value", [float("nan"), float("inf"), float("-inf")])
+def test_occupancy_rejects_non_finite_target(invalid_value):
+    target = torch.ones(6)
+    target[0] = invalid_value
+    with pytest.raises(ValueError, match="x contains non-finite entries"):
+        estimate_occupancy(target, torch.eye(6), max_atoms=6)
+
+
+def test_occupancy_rejects_zero_norm_target():
+    with pytest.raises(ValueError, match="x must have non-zero norm"):
+        estimate_occupancy(torch.zeros(6), torch.eye(6), max_atoms=6)
+
+
+@pytest.mark.parametrize("invalid_value", [float("nan"), float("inf"), float("-inf")])
+def test_occupancy_rejects_non_finite_dictionary(invalid_value):
+    dictionary = torch.eye(6)
+    dictionary[0, 0] = invalid_value
+    with pytest.raises(ValueError, match="dictionary contains non-finite entries"):
+        estimate_occupancy(torch.ones(6), dictionary, max_atoms=6)
+
+
+def test_occupancy_rejects_non_finite_dictionary_norm():
+    dictionary = torch.eye(6)
+    dictionary[0] = torch.finfo(torch.float32).max
+    with pytest.raises(ValueError, match="dictionary contains a non-finite or zero-norm atom"):
+        estimate_occupancy(torch.ones(6), dictionary, max_atoms=6)
+
+
+@pytest.mark.parametrize("complex_input", ["x", "dictionary"])
+def test_occupancy_rejects_complex_inputs(complex_input):
+    target = torch.ones(6)
+    dictionary = torch.eye(6)
+    if complex_input == "x":
+        target = target.to(torch.complex64)
+    else:
+        dictionary = dictionary.to(torch.complex64)
+    with pytest.raises(ValueError, match="x and dictionary must be real-valued"):
+        estimate_occupancy(target, dictionary, max_atoms=6)
+
+
+def test_occupancy_rejects_non_finite_target_norm():
+    target = torch.full((6,), torch.finfo(torch.float32).max)
+    with pytest.raises(ValueError, match="x must have finite norm"):
+        estimate_occupancy(target, torch.eye(6), max_atoms=6)

--- a/tests/unit/tools/test_jacobian_lens_decomposition.py
+++ b/tests/unit/tools/test_jacobian_lens_decomposition.py
@@ -12,10 +12,12 @@ import torch
 
 from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
     JSpaceDecomposition,
+    JSpaceOccupancy,
     _gradient_pursuit_step,
     _nnls_tolerances,
     _nonnegative_least_squares,
     _validate_nnls_kkt,
+    estimate_occupancy,
     get_sparse_decomposition,
 )
 
@@ -753,3 +755,75 @@ def test_rejects_non_2d_dictionary():
 def test_rejects_non_1d_target():
     with pytest.raises(ValueError):
         get_sparse_decomposition(torch.ones(2, 4), torch.eye(4), k=1)
+
+
+# --------------------------------------------------------------------------- #
+# Occupancy estimator (estimate_occupancy)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("planted_atom_count", [1, 4, 7])
+def test_occupancy_recovers_planted_sparsity_on_orthonormal_dictionary(planted_atom_count):
+    """On an orthonormal dictionary a k-sparse planted target has occupancy exactly k: the real
+    greedy captures the planted atoms then saturates, so the point of maximum separation from the
+    random control lands at k."""
+    torch.manual_seed(0)
+    d_model = 24
+    dictionary = torch.linalg.qr(torch.randn(d_model, d_model)).Q  # orthonormal atoms (rows)
+    target = torch.zeros(d_model)
+    for index in range(planted_atom_count):
+        target = target + (3.0 - 0.3 * index) * dictionary[2 * index + 1]
+
+    max_atoms = min(2 * planted_atom_count + 4, d_model)
+    result = estimate_occupancy(target, dictionary, max_atoms=max_atoms)
+
+    assert isinstance(result, JSpaceOccupancy)
+    assert result.occupancy == planted_atom_count
+    assert result.support.numel() == max_atoms
+
+
+def test_occupancy_increases_with_planted_sparsity():
+    """Occupancy tracks the planted sparsity: a 2-sparse target occupies fewer atoms than a
+    9-sparse one on the same orthonormal dictionary (both recovered exactly)."""
+    torch.manual_seed(1)
+    d_model = 24
+    dictionary = torch.linalg.qr(torch.randn(d_model, d_model)).Q
+
+    def planted(count):
+        target = torch.zeros(d_model)
+        for index in range(count):
+            target = target + (3.0 - 0.2 * index) * dictionary[2 * index + 1]
+        return target
+
+    assert (
+        estimate_occupancy(planted(2), dictionary, max_atoms=20).occupancy
+        < estimate_occupancy(planted(9), dictionary, max_atoms=20).occupancy
+    )
+
+
+def test_occupancy_is_deterministic():
+    """Identical inputs and seed give identical results (the random control is seeded)."""
+    torch.manual_seed(2)
+    dictionary = torch.randn(40, 8)
+    target = torch.randn(8)
+    first = estimate_occupancy(target, dictionary, seed=0)
+    second = estimate_occupancy(target, dictionary, seed=0)
+    assert first.occupancy == second.occupancy
+    assert torch.equal(first.support, second.support)
+    assert torch.allclose(first.control_captured_variance, second.control_captured_variance)
+
+
+def test_occupancy_rejects_invalid_inputs():
+    dictionary = torch.eye(6)
+    with pytest.raises(ValueError):
+        estimate_occupancy(torch.ones(6), dictionary, max_atoms=0)
+    with pytest.raises(ValueError):
+        estimate_occupancy(torch.ones(6), dictionary, max_atoms=99)
+    with pytest.raises(ValueError):
+        estimate_occupancy(torch.ones(6), dictionary, num_control_dictionaries=0)
+    with pytest.raises(ValueError):
+        estimate_occupancy(torch.ones(5), dictionary)  # target length != d_model
+    with pytest.raises(ValueError):
+        estimate_occupancy(torch.ones(2, 6), dictionary)  # non-1-D target
+    zero_norm_dictionary = torch.eye(6)
+    zero_norm_dictionary[2] = 0.0
+    with pytest.raises(ValueError):
+        estimate_occupancy(torch.ones(6), zero_norm_dictionary)

--- a/transformer_lens/tools/analysis/__init__.py
+++ b/transformer_lens/tools/analysis/__init__.py
@@ -28,15 +28,21 @@ from transformer_lens.tools.analysis.jacobian_lens import (
 )
 from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
     JSpaceDecomposition,
+    JSpaceOccupancy,
+    JSpaceVarianceProfile,
+    estimate_occupancy,
     get_sparse_decomposition,
 )
 
 __all__ = [
     "DirectLogitAttribution",
     "JSpaceDecomposition",
+    "JSpaceOccupancy",
+    "JSpaceVarianceProfile",
     "JacobianLens",
     "JacobianLensReadout",
     "direct_logit_attribution",
+    "estimate_occupancy",
     "get_act_patch_direct_path",
     "get_act_patch_direct_path_all_sources",
     "get_sparse_decomposition",

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -1036,11 +1036,12 @@ class JacobianLens:
 
         Args:
             model: A raw ``TransformerBridge``.
-            prompts: A prompt, or a sequence of prompts (strings and/or ``[1, seq]`` token tensors).
+            prompts: A prompt, or a sequence of prompts. Each token tensor must represent exactly
+                one prompt and have shape ``[1, seq]``.
             layers: Source layers to profile; defaults to all fitted ``source_layers``.
             k: Number of J-lens vectors per decomposition.
-            skip_first: Skip positions before this index (mirrors the fit's early-position skip);
-                ignored when ``positions`` is given.
+            skip_first: Non-negative index before which positions are skipped (mirrors the fit's
+                early-position skip); not used for sampling when ``positions`` is given.
             positions: Explicit positions to sample instead of ``skip_first`` onward.
             show_progress: Show a tqdm progress bar over prompts.
 
@@ -1048,9 +1049,12 @@ class JacobianLens:
             A :class:`JSpaceVarianceProfile`.
 
         Raises:
-            ValueError: On an invalid model, an unfitted layer, or an empty corpus.
+            ValueError: On an invalid model, an unfitted layer, an empty corpus, a negative
+                ``skip_first``, or a token tensor that does not have shape ``[1, seq]``.
         """
         self.validate_model(model)
+        if skip_first < 0:
+            raise ValueError(f"skip_first must be non-negative, got {skip_first}")
         if layers is None:
             resolved_layers = list(self.source_layers)
         else:
@@ -1078,6 +1082,11 @@ class JacobianLens:
 
         for prompt in tqdm(prompt_list, desc="J-space variance", disable=not show_progress):
             tokens = model.to_tokens(prompt) if isinstance(prompt, str) else prompt
+            if tokens.ndim != 2 or tokens.shape[0] != 1:
+                raise ValueError(
+                    "fraction_of_variance expects each tokenized prompt to have shape "
+                    f"[1, seq], got {tuple(tokens.shape)}"
+                )
             _, cache = model.run_with_cache(tokens, names_filter=lambda name: name in wanted_hooks)
             seq_len = tokens.shape[1]
             sampled = (

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -73,6 +73,9 @@ from tqdm.auto import tqdm
 from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
     DEFAULT_K,
     JSpaceDecomposition,
+    JSpaceOccupancy,
+    JSpaceVarianceProfile,
+    estimate_occupancy,
     get_sparse_decomposition,
 )
 from transformer_lens.utilities.hf_utils import call_hf_with_retry
@@ -899,6 +902,27 @@ class JacobianLens:
             RuntimeError: If the default nonnegative least-squares solver cannot validate its
                 result against the KKT conditions.
         """
+        activation, resolved_layer = self._resolve_activation(
+            model, activation_or_prompt, layer, position
+        )
+        dictionary = self.lens_vector_dictionary(model, resolved_layer)
+        return get_sparse_decomposition(
+            activation.float().to(dictionary.device), dictionary, k, algorithm=algorithm
+        )
+
+    def _resolve_activation(
+        self,
+        model: Any,
+        activation_or_prompt: Union[torch.Tensor, str],
+        layer: int,
+        position: Optional[int],
+    ) -> Tuple[torch.Tensor, int]:
+        """Validate the model and layer, then resolve either a raw ``[d_model]`` activation or a
+        prompt plus ``position`` to the activation vector to analyse.
+
+        Returns ``(activation, resolved_layer)``. Shared by :meth:`decompose` and
+        :meth:`occupancy` so both accept the same input forms with identical validation.
+        """
         self.validate_model(model)
         resolved_layer = _normalize_layer(layer, model.cfg.n_layers)
         if resolved_layer not in self.jacobians:
@@ -938,10 +962,160 @@ class JacobianLens:
             _, cache = model.run_with_cache(tokens, names_filter=lambda name: name == hook_name)
             norm_position = _normalize_positions([position], tokens.shape[1])[0]
             activation = cache[hook_name][0, norm_position, :]
+        return activation, resolved_layer
 
+    @torch.no_grad()
+    def occupancy(
+        self,
+        model: Any,
+        activation_or_prompt: Union[torch.Tensor, str],
+        layer: int,
+        *,
+        position: Optional[int] = None,
+        max_atoms: int = DEFAULT_K,
+        num_control_dictionaries: int = 32,
+        seed: int = 0,
+    ) -> JSpaceOccupancy:
+        """Estimate how many J-lens vectors are meaningfully active in an activation at ``layer``.
+
+        Resolves ``activation_or_prompt`` (a raw ``[d_model]`` vector, or a prompt plus
+        ``position``) exactly as :meth:`decompose`, builds the cached full-vocabulary dictionary
+        via :meth:`lens_vector_dictionary`, and calls :func:`estimate_occupancy`.
+
+        Args:
+            model: A raw ``TransformerBridge``.
+            activation_or_prompt: An activation vector, or a prompt (string / token tensor).
+            layer: Source layer (must be a fitted source layer).
+            position: Token position when a prompt is given; ``None`` for a raw activation.
+            max_atoms: Maximum number of J-lens vectors to consider.
+            num_control_dictionaries: Number of random control dictionaries to average over.
+            seed: Seed for the random control dictionaries (reproducibility).
+
+        Returns:
+            A :class:`JSpaceOccupancy`.
+        """
+        activation, resolved_layer = self._resolve_activation(
+            model, activation_or_prompt, layer, position
+        )
         dictionary = self.lens_vector_dictionary(model, resolved_layer)
-        return get_sparse_decomposition(
-            activation.float().to(dictionary.device), dictionary, k, algorithm=algorithm
+        return estimate_occupancy(
+            activation.float().to(dictionary.device),
+            dictionary,
+            max_atoms=max_atoms,
+            num_control_dictionaries=num_control_dictionaries,
+            seed=seed,
+        )
+
+    @torch.no_grad()
+    def fraction_of_variance(
+        self,
+        model: Any,
+        prompts: Union[str, torch.Tensor, Sequence[Union[str, torch.Tensor]]],
+        layers: Optional[Sequence[int]] = None,
+        *,
+        k: int = DEFAULT_K,
+        skip_first: int = 16,
+        positions: Optional[Sequence[int]] = None,
+        show_progress: bool = False,
+    ) -> JSpaceVarianceProfile:
+        """Profile the J-space share of activation variance over a prompt corpus.
+
+        Each prompt is run once (caching ``blocks.{layer}.hook_out`` for every requested layer).
+        At each sampled position the activation is decomposed and its J-space variance fraction
+        ``||j_space_component||^2 / ||activation||^2`` is recorded. The numerator is the
+        ``j_space_component`` -- the orthogonal projection of the activation onto the span of the
+        selected support (the paper's appendix "J-space component"), *not* the nonnegative
+        ``reconstruction``; the two coincide only when every selected atom stays active. Per layer
+        the profile reports the median of those fractions and the pooled ratio
+        ``sum(||j_space_component||^2) / sum(||activation||^2)`` (the paper's "fraction of total
+        variance").
+
+        A layer that samples no positions -- every prompt shorter than ``skip_first``, or only
+        zero-norm activations -- contributes no fractions: its ``median`` and ``pooled`` are
+        ``float("nan")`` and its ``per_position`` tensor is empty.
+
+        Args:
+            model: A raw ``TransformerBridge``.
+            prompts: A prompt, or a sequence of prompts (strings and/or ``[1, seq]`` token tensors).
+            layers: Source layers to profile; defaults to all fitted ``source_layers``.
+            k: Number of J-lens vectors per decomposition.
+            skip_first: Skip positions before this index (mirrors the fit's early-position skip);
+                ignored when ``positions`` is given.
+            positions: Explicit positions to sample instead of ``skip_first`` onward.
+            show_progress: Show a tqdm progress bar over prompts.
+
+        Returns:
+            A :class:`JSpaceVarianceProfile`.
+
+        Raises:
+            ValueError: On an invalid model, an unfitted layer, or an empty corpus.
+        """
+        self.validate_model(model)
+        if layers is None:
+            resolved_layers = list(self.source_layers)
+        else:
+            resolved_layers = [_normalize_layer(layer, model.cfg.n_layers) for layer in layers]
+            for layer in resolved_layers:
+                if layer not in self.jacobians:
+                    raise ValueError(
+                        f"layer {layer} is not in this lens's source layers; "
+                        f"available: {self.source_layers}"
+                    )
+        prompt_list: List[Union[str, torch.Tensor]] = (
+            [prompts] if isinstance(prompts, (str, torch.Tensor)) else list(prompts)
+        )
+        if not prompt_list:
+            raise ValueError("prompts must be a non-empty prompt or sequence of prompts")
+
+        hook_names = {layer: _resid_post_hook_name(layer) for layer in resolved_layers}
+        wanted_hooks = set(hook_names.values())
+        dictionaries = {
+            layer: self.lens_vector_dictionary(model, layer) for layer in resolved_layers
+        }
+        fractions: Dict[int, List[float]] = {layer: [] for layer in resolved_layers}
+        pooled_j_space: Dict[int, float] = {layer: 0.0 for layer in resolved_layers}
+        pooled_total: Dict[int, float] = {layer: 0.0 for layer in resolved_layers}
+
+        for prompt in tqdm(prompt_list, desc="J-space variance", disable=not show_progress):
+            tokens = model.to_tokens(prompt) if isinstance(prompt, str) else prompt
+            _, cache = model.run_with_cache(tokens, names_filter=lambda name: name in wanted_hooks)
+            seq_len = tokens.shape[1]
+            sampled = (
+                list(range(skip_first, seq_len))
+                if positions is None
+                else _normalize_positions(positions, seq_len)
+            )
+            for layer in resolved_layers:
+                dictionary = dictionaries[layer]
+                activations = cache[hook_names[layer]][0]  # [seq, d_model]
+                for position in sampled:
+                    activation = activations[position].float().to(dictionary.device)
+                    total = float(activation @ activation)
+                    if total <= 0.0:
+                        continue
+                    decomposition = get_sparse_decomposition(activation, dictionary, k)
+                    j_space = float(
+                        decomposition.j_space_component @ decomposition.j_space_component
+                    )
+                    fractions[layer].append(j_space / total)
+                    pooled_j_space[layer] += j_space
+                    pooled_total[layer] += total
+
+        median = {
+            layer: float(torch.tensor(fractions[layer]).median())
+            if fractions[layer]
+            else float("nan")
+            for layer in resolved_layers
+        }
+        pooled = {
+            layer: pooled_j_space[layer] / pooled_total[layer]
+            if pooled_total[layer] > 0
+            else float("nan")
+            for layer in resolved_layers
+        }
+        per_position = {layer: torch.tensor(fractions[layer]) for layer in resolved_layers}
+        return JSpaceVarianceProfile(
+            layers=resolved_layers, median=median, pooled=pooled, per_position=per_position
         )
 
     # ------------------------------------------------------------------ #

--- a/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
@@ -61,7 +61,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List, Tuple
 
 import torch
 
@@ -447,3 +447,157 @@ def get_sparse_decomposition(
         j_space_component=j_space_component,
         non_j_space_component=non_j_space_component,
     )
+
+
+@dataclass
+class JSpaceOccupancy:
+    """Result of a J-space occupancy estimate.
+
+    Attributes:
+        occupancy: Estimated number of meaningfully-active atoms -- the step of maximum
+            separation between the real and random-control cumulative captured variance.
+        marginal_captured_variance: Per-step captured-variance gain of the real greedy selection,
+            shape ``[max_atoms]``.
+        control_captured_variance: Per-step captured-variance gain averaged over the random
+            control dictionaries, shape ``[max_atoms]``.
+        support: Greedily selected atom indices, shape ``[max_atoms]`` (token ids when the
+            dictionary is the vocabulary of J-lens vectors).
+    """
+
+    occupancy: int
+    marginal_captured_variance: torch.Tensor
+    control_captured_variance: torch.Tensor
+    support: torch.Tensor
+
+
+def _greedy_captured_variance_gains(
+    atoms: torch.Tensor, atom_norms: torch.Tensor, target: torch.Tensor, max_atoms: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Greedily select up to ``max_atoms`` atoms and return the per-step captured-variance gains.
+
+    Selection matches :func:`get_sparse_decomposition`: at each step the atom most correlated
+    with the running residual (using unit-normalised atoms) is added. The captured variance at a
+    step is the orthogonal projection of ``target`` onto the selected span,
+    ``||Pi_S target||^2 / ||target||^2``; the returned values are its per-step increments.
+    """
+    total_variance = float(target @ target)
+    support: List[int] = []
+    residual = target.clone()
+    captured_variance_gains: List[float] = []
+    previous_captured_variance = 0.0
+    for _ in range(max_atoms):
+        correlation = (atoms @ residual) / atom_norms
+        for chosen in support:
+            correlation[chosen] = float("-inf")
+        support.append(int(torch.argmax(correlation).item()))
+        active_atoms = atoms[support].T
+        projection = active_atoms @ (torch.linalg.pinv(active_atoms) @ target)
+        captured_variance = float((projection @ projection) / total_variance)
+        captured_variance_gains.append(captured_variance - previous_captured_variance)
+        previous_captured_variance = captured_variance
+        residual = target - projection
+    return torch.tensor(captured_variance_gains), torch.tensor(support, dtype=torch.long)
+
+
+def estimate_occupancy(
+    x: torch.Tensor,
+    dictionary: torch.Tensor,
+    *,
+    max_atoms: int = DEFAULT_K,
+    num_control_dictionaries: int = 32,
+    seed: int = 0,
+) -> JSpaceOccupancy:
+    """Estimate how many dictionary atoms are meaningfully active in ``x``.
+
+    Greedily selects up to ``max_atoms`` atoms and compares the real per-step captured-variance
+    curve against the same greedy run on ``num_control_dictionaries`` random unit-norm
+    dictionaries of the same size. The occupancy is the step of maximum separation between the
+    real and (averaged) control *cumulative* captured variance -- the point past which further
+    atoms add no more than random directions would. Deterministic given ``seed`` and needs no
+    threshold. (Captured variance is a projection, hence scale-free, so the random control atoms
+    are simply unit-norm.)
+
+    Args:
+        x: Target vector, shape ``[d_model]``.
+        dictionary: Atom matrix, shape ``[num_atoms, d_model]`` (rows are atoms).
+        max_atoms: Maximum number of atoms to consider.
+        num_control_dictionaries: Number of random control dictionaries to average over.
+        seed: Seed for the random control dictionaries (reproducibility).
+
+    Returns:
+        An :class:`JSpaceOccupancy`.
+
+    Raises:
+        ValueError: On a non-2-D dictionary, a target whose length does not match ``d_model``,
+            ``max_atoms`` outside ``[1, num_atoms]``, ``num_control_dictionaries < 1``, or a
+            dictionary with non-finite or zero-norm atoms.
+    """
+    if dictionary.ndim != 2:
+        raise ValueError(
+            f"dictionary must be 2-D [num_atoms, d_model], got shape {tuple(dictionary.shape)}"
+        )
+    num_atoms, d_model = dictionary.shape
+    if x.ndim != 1 or x.shape[0] != d_model:
+        raise ValueError(f"x must be 1-D of length d_model={d_model}, got shape {tuple(x.shape)}")
+    if not 1 <= max_atoms <= num_atoms:
+        raise ValueError(f"max_atoms must be between 1 and num_atoms={num_atoms}, got {max_atoms}")
+    if num_control_dictionaries < 1:
+        raise ValueError(
+            f"num_control_dictionaries must be at least 1, got {num_control_dictionaries}"
+        )
+
+    target = x.float()
+    atoms = dictionary.float()
+    if not bool(torch.isfinite(atoms).all()):
+        raise ValueError("dictionary contains non-finite entries")
+    atom_norms = (atoms * atoms).sum(dim=1).sqrt()
+    if bool((atom_norms == 0).any()):
+        raise ValueError("dictionary contains a zero-norm atom")
+
+    real_captured_variance, support = _greedy_captured_variance_gains(
+        atoms, atom_norms, target, max_atoms
+    )
+
+    generator = torch.Generator(device=atoms.device).manual_seed(seed)
+    control_atom_norms = torch.ones(num_atoms, device=atoms.device)
+    control_variance_runs: List[torch.Tensor] = []
+    for _ in range(num_control_dictionaries):
+        random_atoms = torch.randn(
+            num_atoms, d_model, generator=generator, device=atoms.device, dtype=atoms.dtype
+        )
+        random_atoms = random_atoms / (random_atoms * random_atoms).sum(dim=1, keepdim=True).sqrt()
+        control_run_variance, _ = _greedy_captured_variance_gains(
+            random_atoms, control_atom_norms, target, max_atoms
+        )
+        control_variance_runs.append(control_run_variance)
+    control_captured_variance = torch.stack(control_variance_runs).mean(dim=0)
+
+    separation = real_captured_variance.cumsum(dim=0) - control_captured_variance.cumsum(dim=0)
+    occupancy = int(torch.argmax(separation).item()) + 1
+    return JSpaceOccupancy(
+        occupancy=occupancy,
+        marginal_captured_variance=real_captured_variance,
+        control_captured_variance=control_captured_variance,
+        support=support,
+    )
+
+
+@dataclass
+class JSpaceVarianceProfile:
+    """Per-layer J-space variance profile over a prompt corpus.
+
+    Produced by :meth:`JacobianLens.fraction_of_variance`.
+
+    Attributes:
+        layers: The source layers profiled, in order.
+        median: Per-layer median over positions of the J-space variance fraction
+            ``||j_space_component||^2 / ||activation||^2``.
+        pooled: Per-layer pooled ratio ``sum(||j_space_component||^2) / sum(||activation||^2)``
+            across the corpus (the paper's "fraction of total variance").
+        per_position: Per-layer 1-D tensor of the raw per-position variance fractions.
+    """
+
+    layers: List[int]
+    median: Dict[int, float]
+    pooled: Dict[int, float]
+    per_position: Dict[int, torch.Tensor]

--- a/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
@@ -473,12 +473,16 @@ class JSpaceOccupancy:
 def _greedy_captured_variance_gains(
     atoms: torch.Tensor, atom_norms: torch.Tensor, target: torch.Tensor, max_atoms: int
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Greedily select up to ``max_atoms`` atoms and return the per-step captured-variance gains.
+    """Greedily select exactly ``max_atoms`` atoms and return captured-variance gains.
 
-    Selection matches :func:`get_sparse_decomposition`: at each step the atom most correlated
-    with the running residual (using unit-normalised atoms) is added. The captured variance at a
-    step is the orthogonal projection of ``target`` onto the selected span,
+    At each step, add the unused atom with the greatest signed, norm-normalized correlation with
+    the current residual. Project ``target`` orthogonally onto the full selected span using a
+    pseudoinverse, then set the next residual to ``target - projection``. The captured variance is
     ``||Pi_S target||^2 / ||target||^2``; the returned values are its per-step increments.
+
+    This shares the per-step correlation rule with :func:`get_sparse_decomposition`, but not its
+    residual recurrence: sparse decomposition uses a nonnegative coefficient-fit residual and may
+    stop early, while this recurrence does not stop early, so the selected supports can differ.
     """
     total_variance = float(target @ target)
     support: List[int] = []
@@ -509,18 +513,21 @@ def estimate_occupancy(
 ) -> JSpaceOccupancy:
     """Estimate how many dictionary atoms are meaningfully active in ``x``.
 
-    Greedily selects up to ``max_atoms`` atoms and compares the real per-step captured-variance
-    curve against the same greedy run on ``num_control_dictionaries`` random unit-norm
-    dictionaries of the same size. The occupancy is the step of maximum separation between the
-    real and (averaged) control *cumulative* captured variance -- the point past which further
-    atoms add no more than random directions would. Deterministic given ``seed`` and needs no
-    threshold. (Captured variance is a projection, hence scale-free, so the random control atoms
-    are simply unit-norm.)
+    Runs the projection-residual recurrence described in
+    :func:`_greedy_captured_variance_gains` for exactly ``max_atoms`` steps and compares the real
+    per-step captured-variance curve against the same recurrence on ``num_control_dictionaries``
+    random unit-norm dictionaries of the same size. This shares sparse decomposition's per-step
+    correlation rule, but uses an unconstrained span-projection residual rather than a nonnegative
+    coefficient-fit residual, so their supports need not match. The occupancy is the step of
+    maximum separation between the real and (averaged) control *cumulative* captured variance --
+    the point past which further atoms add no more than random directions would. Deterministic
+    given ``seed`` and needs no threshold. (Captured variance is a projection, hence scale-free,
+    so the random control atoms are simply unit-norm.)
 
     Args:
         x: Target vector, shape ``[d_model]``.
         dictionary: Atom matrix, shape ``[num_atoms, d_model]`` (rows are atoms).
-        max_atoms: Maximum number of atoms to consider.
+        max_atoms: Number of atoms to select in the real and control recurrences.
         num_control_dictionaries: Number of random control dictionaries to average over.
         seed: Seed for the random control dictionaries (reproducibility).
 
@@ -528,9 +535,10 @@ def estimate_occupancy(
         An :class:`JSpaceOccupancy`.
 
     Raises:
-        ValueError: On a non-2-D dictionary, a target whose length does not match ``d_model``,
-            ``max_atoms`` outside ``[1, num_atoms]``, ``num_control_dictionaries < 1``, or a
-            dictionary with non-finite or zero-norm atoms.
+        ValueError: On complex inputs, a non-2-D dictionary, a target whose length does not match
+            ``d_model``, ``max_atoms`` outside ``[1, num_atoms]``,
+            ``num_control_dictionaries < 1``, a target with non-finite entries or a non-finite or
+            zero norm, or a dictionary with non-finite or zero-norm atoms.
     """
     if dictionary.ndim != 2:
         raise ValueError(
@@ -545,14 +553,23 @@ def estimate_occupancy(
         raise ValueError(
             f"num_control_dictionaries must be at least 1, got {num_control_dictionaries}"
         )
+    if torch.is_complex(x) or torch.is_complex(dictionary):
+        raise ValueError("x and dictionary must be real-valued")
 
     target = x.float()
     atoms = dictionary.float()
+    if not bool(torch.isfinite(target).all()):
+        raise ValueError("x contains non-finite entries")
+    target_squared_norm = target @ target
+    if not bool(torch.isfinite(target_squared_norm)):
+        raise ValueError("x must have finite norm")
+    if float(target_squared_norm) <= 0.0:
+        raise ValueError("x must have non-zero norm")
     if not bool(torch.isfinite(atoms).all()):
         raise ValueError("dictionary contains non-finite entries")
     atom_norms = (atoms * atoms).sum(dim=1).sqrt()
-    if bool((atom_norms == 0).any()):
-        raise ValueError("dictionary contains a zero-norm atom")
+    if not bool(torch.isfinite(atom_norms).all()) or bool((atom_norms == 0).any()):
+        raise ValueError("dictionary contains a non-finite or zero-norm atom")
 
     real_captured_variance, support = _greedy_captured_variance_gains(
         atoms, atom_norms, target, max_atoms


### PR DESCRIPTION
# Description

Adds **occupancy** and **fraction-of-variance** to the Jacobian lens: two J-space profiling statistics that sit on top of the sparse decomposition (#1596), following Gurnee et al. (2026), "Verbalizable Representations Form a Global Workspace in Language Models" (Transformer Circuits Thread). They quantify two of the paper's qualitative claims: that "only a small number of J-lens vectors are strongly active at a time" (occupancy) and that the J-space is "never more than about 10%" of activation variance, "a median of 6 to 7%" for concept vectors (fraction of variance).

This is the Tier-A follow-up the maintainer explicitly deferred from #1596; it builds directly on that PR's greedy selection and cached J-lens dictionary. **Part of #1539 (Tier-A follow-up to #1596).** No new dependencies.

## New public surface (TransformerBridge only, matching the rest of the Jacobian lens)

Model-free core in `transformer_lens/tools/analysis/jacobian_lens_decomposition.py`:

- `estimate_occupancy(x, dictionary, *, max_atoms=25, num_control_dictionaries=32, seed=0)` returns a `JSpaceOccupancy` (`occupancy`, `marginal_captured_variance`, `control_captured_variance`, `support`).

On `JacobianLens` (additive; existing methods unchanged):

- `occupancy(model, activation_or_prompt, layer, *, position=None, max_atoms=25, num_control_dictionaries=32, seed=0)` resolves a raw `[d_model]` activation or a prompt position exactly as `decompose`, then calls `estimate_occupancy` on the cached full-vocabulary dictionary.
- `fraction_of_variance(model, prompts, layers=None, *, k=25, skip_first=16, positions=None, show_progress=False)` profiles a prompt corpus and returns a `JSpaceVarianceProfile` (`layers`, `median`, `pooled`, `per_position`).

`JSpaceOccupancy`, `JSpaceVarianceProfile`, and `estimate_occupancy` are exported from `transformer_lens.tools.analysis`.

## Occupancy: max-separation versus a random-dictionary control

`estimate_occupancy` runs the same greedy selection as `get_sparse_decomposition` up to `max_atoms`, recording the per-step captured variance `||Pi_S x||² / ||x||²` (orthogonal projection onto the selected span). It runs the same greedy on `num_control_dictionaries` random unit-norm dictionaries of equal size and averages their curves. The occupancy is the step of **maximum separation** between the real and control *cumulative* captured variance: the point past which further vectors add no more than random directions would. It is **deterministic** (seeded) and needs **no threshold**.

An earlier per-step quantile-cutoff variant was calibration-sensitive (planted structure wanted `q ≤ 0.75`, a clean noise floor wanted `q ≥ 0.9`, with no single robust value). The max-separation rule recovers planted sparsity exactly on orthonormal dictionaries (`k=1` gives 1, `k=4` gives 4, `k=7` gives 7) with no tuning, so `quantile` was dropped.

## Fraction of variance: the span-projection operationalization

For each `(layer, position)` at or past `skip_first` (mirroring the fit's early-position skip), `fraction_of_variance` records `||j_space_component||² / ||activation||²` and reports, per layer, the `median` of those fractions and the `pooled` ratio `Σ||j_space||² / Σ||activation||²`. The numerator is the `selected_support` **span projection** (the paper's appendix operationalization), **not** the nonnegative `reconstruction`; the two coincide only when every selected atom stays active. This is named explicitly in the docstring and docs so the number is not misread. A layer that samples no positions (every prompt shorter than `skip_first`, or only zero-norm activations) yields `NaN` `median` and `pooled` values and an empty `per_position`. This is a documented, tested contract.

## Tests

- **Model-free unit** (`test_jacobian_lens_decomposition.py`): planted-sparsity recovery (`occupancy == k`), ordering by planted density, determinism, and input validation.
- **Wrapper unit** (`test_jacobian_lens.py`): occupancy raw and prompt paths, `fraction_of_variance` median and pooled over a corpus, unfitted-layer and empty-corpus rejection, and the no-sample `NaN` contract.
- **gpt2-small integration** (`test_jacobian_lens.py`): occupancy is a small positive integer with `[0, 1]`-bounded cumulative captured-variance curves and is seed-deterministic; `fraction_of_variance` median and pooled land in `[0, 1]`, including the `positions=` override path over a multi-prompt corpus.

## Honesty note

The paper's quantitative occupancy and variance figures are **closed-model** results (Sonnet, Haiku, Opus). Tests and docs assert **shape** (occupancy is a small positive integer; the variance fraction is a small ratio in `[0, 1]`), not the paper's exact numbers, which are not expected to transfer to open weights.

## Docs

A new "Occupancy and fraction of variance" subsection in the "Sparse decomposition" section of `jacobian_lens_fitting.md`, with runnable snippets and the open-weight, shape-only caveat.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Screenshots

Not applicable. This adds an analysis API plus a docs page, with no visual output.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Verification run locally

The change is confined to `transformer_lens/tools/analysis/jacobian_lens*`, so the local run was scoped to the Jacobian-lens surface; CI re-runs the full suite across Python 3.10, 3.11, and 3.12.

- `check-format`: clean under the CI-pinned **black 23.12.1** plus isort (profile=black) on all changed files.
- `mypy`: Success, no issues in the two analysis modules.
- **unit plus integration plus docstring (not slow)**: one pytest invocation over `tests/unit/tools/test_jacobian_lens.py`, `test_jacobian_lens_decomposition.py`, `tests/integration/test_jacobian_lens.py`, and (docstring tier, `--doctest-modules --doctest-plus`) both analysis modules: **246 passed, 4 deselected** (the deselected are the slow `gemma-2-2b-it` cases).
- `build-docs` (Sphinx): builds clean (exit 0) with notebooks excluded; the new page and API entries render. The only warnings touching the new dataclasses are the pre-existing `duplicate object description` re-export pattern (identical to `JSpaceDecomposition`; `-W` is disabled in `conf.py` for exactly this), so no new warning class is introduced. A full local `build-docs` additionally needs `pandoc` for the demo notebooks, absent on this box and present in CI.
- Real-model integration: GPT-2 `occupancy` returns a small positive integer with `[0, 1]`-bounded captured-variance curves, and `fraction_of_variance` returns per-layer `median` and `pooled` ratios in `[0, 1]`.
