### PR TITLE
Fixing issue with OLMo3 on HookedTransformer

### DIFF
--- a/tests/unit/test_post_norm_processing_guards.py
+++ b/tests/unit/test_post_norm_processing_guards.py
@@ -1,0 +1,119 @@
+"""LN folding and writing-weight centering must stay off for post-norm decoders.
+
+Both transforms assume the norm gain sits on a sublayer's INPUT. OLMo 2/3 apply
+ln1/ln2 to the sublayer OUTPUT, so folding is the wrong algebra: on the real
+allenai/Olmo-3-1025-7B it moved log-softmax by 19.73 and dropped argmax agreement
+with HF to 0%. The guard existed but named only OLMo 2, so OLMo 3 folded silently.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+from transformer_lens.loading_from_pretrained import get_pretrained_model_config
+from transformer_lens.utilities.architectures import POST_NORM_ARCHITECTURES
+from transformer_lens.weight_processing import ProcessWeights
+
+
+def _tl_config(architecture: str):
+    from transformer_lens import HookedTransformerConfig
+
+    return HookedTransformerConfig(
+        n_layers=0,
+        d_model=8,
+        n_ctx=16,
+        d_head=4,
+        n_heads=2,
+        d_vocab=10,
+        act_fn="silu",
+        normalization_type="RMS",
+        original_architecture=architecture,
+        positional_embedding_type="rotary",
+    )
+
+
+POST_NORM_MODELS = [
+    ("allenai/Olmo-3-1025-7B", "Olmo3ForCausalLM"),
+    ("allenai/OLMo-2-0425-1B", "Olmo2ForCausalLM"),
+]
+
+
+def _olmo_hf_config(architecture: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        architectures=[architecture],
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=128,
+        num_hidden_layers=4,
+        max_position_embeddings=512,
+        rms_norm_eps=1e-6,
+        vocab_size=100,
+        hidden_act="silu",
+        rope_theta=500000.0,
+        layer_types=["sliding_attention"] * 3 + ["full_attention"],
+        sliding_window=4096,
+        initializer_range=0.02,
+        tie_word_embeddings=False,
+        rope_parameters={
+            "sliding_attention": {"rope_type": "default", "rope_theta": 500000.0},
+            "full_attention": {"rope_type": "default", "rope_theta": 500000.0},
+        },
+    )
+
+
+@pytest.mark.parametrize("model_name,architecture", POST_NORM_MODELS)
+@mock.patch("transformer_lens.loading_from_pretrained.AutoConfig")
+def test_fold_ln_is_refused(mock_auto_config, caplog, model_name, architecture) -> None:
+    mock_auto_config.from_pretrained.return_value = _olmo_hf_config(architecture)
+    with caplog.at_level("WARNING"):
+        get_pretrained_model_config(model_name, fold_ln=True)
+    assert any(
+        "fold_ln=True is incompatible" in record.getMessage() for record in caplog.records
+    ), [r.getMessage() for r in caplog.records]
+
+
+@mock.patch("transformer_lens.loading_from_pretrained.AutoConfig")
+def test_pre_norm_architecture_still_folds(mock_auto_config, caplog) -> None:
+    """Negative control: the guard must not disable folding for everyone."""
+    mock_auto_config.from_pretrained.return_value = SimpleNamespace(
+        architectures=["LlamaForCausalLM"],
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        max_position_embeddings=512,
+        rms_norm_eps=1e-6,
+        vocab_size=100,
+        hidden_act="silu",
+        rope_theta=10000.0,
+    )
+    with caplog.at_level("WARNING"):
+        get_pretrained_model_config("01-ai/Yi-6B", fold_ln=True)
+    assert not any("fold_ln=True is incompatible" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.parametrize("architecture", sorted(POST_NORM_ARCHITECTURES))
+def test_embeddings_are_not_centered(architecture) -> None:
+    """The first attention's input is un-normed, so centering W_E shifts a residual
+    stream nothing re-normalizes."""
+    torch.manual_seed(0)
+    embedding = torch.randn(10, 8)
+    state = {"embed.W_E": embedding.clone()}
+    cfg = _tl_config(architecture)
+    out = ProcessWeights.center_writing_weights(state, cfg)
+    torch.testing.assert_close(out["embed.W_E"], embedding)
+
+
+def test_embeddings_are_centered_for_pre_norm() -> None:
+    """Engagement check: centering is a no-op above only because of the guard."""
+    torch.manual_seed(0)
+    embedding = torch.randn(10, 8)
+    state = {"embed.W_E": embedding.clone()}
+    cfg = _tl_config("LlamaForCausalLM")
+    out = ProcessWeights.center_writing_weights(state, cfg)
+    assert not torch.allclose(out["embed.W_E"], embedding)
+    torch.testing.assert_close(out["embed.W_E"].mean(-1), torch.zeros(10), atol=1e-6, rtol=0)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -75,6 +75,7 @@ from transformer_lens.utilities import (
     init_xavier_uniform_,
     softcap_enabled,
 )
+from transformer_lens.utilities.architectures import POST_NORM_ARCHITECTURES
 from transformer_lens.utilities.devices import move_to_and_update_config
 from transformer_lens.weight_processing import ProcessWeights
 
@@ -1435,18 +1436,20 @@ class HookedTransformer(HookedRootModule):
                     "Setting center_writing_weights=False instead."
                 )
                 center_writing_weights = False
-        # OLMo 2 post-norm is incompatible with fold_ln/center_writing_weights (pre-norm only)
-        if cfg.original_architecture == "Olmo2ForCausalLM":
+        # Post-norm architectures are incompatible with fold_ln/center_writing_weights,
+        # both of which assume the norm gain sits on a sublayer's input.
+        if cfg.original_architecture in POST_NORM_ARCHITECTURES:
             if fold_ln:
                 logging.warning(
-                    "fold_ln=True is incompatible with OLMo 2's post-norm architecture. "
-                    "Setting fold_ln=False."
+                    f"fold_ln=True is incompatible with {cfg.original_architecture}'s "
+                    "post-norm architecture. Setting fold_ln=False."
                 )
                 fold_ln = False
             if center_writing_weights:
                 logging.warning(
-                    "center_writing_weights=True is incompatible with OLMo 2's post-norm "
-                    "architecture. Setting center_writing_weights=False."
+                    f"center_writing_weights=True is incompatible with "
+                    f"{cfg.original_architecture}'s post-norm architecture. "
+                    "Setting center_writing_weights=False."
                 )
                 center_writing_weights = False
         if center_unembed and softcap_enabled(cfg.output_logits_soft_cap):

--- a/transformer_lens/components/transformer_block.py
+++ b/transformer_lens/components/transformer_block.py
@@ -25,6 +25,7 @@ from transformer_lens.config.hooked_transformer_config import HookedTransformerC
 from transformer_lens.factories.mlp_factory import MLPFactory
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.utilities import repeat_along_head_dimension
+from transformer_lens.utilities.architectures import POST_NORM_ARCHITECTURES
 
 
 class TransformerBlock(nn.Module):
@@ -154,7 +155,7 @@ class TransformerBlock(nn.Module):
             key_input = attn_in
             value_input = attn_in
 
-        if self.cfg.original_architecture in ("Olmo2ForCausalLM", "Olmo3ForCausalLM"):
+        if self.cfg.original_architecture in POST_NORM_ARCHITECTURES:
             attn_out = self.attn(
                 query_input=query_input,
                 key_input=key_input,
@@ -182,7 +183,7 @@ class TransformerBlock(nn.Module):
             # and before the hook. We do it before the hook so hook_attn_out captures "that which
             # is added to the residual stream"
             attn_out = self.ln1_post(attn_out)
-        if self.cfg.original_architecture in ("Olmo2ForCausalLM", "Olmo3ForCausalLM"):
+        if self.cfg.original_architecture in POST_NORM_ARCHITECTURES:
             # OLMo 2/3 post-norm: ln1 applies before the residual add, so it must
             # precede the hook for hook_attn_out to capture the additive contribution.
             attn_out = self.ln1(attn_out)
@@ -196,7 +197,7 @@ class TransformerBlock(nn.Module):
             mlp_in = (
                 resid_mid if not self.cfg.use_hook_mlp_in else self.hook_mlp_in(resid_mid.clone())
             )
-            if self.cfg.original_architecture in ("Olmo2ForCausalLM", "Olmo3ForCausalLM"):
+            if self.cfg.original_architecture in POST_NORM_ARCHITECTURES:
                 # Post-norm: apply_mlp applies ln2 before hook_mlp_out internally.
                 mlp_out = self.apply_mlp(mlp_in)
             else:
@@ -228,7 +229,7 @@ class TransformerBlock(nn.Module):
         mlp_out = self.mlp(normalized_resid)  # [batch, pos, d_model]
         if self.cfg.use_normalization_before_and_after:
             mlp_out = self.ln2_post(mlp_out)
-        if self.cfg.original_architecture in ("Olmo2ForCausalLM", "Olmo3ForCausalLM"):
+        if self.cfg.original_architecture in POST_NORM_ARCHITECTURES:
             # OLMo 2/3 post-norm: ln2 applies before the residual add, so it must
             # precede the hook for hook_mlp_out to capture the additive contribution.
             mlp_out = self.ln2(mlp_out)

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -58,6 +58,7 @@ from transformer_lens.pretrained.weight_conversions import (
     convert_t5_weights,
 )
 from transformer_lens.supported_models import MODEL_ALIASES, OFFICIAL_MODEL_NAMES
+from transformer_lens.utilities.architectures import POST_NORM_ARCHITECTURES
 from transformer_lens.utilities.heterogeneous_config import het_safe_view
 from transformer_lens.utilities.hf_utils import get_rotary_pct_from_config
 from transformer_lens.utilities.quantization import (
@@ -1785,11 +1786,12 @@ def get_pretrained_model_config(
         )
         fold_ln = False
 
-    # OLMo 2 uses post-norm (norm after attention/MLP, not before), so folding
-    # the norm weights into adjacent linear layers is not mathematically valid.
-    if cfg_dict.get("original_architecture") == "Olmo2ForCausalLM" and fold_ln:
+    # Post-norm blocks normalize the sublayer output, so folding the norm weights
+    # into adjacent linear layers is not mathematically valid.
+    architecture = cfg_dict.get("original_architecture")
+    if architecture in POST_NORM_ARCHITECTURES and fold_ln:
         logging.warning(
-            "fold_ln=True is incompatible with OLMo 2's post-norm architecture. "
+            f"fold_ln=True is incompatible with {architecture}'s post-norm architecture. "
             "Setting fold_ln=False."
         )
         fold_ln = False

--- a/transformer_lens/utilities/architectures.py
+++ b/transformer_lens/utilities/architectures.py
@@ -25,6 +25,14 @@ SEQ2SEQ_ARCHITECTURES: set[str] = {
     "SwitchTransformersForConditionalGeneration",
 }
 
+# Post-norm decoders: ln1/ln2 normalize each sublayer's OUTPUT before the residual
+# add, so LN folding and writing-weight centering (which assume the gain sits on a
+# sublayer's INPUT) are not valid algebra for them.
+POST_NORM_ARCHITECTURES: set[str] = {
+    "Olmo2ForCausalLM",
+    "Olmo3ForCausalLM",
+}
+
 # Masked language models (BERT-style, no text generation)
 MASKED_LM_ARCHITECTURES: set[str] = {
     "BertForMaskedLM",

--- a/transformer_lens/weight_processing.py
+++ b/transformer_lens/weight_processing.py
@@ -16,6 +16,7 @@ from transformer_lens.config.transformer_lens_config import TransformerLensConfi
 from transformer_lens.FactoredMatrix import FactoredMatrix
 from transformer_lens.model_bridge.architecture_adapter import ArchitectureAdapter
 from transformer_lens.utilities import filter_dict_by_prefix
+from transformer_lens.utilities.architectures import POST_NORM_ARCHITECTURES
 
 
 class ProcessWeights:
@@ -1130,9 +1131,11 @@ class ProcessWeights:
         Returns:
             Dict[str, torch.Tensor]: Modified state dict with centered writing weights.
         """
-        # Skip centering for Olmo2 models - input of attn of 1st layer is not normed
-        if getattr(cfg, "original_architecture", None) == "Olmo2ForCausalLM":
-            print("Not centering embedding weights for Olmo2ForCausalLM")
+        # Post-norm models leave the first attention's input un-normed, so centering
+        # the embedding would shift a residual stream nothing re-normalizes.
+        architecture = getattr(cfg, "original_architecture", None)
+        if architecture in POST_NORM_ARCHITECTURES:
+            print(f"Not centering embedding weights for {architecture}")
         else:
             # Make a deep copy to avoid modifying the original
             embed_W_E_key = ProcessWeights._get_param_key("embed.W_E", adapter)


### PR DESCRIPTION
# Description

While reverifying models to confirm all our bug fixes from v3.7.x did not introduce any unwanted regression, I discovered a bug in OLMo3 on HookedTransformer, that this commit resolves.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility