### PR TITLE
Fix TransformerBridge padding-side semantics

### DIFF
--- a/tests/acceptance/model_bridge/test_run_with_cache_batch.py
+++ b/tests/acceptance/model_bridge/test_run_with_cache_batch.py
@@ -1,8 +1,8 @@
 """Tests that batched run_with_cache and run_with_hooks produce correct results.
 
-Without an attention mask, HF models attend to padding tokens and contaminate
-both logits and cached activations for shorter sequences in a batch. These
-tests guard against that regression.
+The default right-padded layout places each row's last real token at a
+different batch position. These tests compare each row at that position rather
+than assuming that every real sequence ends at index ``-1``.
 """
 
 import torch
@@ -14,6 +14,7 @@ def test_run_with_cache_batch_matches_individual(gpt2_bridge):
         "Hello, my dog is cute",
         "This is a much longer text. Hello, my cat is cute",
     ]
+    last_token_positions = [gpt2_bridge.to_tokens(prompt).shape[1] - 1 for prompt in prompts]
 
     # Individual runs
     individual_logits = []
@@ -23,9 +24,8 @@ def test_run_with_cache_batch_matches_individual(gpt2_bridge):
 
     # Batched run
     batched_logits, _ = gpt2_bridge.run_with_cache(prompts)
-    # With left-padding forced internally, position -1 is the last real token
     for i in range(len(prompts)):
-        batched_last = batched_logits[i, -1, :]
+        batched_last = batched_logits[i, last_token_positions[i], :]
         assert torch.allclose(
             individual_logits[i], batched_last, atol=1e-4
         ), f"Prompt {i} logit mismatch between individual and batched run_with_cache"
@@ -38,6 +38,7 @@ def test_run_with_hooks_batch_matches_individual(gpt2_bridge):
         "Hello, my dog is cute",
         "This is a much longer text. Hello, my cat is cute",
     ]
+    last_token_positions = [gpt2_bridge.to_tokens(prompt).shape[1] - 1 for prompt in prompts]
 
     # Capture resid_post at last layer for last token
     captured_individual = []
@@ -56,9 +57,8 @@ def test_run_with_hooks_batch_matches_individual(gpt2_bridge):
     captured_batched = []
 
     def capture_batched(tensor, hook):
-        # For left-padded batch, last real token is at position -1 for all
         for i in range(tensor.shape[0]):
-            captured_batched.append(tensor[i, -1, :].detach().clone())
+            captured_batched.append(tensor[i, last_token_positions[i], :].detach().clone())
 
     gpt2_bridge.run_with_hooks(
         prompts,

--- a/tests/integration/model_bridge/test_padding_side.py
+++ b/tests/integration/model_bridge/test_padding_side.py
@@ -1,0 +1,95 @@
+"""Padding-side behavior for ragged TransformerBridge text batches."""
+
+import pytest
+import torch
+
+PROMPTS = ["Short", "This is a longer sentence for padding."]
+
+
+def _real_tokens(bridge, prompt: str) -> int:
+    return bridge.to_tokens(prompt).shape[1]
+
+
+def test_to_tokens_honors_padding_side(distilgpt2_bridge) -> None:
+    """The per-call argument must override the tokenizer default."""
+    bridge = distilgpt2_bridge
+    left = bridge.to_tokens(PROMPTS, padding_side="left")
+    right = bridge.to_tokens(PROMPTS, padding_side="right")
+    short_length = _real_tokens(bridge, PROMPTS[0])
+    pad_length = left.shape[1] - short_length
+
+    assert not torch.equal(left, right)
+    torch.testing.assert_close(left[0, pad_length:], right[0, :short_length])
+    assert torch.all(left[0, :pad_length] == bridge.tokenizer.pad_token_id)
+    assert torch.all(right[0, short_length:] == bridge.tokenizer.pad_token_id)
+
+
+@pytest.mark.parametrize("padding_side", ["left", "right"])
+def test_ragged_forward_preserves_single_prompt_logits(distilgpt2_bridge, padding_side) -> None:
+    """Padding must not change logits at any real-token position."""
+    bridge = distilgpt2_bridge
+    with torch.inference_mode():
+        batch_logits = bridge(PROMPTS, padding_side=padding_side)
+        single_logits = [bridge(prompt)[0] for prompt in PROMPTS]
+
+    for row, prompt_logits in enumerate(single_logits):
+        length = prompt_logits.shape[0]
+        actual = (
+            batch_logits[row, -length:] if padding_side == "left" else batch_logits[row, :length]
+        )
+        torch.testing.assert_close(actual, prompt_logits, rtol=1e-6, atol=1e-5)
+
+
+def test_ragged_compatibility_logits_match_hooked_transformer(
+    distilgpt2_bridge_compat, distilgpt2_hooked_processed
+) -> None:
+    """Default string-list forwarding must use HookedTransformer's layout."""
+    with torch.inference_mode():
+        bridge_logits = distilgpt2_bridge_compat(PROMPTS)
+        hooked_logits = distilgpt2_hooked_processed(PROMPTS)
+
+    torch.testing.assert_close(bridge_logits, hooked_logits, rtol=0, atol=1e-5)
+
+
+def test_default_forward_matches_to_tokens_layout(distilgpt2_bridge) -> None:
+    """String-list forwarding must use the same default layout as ``to_tokens``."""
+    bridge = distilgpt2_bridge
+    tokens = bridge.to_tokens(PROMPTS)
+
+    with torch.inference_mode():
+        text_logits = bridge(PROMPTS)
+        token_logits = bridge(tokens)
+
+    torch.testing.assert_close(text_logits, token_logits, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("padding_side", ["left", "right"])
+def test_forward_respects_tokenizer_padding_side(distilgpt2_bridge, padding_side) -> None:
+    """The tokenizer setting controls forward when no per-call override is given."""
+    bridge = distilgpt2_bridge
+    original = bridge.tokenizer.padding_side
+    try:
+        bridge.tokenizer.padding_side = padding_side
+        with torch.inference_mode():
+            default_logits = bridge(PROMPTS)
+            explicit_logits = bridge(PROMPTS, padding_side=padding_side)
+    finally:
+        bridge.tokenizer.padding_side = original
+
+    torch.testing.assert_close(default_logits, explicit_logits, rtol=0, atol=0)
+
+
+def test_batched_generation_still_forces_left_padding(distilgpt2_bridge) -> None:
+    """Generation keeps real tokens flush-right even when right padding is requested."""
+    bridge = distilgpt2_bridge
+    _, input_tokens = bridge.generate(
+        PROMPTS,
+        max_new_tokens=1,
+        do_sample=False,
+        padding_side="right",
+        return_input_tokens=True,
+        verbose=False,
+    )
+
+    expected = bridge.to_tokens(PROMPTS, padding_side="left")
+    assert torch.equal(input_tokens, expected)

--- a/tests/unit/utilities/test_tokenize_utils.py
+++ b/tests/unit/utilities/test_tokenize_utils.py
@@ -1,0 +1,33 @@
+"""Tests for per-call padding-side overrides in tokenization utilities."""
+
+from copy import deepcopy
+
+import torch
+
+from transformer_lens import utils
+
+
+def test_attention_mask_uses_explicit_padding_side(gpt2_tokenizer) -> None:
+    tokenizer = deepcopy(gpt2_tokenizer)
+    tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "right"
+    pad = tokenizer.pad_token_id
+    tokens = torch.tensor([[pad, pad, 10, 11], [pad, 20, 21, 22]])
+
+    mask = utils.get_attention_mask(tokenizer, tokens, prepend_bos=True, padding_side="left")
+
+    assert torch.equal(mask, torch.tensor([[0, 1, 1, 1], [1, 1, 1, 1]]))
+
+
+def test_bos_removal_uses_explicit_padding_side(gpt2_tokenizer) -> None:
+    tokenizer = deepcopy(gpt2_tokenizer)
+    tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.bos_token = tokenizer.convert_ids_to_tokens(0)
+    tokenizer.padding_side = "right"
+    pad = tokenizer.pad_token_id
+    bos = tokenizer.bos_token_id
+    tokens = torch.tensor([[pad, bos, 10, 11], [bos, 20, 21, 22]])
+
+    result = utils.get_tokens_with_bos_removed(tokenizer, tokens, padding_side="left")
+
+    assert torch.equal(result, torch.tensor([[pad, 10, 11], [20, 21, 22]]))

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -1229,6 +1229,7 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             input,
             return_tensors="pt",
             padding=True,
+            padding_side=padding_side,
             truncation=truncate,
             max_length=self.cfg.n_ctx if truncate else None,
         )["input_ids"]
@@ -1241,7 +1242,9 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             while tokens.shape[-1] > 1 and (tokens[:, -1] == self.tokenizer.eos_token_id).all():
                 tokens = tokens[:, :-1]
         if not prepend_bos and tokenizer_prepends_bos:
-            tokens = utils.get_tokens_with_bos_removed(self.tokenizer, tokens)
+            tokens = utils.get_tokens_with_bos_removed(
+                self.tokenizer, tokens, padding_side=padding_side
+            )
         if move_to_device:
             tokens = tokens.to(self.cfg.device)
         return tokens
@@ -2044,16 +2047,17 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             else:
                 kwargs.pop("one_zero_attention_mask")
 
-        # Detect batched list input that will need padding. For this case we force
-        # left-padding internally and auto-compute attention_mask + position_ids
-        # (unless the caller passed them explicitly) so pad tokens don't contaminate
-        # attention or position embeddings.
+        # Detect batched list input that may need padding. Forward follows the
+        # requested/tokenizer side; generation separately forces left-padding.
         _is_batched_list = (
             isinstance(input, list)
             and len(input) > 1
             and not getattr(self.cfg, "is_audio_model", False)
             and not getattr(self.cfg, "is_visual_model", False)
         )
+        _resolved_padding_side = padding_side
+        if _resolved_padding_side is None and self.tokenizer is not None:
+            _resolved_padding_side = getattr(self.tokenizer, "padding_side", "right")
 
         try:
             if isinstance(input, (str, list)):
@@ -2067,20 +2071,9 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                         "Visual models require tensor input (pixel values), not text. "
                         "Pass a torch.Tensor or use the pixel_values parameter."
                     )
-                if _is_batched_list and padding_side is None:
-                    # Force left-padding so real tokens are flush-right.
-                    _orig_padding_side = self.tokenizer.padding_side
-                    self.tokenizer.padding_side = "left"
-                    try:
-                        input_ids = self.to_tokens(
-                            input, prepend_bos=prepend_bos, padding_side=padding_side
-                        )
-                    finally:
-                        self.tokenizer.padding_side = _orig_padding_side
-                else:
-                    input_ids = self.to_tokens(
-                        input, prepend_bos=prepend_bos, padding_side=padding_side
-                    )
+                input_ids = self.to_tokens(
+                    input, prepend_bos=prepend_bos, padding_side=_resolved_padding_side
+                )
             else:
                 input_ids = input
                 # Promote 1D integer token tensors to 2D [batch=1, seq] to match
@@ -2099,25 +2092,27 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
                 isinstance(input_ids, torch.Tensor) and input_ids.is_floating_point()
             )
 
-            # Auto-compute attention_mask + position_ids for batched list input
-            # when the caller didn't supply them. Matches HF generation convention.
+            # Left padding needs a mask and corrected positions. Right padding is
+            # harmless for causal real-token positions and remains unmasked to
+            # match HookedTransformer; bidirectional/encoder inputs still need it.
             if (
                 _is_batched_list
                 and attention_mask is None
                 and self.tokenizer is not None
                 and self.tokenizer.pad_token_id is not None
                 and not _is_inputs_embeds
+                and (
+                    _resolved_padding_side == "left"
+                    or is_encoder_decoder
+                    or not self.adapter.supports_causal_loss
+                )
             ):
-                _prev_side = self.tokenizer.padding_side
-                self.tokenizer.padding_side = "left"
-                try:
-                    attention_mask = utils.get_attention_mask(
-                        self.tokenizer,
-                        input_ids,
-                        prepend_bos=getattr(self.cfg, "default_prepend_bos", True),
-                    ).to(self.cfg.device)
-                finally:
-                    self.tokenizer.padding_side = _prev_side
+                attention_mask = utils.get_attention_mask(
+                    self.tokenizer,
+                    input_ids,
+                    prepend_bos=getattr(self.cfg, "default_prepend_bos", True),
+                    padding_side=_resolved_padding_side,
+                ).to(self.cfg.device)
                 # Gated on the target for the same reason the derivation below is:
                 # a fixed-signature forward raises TypeError on the kwarg, and a
                 # model that owns its own position derivation is overridden by it

--- a/transformer_lens/utilities/tokenize_utils.py
+++ b/transformer_lens/utilities/tokenize_utils.py
@@ -202,7 +202,9 @@ def get_input_with_manually_prepended_bos(
 
 
 def get_tokens_with_bos_removed(
-    tokenizer: PreTrainedTokenizerBase, tokens: torch.Tensor
+    tokenizer: PreTrainedTokenizerBase,
+    tokens: torch.Tensor,
+    padding_side: str | None = None,
 ) -> torch.Tensor:
     """
     Removes the bos token from the beginning of each sequence in `tokens`.
@@ -211,11 +213,15 @@ def get_tokens_with_bos_removed(
     Args:
         tokenizer (PreTrainedTokenizerBase): The tokenizer used to tokenize the input.
         tokens (torch.Tensor): The tokenized input.
+        padding_side: The side used to pad ``tokens``. Defaults to the tokenizer setting.
 
     Returns:
         torch.Tensor: The tokenized input with the bos token removed.
     """
-    if tokenizer.padding_side == "right":
+    if padding_side is None:
+        padding_side = tokenizer.padding_side
+
+    if padding_side == "right":
         return tokens[..., 1:]
 
     else:
@@ -234,7 +240,10 @@ def get_tokens_with_bos_removed(
 
 
 def get_attention_mask(
-    tokenizer: PreTrainedTokenizerBase, tokens: torch.Tensor, prepend_bos: bool
+    tokenizer: PreTrainedTokenizerBase,
+    tokens: torch.Tensor,
+    prepend_bos: bool,
+    padding_side: str | None = None,
 ) -> torch.Tensor:
     """
     Computes the attention mask for the tokenized input.
@@ -246,6 +255,7 @@ def get_attention_mask(
         tokenizer (PreTrainedTokenizerBase): The tokenizer used for tokenization.
         tokens (torch.Tensor): The tokenized input.
         prepend_bos (bool): If True, a BOS token is prepended to the input.
+        padding_side: The side used to pad ``tokens``. Defaults to the tokenizer setting.
 
     Returns:
         torch.Tensor: The attention mask for the input.
@@ -255,9 +265,11 @@ def get_attention_mask(
     attention_mask = torch.ones_like(tokens)
     if tokenizer is None:
         return attention_mask
+    if padding_side is None:
+        padding_side = tokenizer.padding_side
     is_not_pad_token = tokens.ne(tokenizer.pad_token_id)
 
-    if tokenizer.padding_side == "right":
+    if padding_side == "right":
         # Zero-out the rightmost trailing pad tokens
         is_trailing_pad = get_cumsum_along_dim(is_not_pad_token, -1, reverse=True) == 0
         attention_mask[is_trailing_pad] = 0


### PR DESCRIPTION
# Description

`TransformerBridge.to_tokens()` accepted `padding_side` but did not forward it to the tokenizer, so per-call left/right overrides produced the same layout. Batched string forwarding also forced left padding for ordinary forward passes, diverging from the tokenizer default, `to_tokens()`, and HookedTransformer compatibility behavior.

This change:
- forwards the resolved padding side through tokenization and BOS removal;
- preserves requested or tokenizer padding for ordinary forward passes;
- keeps batched generation left-padded;
- limits automatic mask and position derivation to layouts and model types that require it.

Regression coverage checks per-call overrides, real-token logit parity for both padding sides, compatibility-mode parity, forward and tokenization layout consistency, generation behavior, BOS removal, and attention-mask construction.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

# Testing

- `uv run pytest -q tests/unit/utilities/test_tokenize_utils.py tests/integration/model_bridge/test_padding_side.py tests/acceptance/model_bridge/test_run_with_cache_batch.py` — 12 passed
- `make check-format`
- `uv run mypy .` — no issues in 388 source files
- `make unit-test` — 5,056 passed
- `make docstring-test` — 18 passed
- `make acceptance-test` — 209 passed
- `CI=1 uv run pytest -q tests/integration/model_bridge/test_bridge_integration.py --reruns 0` — 20 passed, 1 skipped