### PR TITLE
Fix OLMo 2 attention input fork state

### DIFF
--- a/tests/integration/model_bridge/test_olmo2_hook_semantics.py
+++ b/tests/integration/model_bridge/test_olmo2_hook_semantics.py
@@ -191,3 +191,40 @@ def test_compatibility_mode_preserves_residual_semantics() -> None:
             cache[f"blocks.{layer}.hook_resid_post"],
             cache[f"blocks.{layer}.hook_resid_mid"] + cache[f"blocks.{layer}.hook_mlp_out"],
         )
+
+
+@pytest.mark.parametrize("use_split_qkv", [True, False], ids=["split_qkv", "attn_in"])
+def test_attention_input_forks_are_stateless(use_split_qkv: bool) -> None:
+    """OLMo 2 has no pre-attention norm, so input forks must read resid_pre
+    directly and must not retain the preceding forward's post-norm output.
+    """
+    bridge = TransformerBridge.boot_transformers(MODEL, device="cpu", dtype=torch.float32)
+    tokens = torch.tensor([[1, 2, 3, 4, 5]])
+
+    with torch.no_grad():
+        expected = bridge(tokens).clone()
+
+    if use_split_qkv:
+        bridge.set_use_split_qkv_input(True)
+        hook_name = "blocks.1.attn.hook_q_input"
+    else:
+        bridge.set_use_attn_in(True)
+        hook_name = "blocks.1.attn.hook_attn_in"
+
+    try:
+        with torch.no_grad():
+            first_logits, first_cache = bridge.run_with_cache(tokens)
+            second_logits, second_cache = bridge.run_with_cache(tokens)
+    finally:
+        if use_split_qkv:
+            bridge.set_use_split_qkv_input(False)
+        else:
+            bridge.set_use_attn_in(False)
+
+    for cache in (first_cache, second_cache):
+        expected_input = cache["blocks.1.hook_resid_pre"].unsqueeze(2)
+        torch.testing.assert_close(cache[hook_name], expected_input.expand_as(cache[hook_name]))
+
+    torch.testing.assert_close(first_logits, expected, atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(second_logits, expected, atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(second_logits, first_logits, atol=0, rtol=0)

--- a/transformer_lens/model_bridge/generalized_components/block.py
+++ b/transformer_lens/model_bridge/generalized_components/block.py
@@ -135,6 +135,8 @@ class BlockBridge(GeneralizedComponent):
         attn = self.submodules.get("attn") if self.submodules else None
         if (
             ln1 is not None
+            # Post-norm blocks reuse ln1 for the attention output, not its input.
+            and not self.mlp_reads_resid_directly
             and isinstance(attn, AttentionBridge)
             and getattr(attn, "supports_split_qkv_fork", False)
             and getattr(ln1, "original_component", None) is not None


### PR DESCRIPTION
# Description

OLMo 2 uses post-norm blocks, so `ln1` runs after attention. `BlockBridge` was wiring every `ln1` as the pre-attention capture for `use_split_qkv_input` and `use_attn_in`. The captured post-attention tensor then leaked into the next forward and replaced the current residual input, causing logits and activations to drift across identical runs.

Skip the pre-`ln1` capture for blocks already marked as reading the residual directly, and add regression coverage for both attention input fork modes. The tests verify that the fork input matches `hook_resid_pre`, outputs remain baseline-equivalent, and repeated forwards are bitwise deterministic.

Fixes #1687

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `pytest tests/integration/model_bridge/test_olmo2_hook_semantics.py -q` — 9 passed
- `pytest tests/unit/model_bridge/supported_architectures/test_olmo2_adapter.py tests/unit/model_bridge/supported_architectures/test_olmo3_adapter.py tests/unit/model_bridge/supported_architectures/test_olmo_adapter.py tests/unit/model_bridge/supported_architectures/test_olmo_hybrid_adapter.py tests/unit/model_bridge/supported_architectures/test_flex_olmo_adapter.py -q` — 62 passed
- `pytest tests/unit/model_bridge/compatibility/test_split_qkv.py -q` — 7 passed
- `make unit-test` — 5029 passed, 35 skipped, 44 deselected, 8 xfailed
- `uv run mypy .`
- `make check-format`

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility