### PR TITLE
Fix batchless accumulated residual normalization

### DIFF
--- a/tests/unit/test_activation_cache.py
+++ b/tests/unit/test_activation_cache.py
@@ -1,0 +1,63 @@
+import pytest
+import torch
+
+from transformer_lens import ActivationCache
+from transformer_lens.config import TransformerBridgeConfig
+from transformer_lens.model_bridge import TransformerBridge
+
+
+@pytest.fixture(scope="module", params=["LN", "RMS"])
+def activation_cache(request: pytest.FixtureRequest) -> ActivationCache:
+    cfg = TransformerBridgeConfig(
+        n_layers=2,
+        d_model=16,
+        n_ctx=8,
+        d_head=4,
+        n_heads=4,
+        d_vocab=32,
+        act_fn="gelu",
+        normalization_type=request.param,
+    )
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(0)
+        model = TransformerBridge.boot_native(cfg)
+    tokens = torch.tensor(
+        [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12],
+        ]
+    )
+    _, cache = model.run_with_cache(tokens)
+    return cache
+
+
+@pytest.mark.parametrize("layer", [1, -1], ids=["cached-scale", "recomputed-final-ln"])
+@pytest.mark.parametrize(
+    "pos_slice", [None, (1, 3), -1], ids=["all-positions", "position-slice", "scalar-position"]
+)
+@pytest.mark.parametrize("apply_ln", [False, True], ids=["raw", "normalized"])
+def test_batchless_accumulated_resid_matches_batched_row(
+    activation_cache: ActivationCache,
+    layer: int,
+    pos_slice: tuple[int, int] | int | None,
+    apply_ln: bool,
+) -> None:
+    batch_index = 1
+    batched = activation_cache.accumulated_resid(
+        layer=layer,
+        pos_slice=pos_slice,
+        apply_ln=apply_ln,
+    )
+
+    batchless_cache = activation_cache.apply_slice_to_batch_dim(batch_index)
+    assert not batchless_cache.has_batch_dim
+    batchless = batchless_cache.accumulated_resid(
+        layer=layer,
+        pos_slice=pos_slice,
+        apply_ln=apply_ln,
+    )
+
+    expected = batched[:, batch_index]
+    assert batchless.shape == expected.shape
+    torch.testing.assert_close(batchless, expected)

--- a/transformer_lens/ActivationCache.py
+++ b/transformer_lens/ActivationCache.py
@@ -521,6 +521,7 @@ class ActivationCache:
                 layer,
                 pos_slice=pos_slice,
                 mlp_input=mlp_input,
+                has_batch_dim=self.has_batch_dim,
                 recompute_ln=recompute_ln,
             )
         if return_labels:
@@ -1402,17 +1403,17 @@ class ActivationCache:
         # Logit lens: apply final layer norm to each component with recomputed statistics
         if recompute_ln and layer == self.model.cfg.n_layers and hasattr(self.model, "ln_final"):
             ln_final = self.model.ln_final
-            had_pos_dim = residual_stack.ndim == 4
             results = []
             for i in range(residual_stack.shape[0]):
                 x = residual_stack[i]
-                # ln_final expects (batch, pos, d_model); ensure pos dim present
+                original_shape = x.shape
+                # ln_final expects (batch, pos, d_model); restore missing structural dimensions
+                if not has_batch_dim:
+                    x = x.unsqueeze(0)
                 if x.ndim == 2:
                     x = x.unsqueeze(1)
                 out = ln_final(x)
-                if not had_pos_dim:
-                    out = out.squeeze(1)
-                results.append(out)
+                results.append(out.reshape(original_shape))
             return torch.stack(results, dim=0)
 
         # Center the stack onlny if the model uses LayerNorm


### PR DESCRIPTION
# Description

Fix `ActivationCache.accumulated_resid(..., apply_ln=True)` for caches whose batch dimension has been removed before selecting a scalar position.

The final-normalization recomputation path previously inferred batch and position semantics only from tensor rank. A batchless scalar residual stack has shape `[components, d_model]`, so each component reached `ln_final` as a one-dimensional tensor and then failed when the code attempted `squeeze(1)`.

`accumulated_resid()` now forwards the cache's explicit `has_batch_dim` state. The recomputation path temporarily restores the structural batch and position dimensions expected by `ln_final`, then reshapes each result back to its original component shape.

The new download-free regression matrix uses tiny native LN and RMS models. It compares batchless outputs against the corresponding row of the batched result across scalar, sliced, and unsliced positions, with and without normalization, for both cached-scale and final-normalization recomputation paths.

Fixes #1677

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Validation

- `66 passed` across the new unit regression matrix and the existing `tests/acceptance/test_activation_cache.py` surface
- `mypy .`: success across 434 source files
- pycln, isort, Black, and `git diff --check`: clean

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

No documentation text changes are required because this restores the existing batchless `ActivationCache` shape contract without changing the public API.
