### PR TITLE
Fixing edge cases on heterogeneous configs

### DIFF
--- a/tests/unit/model_bridge/test_config_mapping.py
+++ b/tests/unit/model_bridge/test_config_mapping.py
@@ -258,3 +258,57 @@ def test_bridge_config_retains_per_layer_fields() -> None:
     )
     assert bridge_config.per_layer_head_dim == [256] * 5 + [512]
     assert bridge_config.per_layer_num_key_value_heads == [16] * 5 + [4]
+
+
+def test_softcap_reads_survive_per_layer_registration() -> None:
+    """The softcap getattrs sat below the het-protected passthrough loop; a
+    per-layer-registered softcap field raised straight through the default."""
+    config = _HeterogeneousConfig(
+        {"final_logit_softcapping": [30.0, 30.0, 30.0, 30.0, 30.0, 30.0]},
+        **_GEMMA4_GLOBALS,
+        num_attention_heads=4,
+        head_dim=4,
+    )
+    from transformer_lens.model_bridge.sources._bridge_builder import (
+        build_bridge_config_from_hf,
+    )
+
+    bridge_config = build_bridge_config_from_hf(config, "TestArch", "test-model", torch.float32)
+    assert bridge_config.output_logits_soft_cap == 30.0
+
+
+def test_rotary_pct_chain_survives_per_layer_registration() -> None:
+    """hasattr does NOT suppress the het raise; the chain probes rotary_pct
+    and rope_parameters directly."""
+    from transformer_lens.utilities.hf_utils import get_rotary_pct_from_config
+
+    config = _HeterogeneousConfig(
+        {"rotary_pct": [0.25, 0.25, 0.25, 0.25, 0.25, 0.25]},
+        **_GEMMA4_GLOBALS,
+    )
+    assert get_rotary_pct_from_config(config) == 0.25
+
+
+def test_rotary_chain_survives_dict_valued_per_layer_rope() -> None:
+    """rope_parameters is dict-valued in 5.x, and per-layer rope is the natural
+    shape for layer-typed models. majority_value counted by HASHING, so the
+    unhashable value raised TypeError inside the safety machinery itself —
+    which hasattr does not suppress."""
+    from transformer_lens.utilities.hf_utils import get_rotary_pct_from_config
+
+    config = _HeterogeneousConfig(
+        {"rope_parameters": [{"partial_rotary_factor": 0.5}] * 6},
+        **_GEMMA4_GLOBALS,
+    )
+    assert get_rotary_pct_from_config(config) == 0.5
+
+
+def test_majority_value_counts_unhashables_by_equality() -> None:
+    from transformer_lens.utilities.heterogeneous_config import majority_value
+
+    sliding = {"rope_theta": 10_000.0}
+    full = {"rope_theta": 1_000_000.0}
+    assert majority_value([sliding, full, sliding]) == sliding
+    # Tie-break toward the earliest layer, as before for hashables.
+    assert majority_value([full, sliding]) == full
+    assert majority_value([3, 3, 7]) == 3

--- a/tests/unit/model_bridge/test_stack_block_params_hybrid.py
+++ b/tests/unit/model_bridge/test_stack_block_params_hybrid.py
@@ -1,0 +1,58 @@
+"""_stack_block_params on interleaved-MoE (hybrid) models.
+
+The filter matched on the FIRST path segment only, and every block has `mlp` —
+so nothing was filtered and the sparse layer's AttributeError killed the
+accessor for the whole model instead of returning the dense layers.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from transformer_lens.model_bridge.bridge import TransformerBridge
+
+
+class _DenseMLP(torch.nn.Module):
+    def __init__(self, value: float) -> None:
+        super().__init__()
+        self.W_in = torch.full((4, 8), value)
+
+
+class _SparseMLP(torch.nn.Module):
+    """MoE layer: per-expert weights, no single W_in."""
+
+    @property
+    def W_in(self):
+        raise AttributeError("W_in exists only on dense layers")
+
+
+class _Block(torch.nn.Module):
+    def __init__(self, mlp) -> None:
+        super().__init__()
+        self.mlp = mlp  # nn.Module assignment registers into _modules
+
+
+def _stub(mlps):
+    return SimpleNamespace(
+        blocks=[_Block(m) for m in mlps],
+        cfg=SimpleNamespace(n_devices=1, device=None),
+    )
+
+
+def test_interleaved_model_stacks_dense_layers_only(caplog) -> None:
+    stub = _stub([_DenseMLP(0.0), _SparseMLP(), _DenseMLP(2.0)])
+    with caplog.at_level("WARNING"):
+        stacked = TransformerBridge._stack_block_params(stub, "mlp.W_in")
+    assert stacked.shape == (2, 4, 8)
+    assert torch.equal(stacked[1], torch.full((4, 8), 2.0))
+    # The hybrid warning must carry the index mapping, as designed.
+    assert any("only 2/3 blocks" in record.getMessage() for record in caplog.records)
+
+
+def test_all_sparse_raises_with_the_full_path() -> None:
+    stub = _stub([_SparseMLP(), _SparseMLP()])
+    with pytest.raises(AttributeError, match="mlp.W_in"):
+        TransformerBridge._stack_block_params(stub, "mlp.W_in")

--- a/tests/unit/pretrained_weight_conversions/test_gemma.py
+++ b/tests/unit/pretrained_weight_conversions/test_gemma.py
@@ -319,3 +319,40 @@ class TestGemmaDeviceConsistency:
             w_out = state_dict[f"blocks.{layer}.mlp.W_out"]
             b_out = state_dict[f"blocks.{layer}.mlp.b_out"]
             assert w_out.device == b_out.device
+
+
+class MockGemma5xMultimodalModel(nn.Module):
+    """transformers 5.x shape: language_model moved UNDER .model."""
+
+    def __init__(self, cfg: HookedTransformerConfig):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.language_model = nn.Module()
+        base = self.model.language_model
+        base.embed_tokens = nn.Embedding(cfg.d_vocab, cfg.d_model)
+        base.norm = nn.LayerNorm(cfg.d_model)
+        base.layers = nn.ModuleList(
+            [MockGemmaLayer(cfg, use_qk_norm=cfg.use_qk_norm) for _ in range(cfg.n_layers)]
+        )
+
+
+class TestGemma5xMultimodalDetection:
+    """5.x moved language_model under .model; the old top-level probe silently
+    reported text-only there and converted the multimodal model down the
+    wrong path (reading .model as if it were the text transformer)."""
+
+    def test_5x_shape_converts_the_language_model(self):
+        cfg = get_gemma3_config()
+        model = MockGemma5xMultimodalModel(cfg)
+        state_dict = convert_gemma_weights(model, cfg)
+        expected = model.model.language_model.embed_tokens.weight
+        # Gemma scales embeddings by sqrt(d_model); undo it to pin the source.
+        import math
+
+        torch.testing.assert_close(state_dict["embed.W_E"] / math.sqrt(cfg.d_model), expected)
+
+    def test_4x_shape_still_converts(self):
+        cfg = get_gemma3_config()
+        model = MockGemmaMultimodalModel(cfg)
+        state_dict = convert_gemma_weights(model, cfg)
+        assert "embed.W_E" in state_dict

--- a/tests/unit/test_loading_from_pretrained_utilities.py
+++ b/tests/unit/test_loading_from_pretrained_utilities.py
@@ -306,7 +306,7 @@ def test_fill_missing_keys_raises_on_missing_attention_weights():
         k: v for k, v in default_state_dict.items() if not k.endswith("attn.W_K")
     }
 
-    with pytest.raises(ValueError, match="attention weight matrices"):
+    with pytest.raises(ValueError, match="missing weight matrices"):
         fill_missing_keys(model, incomplete_state_dict)
 
 
@@ -498,3 +498,72 @@ class TestArchitectureConfigs:
         cfg_dict = convert_hf_model_config(str(tmp_path))
 
         assert cfg_dict["parallel_attn_mlp"] is use_parallel_residual
+
+
+class TestHetConfigThroughConvertHfModelConfig:
+    """convert_hf_model_config had zero het protection: transformers>=5.15
+    per-layer fields raise (not AttributeError) on global reads, so the branch
+    chain's own hasattr probes were crash sites."""
+
+    @mock.patch("transformer_lens.loading_from_pretrained.AutoConfig")
+    def test_per_layer_field_resolves_to_majority(self, mock_auto_config: mock.MagicMock):
+        from tests.unit.model_bridge.test_config_mapping import _HeterogeneousConfig
+        from transformer_lens.loading_from_pretrained import convert_hf_model_config
+
+        mock_auto_config.from_pretrained.return_value = _HeterogeneousConfig(
+            {"scale_attn_by_inverse_layer_idx": [False, False]},
+            architectures=["GPT2LMHeadModel"],
+            n_embd=128,
+            n_head=4,
+            n_layer=2,
+            num_hidden_layers=2,
+            n_ctx=1024,
+            layer_norm_epsilon=1e-5,
+            vocab_size=50257,
+            activation_function="gelu_new",
+        )
+        cfg_dict = convert_hf_model_config("gpt2")
+        assert cfg_dict["scale_attn_by_inverse_layer_idx"] is False
+
+
+class TestFillMissingKeysFailLoud:
+    """Zero-filling an MLP weight matrix is the same silent-sublayer-death as
+    the attention case; norm fills are frequently right but must be named."""
+
+    @staticmethod
+    def _model_and_state(missing_leaf):
+        cfg = get_default_config()
+        cfg.attn_only = False
+        model = HookedTransformer(
+            HookedTransformerConfig(
+                d_model=128,
+                d_head=8,
+                n_heads=16,
+                n_ctx=128,
+                n_layers=1,
+                d_vocab=50257,
+                d_mlp=256,
+                act_fn="relu",
+            )
+        )
+        state_dict = model.state_dict()
+        removed = [key for key in state_dict if key.rsplit(".", 1)[-1] == missing_leaf]
+        assert removed, f"fixture produced no {missing_leaf} keys"
+        for key in removed:
+            del state_dict[key]
+        return model, state_dict
+
+    @pytest.mark.parametrize("leaf", ["W_in", "W_out"])
+    def test_missing_mlp_matrices_raise(self, leaf):
+        model, state_dict = self._model_and_state(leaf)
+        with pytest.raises(ValueError, match=leaf):
+            fill_missing_keys(model, state_dict)
+
+    @mock.patch("logging.warning")
+    def test_missing_norm_keys_warn_by_name(self, mock_warning: mock.MagicMock):
+        model, state_dict = self._model_and_state("w")
+        fill_missing_keys(model, state_dict)
+        norm_warnings = [
+            call for call in mock_warning.call_args_list if "normalization" in str(call.args[0])
+        ]
+        assert norm_warnings, "norm fills must be named, not silent"

--- a/tests/unit/test_optional_submodule.py
+++ b/tests/unit/test_optional_submodule.py
@@ -281,7 +281,7 @@ class TestStackBlockParams:
 
     def test_raises_when_no_blocks_match(self):
         bridge = _make_hybrid_bridge()
-        with pytest.raises(AttributeError, match="No blocks have"):
+        with pytest.raises(AttributeError, match="No blocks resolve"):
             bridge._stack_block_params("nonexistent")
 
     def test_succeeds_on_universal_submodule(self):

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -58,6 +58,7 @@ from transformer_lens.pretrained.weight_conversions import (
     convert_t5_weights,
 )
 from transformer_lens.supported_models import MODEL_ALIASES, OFFICIAL_MODEL_NAMES
+from transformer_lens.utilities.heterogeneous_config import het_safe_view
 from transformer_lens.utilities.hf_utils import get_rotary_pct_from_config
 from transformer_lens.utilities.quantization import (
     quantization_method,
@@ -170,6 +171,10 @@ def convert_hf_model_config(model_name: str, **kwargs: Any) -> dict[str, Any]:
             token=huggingface_token if len(huggingface_token) > 0 else None,
             **kwargs,
         )
+        # het view: transformers>=5.15 per-layer fields raise (not
+        # AttributeError) on global reads, so every hasattr/getattr probe in
+        # the branch chain below is a crash site without it.
+        hf_config = het_safe_view(hf_config)
         architecture = hf_config.architectures[0]
 
     cfg_dict: dict[str, Any]
@@ -2193,29 +2198,51 @@ def fill_missing_keys(
     # mismatch (e.g. W_K written where GroupedQueryAttention expects _W_K).
     # Filling it with an empty tensor silently zeroes the sublayer while every
     # downstream number still looks plausible — fail loudly instead.
-    attention_weight_names = {"W_Q", "W_K", "W_V", "W_O", "_W_K", "_W_V"}
-    missing_attention_weights = sorted(
+    # W_in/W_gate/W_out join the attention set: zero-filling an MLP matrix is
+    # the same silent-sublayer-death, just on the other branch.
+    fail_loud_weight_names = {
+        "W_Q",
+        "W_K",
+        "W_V",
+        "W_O",
+        "_W_K",
+        "_W_V",
+        "W_in",
+        "W_gate",
+        "W_out",
+    }
+    missing_fail_loud = sorted(
         key
         for key in missing_keys
-        if "hf_model" not in key and key.rsplit(".", 1)[-1] in attention_weight_names
+        if "hf_model" not in key and key.rsplit(".", 1)[-1] in fail_loud_weight_names
     )
-    if missing_attention_weights:
+    if missing_fail_loud:
         raise ValueError(
-            f"Pretrained state dict is missing attention weight matrices the model "
-            f"expects: {missing_attention_weights}. This usually means the weight "
-            f"converter and the instantiated attention module disagree on parameter "
+            f"Pretrained state dict is missing weight matrices the model "
+            f"expects: {missing_fail_loud}. This usually means the weight "
+            f"converter and the instantiated module disagree on parameter "
             f"naming (e.g. GQA's underscore-prefixed _W_K/_W_V vs W_K/W_V). Refusing "
             f"to zero-fill them, which would silently produce wrong outputs."
         )
+    # Norm weights fill with DEFAULTS (w=1, b=0), which is frequently correct
+    # (models without biases) but silently wrong when the checkpoint really has
+    # them — so the fill is named, not silent.
+    norm_key_names = {"w", "b"}
     for key in missing_keys:
         if "hf_model" in key:
             # Skip keys that are from the HuggingFace model, if loading from HF.
             continue
+        leaf = key.rsplit(".", 1)[-1]
         if "W_" in key:
             logging.warning(
                 "Missing key for a weight matrix in pretrained, filled in with an empty tensor: {}".format(
                     key
                 )
+            )
+        elif leaf in norm_key_names and ("ln" in key or "norm" in key):
+            logging.warning(
+                "Missing normalization key in pretrained, filled with its default "
+                "(identity norm): {}".format(key)
             )
         state_dict[key] = default_state_dict[key]
     return state_dict

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -1419,43 +1419,48 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
     ) -> torch.Tensor:
         """Stack a parameter across all blocks; falls back to matching-only on hybrids.
 
-        On hybrid models, logs a warning about index mapping and returns only
-        blocks that have the submodule. First path segment is checked against
-        _modules; deeper segments resolve via getattr (intentional — W_Q etc.
-        are exposed via __getattr__ delegation).
+        Filters on FULL-path resolution, not the first segment: on interleaved
+        MoE, every block has `mlp` but only dense layers expose `mlp.W_in`, so
+        a first-segment filter matched everything and the sparse layer's
+        AttributeError killed the accessor for the whole model.
         """
         first_attr = attr_path.split(".")[0]
-        matching_blocks = [
-            (i, block) for i, block in enumerate(self.blocks) if first_attr in block._modules
-        ]
+        matching_blocks = []
+        for i, block in enumerate(self.blocks):
+            if first_attr not in block._modules:
+                continue
+            try:
+                weight = _resolve_attr_path(block, attr_path)
+            except AttributeError:
+                continue
+            matching_blocks.append((i, weight))
 
         if len(matching_blocks) == 0:
             raise AttributeError(
-                f"No blocks have submodule '{first_attr}'. "
+                f"No blocks resolve '{attr_path}'. "
                 f"Use bridge.blocks_with('{first_attr}') to check availability."
             )
 
         if len(matching_blocks) < len(self.blocks):
             indices = [i for i, _ in matching_blocks]
             logging.warning(
-                "Hybrid model: only %d/%d blocks have '%s'. Returning stacked tensor "
+                "Hybrid model: only %d/%d blocks resolve '%s'. Returning stacked tensor "
                 "for layers %s only. Tensor index i corresponds to original layer "
                 "indices[i], not layer i. For explicit index mapping, use "
                 "bridge.stack_params_for('%s', '%s').",
                 len(matching_blocks),
                 len(self.blocks),
-                first_attr,
+                attr_path,
                 indices,
                 first_attr,
                 attr_path,
             )
 
         weights: List[torch.Tensor] = []
-        for _, block in matching_blocks:
-            w = _resolve_attr_path(block, attr_path)
+        for _, weight in matching_blocks:
             if reshape_fn is not None:
-                w = reshape_fn(w)
-            weights.append(w)
+                weight = reshape_fn(weight)
+            weights.append(weight)
         # Under a device_map split, per-block tensors live on different devices.
         # torch.stack requires a common device; gather onto cfg.device (the embedding /
         # input device — a natural "home" for cross-layer reductions).

--- a/transformer_lens/model_bridge/sources/_bridge_builder.py
+++ b/transformer_lens/model_bridge/sources/_bridge_builder.py
@@ -13,7 +13,11 @@ from transformer_lens.factories.architecture_adapter_factory import (
 )
 from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
 from transformer_lens.model_bridge.bridge import TransformerBridge
-from transformer_lens.utilities.heterogeneous_config import per_layer_attr_names
+from transformer_lens.utilities.heterogeneous_config import (
+    het_safe_view,
+    per_layer_attr_names,
+    safe_config_get,
+)
 
 # Architecture-agnostic; do not extend per-architecture.
 _HF_PASSTHROUGH_ATTRS = [
@@ -195,7 +199,10 @@ def build_bridge_config_from_hf(
         if val is not None:
             setattr(bridge_config, attr, val)
 
-    # Gemma2: HF softcap field names differ from TL's.
+    # Gemma2: HF softcap field names differ from TL's. Read through the het
+    # view: a per-layer-registered field raises (not AttributeError) on raw
+    # getattr, so the default would not save us.
+    effective_config = het_safe_view(effective_config)
     final_logit_softcapping = getattr(effective_config, "final_logit_softcapping", None)
     if final_logit_softcapping is not None:
         bridge_config.output_logits_soft_cap = float(final_logit_softcapping)
@@ -209,9 +216,13 @@ def build_bridge_config_from_hf(
     # Nested encoder sub-configs (T5Gemma family): n_heads/n_key_value_heads are
     # decoder-effective, so expose encoder head counts for per-side conversions.
     # T5Gemma2 nests them one level deeper (encoder.text_config).
-    encoder_subconfig = getattr(hf_config, "encoder", None)
+    encoder_subconfig = safe_config_get(hf_config, "encoder")
+    if encoder_subconfig is not None:
+        encoder_subconfig = het_safe_view(encoder_subconfig)
     if encoder_subconfig is not None and not hasattr(encoder_subconfig, "num_attention_heads"):
-        encoder_subconfig = getattr(encoder_subconfig, "text_config", None)
+        encoder_subconfig = safe_config_get(encoder_subconfig, "text_config")
+        if encoder_subconfig is not None:
+            encoder_subconfig = het_safe_view(encoder_subconfig)
     if encoder_subconfig is not None:
         enc_heads = getattr(encoder_subconfig, "num_attention_heads", None)
         if enc_heads is not None:

--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -709,7 +709,9 @@ def boot(
         if val is not None:
             setattr(bridge_config, attr, val)
 
-    # Gemma2 softcapping: HF names differ from TL names, need explicit mapping
+    # Gemma2 softcapping: HF names differ from TL names. het view: per-layer
+    # fields raise (not AttributeError) on raw getattr.
+    effective_config = het_safe_view(effective_config)
     final_logit_softcapping = getattr(effective_config, "final_logit_softcapping", None)
     if final_logit_softcapping is not None:
         bridge_config.output_logits_soft_cap = float(final_logit_softcapping)

--- a/transformer_lens/pretrained/weight_conversions/gemma.py
+++ b/transformer_lens/pretrained/weight_conversions/gemma.py
@@ -10,21 +10,17 @@ def convert_gemma_weights(gemma, cfg: HookedTransformerConfig):
     assert cfg.n_key_value_heads is not None  # keep mypy happy
     assert cfg.d_mlp is not None  # keep mypy happy
 
-    # Check if this is a multimodal model (Gemma3ForConditionalGeneration)
-    # Multimodal models have language_model attribute, text-only models don't
-    is_multimodal = hasattr(gemma, "language_model")
+    # Multimodal detection must survive transformers 5.x, which moved
+    # Gemma3ForConditionalGeneration's language_model under .model — the old
+    # top-level probe silently reported text-only there and converted the
+    # multimodal model down the wrong path.
+    language_model = getattr(gemma, "language_model", None)
+    if language_model is None:
+        language_model = getattr(getattr(gemma, "model", None), "language_model", None)
 
-    # Get the actual model
-    # For multimodal: gemma.language_model.model is Gemma3TextModel which has layers/embed_tokens
-    # For text-only: gemma has .model which contains layers/embed_tokens
-    if is_multimodal:
-        # Multimodal structure: gemma.language_model.model contains the text transformer
-        # We skip gemma.vision_tower entirely to save memory
-        if hasattr(gemma.language_model, "model"):
-            base_model = gemma.language_model.model
-        else:
-            # Fallback if structure is different
-            base_model = gemma.language_model
+    if language_model is not None:
+        # Vision tower is skipped entirely; only the text transformer converts.
+        base_model = getattr(language_model, "model", language_model)
     else:
         # Text-only Gemma3ForCausalLM has .model wrapper
         base_model = gemma.model

--- a/transformer_lens/utilities/heterogeneous_config.py
+++ b/transformer_lens/utilities/heterogeneous_config.py
@@ -29,11 +29,23 @@ def per_layer_values(config: Any, name: str) -> list:
 
 
 def majority_value(values: list) -> Any:
-    """Most common value in a per-layer list; ties break toward the earliest layer."""
-    counts: dict = {}
-    for v in values:
-        counts[v] = counts.get(v, 0) + 1
-    return max(counts, key=lambda v: (counts[v], -values.index(v)))
+    """Most common value in a per-layer list; ties break toward the earliest layer.
+
+    Counts by equality, not hashing: per-layer values can be dicts
+    (rope_parameters in 5.x), and a TypeError here escapes hasattr
+    """
+    distinct: list = []
+    counts: list[int] = []
+    for value in values:
+        for index, seen in enumerate(distinct):
+            if seen == value:
+                counts[index] += 1
+                break
+        else:
+            distinct.append(value)
+            counts.append(1)
+    best = max(range(len(distinct)), key=lambda i: (counts[i], -values.index(distinct[i])))
+    return distinct[best]
 
 
 def safe_config_get(config: Any, name: str, default: Any = None) -> Any:

--- a/transformer_lens/utilities/hf_utils.py
+++ b/transformer_lens/utilities/hf_utils.py
@@ -136,6 +136,11 @@ def get_rotary_pct_from_config(config: Any) -> float:
     if config is None:
         return 1.0
 
+    # het view: hasattr does NOT suppress the per-layer-registered raise.
+    from transformer_lens.utilities.heterogeneous_config import het_safe_view
+
+    config = het_safe_view(config)
+
     # Try the old attribute first (transformers v4)
     if hasattr(config, "rotary_pct"):
         return getattr(config, "rotary_pct", 1.0)


### PR DESCRIPTION
# Description

Three small correctness items from the sweep's fix order (8, 10, 11), bundled because each is a few lines plus tests.

- Raw config reads routed through the het helper – transformers>=5.15 heterogeneous configs raise, so neither `hasattr` nor `getattr(..., default)` suppresses it. On any global read of a per-layer-registered field. Four sites still read raw: the Gemma2 softcap `getattr`s in `_bridge_builder.py` and their twin in `sources/transformers.py`'s boot; the T5Gemma encoder-subconfig probes; `get_rotary_pct_from_config`'s `hasattr` chain; and `HookedTransformer`'s `convert_hf_model_config`, which had zero het protection across its whole branch chain. All now read through `het_safe_view`/`safe_config_get` (transparent for ordinary configs). 
- `fill_missing_keys` fail-loud set extended – Zero-filling a missing `W_in`/`W_gate`/`W_out` is the same silent-sublayer-death as the attention case #1620 established, the MLP branch just dies instead. Those leaves now raise alongside the attention set and missing norm keys warn by name instead of filling silently.
- `_stack_block_params` filters on full-path resolution – It filtered hybrids on the first path segment only. On interleaved MoE every block has `mlp`, so nothing was filtered and the sparse layer's `AttributeError` killed `bridge.W_in`/`W_gate`/`W_out` for the whole model. It now resolves the full path per block and skips non-resolving layers, so the existing hybrid warning finally does the job it was written for. 
- `gemma.py` recognizes transformers 5.x's multimodal layout – 5.x moved `Gemma3ForConditionalGeneration.language_model` under `.model`. The old top-level `hasattr` probe silently reported *text-only* there and converted the multimodal model down the wrong path. TL's own load path worked only by chance (it loads via `AutoModel`, whose return does carry top-level `.language_model`), but a user-supplied `hf_model=` hit it. The probe now checks both locations.
- `majority_value` crashed on unhashable per-layer values – It counted by hashing (`counts[v]`), so a dict-valued per-layer field such as `rope_parameters` raised TypeError *inside the safety machinery itself*, at exactly the sites this PR routes through it. Reproduced against `get_rotary_pct_from_config`, then fixed by counting by equality in the one shared function, covering `safe_config_get` and the view together. Tie-break-toward-earliest-layer semantics preserved and pinned for hashables too. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x]  I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my 
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility