### PR TITLE
Fix OLMo 2 attention input state leakage

### DIFF
--- a/tests/integration/model_bridge/test_olmo2_attention_input_state.py
+++ b/tests/integration/model_bridge/test_olmo2_attention_input_state.py
@@ -1,0 +1,73 @@
+"""OLMo 2 attention-input fork regression tests using a tiny local HF model."""
+
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+from transformers.models.olmo2 import Olmo2Config
+
+from transformer_lens.model_bridge import TransformerBridge
+from transformer_lens.model_bridge.sources._bridge_builder import (
+    build_bridge_config_from_hf,
+)
+from transformer_lens.model_bridge.supported_architectures.olmo2 import (
+    Olmo2ArchitectureAdapter,
+)
+
+
+class _Tokenizer:
+    pass
+
+
+def _tiny_olmo2_bridge() -> TransformerBridge:
+    torch.manual_seed(0)
+    config = Olmo2Config(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+    )
+    config.architectures = ["Olmo2ForCausalLM"]
+    hf_model = AutoModelForCausalLM.from_config(config).to(torch.float32).eval()
+    bridge_config = build_bridge_config_from_hf(
+        hf_model.config, "Olmo2ForCausalLM", "olmo2-tiny", torch.float32
+    )
+    return TransformerBridge(
+        hf_model, Olmo2ArchitectureAdapter(bridge_config), tokenizer=_Tokenizer()
+    )
+
+
+@pytest.mark.parametrize(
+    ("setter_name", "input_hook_names"),
+    [
+        (
+            "set_use_split_qkv_input",
+            (
+                "blocks.1.attn.hook_q_input",
+                "blocks.1.attn.hook_k_input",
+                "blocks.1.attn.hook_v_input",
+            ),
+        ),
+        ("set_use_attn_in", ("blocks.1.attn.hook_attn_in",)),
+    ],
+)
+def test_attention_input_fork_does_not_leak_state_between_forwards(
+    setter_name: str, input_hook_names: tuple[str, ...]
+) -> None:
+    bridge = _tiny_olmo2_bridge()
+    bridge.enable_compatibility_mode()
+    getattr(bridge, setter_name)(True)
+    tokens = torch.tensor([[1, 2, 3, 4, 5]])
+
+    with torch.no_grad():
+        first_logits, first_cache = bridge.run_with_cache(tokens)
+        second_logits, second_cache = bridge.run_with_cache(tokens)
+
+    torch.testing.assert_close(second_logits, first_logits, rtol=0, atol=0)
+    for hook_name in input_hook_names:
+        torch.testing.assert_close(second_cache[hook_name], first_cache[hook_name], rtol=0, atol=0)
+        for cache in (first_cache, second_cache):
+            expected = cache["blocks.1.hook_resid_pre"].unsqueeze(2).expand_as(cache[hook_name])
+            torch.testing.assert_close(cache[hook_name], expected, rtol=0, atol=0)

--- a/transformer_lens/model_bridge/generalized_components/block.py
+++ b/transformer_lens/model_bridge/generalized_components/block.py
@@ -190,6 +190,16 @@ class BlockBridge(GeneralizedComponent):
             return bool(cfg.use_hook_mlp_in)
         return self._use_hook_mlp_in
 
+    def _clear_attention_capture(self) -> None:
+        """Release the transient residual captured for attention input forks."""
+        from transformer_lens.model_bridge.generalized_components.attention import (
+            AttentionBridge,
+        )
+
+        attn = self.submodules.get("attn") if self.submodules else None
+        if isinstance(attn, AttentionBridge):
+            attn._captured_pre_ln_residual = None
+
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         """Forward pass through the block bridge.
 
@@ -209,6 +219,7 @@ class BlockBridge(GeneralizedComponent):
             )
 
         self._maybe_wire_capture_hooks()
+        self._clear_attention_capture()
         self._check_stop_at_layer(*args, **kwargs)
         args, kwargs = self._hook_input_hidden_states(args, kwargs)
 
@@ -216,7 +227,10 @@ class BlockBridge(GeneralizedComponent):
         # This prevents errors when passing encoder-specific params to decoder-only models
         filtered_kwargs = self._filter_kwargs_for_forward(kwargs, len(args))
 
-        output = self.original_component(*args, **filtered_kwargs)
+        try:
+            output = self.original_component(*args, **filtered_kwargs)
+        finally:
+            self._clear_attention_capture()
         force_tuple_for_bare_tensor = self._is_standalone_hidden_state_call(args, filtered_kwargs)
         return self._apply_output_hook(
             output, force_tuple_for_bare_tensor=force_tuple_for_bare_tensor


### PR DESCRIPTION
# Description

OLMo 2 is post-norm, so its `ln1` capture runs after attention. The specialized attention reconstruction path did not clear `_captured_pre_ln_residual`, causing the following forward to feed the previous run's captured tensor into `hook_q_input` / `hook_k_input` / `hook_v_input` or `hook_attn_in`.

This change makes `BlockBridge` own the lifetime of that transient capture: it clears stale state at block entry and releases the current capture in a `finally` block. Repeated identical forwards are deterministic again, and the forked attention inputs match `hook_resid_pre`.

The regression uses a tiny local `Olmo2Config` model, so it exercises the real post-norm adapter path without a Hub download. It covers both `set_use_split_qkv_input(True)` and `set_use_attn_in(True)` across two consecutive forwards.

No new dependencies are required.

Fixes #1687

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

N/A — no user-interface change.

# Checklist

- [x] I have commented the state-lifetime helper where its purpose is not obvious
- [x] Documentation is unchanged because the public API and intended behavior are unchanged
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Validation

- `uv run pytest tests/integration/model_bridge/test_olmo2_attention_input_state.py -q` — 2 passed
- Related split-QKV, Mistral attention-input, and OLMo 2 hook semantics tests — 18 passed
- `make check-format` — passed
- `uv run mypy .` — passed (388 source files)
- `make unit-test` — 5,028 passed, 36 skipped, 44 deselected, 8 xfailed
