### PR TITLE
Issues with seq2seq loss

### DIFF
--- a/tests/integration/model_bridge/test_seq2seq_benchmark_loss.py
+++ b/tests/integration/model_bridge/test_seq2seq_benchmark_loss.py
@@ -1,0 +1,35 @@
+"""Benchmark loss calls must supply labels and a resolvable ablation hook on seq2seq.
+
+The bridge refuses label-less return_type="loss" for encoder-decoder models
+(encoder input_ids are not decoder targets). forward_pass.py was updated when
+that guard landed; hook_registration and weight_processing kept the bare call,
+so P2 hook_functionality errored on all seven seq2seq architectures. The
+ablation hook also targeted blocks.0.* which does not exist on encoder-decoder
+bridges, silently no-opping the whole check.
+"""
+
+import pytest
+
+from transformer_lens.benchmarks.hook_registration import benchmark_hook_functionality
+from transformer_lens.benchmarks.utils import BenchmarkSeverity, bridge_self_target_loss
+from transformer_lens.model_bridge import TransformerBridge
+
+TEXT = "translate English to German: Hello world"
+
+
+@pytest.fixture(scope="module")
+def t5():
+    return TransformerBridge.boot_transformers("google-t5/t5-small", device="cpu")
+
+
+def test_self_target_loss_is_finite_on_seq2seq(t5) -> None:
+    loss = bridge_self_target_loss(t5, TEXT)
+    assert loss.ndim == 0 and loss.isfinite()
+
+
+def test_hook_functionality_runs_and_the_ablation_bites(t5) -> None:
+    result = benchmark_hook_functionality(t5, TEXT)
+    assert result.passed, result.message
+    assert result.severity != BenchmarkSeverity.ERROR, result.message
+    # A vacuous run (unresolvable hook) reports "minimal effect: 0.000000".
+    assert "minimal effect" not in result.message, result.message

--- a/tests/unit/test_moe_fold_guard.py
+++ b/tests/unit/test_moe_fold_guard.py
@@ -1,37 +1,104 @@
-"""MoE models must keep their norm gains: nothing folds them in.
+"""MoE models fold their norms like dense models do.
 
-`get_pretrained_model_config(fold_ln=True)` swaps the norm for its gain-less
-*Pre variant on the assumption that `process_weights_` folds the gains into the
-next weights. `process_weights_` refuses to fold MoE experts, so the two
-decisions disagreed and the gains were dropped entirely — OLMoE-1B-7B landed
-20.5 off HF in log-softmax with 0% argmax agreement.
+History: HT once switched MoE models to the gain-less *Pre norm while its
+process step refused to fold the experts, silently dropping the gains entirely
+(OLMoE sat 20.5 off HF in log-softmax, 0% argmax). A guard then refused folding
+outright, which diverged from the bridge (which folds) at unembed.hook_in. The
+shared ProcessWeights fold handles the router and every expert's W_in/W_gate,
+and HT-with-MoE-fold measures bit-exact against HF (0.0000 log-softmax,
+100% argmax on OLMoE-1B-7B), so folding is simply enabled.
 """
+
+from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 
 from transformer_lens.loading_from_pretrained import get_pretrained_model_config
 
-MOE_MODELS = ["allenai/OLMoE-1B-7B-0924", "mistralai/Mixtral-8x7B-v0.1"]
 
-
-@pytest.mark.parametrize("model_name", MOE_MODELS)
-def test_moe_keeps_its_norm_gains(model_name: str) -> None:
-    cfg = get_pretrained_model_config(model_name, fold_ln=True)
-    assert cfg.num_experts and cfg.num_experts > 1, "fixture must be a MoE model"
-    assert cfg.normalization_type == "RMS", (
-        f"{model_name} normalization_type={cfg.normalization_type}: the gain-less "
-        "*Pre variant means the norm weights were dropped with nothing folding them in"
+def _moe_config(architecture: str, num_experts: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        architectures=[architecture],
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        max_position_embeddings=512,
+        rms_norm_eps=1e-6,
+        vocab_size=100,
+        hidden_act="silu",
+        rope_theta=500000.0,
+        sliding_window=None,
+        num_experts=num_experts,
+        num_local_experts=num_experts,
+        num_experts_per_tok=2,
+        norm_topk_prob=False,
+        tie_word_embeddings=False,
+        initializer_range=0.02,
     )
 
 
-def test_dense_models_still_fold() -> None:
-    """Negative control: the guard must not disable folding for everyone."""
-    cfg = get_pretrained_model_config("Qwen/Qwen2.5-0.5B", fold_ln=True)
-    assert cfg.num_experts is None
-    assert cfg.normalization_type == "RMSPre"
-
-
-def test_moe_fold_warns(caplog) -> None:
+@pytest.mark.parametrize(
+    "model_name,architecture,n_experts",
+    [
+        ("allenai/OLMoE-1B-7B-0924", "OlmoeForCausalLM", 64),
+        ("mistralai/Mixtral-8x7B-v0.1", "MixtralForCausalLM", 8),
+    ],
+)
+@mock.patch("transformer_lens.loading_from_pretrained.AutoConfig")
+def test_moe_folds_like_dense(mock_auto_config, caplog, model_name, architecture, n_experts):
+    """fold_ln=True switches MoE to the folded *Pre norm, same as dense, without
+    a refusal warning — the gains are folded into router and experts, not dropped."""
+    mock_auto_config.from_pretrained.return_value = _moe_config(architecture, n_experts)
     with caplog.at_level("WARNING"):
-        get_pretrained_model_config(MOE_MODELS[0], fold_ln=True)
-    assert any("not supported for MoE" in r.getMessage() for r in caplog.records)
+        cfg = get_pretrained_model_config(model_name, fold_ln=True)
+    assert cfg.num_experts == n_experts
+    assert cfg.normalization_type == "RMSPre", cfg.normalization_type
+    assert not any("MoE" in r.getMessage() for r in caplog.records), [
+        r.getMessage() for r in caplog.records
+    ]
+
+
+def test_process_weights_folds_moe_and_preserves_outputs() -> None:
+    """The fold must engage (norms swap to *Pre) and be equivalence-preserving on
+    a MoE model — a skipped fold leaves RMS modules; a broken fold moves logits."""
+    import torch
+
+    from transformer_lens import HookedTransformer, HookedTransformerConfig
+    from transformer_lens.components import RMSNormPre
+
+    torch.manual_seed(0)
+    cfg = HookedTransformerConfig(
+        n_layers=2,
+        d_model=32,
+        d_head=8,
+        n_heads=4,
+        d_mlp=64,
+        d_vocab=50,
+        n_ctx=16,
+        act_fn="silu",
+        normalization_type="RMS",
+        gated_mlp=True,
+        num_experts=4,
+        experts_per_token=2,
+    )
+    model = HookedTransformer(cfg)
+    with torch.no_grad():
+        for name, param in model.named_parameters():
+            torch.nn.init.normal_(param, std=0.2)
+        # Non-trivial gains, or folding is a vacuous multiply-by-one.
+        for block in model.blocks:
+            block.ln1.w.copy_(torch.rand_like(block.ln1.w) + 0.5)
+            block.ln2.w.copy_(torch.rand_like(block.ln2.w) + 0.5)
+        model.ln_final.w.copy_(torch.rand_like(model.ln_final.w) + 0.5)
+    model.eval()
+    tokens = torch.randint(0, 50, (1, 8))
+    with torch.no_grad():
+        before = model(tokens)
+    model.process_weights_(fold_ln=True, center_writing_weights=False, center_unembed=False)
+    assert isinstance(model.blocks[0].ln2, RMSNormPre), type(model.blocks[0].ln2).__name__
+    with torch.no_grad():
+        after = model(tokens)
+    torch.testing.assert_close(after, before, atol=1e-4, rtol=1e-4)

--- a/transformer_lens/HookedTransformer.py
+++ b/transformer_lens/HookedTransformer.py
@@ -1689,12 +1689,7 @@ class HookedTransformer(HookedRootModule):
 
         state_dict = self.fill_missing_keys(state_dict)
         if fold_ln:
-            if self.cfg.num_experts and self.cfg.num_experts > 1:
-                logging.warning(
-                    "You are using MoE, so the layer norm weights can't be folded! Skipping"
-                )
-                fold_ln = False
-            elif self.cfg.normalization_type not in ["LN", "LNPre", "RMS", "RMSPre"]:
+            if self.cfg.normalization_type not in ["LN", "LNPre", "RMS", "RMSPre"]:
                 logging.warning(
                     "You are not using LayerNorm or RMSNorm, so the layer norm weights can't be folded! Skipping"
                 )

--- a/transformer_lens/benchmarks/forward_pass.py
+++ b/transformer_lens/benchmarks/forward_pass.py
@@ -8,6 +8,7 @@ from transformer_lens import HookedTransformer
 from transformer_lens.benchmarks.utils import (
     BenchmarkResult,
     BenchmarkSeverity,
+    bridge_self_target_loss,
     compare_scalars,
     compare_tensors,
 )
@@ -16,8 +17,7 @@ from transformer_lens.model_bridge import TransformerBridge
 
 def _compute_self_target_loss(bridge: TransformerBridge, test_text: str) -> torch.Tensor:
     """Compute loss with the tokenized input supplied as explicit labels."""
-    labels = bridge.to_tokens(test_text)
-    return bridge(test_text, labels=labels, return_type="loss")
+    return bridge_self_target_loss(bridge, test_text)
 
 
 def _is_encoder_decoder(model: torch.nn.Module) -> bool:

--- a/transformer_lens/benchmarks/hook_registration.py
+++ b/transformer_lens/benchmarks/hook_registration.py
@@ -8,6 +8,7 @@ from transformer_lens import HookedTransformer
 from transformer_lens.benchmarks.utils import (
     BenchmarkResult,
     BenchmarkSeverity,
+    bridge_self_target_loss,
     compare_activation_dicts,
     compare_scalars,
     filter_expected_missing_hooks,
@@ -696,9 +697,26 @@ def benchmark_hook_functionality(
             return activation
 
         # Test bridge
-        bridge_original = bridge(test_text, return_type="loss")
+        # Encoder-decoder bridges name their stacks; a bare blocks.* hook would
+        # silently no-op and make the ablation vacuous.
+        ablation_target = next(
+            (
+                name
+                for name in (
+                    "blocks.0.attn.hook_v",
+                    "encoder_blocks.0.attn.hook_v",
+                    "decoder_blocks.0.attn.hook_v",
+                )
+                if name in bridge.hook_dict
+            ),
+            "blocks.0.attn.hook_v",
+        )
+        bridge_original = bridge_self_target_loss(bridge, test_text)
         bridge_ablated = bridge.run_with_hooks(
-            test_text, return_type="loss", fwd_hooks=[("blocks.0.attn.hook_v", ablation_hook)]
+            test_text,
+            return_type="loss",
+            labels=bridge.to_tokens(test_text),
+            fwd_hooks=[(ablation_target, ablation_hook)],
         )
         bridge_effect = bridge_ablated - bridge_original
 

--- a/transformer_lens/benchmarks/utils.py
+++ b/transformer_lens/benchmarks/utils.py
@@ -459,3 +459,13 @@ def format_results(results: List[BenchmarkResult]) -> str:
     output.append("=" * 80)
 
     return "\n".join(output)
+
+
+def bridge_self_target_loss(bridge, test_text: str):
+    """Loss with the tokenized input as explicit labels.
+
+    Seq2seq bridges refuse label-less return_type="loss" (encoder input_ids are
+    not decoder targets), so every benchmark loss call routes through here.
+    """
+    labels = bridge.to_tokens(test_text)
+    return bridge(test_text, labels=labels, return_type="loss")

--- a/transformer_lens/benchmarks/weight_processing.py
+++ b/transformer_lens/benchmarks/weight_processing.py
@@ -8,6 +8,7 @@ from transformer_lens import HookedTransformer
 from transformer_lens.benchmarks.utils import (
     BenchmarkResult,
     BenchmarkSeverity,
+    bridge_self_target_loss,
     is_tiny_test_model,
     safe_allclose,
 )
@@ -147,7 +148,7 @@ def benchmark_weight_sharing(
     """
     try:
         # Get baseline loss
-        bridge_original = bridge(test_text, return_type="loss")
+        bridge_original = bridge_self_target_loss(bridge, test_text)
 
         if reference_model is not None:
             reference_original = reference_model(test_text, return_type="loss")
@@ -212,7 +213,7 @@ def benchmark_weight_sharing(
                 reference_model.blocks[bridge_attn_idx].attn.W_V[0, :, :] = 0
 
             # Test modified losses
-            bridge_modified = bridge(test_text, return_type="loss")
+            bridge_modified = bridge_self_target_loss(bridge, test_text)
             reference_modified = reference_model(test_text, return_type="loss")
 
             bridge_change = bridge_modified - bridge_original
@@ -254,7 +255,7 @@ def benchmark_weight_sharing(
         with torch.no_grad():
             ws_attn_block.attn.W_V[0, :, :] = 0
 
-        bridge_modified = bridge(test_text, return_type="loss")
+        bridge_modified = bridge_self_target_loss(bridge, test_text)
         change = abs(bridge_modified - bridge_original)
 
         # Restore weights
@@ -302,7 +303,7 @@ def benchmark_weight_modification(
     """
     try:
         # Get original loss
-        original_loss = bridge(test_text, return_type="loss")
+        original_loss = bridge_self_target_loss(bridge, test_text)
 
         # Find first block with attention (hybrid models may not have attn on block 0)
         wm_attn_blocks = bridge.blocks_with("attn")
@@ -334,7 +335,7 @@ def benchmark_weight_modification(
 
         # Get modified loss (with error handling to restore weights)
         try:
-            modified_loss = bridge(test_text, return_type="loss")
+            modified_loss = bridge_self_target_loss(bridge, test_text)
         except Exception as forward_error:
             # Restore weights before reporting error
             with torch.no_grad():
@@ -369,7 +370,7 @@ def benchmark_weight_modification(
                 with torch.no_grad():
                     original_mlp_w = mlp_block.mlp.out.weight.clone()
                     mlp_block.mlp.out.weight[0, :] = 0
-                mlp_modified_loss = bridge(test_text, return_type="loss")
+                mlp_modified_loss = bridge_self_target_loss(bridge, test_text)
                 with torch.no_grad():
                     mlp_block.mlp.out.weight.copy_(original_mlp_w)
                 mlp_change = abs(mlp_modified_loss - original_loss)

--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -1801,17 +1801,6 @@ def get_pretrained_model_config(
 
     cfg_dict["dtype"] = dtype
 
-    # process_weights_ refuses to fold MoE experts, so flipping the norm to its
-    # gain-less *Pre variant here would drop the gains with nothing folding them
-    # in — the model silently loses its norm weights entirely.
-    num_experts = cfg_dict.get("num_experts")
-    if fold_ln and num_experts and num_experts > 1:
-        logging.warning(
-            "fold_ln=True is not supported for MoE models (experts are never folded). "
-            "Setting fold_ln=False."
-        )
-        fold_ln = False
-
     if fold_ln:
         if cfg_dict["normalization_type"] in ["LN", "LNPre"]:
             cfg_dict["normalization_type"] = "LNPre"


### PR DESCRIPTION
# Description

- Resolves an issue with seq2seq `loss` return type
- Resolves an issue with MoE folding of layer norm
- Adds handling for `ablation` on encoder-decoder models that have different block trees

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility