### PR TITLE
August 19th Verification Sweep Fixes

### DIFF
--- a/tests/QUARANTINES.md
+++ b/tests/QUARANTINES.md
@@ -79,36 +79,17 @@ Big-model adapter tests use `@pytest.mark.slow`, CI tier filters `-m "not slow"`
 
 | Path | Reason | Issue |
 |---|---|---|
-| [`unit/model_bridge/test_bridge_generate_no_tokenizer.py`:30,128](unit/model_bridge/test_bridge_generate_no_tokenizer.py) | `skipif(_MACOS_ARM64)` — KV-cache NaN | Upstream PyTorch/HF on M-series Macs |
-| [`integration/model_bridge/test_bridge_generate_stopping_criteria.py`](integration/model_bridge/test_bridge_generate_stopping_criteria.py) | `skipif(_MACOS_ARM64)`, KV-cache NaN (one `use_past_kv_cache=True` test) | Upstream PyTorch/HF on M-series Macs |
 | [`acceptance/test_hooked_transformer.py`](acceptance/test_hooked_transformer.py) | `redwood_attn_2l` (2 tests) — `ArthurConmy/redwood_tokenizer`'s merges name a token missing from its vocab (`Ġpati`), rejected by tokenizers >= 0.20 on both the fast and slow paths | Third-party repo; the weights load fine, only the tokenizer is unusable |
 
-**Un-skip:** when upstream resolves. Don't bypass — produces NaN logits. The redwood skip is
-evaluated at collection by actually attempting the load, so it disappears on its own if the repo
-is fixed or the tokenizers constraint relaxes; substituting a different tokenizer is not a fix
-(it would change token ids and invalidate the pinned expected loss).
+**Un-skip:** evaluated at collection by actually attempting the load, so it disappears on its own
+if the repo is fixed or the tokenizers constraint relaxes; substituting a different tokenizer is
+not a fix (it would change token ids and invalidate the pinned expected loss).
 
 ---
 
 ## ⚠️ Technical debt — whole-file
 
 No modules are currently quarantined this way.
-
-**Resolved 2026-08-17.** `acceptance/test_hooked_transformer.py`, `test_hooked_encoder.py` and
-`test_hooked_encoder_decoder.py` had carried module-level `pytest.mark.skip(reason="CI test
-pollution")` since #1129. Re-running them found no pollution: each passes alone, and the full
-acceptance tier with all three enabled is green (231 passed, 39 skipped). What the skips were
-hiding was four genuine failures, all now fixed at the source:
-
-| Was failing | Actual cause |
-|---|---|
-| `test_bert_block` | transformers 5.x returns a tensor from `BertLayer.forward`, so the test's `[0]` took batch element 0 instead of tuple element 0 |
-| `test_bloom_similarity_*` (×2) | the HF fixture loaded bloom at its checkpoint dtype (fp16) while TL loads fp32 — the comparison measured HF's own fp16 error (0.259 log-softmax against *itself*), not TL |
-| `test_model[redwood_attn_2l]`, `test_from_pretrained_no_processing[redwood_attn_2l]` | `ArthurConmy/redwood_tokenizer` has merges referencing a token absent from its vocab, which tokenizers >= 0.20 rejects; see the per-test skip below |
-
-Two silent TransformerLens bugs also lived in this blind spot the whole time: T5's decoder
-self-attention was never causally masked, and its relative-position bias used the encoder's
-bucketing. Both are fixed. Keep these modules enabled.
 
 ---
 

--- a/tests/integration/model_bridge/test_bloom_gated_hooks.py
+++ b/tests/integration/model_bridge/test_bloom_gated_hooks.py
@@ -1,0 +1,44 @@
+"""Bloom's gated attention hooks must fire like every other joint-QKV bridge.
+
+`BloomAttentionBridge` overrides both `forward` and `_reconstruct_attention`, and
+the overrides projected Q/K/V directly and always took the plain output
+projection. `hook_result`, `hook_q_input`, `hook_k_input`, `hook_v_input` and
+`hook_attn_in` therefore never fired — enabling `use_attn_result` on a Bloom
+model silently produced nothing.
+"""
+
+import pytest
+import torch
+
+from transformer_lens.benchmarks import benchmark_gated_hooks_fire
+from transformer_lens.model_bridge import TransformerBridge
+
+MODEL = "bigscience/bloom-560m"
+PROMPT = "The theory of relativity explains that the speed of light"
+
+
+@pytest.fixture(scope="module")
+def bridge():
+    return TransformerBridge.boot_transformers(MODEL, device="cpu")
+
+
+def test_every_gated_hook_fires(bridge) -> None:
+    result = benchmark_gated_hooks_fire(bridge, PROMPT)
+    assert result.passed, result.message
+    fired = (result.details or {}).get("fired_counts", {})
+    assert fired and all(count > 0 for count in fired.values()), fired
+
+
+@pytest.mark.parametrize("flag", ["use_attn_result", "use_split_qkv_input", "use_attn_in"])
+def test_gated_paths_preserve_the_output(bridge, flag: str) -> None:
+    """The fork re-parameterizes the same math, so logits must not move beyond
+    the op-order noise a correct implementation shows (gpt2 1e-4, pythia 4e-3)."""
+    tokens = bridge.to_tokens(PROMPT)
+    with torch.no_grad():
+        baseline = bridge(tokens).float()
+        setattr(bridge.cfg, flag, True)
+        try:
+            gated = bridge(tokens).float()
+        finally:
+            setattr(bridge.cfg, flag, False)
+    torch.testing.assert_close(gated, baseline, atol=5e-3, rtol=1e-3)

--- a/tests/integration/model_bridge/test_bridge_generate_stopping_criteria.py
+++ b/tests/integration/model_bridge/test_bridge_generate_stopping_criteria.py
@@ -18,13 +18,10 @@ use_past_kv_cache=False so the tests stay robust on macOS-arm64 CI where the
 cached-eager-attention path can NaN (issue #1322).
 """
 
-import platform
 
 import pytest
 import torch
 from transformers import StoppingCriteria, StoppingCriteriaList
-
-_MACOS_ARM64 = platform.system() == "Darwin" and platform.machine() == "arm64"
 
 # Common kwargs for the greedy, macOS-safe, token-returning generate calls below.
 _GEN = dict(do_sample=False, use_past_kv_cache=False, return_type="tokens", verbose=False)
@@ -225,7 +222,6 @@ def test_batched_generation_stops(bridge_with_pad):
     assert torch.equal(out1, out2), "batched greedy generation must be deterministic"
 
 
-@pytest.mark.skipif(_MACOS_ARM64, reason="Upstream macOS-arm64 KV-cache NaN, see issue #1322.")
 def test_stop_string_with_kv_cache(bridge):
     """stop_strings also works on the default KV-cache path (not only the no-cache path)."""
     tokens = bridge.to_tokens("The quick brown")

--- a/tests/integration/model_bridge/test_bridge_layer_past_cache.py
+++ b/tests/integration/model_bridge/test_bridge_layer_past_cache.py
@@ -1,0 +1,72 @@
+"""Architectures that name the KV cache `layer_past` must still populate it.
+
+GPT-NeoX, GPT-J, Bloom, Falcon, MPT, CodeGen and GPT-BigCode take the cache as
+`layer_past`; everything modern takes `past_key_values`. Reading only the latter
+left the cache empty, so each decode step attended to itself alone and generation
+silently ignored the prompt — pythia-1.4b answered every prompt with
+" the first time.\\n\\n\\n...".
+"""
+
+import pytest
+import torch
+from transformers import DynamicCache
+
+from transformer_lens.model_bridge import TransformerBridge
+
+MODEL = "EleutherAI/pythia-70m"  # GPTNeoX: takes `layer_past`
+PROMPT = "The theory of relativity explains that"
+
+
+@pytest.fixture(scope="module")
+def bridge():
+    return TransformerBridge.boot_transformers(MODEL, device="cpu")
+
+
+def test_forward_populates_a_layer_past_cache(bridge) -> None:
+    cache = DynamicCache()
+    tokens = bridge.to_tokens(PROMPT)
+    with torch.no_grad():
+        bridge(tokens, past_key_values=cache, use_cache=True)
+    assert (
+        cache.get_seq_length() == tokens.shape[1]
+    ), f"cache holds {cache.get_seq_length()} of {tokens.shape[1]} tokens"
+
+
+def test_cached_generation_matches_uncached(bridge) -> None:
+    """The cache is an optimization: it must not change what is generated."""
+    outputs = {}
+    for use_cache in (True, False):
+        torch.manual_seed(42)
+        outputs[use_cache] = bridge.generate(
+            PROMPT,
+            max_new_tokens=15,
+            do_sample=False,
+            verbose=False,
+            use_past_kv_cache=use_cache,
+        )
+    assert outputs[True] == outputs[False], f"cached={outputs[True]!r}\nuncached={outputs[False]!r}"
+
+
+def test_generation_depends_on_the_prompt(bridge) -> None:
+    """Engagement check: an empty cache made every prompt yield the same text,
+    which prompt-independent output is the loudest symptom of."""
+    torch.manual_seed(42)
+    a = bridge.generate(
+        "The theory of relativity explains that",
+        max_new_tokens=12,
+        do_sample=False,
+        verbose=False,
+        use_past_kv_cache=True,
+    )
+    torch.manual_seed(42)
+    b = bridge.generate(
+        "Modern computing relies heavily on",
+        max_new_tokens=12,
+        do_sample=False,
+        verbose=False,
+        use_past_kv_cache=True,
+    )
+    assert (
+        a[len("The theory of relativity explains that") :]
+        != b[len("Modern computing relies heavily on") :]
+    )

--- a/tests/unit/model_bridge/test_bridge_generate_no_tokenizer.py
+++ b/tests/unit/model_bridge/test_bridge_generate_no_tokenizer.py
@@ -8,7 +8,6 @@ from HF; tests then clear ``bridge.tokenizer`` to exercise the tokenizer-free
 generation path (algorithmic/custom-tokenized use cases).
 """
 
-import platform
 
 import pytest
 import torch
@@ -16,8 +15,6 @@ import torch
 from transformer_lens.model_bridge import TransformerBridge
 
 _PROMPT_TOKENS = torch.tensor([[15496, 11, 314, 1101, 257]], dtype=torch.long)
-
-_MACOS_ARM64 = platform.system() == "Darwin" and platform.machine() == "arm64"
 
 
 @pytest.fixture(scope="module")
@@ -27,7 +24,6 @@ def tokenizer_free_bridge():
     return bridge
 
 
-@pytest.mark.skipif(_MACOS_ARM64, reason="Upstream macOS-arm64 KV-cache NaN; see linked issue.")
 def test_generate_without_tokenizer_stop_at_eos_false_kv_cache(tokenizer_free_bridge):
     """generate() with no tokenizer, stop_at_eos=False, use_past_kv_cache=True."""
     bridge = tokenizer_free_bridge
@@ -164,7 +160,6 @@ def test_generate_string_input_without_tokenizer_errors(tokenizer_free_bridge):
         bridge.generate("hello", max_new_tokens=3, verbose=False)
 
 
-@pytest.mark.skipif(_MACOS_ARM64, reason="Upstream macOS-arm64 KV-cache NaN; see linked issue.")
 def test_generate_return_type_str_without_tokenizer_errors(tokenizer_free_bridge):
     """generate(return_type='str') must error when no tokenizer is set.
 

--- a/tests/unit/test_gradient_mismatch_grading.py
+++ b/tests/unit/test_gradient_mismatch_grading.py
@@ -1,0 +1,130 @@
+"""Gradient mismatches are graded on scale-aware statistics, not worst-case elements.
+
+Registering backward hooks forces normalization off HF's native autograd onto the
+python-norm path, which shifts results at float-rounding scale. Elementwise
+`allclose` graded that shift as failure: one element of 55,296 crossing the
+tolerance scored the same as a real divergence. The band accepts a mismatch only
+when it is both diffuse (rel_l2) and localized to a handful of elements (COUNT,
+not fraction — detection guarantees count >= 1, so a fractional guard was
+unsatisfiable below 10,000 elements and re-created the false failure on
+gemma-3-270m's 6,912-element MQA hook_rot_k).
+"""
+
+import pytest
+
+from transformer_lens.benchmarks.backward_gradients import (
+    OVER_TOLERANCE_MAX_ELEMENTS,
+    REL_L2_TOLERANCE,
+    gradient_mismatch_is_numerical_noise,
+)
+
+# Measured bridge-vs-HT fallback noise. Only mismatches the detection gate records
+# can reach the classifier, so every fixture has count >= 1 (frac-zero rows from
+# the original study never reach it and prove nothing).
+NOISE = [
+    ("Qwen3-0.6B rot_q [1,27,16,128]", 1.714e-05, 1),
+    ("gemma-3-270m rot_k [1,27,1,256] (MQA, 6912 elements)", 5.0e-05, 1),
+]
+# Injected bugs of known severity on the Qwen3 rot_q tensor (55,296 elements).
+BUGS = [
+    ("one head scaled 1%", 2.97e-03, 758),
+    ("uniform scale 0.1%", 1.00e-03, 432),
+    ("60 elements +50", 1.09e-02, 60),
+]
+
+
+@pytest.mark.parametrize("label,rel_l2,count", NOISE)
+def test_fallback_noise_is_accepted(label: str, rel_l2: float, count: int) -> None:
+    assert gradient_mismatch_is_numerical_noise(rel_l2, count), label
+
+
+@pytest.mark.parametrize("label,rel_l2,count", BUGS)
+def test_real_divergence_is_rejected(label: str, rel_l2: float, count: int) -> None:
+    assert not gradient_mismatch_is_numerical_noise(rel_l2, count), label
+
+
+def test_thresholds_keep_a_margin_on_both_dimensions() -> None:
+    """Both guards must sit clear of both populations, not graze either."""
+    worst_noise_rel = max(rel for _, rel, _ in NOISE)
+    best_bug_rel = min(rel for _, rel, _ in BUGS)
+    assert worst_noise_rel * 2 <= REL_L2_TOLERANCE, worst_noise_rel
+    assert best_bug_rel >= REL_L2_TOLERANCE * 5, best_bug_rel
+    worst_noise_count = max(count for _, _, count in NOISE)
+    best_bug_count = min(count for _, _, count in BUGS)
+    assert worst_noise_count * 3 <= OVER_TOLERANCE_MAX_ELEMENTS + 1, worst_noise_count
+    assert best_bug_count >= OVER_TOLERANCE_MAX_ELEMENTS * 10, best_bug_count
+
+
+def test_localized_divergence_is_rejected_even_when_diffuse_error_is_small() -> None:
+    """The count is the guard: a concentrated error rel_l2 would dilute still fails."""
+    assert not gradient_mismatch_is_numerical_noise(REL_L2_TOLERANCE / 10, 60)
+    assert not gradient_mismatch_is_numerical_noise(1e-2, 1)
+
+
+def test_zero_reference_divergence_is_rejected() -> None:
+    """A zero reference gradient with a nonzero bridge gradient records
+    rel_l2=inf in the benchmark body — maximal divergence, never noise."""
+    assert not gradient_mismatch_is_numerical_noise(float("inf"), 1)
+
+
+def test_boundaries_are_inclusive() -> None:
+    """Pin the <= contract on both dimensions."""
+    assert gradient_mismatch_is_numerical_noise(REL_L2_TOLERANCE, OVER_TOLERANCE_MAX_ELEMENTS)
+    assert not gradient_mismatch_is_numerical_noise(
+        REL_L2_TOLERANCE * 1.01, OVER_TOLERANCE_MAX_ELEMENTS
+    )
+    assert not gradient_mismatch_is_numerical_noise(
+        REL_L2_TOLERANCE, OVER_TOLERANCE_MAX_ELEMENTS + 1
+    )
+
+
+class TestMismatchStatsHelper:
+    """The stats the classifier consumes, driven with synthetic tensors."""
+
+    def test_zero_reference_nonzero_bridge_is_infinite(self) -> None:
+        import torch
+
+        from transformer_lens.benchmarks.backward_gradients import (
+            gradient_mismatch_stats,
+        )
+
+        stats = gradient_mismatch_stats(torch.ones(100), torch.zeros(100), 0.2, 3e-4)
+        assert stats["rel_l2"] == float("inf")
+        assert not gradient_mismatch_is_numerical_noise(stats["rel_l2"], stats["over_count"])
+
+    def test_matching_zeros_agree(self) -> None:
+        import torch
+
+        from transformer_lens.benchmarks.backward_gradients import (
+            gradient_mismatch_stats,
+        )
+
+        stats = gradient_mismatch_stats(torch.zeros(100), torch.zeros(100), 0.2, 3e-4)
+        assert stats["rel_l2"] == 0.0 and stats["over_count"] == 0
+
+    def test_over_count_matches_detection_predicate(self) -> None:
+        import torch
+
+        from transformer_lens.benchmarks.backward_gradients import (
+            gradient_mismatch_stats,
+        )
+
+        ref = torch.full((6912,), 258.0)  # gemma-3-270m rot_k scale
+        bridge = ref.clone()
+        bridge[0] += 0.5  # one element past atol + rtol*|ref|
+        stats = gradient_mismatch_stats(bridge, ref, 0.2, 3e-4)
+        assert stats["over_count"] == 1
+        assert gradient_mismatch_is_numerical_noise(stats["rel_l2"], stats["over_count"]), stats
+
+
+class TestFp32GradientPredicate:
+    def test_reduced_precision_needs_upcast(self) -> None:
+        import torch
+
+        from transformer_lens.benchmarks.backward_gradients import needs_fp32_gradients
+
+        assert needs_fp32_gradients(torch.bfloat16)
+        assert needs_fp32_gradients(torch.float16)
+        assert not needs_fp32_gradients(torch.float32)
+        assert not needs_fp32_gradients(torch.float64)
+        assert not needs_fp32_gradients(None)

--- a/tests/unit/test_moe_fold_guard.py
+++ b/tests/unit/test_moe_fold_guard.py
@@ -1,0 +1,37 @@
+"""MoE models must keep their norm gains: nothing folds them in.
+
+`get_pretrained_model_config(fold_ln=True)` swaps the norm for its gain-less
+*Pre variant on the assumption that `process_weights_` folds the gains into the
+next weights. `process_weights_` refuses to fold MoE experts, so the two
+decisions disagreed and the gains were dropped entirely — OLMoE-1B-7B landed
+20.5 off HF in log-softmax with 0% argmax agreement.
+"""
+
+import pytest
+
+from transformer_lens.loading_from_pretrained import get_pretrained_model_config
+
+MOE_MODELS = ["allenai/OLMoE-1B-7B-0924", "mistralai/Mixtral-8x7B-v0.1"]
+
+
+@pytest.mark.parametrize("model_name", MOE_MODELS)
+def test_moe_keeps_its_norm_gains(model_name: str) -> None:
+    cfg = get_pretrained_model_config(model_name, fold_ln=True)
+    assert cfg.num_experts and cfg.num_experts > 1, "fixture must be a MoE model"
+    assert cfg.normalization_type == "RMS", (
+        f"{model_name} normalization_type={cfg.normalization_type}: the gain-less "
+        "*Pre variant means the norm weights were dropped with nothing folding them in"
+    )
+
+
+def test_dense_models_still_fold() -> None:
+    """Negative control: the guard must not disable folding for everyone."""
+    cfg = get_pretrained_model_config("Qwen/Qwen2.5-0.5B", fold_ln=True)
+    assert cfg.num_experts is None
+    assert cfg.normalization_type == "RMSPre"
+
+
+def test_moe_fold_warns(caplog) -> None:
+    with caplog.at_level("WARNING"):
+        get_pretrained_model_config(MOE_MODELS[0], fold_ln=True)
+    assert any("not supported for MoE" in r.getMessage() for r in caplog.records)

--- a/transformer_lens/benchmarks/backward_gradients.py
+++ b/transformer_lens/benchmarks/backward_gradients.py
@@ -14,6 +14,59 @@ from transformer_lens.benchmarks.utils import (
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge import TransformerBridge
 
+# Grading band for numerical (non-convention) gradient mismatches. Registering
+# backward hooks forces normalization off HF's native autograd onto the python
+# norm, which shifts results at float-rounding scale; measured noise is ~1e-5
+# rel_l2 with a single over-tolerance element, while injected bugs start at
+# ~1e-3 rel_l2 with 60+ elements over. Valid for fp32 gradients only — the
+# gradient section upcasts reduced-precision models before comparing.
+REL_L2_TOLERANCE = 1e-4
+OVER_TOLERANCE_MAX_ELEMENTS = 3
+
+
+def needs_fp32_gradients(dtype: Optional[torch.dtype]) -> bool:
+    """Reduced-precision gradients cannot be graded against the fp32-calibrated
+    band — bf16's rounding floor alone is ~2e-3 rel_l2, inside the bug band."""
+    return dtype is not None and dtype not in (torch.float32, torch.float64)
+
+
+def gradient_mismatch_stats(
+    bridge_finite: torch.Tensor,
+    reference_finite: torch.Tensor,
+    abs_tolerance: float,
+    rel_tolerance: float,
+) -> dict:
+    """Scale-aware statistics for grading one recorded gradient mismatch.
+
+    A zero reference with a nonzero bridge gradient is the maximally divergent
+    case, not perfect agreement, so rel_l2 is inf there rather than 0.
+    """
+    bf, rf = bridge_finite.float(), reference_finite.float()
+    ref_norm = torch.norm(rf)
+    diff_norm = torch.norm(bf - rf)
+    if ref_norm > 0:
+        rel_l2 = (diff_norm / ref_norm).item()
+    else:
+        rel_l2 = 0.0 if diff_norm == 0 else float("inf")
+    over_count = int(
+        (torch.abs(bf - rf) > abs_tolerance + rel_tolerance * torch.abs(rf)).sum().item()
+    )
+    return {"rel_l2": rel_l2, "over_count": over_count}
+
+
+def gradient_mismatch_is_numerical_noise(rel_l2: float, over_count: int) -> bool:
+    """True when a gradient mismatch is diffuse and tiny rather than a divergence.
+
+    Elementwise worst-case cannot separate the two: one element of 55k crossing
+    the tolerance scores the same as a head scaled by 1%. rel_l2 separates them
+    by 58x or more, and the element COUNT guards the localized case rel_l2 would
+    dilute. A count (not a fraction) keeps the band reachable on small tensors:
+    detection guarantees count >= 1, so a fractional guard of 1e-4 was
+    arithmetically unsatisfiable below 10,000 elements (gemma-3-270m's MQA
+    hook_rot_k is 6,912).
+    """
+    return rel_l2 <= REL_L2_TOLERANCE and over_count <= OVER_TOLERANCE_MAX_ELEMENTS
+
 
 def benchmark_backward_hooks(
     bridge: TransformerBridge,
@@ -119,6 +172,7 @@ def benchmark_backward_hooks(
         ]
 
         mismatches = []
+        mismatch_stats: dict = {}
         for hook_name in sorted(common_hooks):
             if hook_name in excluded_hooks:
                 continue
@@ -148,8 +202,16 @@ def benchmark_backward_hooks(
                     mean_diff = torch.mean(torch.abs(bf - rf)).item()
                     rel_diff = torch.abs(bf - rf) / (torch.abs(bf) + 1e-8)
                     mean_rel = rel_diff.mean().item()
+                    # Scale-aware stats for grading. Elementwise worst-case alone
+                    # cannot separate a real divergence from the float-rounding
+                    # shift the python-norm fallback introduces when backward
+                    # hooks force normalization off HF's native autograd path.
+                    stats = gradient_mismatch_stats(bf, rf, abs_tolerance, rel_tolerance)
+                    mismatch_stats[hook_name] = stats
                     mismatches.append(
-                        f"{hook_name}: Value mismatch - max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}, mean_rel={mean_rel:.6f}"
+                        f"{hook_name}: Value mismatch - max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}, "
+                        f"mean_rel={mean_rel:.6f}, rel_l2={stats['rel_l2']:.3e}, "
+                        f"over_count={stats['over_count']}"
                     )
 
         tested_hooks = len(common_hooks) - len(excluded_hooks)
@@ -184,8 +246,25 @@ def benchmark_backward_hooks(
                 "mlp.hook_pre",
                 "hook_mlp_out",
             ]
+
+            def within_noise_band(entry: str) -> bool:
+                """Diffuse, tiny deviation — the fallback's rounding, not a divergence.
+
+                Measured noise across architectures is rel_l2 ~1e-5 with a single
+                over-tolerance element on the rotary hooks (the only ones outside
+                the pattern list); injected bugs of a 1% head scale or a 0.1%
+                uniform scale land at rel_l2 1e-3+ with 60+ elements over.
+                """
+                name = entry.split(":")[0]
+                stats = mismatch_stats.get(name)
+                if stats is None:
+                    return False
+                return gradient_mismatch_is_numerical_noise(stats["rel_l2"], stats["over_count"])
+
             acceptable_mismatches = [
-                m for m in mismatches if any(pattern in m for pattern in acceptable_patterns)
+                m
+                for m in mismatches
+                if any(pattern in m for pattern in acceptable_patterns) or within_noise_band(m)
             ]
 
             if len(acceptable_mismatches) == len(mismatches):

--- a/transformer_lens/benchmarks/backward_gradients.py
+++ b/transformer_lens/benchmarks/backward_gradients.py
@@ -169,6 +169,10 @@ def benchmark_backward_hooks(
                 "k_norm",  # QK norm: Bridge uses 4D, HT uses 2D (shape convention)
                 "ln1.hook_",
                 "ln2.hook_",
+                # Sandwich norms (gemma-2/3): same class as ln1/ln2 above, which
+                # predate them.
+                "ln1_post.hook_",
+                "ln2_post.hook_",
                 "ln_final.hook_",
                 "hook_resid_mid",
                 "hook_resid_pre",
@@ -402,6 +406,9 @@ def benchmark_critical_backward_hooks(
                 "k_norm",  # QK norm: Bridge uses 4D, HT uses 2D (shape convention)
                 "ln1.hook_",
                 "ln2.hook_",
+                # Sandwich norms (gemma-2/3): same class as ln1/ln2 above.
+                "ln1_post.hook_",
+                "ln2_post.hook_",
                 "hook_resid_pre",
                 "hook_resid_mid",
                 "hook_resid_post",

--- a/transformer_lens/benchmarks/main_benchmark.py
+++ b/transformer_lens/benchmarks/main_benchmark.py
@@ -31,6 +31,7 @@ from transformer_lens.benchmarks.backward_gradients import (
     benchmark_backward_hooks,
     benchmark_critical_backward_hooks,
     benchmark_gradient_computation,
+    needs_fp32_gradients,
 )
 from transformer_lens.benchmarks.component_benchmark import benchmark_all_components
 from transformer_lens.benchmarks.forward_pass import (
@@ -512,17 +513,20 @@ def run_comparison_benchmarks(
     if verbose:
         print("6. Backward Gradient Benchmarks")
 
-    # MPS does not support bfloat16 autograd. Upcast to float32 for gradient tests if needed.
+    # Gradient comparisons are graded against fp32-calibrated thresholds
+    # (REL_L2_TOLERANCE): bf16's rounding floor alone is ~2e-3 rel_l2, inside the
+    # measured bug band, so reduced-precision gradients cannot be graded at all.
+    # Upcast for the gradient section on every device (MPS additionally lacks
+    # bf16 autograd), then restore below.
     bridge_grad_dtype = bridge_model.cfg.dtype if hasattr(bridge_model, "cfg") else None
-    bridge_device = next(bridge_model.parameters()).device
-    mps_bf16_upcast = str(bridge_device).startswith("mps") and bridge_grad_dtype == torch.bfloat16
-    if mps_bf16_upcast:
+    grad_fp32_upcast = needs_fp32_gradients(bridge_grad_dtype)
+    if grad_fp32_upcast:
         try:
             bridge_model.to(torch.float32)
             if reference_model is not None:
                 reference_model.to(torch.float32)
         except Exception:
-            mps_bf16_upcast = False  # Upcast failed; proceed as-is
+            grad_fp32_upcast = False  # Upcast failed; proceed as-is
 
     if ht_available:
         try:
@@ -561,7 +565,7 @@ def run_comparison_benchmarks(
             if verbose:
                 print(f"✗ Gradient benchmark failed: {e}\n")
 
-    if mps_bf16_upcast and bridge_grad_dtype is not None:
+    if grad_fp32_upcast and bridge_grad_dtype is not None:
         try:
             bridge_model.to(bridge_grad_dtype)
             if reference_model is not None:

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1801,6 +1801,17 @@ def get_pretrained_model_config(
 
     cfg_dict["dtype"] = dtype
 
+    # process_weights_ refuses to fold MoE experts, so flipping the norm to its
+    # gain-less *Pre variant here would drop the gains with nothing folding them
+    # in — the model silently loses its norm weights entirely.
+    num_experts = cfg_dict.get("num_experts")
+    if fold_ln and num_experts and num_experts > 1:
+        logging.warning(
+            "fold_ln=True is not supported for MoE models (experts are never folded). "
+            "Setting fold_ln=False."
+        )
+        fold_ln = False
+
     if fold_ln:
         if cfg_dict["normalization_type"] in ["LN", "LNPre"]:
             cfg_dict["normalization_type"] = "LNPre"

--- a/transformer_lens/model_bridge/generalized_components/attention.py
+++ b/transformer_lens/model_bridge/generalized_components/attention.py
@@ -430,13 +430,18 @@ class AttentionBridge(GeneralizedComponent):
         """
         past_key_values = kwargs.get("past_key_values", None)
         if past_key_values is None:
+            # GPT-NeoX/GPT-J/Bloom/Falcon/MPT/CodeGen/GPTBigCode still name the
+            # cache `layer_past`; missing it leaves the cache empty, so every
+            # decode step attends to itself alone and generation ignores the prompt.
+            past_key_values = kwargs.get("layer_past", None)
+        if past_key_values is None:
             return k, v
         layer_idx = getattr(self, "_layer_idx", None)
         if layer_idx is None:
             logger.warning(
                 "%s: past_key_values provided but _layer_idx is None "
-                "(HF component missing layer_idx attribute). "
-                "KV cache update skipped — generation will be slow.",
+                "(HF component missing layer_idx attribute). KV cache update "
+                "skipped — cached generation will ignore earlier tokens.",
                 self.name,
             )
             return k, v

--- a/transformer_lens/model_bridge/generalized_components/bloom_attention.py
+++ b/transformer_lens/model_bridge/generalized_components/bloom_attention.py
@@ -101,10 +101,15 @@ class BloomAttentionBridge(JointQKVAttentionBridge):
         # Apply input hook
         hooked_input = self.hook_in(hidden_states)
 
-        # Run through split Q/K/V projections (these fire hook_q, hook_k, hook_v)
-        q_output = self.q(hooked_input)
-        k_output = self.k(hooked_input)
-        v_output = self.v(hooked_input)
+        # Run through split Q/K/V projections (these fire hook_q, hook_k, hook_v),
+        # via the per-head fork when use_split_qkv_input / use_attn_in is set so
+        # those gated hooks fire here as they do on every other joint-QKV bridge.
+        if self._is_split_qkv_fork_active():
+            q_output, k_output, v_output = self._split_forward_qkv(hooked_input)
+        else:
+            q_output = self.q(hooked_input)
+            k_output = self.k(hooked_input)
+            v_output = self.v(hooked_input)
 
         # Reconstruct attention with ALiBi (fires hook_attn_scores, hook_pattern)
         attn_output, attn_weights = self._reconstruct_attention(
@@ -199,7 +204,18 @@ class BloomAttentionBridge(JointQKVAttentionBridge):
         attn_output = self._reshape_attn_output(
             attn_output, batch_size, seq_len, num_heads, head_dim
         )
-        attn_output = self._apply_output_projection(attn_output)
+        if (
+            bool(getattr(self.config, "use_attn_result", False))
+            and hasattr(self, "o")
+            and self.o.original_component is not None
+        ):
+            # Fire hook_z on the flat pre-projection tensor first, so patches at
+            # hook_z reach the per-head computation (same order as the parent).
+            attn_output = self.o.hook_in(attn_output)
+            z_4d = attn_output.view(batch_size, seq_len, num_heads, head_dim)
+            attn_output = self._compute_per_head_result(z_4d, num_heads, head_dim)
+        else:
+            attn_output = self._apply_output_projection(attn_output)
 
         return (attn_output, attn_weights)
 


### PR DESCRIPTION
# Description

Additional bug fixes related to a new verification sweep done after the last weeks worth of bug fixes.

- Fixed a series of Gemma hooks that were not properly gated
- Improved gradient testing to better detect flaws like the flaw we found in the Gemma process
- Fixed a bug with OLMo MoE expert management in HookedTransformer
- Fixed a bug within Bloom QKV split

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility