### PR TITLE
Fix TransformerBridge parameter counting

### DIFF
--- a/tests/unit/model_bridge/test_n_params_total.py
+++ b/tests/unit/model_bridge/test_n_params_total.py
@@ -1,0 +1,27 @@
+"""Tests for ``TransformerBridge.n_params_total`` on real model layouts."""
+
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+
+from transformer_lens.model_bridge import TransformerBridge
+
+
+@pytest.mark.parametrize("model_name", ["gpt2", "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"])
+def test_n_params_total_matches_uninstrumented_model(model_name: str) -> None:
+    hf_model = AutoModelForCausalLM.from_pretrained(
+        model_name, dtype=torch.float32, attn_implementation="eager"
+    )
+    expected = sum(parameter.numel() for parameter in hf_model.parameters())
+    bridge = TransformerBridge.boot_transformers(model_name, hf_model=hf_model)
+    bridge.enable_compatibility_mode()
+    assert bridge.n_params_total == expected
+
+    if "Qwen2" in model_name:
+        tl_parameters = bridge.tl_parameters()
+        for name in ("W_K", "W_V"):
+            weight = tl_parameters[f"blocks.0.attn.{name}"]
+            assert weight.shape[0] == bridge.cfg.n_heads
+            assert torch.count_nonzero(weight)
+        assert not torch.count_nonzero(tl_parameters["pos_embed.W_pos"])
+        assert bridge.n_params_total < sum(p.numel() for p in tl_parameters.values())

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -198,6 +198,7 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             tokenizer: The tokenizer to use (required)
         """
         super().__init__()
+        self._n_params_total = sum(parameter.numel() for parameter in model.parameters())
         self.__dict__["original_model"] = model
         self.adapter = adapter
         self.cfg = adapter.cfg
@@ -843,18 +844,17 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
 
     @property
     def n_params_total(self) -> int:
-        """Total number of parameters in the model, including embeddings, biases,
-        and layer norm weights.
+        """Number of parameters in the wrapped model before bridge instrumentation.
 
-        Mirrors :attr:`HookedTransformer.n_params_total`. Use this when you want
-        the actual parameter count for memory budgeting, comparison with
-        HuggingFace's ``model.num_parameters()``, or alignment with reported
-        model sizes in papers (e.g. the Pythia suite).
+        This follows PyTorch's parameter iteration semantics, counting tied
+        parameters once. Bridge-created split views and synthetic zero tensors
+        are excluded, so the result can differ from
+        :attr:`HookedTransformer.n_params_total` and :meth:`tl_parameters`.
 
         Returns:
-            int: ``sum(p.numel() for p in self.parameters())``
+            int: Parameter count of the uninstrumented wrapped model.
         """
-        return sum(p.numel() for p in self.parameters())
+        return self._n_params_total
 
     def clear_hook_registry(self) -> None:
         """Clear the hook registry and force re-initialization."""


### PR DESCRIPTION
# Description

Make `TransformerBridge.n_params_total` preserve the wrapped model's ordinary PyTorch parameter count from before bridge instrumentation. This counts tied parameters once and excludes bridge-created split projection views and synthetic analysis tensors, so fused/GQA layouts and RoPE's fabricated `pos_embed.W_pos` cannot inflate the result.

The property docstring now states this convention and its intentional difference from `HookedTransformer.n_params_total` and `tl_parameters()`. Regression coverage uses both GPT-2 and the CI-cached `trl-internal-testing/tiny-Qwen2ForCausalLM-2.5`, with explicit checks for nonzero GQA K/V tensors and the synthetic RoPE placeholder.

Fixes #1691

Dependencies: N/A.

Validation:

- `uv run pytest tests/unit/model_bridge/test_n_params_total.py tests/unit/model_bridge/test_get_params_util.py -q` — 10 passed
- `make check-format` — passed
- `uv run mypy .` — passed (388 source files)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (N/A)
- [ ] Breaking change (N/A)
- [x] This change requires a documentation update (included in the property docstring)

### Screenshots

N/A — this change has no user-interface output.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
