### PR TITLE
Fix compatibility attention mask sentinel

### DIFF
--- a/tests/integration/model_bridge/compatibility/test_bridge_cache_behavior.py
+++ b/tests/integration/model_bridge/compatibility/test_bridge_cache_behavior.py
@@ -128,9 +128,8 @@ class TestCacheEqualityWithHookedTransformer:
     def test_cache_values_match(self, bridge_compat, reference_ht):
         """Cache activations should match between bridge and HookedTransformer.
 
-        Note: Raw attention scores use different masking sentinels:
-        HookedTransformer uses -inf, Bridge uses torch.finfo(dtype).min.
-        Unmasked scores and resulting patterns should still match.
+        Compatibility mode normalizes masked attention scores to -inf, matching
+        HookedTransformer. Unmasked scores and resulting patterns should match.
         """
         prompt = "Hello World!"
         _, bridge_cache = bridge_compat.run_with_cache(prompt)
@@ -148,7 +147,7 @@ class TestCacheEqualityWithHookedTransformer:
             ), f"Shape mismatch for {hook}: {ht_act.shape} vs {bridge_act.shape}"
 
             if hook == "blocks.0.attn.hook_attn_scores":
-                # Different masking sentinels — compare only unmasked positions
+                # Compare the informative, unmasked scores separately.
                 masked = torch.isinf(ht_act)
                 unmasked = ~masked
                 assert torch.allclose(

--- a/tests/integration/model_bridge/test_attention_score_sentinel.py
+++ b/tests/integration/model_bridge/test_attention_score_sentinel.py
@@ -1,0 +1,67 @@
+"""Compatibility-mode attention-score sentinel regression coverage."""
+
+import torch
+
+SCORES = "blocks.0.attn.hook_attn_scores"
+PATTERN = "blocks.0.attn.hook_pattern"
+
+
+def test_gpt2_compatibility_scores_use_negative_infinity(
+    gpt2_bridge_compat, gpt2_hooked_processed
+) -> None:
+    """GPT-2's direct HF mask is normalized before the compatibility hook."""
+    tokens = gpt2_hooked_processed.to_tokens("The capital of France is")
+    _, bridge_cache = gpt2_bridge_compat.run_with_cache(tokens, names_filter=[SCORES])
+    _, hooked_cache = gpt2_hooked_processed.run_with_cache(tokens, names_filter=[SCORES])
+
+    bridge_scores, hooked_scores = bridge_cache[SCORES], hooked_cache[SCORES]
+    causal_mask = torch.isneginf(hooked_scores)
+    assert causal_mask.any()
+    assert torch.isneginf(bridge_scores[causal_mask]).all()
+    torch.testing.assert_close(
+        bridge_scores[~causal_mask], hooked_scores[~causal_mask], rtol=0, atol=0
+    )
+
+
+def test_gpt2_left_padding_uses_negative_infinity_and_finite_patterns(
+    gpt2_bridge_compat,
+) -> None:
+    """Fully masked pad queries are zeroed after softmax in compatibility mode."""
+    long = gpt2_bridge_compat.to_tokens("The capital of France is")
+    short = gpt2_bridge_compat.to_tokens("Paris")
+    n_pad = long.shape[1] - short.shape[1]
+    padded_short = torch.cat([torch.zeros_like(long[:, :n_pad]), short], dim=1)
+    tokens = torch.cat([long, padded_short], dim=0)
+    attention_mask = torch.cat(
+        [
+            torch.ones_like(long),
+            torch.cat([torch.zeros_like(long[:, :n_pad]), torch.ones_like(short)], dim=1),
+        ],
+        dim=0,
+    )
+
+    _, cache = gpt2_bridge_compat.run_with_cache(
+        tokens, attention_mask=attention_mask, names_filter=[SCORES, PATTERN]
+    )
+    scores, pattern = cache[SCORES], cache[PATTERN]
+    key_padding = ~attention_mask.bool()[:, None, None, :]
+    causal = torch.triu(torch.ones(long.shape[1], long.shape[1], dtype=torch.bool), diagonal=1)[
+        None, None
+    ]
+    masked = (key_padding | causal).expand_as(scores)
+
+    assert torch.isneginf(scores[masked]).all()
+    assert torch.isfinite(pattern).all()
+
+
+def test_gpt2_mixed_dtype_mask_is_normalized_before_addition(gpt2_bridge_compat) -> None:
+    """A lower-precision HF mask sentinel must survive score upcasting."""
+    scores = torch.zeros(1, 1, 2, 2, dtype=torch.float32)
+    attention_mask = torch.zeros_like(scores, dtype=torch.float16)
+    attention_mask[..., 0, 1] = torch.finfo(torch.float16).min
+
+    actual = gpt2_bridge_compat.blocks[0].attn._apply_reconstruct_attention_mask(
+        scores, attention_mask, seq_len=2
+    )
+
+    assert torch.isneginf(actual[..., 0, 1]).all()

--- a/transformer_lens/model_bridge/generalized_components/alibi_joint_qkv_attention.py
+++ b/transformer_lens/model_bridge/generalized_components/alibi_joint_qkv_attention.py
@@ -118,6 +118,7 @@ class ALiBiJointQKVAttentionBridge(JointQKVAttentionBridge):
         # Add attention mask
         attention_mask = kwargs.get("attention_mask", None)
         if attention_mask is not None:
+            attention_mask = self._normalize_compatibility_mask_sentinel(attention_mask)
             attn_scores = attn_scores + attention_mask[:, :, :, : attn_scores.shape[-1]]
 
         attn_scores = self.hook_attn_scores(attn_scores)

--- a/transformer_lens/model_bridge/generalized_components/attention.py
+++ b/transformer_lens/model_bridge/generalized_components/attention.py
@@ -518,9 +518,24 @@ class AttentionBridge(GeneralizedComponent):
             attn_weights = torch.nn.functional.softmax(attn_scores, dim=-1)
             if target_dtype is not None:
                 attn_weights = attn_weights.to(target_dtype)
+        attn_weights = self._scrub_compatibility_pattern_nans(attn_weights)
         attn_weights = self._apply_attn_dropout(attn_weights)
         attn_weights = self.hook_pattern(attn_weights)
         return attn_weights
+
+    def _scrub_compatibility_pattern_nans(self, pattern: torch.Tensor) -> torch.Tensor:
+        """Match HookedTransformer for fully masked attention rows."""
+        if self.compatibility_mode:
+            pattern = torch.where(torch.isnan(pattern), torch.zeros_like(pattern), pattern)
+        return pattern
+
+    def _normalize_compatibility_mask_sentinel(self, attention_mask: torch.Tensor) -> torch.Tensor:
+        """Normalize additive mask sentinels before dtype conversion or addition."""
+        if self.compatibility_mode and attention_mask.is_floating_point():
+            attention_mask = attention_mask.masked_fill(
+                attention_mask <= torch.finfo(attention_mask.dtype).min, -torch.inf
+            )
+        return attention_mask
 
     def _reshape_attn_output(
         self,
@@ -558,6 +573,7 @@ class AttentionBridge(GeneralizedComponent):
         if q_seq_len is None:
             q_seq_len = seq_len
         min_dtype = torch.finfo(attn_scores.dtype).min
+        mask_value = -torch.inf if self.compatibility_mode else min_dtype
         use_direct_hf_mask = attention_mask is not None and attention_mask.ndim >= 4
         # Bidirectional attention (encoders) and cross-attention have no causal
         # structure, so only synthesize the triangular mask for causal self-attention.
@@ -569,29 +585,29 @@ class AttentionBridge(GeneralizedComponent):
                 q_seq_len, seq_len, device=attn_scores.device, dtype=torch.bool
             )
             causal_mask = torch.tril(causal_mask, diagonal=seq_len - q_seq_len)
-            attn_scores = attn_scores.masked_fill(~causal_mask, min_dtype)
+            attn_scores = attn_scores.masked_fill(~causal_mask, mask_value)
 
-        if attention_mask is None:
-            return attn_scores
+        if attention_mask is not None:
+            if attention_mask.shape[-1] != seq_len:
+                attention_mask = attention_mask[..., :seq_len]
+            if attention_mask.ndim >= 3 and attention_mask.shape[-2] != q_seq_len:
+                # Extra query rows mean a full-sequence mask on a cached decode step,
+                # where the live queries are the LAST rows; taking the first hands
+                # every step position 0 (Baichuan-13B fuses ALiBi slopes in here).
+                attention_mask = attention_mask[..., -q_seq_len:, :]
 
-        if attention_mask.shape[-1] != seq_len:
-            attention_mask = attention_mask[..., :seq_len]
-        if attention_mask.ndim >= 3 and attention_mask.shape[-2] != q_seq_len:
-            # Extra query rows mean a full-sequence mask on a cached decode step,
-            # where the live queries are the LAST rows; taking the first hands
-            # every step position 0 (Baichuan-13B fuses ALiBi slopes in here).
-            attention_mask = attention_mask[..., -q_seq_len:, :]
+            if attention_mask.dtype == torch.bool:
+                attention_mask = torch.where(
+                    attention_mask,
+                    torch.zeros((), dtype=attn_scores.dtype, device=attn_scores.device),
+                    torch.full((), mask_value, dtype=attn_scores.dtype, device=attn_scores.device),
+                )
+            else:
+                attention_mask = self._normalize_compatibility_mask_sentinel(attention_mask)
+                attention_mask = attention_mask.to(dtype=attn_scores.dtype)
+            attn_scores = attn_scores + attention_mask
 
-        if attention_mask.dtype == torch.bool:
-            attention_mask = torch.where(
-                attention_mask,
-                torch.zeros((), dtype=attn_scores.dtype, device=attn_scores.device),
-                torch.full((), min_dtype, dtype=attn_scores.dtype, device=attn_scores.device),
-            )
-        else:
-            attention_mask = attention_mask.to(dtype=attn_scores.dtype)
-
-        return attn_scores + attention_mask
+        return attn_scores
 
     def _get_n_heads(self, use_kv: bool = False) -> int:
         """Resolve the number of attention heads from config.

--- a/transformer_lens/model_bridge/generalized_components/mla_attention.py
+++ b/transformer_lens/model_bridge/generalized_components/mla_attention.py
@@ -296,6 +296,7 @@ class MLAAttentionBridge(PositionEmbeddingHooksMixin, AttentionBridge):
         attn_scores = torch.matmul(query_states, key_states.transpose(-2, -1)) * scaling
 
         if attention_mask is not None:
+            attention_mask = self._normalize_compatibility_mask_sentinel(attention_mask)
             attn_scores = attn_scores + attention_mask
 
         attn_scores = self.hook_attn_scores(attn_scores)

--- a/transformer_lens/model_bridge/generalized_components/mpt_alibi_attention.py
+++ b/transformer_lens/model_bridge/generalized_components/mpt_alibi_attention.py
@@ -92,9 +92,10 @@ class MPTALiBiAttentionBridge(ALiBiJointQKVAttentionBridge):
         # MPT passes a bool 4D mask (True = masked), not an additive float mask.
         attention_mask = kwargs.get("attention_mask", None)
         if attention_mask is not None:
-            attn_scores = attn_scores.masked_fill(
-                attention_mask, torch.finfo(attn_scores.dtype).min
+            mask_value = (
+                -torch.inf if self.compatibility_mode else torch.finfo(attn_scores.dtype).min
             )
+            attn_scores = attn_scores.masked_fill(attention_mask, mask_value)
 
         attn_scores = self.hook_attn_scores(attn_scores)
 

--- a/transformer_lens/model_bridge/generalized_components/position_embeddings_attention.py
+++ b/transformer_lens/model_bridge/generalized_components/position_embeddings_attention.py
@@ -622,6 +622,7 @@ class PositionEmbeddingsAttentionBridge(PositionEmbeddingHooksMixin, AttentionBr
             attn_weights = torch.nn.functional.softmax(attn_scores, dim=-1, dtype=torch.float32).to(
                 query_states.dtype
             )
+        attn_weights = self._scrub_compatibility_pattern_nans(attn_weights)
 
         # --- Dropout ---
         dropout_rate = getattr(hf_attn, "attention_dropout", 0.0)

--- a/transformer_lens/model_bridge/supported_architectures/llada.py
+++ b/transformer_lens/model_bridge/supported_architectures/llada.py
@@ -124,6 +124,7 @@ class _LLaDAAttentionBridge(AttentionBridge):
         attn_scores = self.hook_attn_scores(attn_scores)
 
         pattern = torch.nn.functional.softmax(attn_scores, dim=-1, dtype=torch.float32).to(q.dtype)
+        pattern = self._scrub_compatibility_pattern_nans(pattern)
         dropout = float(getattr(block.config, "attention_dropout", 0.0))
         if block.training and dropout > 0.0:
             pattern = torch.nn.functional.dropout(pattern, p=dropout, training=True)


### PR DESCRIPTION
# Description

In compatibility mode, normalize fully assembled attention masks from `torch.finfo(dtype).min` to `-inf` before exposing `hook_attn_scores`. Normalizing after causal and Hugging Face masks are combined covers GPT-2's direct 4D-mask path while leaving native-mode and unmasked score values unchanged.

Fixes #1692

Dependencies: N/A.

Validation:

- `uv run pytest tests/integration/model_bridge/test_attention_score_sentinel.py tests/unit/model_bridge/generalized_components/test_joint_qkv_attention.py -q` — 10 passed
- `make check-format` — passed
- `uv run mypy .` — passed (388 source files)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality) — N/A
- [ ] Breaking change (fix or feature which changes existing behavior) — N/A
- [ ] This change requires a documentation update — N/A

### Screenshots

N/A.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A; no public API changed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
