### PR TITLE
Fix batched TransformerBridge padding semantics

### DIFF
--- a/tests/acceptance/model_bridge/test_run_with_cache_batch.py
+++ b/tests/acceptance/model_bridge/test_run_with_cache_batch.py
@@ -7,6 +7,19 @@ tests guard against that regression.
 
 import torch
 
+from transformer_lens.utilities import get_attention_mask
+
+
+def _last_real_token_positions(model, prompts: list[str]) -> torch.Tensor:
+    tokens = model.to_tokens(prompts)
+    attention_mask = get_attention_mask(
+        model.tokenizer,
+        tokens,
+        prepend_bos=getattr(model.cfg, "default_prepend_bos", True),
+    )
+    positions = torch.arange(tokens.shape[1], device=tokens.device).expand_as(tokens)
+    return positions.masked_fill(attention_mask == 0, -1).max(dim=1).values
+
 
 def test_run_with_cache_batch_matches_individual(gpt2_bridge):
     """Batched run_with_cache logits at the last real token should match per-prompt runs."""
@@ -23,9 +36,9 @@ def test_run_with_cache_batch_matches_individual(gpt2_bridge):
 
     # Batched run
     batched_logits, _ = gpt2_bridge.run_with_cache(prompts)
-    # With left-padding forced internally, position -1 is the last real token
-    for i in range(len(prompts)):
-        batched_last = batched_logits[i, -1, :]
+    last_real_positions = _last_real_token_positions(gpt2_bridge, prompts)
+    for i, position in enumerate(last_real_positions):
+        batched_last = batched_logits[i, position, :]
         assert torch.allclose(
             individual_logits[i], batched_last, atol=1e-4
         ), f"Prompt {i} logit mismatch between individual and batched run_with_cache"
@@ -54,11 +67,11 @@ def test_run_with_hooks_batch_matches_individual(gpt2_bridge):
 
     # Batched run
     captured_batched = []
+    last_real_positions = _last_real_token_positions(gpt2_bridge, prompts)
 
     def capture_batched(tensor, hook):
-        # For left-padded batch, last real token is at position -1 for all
-        for i in range(tensor.shape[0]):
-            captured_batched.append(tensor[i, -1, :].detach().clone())
+        for i, position in enumerate(last_real_positions):
+            captured_batched.append(tensor[i, position, :].detach().clone())
 
     gpt2_bridge.run_with_hooks(
         prompts,

--- a/tests/unit/model_bridge/test_batched_string_padding.py
+++ b/tests/unit/model_bridge/test_batched_string_padding.py
@@ -1,0 +1,115 @@
+"""Padding behavior for ragged string lists passed to TransformerBridge."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import torch
+
+from transformer_lens.utilities import get_attention_mask
+
+PROMPTS = ["The quick brown fox", "Hello there, world! This is a longer sentence."]
+RESID_PRE = "blocks.0.hook_resid_pre"
+
+
+@pytest.fixture(scope="module")
+def compatibility_bridge():
+    """A cached model used for token-layout and real-token numerical checks."""
+    from transformer_lens.model_bridge import TransformerBridge
+
+    bridge = TransformerBridge.boot_transformers("distilgpt2", device="cpu", dtype=torch.float32)
+    bridge.enable_compatibility_mode()
+    bridge.eval()
+    return bridge
+
+
+def test_to_tokens_honors_explicit_padding_side(compatibility_bridge) -> None:
+    """A per-call padding override must win without mutating the shared tokenizer."""
+    tokenizer = compatibility_bridge.tokenizer
+    original_side = tokenizer.padding_side
+    tokenizer.padding_side = "right"
+    try:
+        left = compatibility_bridge.to_tokens(PROMPTS, padding_side="left")
+        right = compatibility_bridge.to_tokens(PROMPTS, padding_side="right")
+
+        assert not torch.equal(left, right)
+        assert left[0, 0].item() == tokenizer.pad_token_id
+        assert left[0, -1].item() != tokenizer.pad_token_id
+        assert right[0, -1].item() == tokenizer.pad_token_id
+        assert tokenizer.padding_side == "right"
+    finally:
+        tokenizer.padding_side = original_side
+
+
+@pytest.mark.parametrize("padding_side", ["left", "right"])
+def test_ragged_forward_matches_public_layout_and_single_sequences(
+    compatibility_bridge, monkeypatch, padding_side: str
+) -> None:
+    """String-list forward uses public token layout and preserves real-token values."""
+    tokenizer = compatibility_bridge.tokenizer
+    original_side = tokenizer.padding_side
+    tokenizer.padding_side = padding_side
+    try:
+        expected_tokens = compatibility_bridge.to_tokens(PROMPTS)
+        attention_mask = get_attention_mask(tokenizer, expected_tokens, prepend_bos=True).bool()
+        tokenization_calls: list[torch.Tensor] = []
+        original_to_tokens: Callable[..., torch.Tensor] = compatibility_bridge.to_tokens
+
+        def recording_to_tokens(input: Any, *args: Any, **kwargs: Any) -> torch.Tensor:
+            tokens = original_to_tokens(input, *args, **kwargs)
+            if isinstance(input, list):
+                tokenization_calls.append(tokens.detach().clone())
+            return tokens
+
+        monkeypatch.setattr(compatibility_bridge, "to_tokens", recording_to_tokens)
+
+        with torch.no_grad():
+            batch_logits, batch_cache = compatibility_bridge.run_with_cache(
+                PROMPTS, names_filter=[RESID_PRE]
+            )
+            single_results = [
+                compatibility_bridge.run_with_cache(prompt, names_filter=[RESID_PRE])
+                for prompt in PROMPTS
+            ]
+
+        assert len(tokenization_calls) == 1
+        assert torch.equal(tokenization_calls[0], expected_tokens)
+
+        for index, (single_logits, single_cache) in enumerate(single_results):
+            real_tokens = attention_mask[index]
+            torch.testing.assert_close(
+                batch_logits[index, real_tokens], single_logits[0], rtol=1e-5, atol=1e-4
+            )
+            torch.testing.assert_close(
+                batch_cache[RESID_PRE][index, real_tokens],
+                single_cache[RESID_PRE][0],
+                rtol=1e-5,
+                atol=1e-4,
+            )
+    finally:
+        tokenizer.padding_side = original_side
+
+
+def test_generate_keeps_left_padding_for_ragged_strings(compatibility_bridge) -> None:
+    """Generation keeps real tokens flush-right even when the tokenizer defaults right."""
+    tokenizer = compatibility_bridge.tokenizer
+    original_side = tokenizer.padding_side
+    try:
+        tokenizer.padding_side = "left"
+        expected_tokens = compatibility_bridge.to_tokens(PROMPTS)
+        tokenizer.padding_side = "right"
+
+        _, input_tokens = compatibility_bridge.generate(
+            PROMPTS,
+            max_new_tokens=1,
+            do_sample=False,
+            verbose=False,
+            return_input_tokens=True,
+        )
+
+        assert torch.equal(input_tokens, expected_tokens)
+        assert tokenizer.padding_side == "right"
+    finally:
+        tokenizer.padding_side = original_side

--- a/tests/unit/model_bridge/test_batched_string_padding.py
+++ b/tests/unit/model_bridge/test_batched_string_padding.py
@@ -43,6 +43,22 @@ def test_to_tokens_honors_explicit_padding_side(compatibility_bridge) -> None:
         tokenizer.padding_side = original_side
 
 
+def test_default_right_padded_text_matches_pretokenized_logits(compatibility_bridge) -> None:
+    """Default text forwarding must match the public right-padded token layout."""
+    tokenizer = compatibility_bridge.tokenizer
+    original_side = tokenizer.padding_side
+    tokenizer.padding_side = "right"
+    try:
+        tokens = compatibility_bridge.to_tokens(PROMPTS)
+        with torch.no_grad():
+            text_logits = compatibility_bridge(PROMPTS)
+            token_logits = compatibility_bridge(tokens)
+
+        torch.testing.assert_close(text_logits, token_logits, rtol=0, atol=0)
+    finally:
+        tokenizer.padding_side = original_side
+
+
 @pytest.mark.parametrize("padding_side", ["left", "right"])
 def test_ragged_forward_matches_public_layout_and_single_sequences(
     compatibility_bridge, monkeypatch, padding_side: str

--- a/tests/unit/utilities/test_tokenize_utils.py
+++ b/tests/unit/utilities/test_tokenize_utils.py
@@ -1,0 +1,33 @@
+"""Tests for per-call padding-side overrides in tokenization utilities."""
+
+from copy import deepcopy
+
+import torch
+
+from transformer_lens import utils
+
+
+def test_attention_mask_uses_explicit_padding_side(gpt2_tokenizer) -> None:
+    tokenizer = deepcopy(gpt2_tokenizer)
+    tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "right"
+    pad = tokenizer.pad_token_id
+    tokens = torch.tensor([[pad, pad, 10, 11], [pad, 20, 21, 22]])
+
+    mask = utils.get_attention_mask(tokenizer, tokens, prepend_bos=True, padding_side="left")
+
+    assert torch.equal(mask, torch.tensor([[0, 1, 1, 1], [1, 1, 1, 1]]))
+
+
+def test_bos_removal_uses_explicit_padding_side(gpt2_tokenizer) -> None:
+    tokenizer = deepcopy(gpt2_tokenizer)
+    tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.bos_token = tokenizer.convert_ids_to_tokens(0)
+    tokenizer.padding_side = "right"
+    pad = tokenizer.pad_token_id
+    bos = tokenizer.bos_token_id
+    tokens = torch.tensor([[pad, bos, 10, 11], [bos, 20, 21, 22]])
+
+    result = utils.get_tokens_with_bos_removed(tokenizer, tokens, padding_side="left")
+
+    assert torch.equal(result, torch.tensor([[pad, 10, 11], [20, 21, 22]]))

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -1265,33 +1265,31 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             prepend_bos = getattr(self.cfg, "default_prepend_bos", True)
         if padding_side is None:
             padding_side = getattr(self.tokenizer, "padding_side", "right")
-        original_padding_side = self.tokenizer.padding_side
-        self.tokenizer.padding_side = padding_side
-        try:
-            tokenizer_prepends_bos = getattr(self.cfg, "tokenizer_prepends_bos", True)
-            if prepend_bos and (not tokenizer_prepends_bos):
-                input = utils.get_input_with_manually_prepended_bos(self.tokenizer.bos_token, input)
-            if isinstance(input, str):
-                input = [input]
-            tokens = self.tokenizer(
-                input,
-                return_tensors="pt",
-                padding=True,
-                truncation=truncate,
-                max_length=self.cfg.n_ctx if truncate else None,
-            )["input_ids"]
-            # Strip auto-appended EOS tokens (e.g., OLMo)
-            if (
-                getattr(self.cfg, "tokenizer_appends_eos", False)
-                and self.tokenizer.eos_token_id is not None
-            ):
-                # Remove trailing EOS, keep at least 1 token
-                while tokens.shape[-1] > 1 and (tokens[:, -1] == self.tokenizer.eos_token_id).all():
-                    tokens = tokens[:, :-1]
-            if not prepend_bos and tokenizer_prepends_bos:
-                tokens = utils.get_tokens_with_bos_removed(self.tokenizer, tokens)
-        finally:
-            self.tokenizer.padding_side = original_padding_side
+        tokenizer_prepends_bos = getattr(self.cfg, "tokenizer_prepends_bos", True)
+        if prepend_bos and (not tokenizer_prepends_bos):
+            input = utils.get_input_with_manually_prepended_bos(self.tokenizer.bos_token, input)
+        if isinstance(input, str):
+            input = [input]
+        tokens = self.tokenizer(
+            input,
+            return_tensors="pt",
+            padding=True,
+            padding_side=padding_side,
+            truncation=truncate,
+            max_length=self.cfg.n_ctx if truncate else None,
+        )["input_ids"]
+        # Strip auto-appended EOS tokens (e.g., OLMo)
+        if (
+            getattr(self.cfg, "tokenizer_appends_eos", False)
+            and self.tokenizer.eos_token_id is not None
+        ):
+            # Remove trailing EOS, keep at least 1 token
+            while tokens.shape[-1] > 1 and (tokens[:, -1] == self.tokenizer.eos_token_id).all():
+                tokens = tokens[:, :-1]
+        if not prepend_bos and tokenizer_prepends_bos:
+            tokens = utils.get_tokens_with_bos_removed(
+                self.tokenizer, tokens, padding_side=padding_side
+            )
         if move_to_device:
             tokens = tokens.to(self.cfg.device)
         return tokens
@@ -2094,14 +2092,17 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             else:
                 kwargs.pop("one_zero_attention_mask")
 
-        # Detect batched list input that may need padding. Auto-compute
-        # attention_mask + position_ids unless the caller passed them explicitly.
+        # Detect batched list input that may need padding. Forward follows the
+        # requested/tokenizer side; generation separately forces left-padding.
         _is_batched_list = (
             isinstance(input, list)
             and len(input) > 1
             and not getattr(self.cfg, "is_audio_model", False)
             and not getattr(self.cfg, "is_visual_model", False)
         )
+        _resolved_padding_side = padding_side
+        if _resolved_padding_side is None and self.tokenizer is not None:
+            _resolved_padding_side = getattr(self.tokenizer, "padding_side", "right")
 
         try:
             if isinstance(input, (str, list)):
@@ -2136,27 +2137,27 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                 isinstance(input_ids, torch.Tensor) and input_ids.is_floating_point()
             )
 
-            # Auto-compute attention_mask + position_ids for batched list input
-            # when the caller didn't supply them. Matches HF generation convention.
+            # Left padding needs a mask and corrected positions. Right padding is
+            # harmless for causal real-token positions and remains unmasked to
+            # match HookedTransformer; bidirectional/encoder inputs still need it.
             if (
                 _is_batched_list
                 and attention_mask is None
                 and self.tokenizer is not None
                 and self.tokenizer.pad_token_id is not None
                 and not _is_inputs_embeds
-            ):
-                _prev_side = self.tokenizer.padding_side
-                self.tokenizer.padding_side = (
-                    padding_side if padding_side is not None else _prev_side
+                and (
+                    _resolved_padding_side == "left"
+                    or is_encoder_decoder
+                    or not self.adapter.supports_causal_loss
                 )
-                try:
-                    attention_mask = utils.get_attention_mask(
-                        self.tokenizer,
-                        input_ids,
-                        prepend_bos=getattr(self.cfg, "default_prepend_bos", True),
-                    ).to(self.cfg.device)
-                finally:
-                    self.tokenizer.padding_side = _prev_side
+            ):
+                attention_mask = utils.get_attention_mask(
+                    self.tokenizer,
+                    input_ids,
+                    prepend_bos=getattr(self.cfg, "default_prepend_bos", True),
+                    padding_side=_resolved_padding_side,
+                ).to(self.cfg.device)
                 # Gated on the target for the same reason the derivation below is:
                 # a fixed-signature forward raises TypeError on the kwarg, and a
                 # model that owns its own position derivation is overridden by it

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -1265,28 +1265,33 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             prepend_bos = getattr(self.cfg, "default_prepend_bos", True)
         if padding_side is None:
             padding_side = getattr(self.tokenizer, "padding_side", "right")
-        tokenizer_prepends_bos = getattr(self.cfg, "tokenizer_prepends_bos", True)
-        if prepend_bos and (not tokenizer_prepends_bos):
-            input = utils.get_input_with_manually_prepended_bos(self.tokenizer.bos_token, input)
-        if isinstance(input, str):
-            input = [input]
-        tokens = self.tokenizer(
-            input,
-            return_tensors="pt",
-            padding=True,
-            truncation=truncate,
-            max_length=self.cfg.n_ctx if truncate else None,
-        )["input_ids"]
-        # Strip auto-appended EOS tokens (e.g., OLMo)
-        if (
-            getattr(self.cfg, "tokenizer_appends_eos", False)
-            and self.tokenizer.eos_token_id is not None
-        ):
-            # Remove trailing EOS, keep at least 1 token
-            while tokens.shape[-1] > 1 and (tokens[:, -1] == self.tokenizer.eos_token_id).all():
-                tokens = tokens[:, :-1]
-        if not prepend_bos and tokenizer_prepends_bos:
-            tokens = utils.get_tokens_with_bos_removed(self.tokenizer, tokens)
+        original_padding_side = self.tokenizer.padding_side
+        self.tokenizer.padding_side = padding_side
+        try:
+            tokenizer_prepends_bos = getattr(self.cfg, "tokenizer_prepends_bos", True)
+            if prepend_bos and (not tokenizer_prepends_bos):
+                input = utils.get_input_with_manually_prepended_bos(self.tokenizer.bos_token, input)
+            if isinstance(input, str):
+                input = [input]
+            tokens = self.tokenizer(
+                input,
+                return_tensors="pt",
+                padding=True,
+                truncation=truncate,
+                max_length=self.cfg.n_ctx if truncate else None,
+            )["input_ids"]
+            # Strip auto-appended EOS tokens (e.g., OLMo)
+            if (
+                getattr(self.cfg, "tokenizer_appends_eos", False)
+                and self.tokenizer.eos_token_id is not None
+            ):
+                # Remove trailing EOS, keep at least 1 token
+                while tokens.shape[-1] > 1 and (tokens[:, -1] == self.tokenizer.eos_token_id).all():
+                    tokens = tokens[:, :-1]
+            if not prepend_bos and tokenizer_prepends_bos:
+                tokens = utils.get_tokens_with_bos_removed(self.tokenizer, tokens)
+        finally:
+            self.tokenizer.padding_side = original_padding_side
         if move_to_device:
             tokens = tokens.to(self.cfg.device)
         return tokens
@@ -2089,10 +2094,8 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             else:
                 kwargs.pop("one_zero_attention_mask")
 
-        # Detect batched list input that will need padding. For this case we force
-        # left-padding internally and auto-compute attention_mask + position_ids
-        # (unless the caller passed them explicitly) so pad tokens don't contaminate
-        # attention or position embeddings.
+        # Detect batched list input that may need padding. Auto-compute
+        # attention_mask + position_ids unless the caller passed them explicitly.
         _is_batched_list = (
             isinstance(input, list)
             and len(input) > 1
@@ -2112,20 +2115,9 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                         "Visual models require tensor input (pixel values), not text. "
                         "Pass a torch.Tensor or use the pixel_values parameter."
                     )
-                if _is_batched_list and padding_side is None:
-                    # Force left-padding so real tokens are flush-right.
-                    _orig_padding_side = self.tokenizer.padding_side
-                    self.tokenizer.padding_side = "left"
-                    try:
-                        input_ids = self.to_tokens(
-                            input, prepend_bos=prepend_bos, padding_side=padding_side
-                        )
-                    finally:
-                        self.tokenizer.padding_side = _orig_padding_side
-                else:
-                    input_ids = self.to_tokens(
-                        input, prepend_bos=prepend_bos, padding_side=padding_side
-                    )
+                input_ids = self.to_tokens(
+                    input, prepend_bos=prepend_bos, padding_side=padding_side
+                )
             else:
                 input_ids = input
                 # Promote 1D integer token tensors to 2D [batch=1, seq] to match
@@ -2154,7 +2146,9 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                 and not _is_inputs_embeds
             ):
                 _prev_side = self.tokenizer.padding_side
-                self.tokenizer.padding_side = "left"
+                self.tokenizer.padding_side = (
+                    padding_side if padding_side is not None else _prev_side
+                )
                 try:
                     attention_mask = utils.get_attention_mask(
                         self.tokenizer,

--- a/transformer_lens/utilities/tokenize_utils.py
+++ b/transformer_lens/utilities/tokenize_utils.py
@@ -211,7 +211,9 @@ def get_input_with_manually_prepended_bos(
 
 
 def get_tokens_with_bos_removed(
-    tokenizer: PreTrainedTokenizerBase, tokens: torch.Tensor
+    tokenizer: PreTrainedTokenizerBase,
+    tokens: torch.Tensor,
+    padding_side: str | None = None,
 ) -> torch.Tensor:
     """
     Removes the bos token from the beginning of each sequence in `tokens`.
@@ -220,6 +222,7 @@ def get_tokens_with_bos_removed(
     Args:
         tokenizer (PreTrainedTokenizerBase): The tokenizer used to tokenize the input.
         tokens (torch.Tensor): The tokenized input.
+        padding_side: The side used to pad ``tokens``. Defaults to the tokenizer setting.
 
     Returns:
         torch.Tensor: The tokenized input with the bos token removed.
@@ -232,7 +235,10 @@ def get_tokens_with_bos_removed(
         # BERT tokenizer), and compare tokens against None under left padding.
         return tokens
 
-    if tokenizer.padding_side == "right":
+    if padding_side is None:
+        padding_side = tokenizer.padding_side
+
+    if padding_side == "right":
         return tokens[..., 1:]
 
     else:
@@ -251,7 +257,10 @@ def get_tokens_with_bos_removed(
 
 
 def get_attention_mask(
-    tokenizer: PreTrainedTokenizerBase, tokens: torch.Tensor, prepend_bos: bool
+    tokenizer: PreTrainedTokenizerBase,
+    tokens: torch.Tensor,
+    prepend_bos: bool,
+    padding_side: str | None = None,
 ) -> torch.Tensor:
     """
     Computes the attention mask for the tokenized input.
@@ -263,6 +272,7 @@ def get_attention_mask(
         tokenizer (PreTrainedTokenizerBase): The tokenizer used for tokenization.
         tokens (torch.Tensor): The tokenized input.
         prepend_bos (bool): If True, a BOS token is prepended to the input.
+        padding_side: The side used to pad ``tokens``. Defaults to the tokenizer setting.
 
     Returns:
         torch.Tensor: The attention mask for the input.
@@ -272,9 +282,11 @@ def get_attention_mask(
     attention_mask = torch.ones_like(tokens)
     if tokenizer is None:
         return attention_mask
+    if padding_side is None:
+        padding_side = tokenizer.padding_side
     is_not_pad_token = tokens.ne(tokenizer.pad_token_id)
 
-    if tokenizer.padding_side == "right":
+    if padding_side == "right":
         # Zero-out the rightmost trailing pad tokens
         is_trailing_pad = get_cumsum_along_dim(is_not_pad_token, -1, reverse=True) == 0
         attention_mask[is_trailing_pad] = 0


### PR DESCRIPTION
# Description

Ragged string lists took two inconsistent tokenization paths in `TransformerBridge`:

- `to_tokens(..., padding_side=...)` resolved the requested side but never passed it to the tokenizer.
- ordinary string-list forward silently forced left padding, so its internal layout could differ from the public `to_tokens` result and from `HookedTransformer`'s default right-padding behavior.

This change passes the resolved side through tokenization and side-dependent BOS/mask utilities without mutating the shared tokenizer, and lets ordinary batched forward follow the explicit argument or tokenizer setting. Left padding, encoder-decoder models, and non-causal models still receive an automatic attention mask; causal right padding remains unmasked so the full logits match `HookedTransformer` and the equivalent pre-tokenized call. The independent forced-left-padding paths in `generate()` and `generate_stream()` are unchanged.

Fixes #1690

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

### Screenshots

N/A — behavioral code fix with regression tests.

## Validation

- Initial regression before the fix: 2 failed / 2 passed, covering the ignored explicit side and public-vs-forward layout mismatch.
- CI follow-up regression: the legacy batched cache acceptance assertions failed under right padding; they now locate each row's last real token from its attention mask.
- Full-tensor compatibility regression: RED with a 3.0087 max difference between text-list and pre-tokenized forwarding; GREEN at exactly 0.0. The independent `HookedTransformer` comparison is also exactly 0.0.
- Focused tokenization, utility, cache, left-padding, mask, position-id, and generation selection: 77 passed.
- Initial `make unit-test`: 5,058 passed, 36 skipped, 44 deselected, 8 existing xfailed, 0 failed.
- Follow-up unit selection: 5,057 passed with 10 SoLU setup errors caused solely by offline mode; those exact 10 pre-existing tests passed after disabling offline mode.
- `make check-format`: passed.
- `uv run mypy .`: no issues in 388 source files.
- `git diff --check`: passed.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (no documentation change required; existing API docs already describe the intended behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
