### PR TITLE
Fix Cohere compatibility logit scaling

### DIFF
--- a/tests/integration/model_bridge/test_cohere_adapter.py
+++ b/tests/integration/model_bridge/test_cohere_adapter.py
@@ -17,15 +17,62 @@ from typing import Any
 
 import pytest
 import torch
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, CohereConfig, CohereForCausalLM
 
 from transformer_lens.model_bridge.bridge import TransformerBridge
 from transformer_lens.model_bridge.generalized_components import NormalizationBridge
 from transformer_lens.model_bridge.generalized_components.position_embeddings_attention import (
     PositionEmbeddingsAttentionBridge,
 )
+from transformer_lens.model_bridge.sources import build_bridge_from_module
 
 MODEL = "trl-internal-testing/tiny-CohereForCausalLM"
+
+
+def _tiny_cohere_bridge(logit_scale: float = 0.5) -> TransformerBridge:
+    config = CohereConfig(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+        logit_scale=logit_scale,
+        attention_bias=False,
+        use_qk_norm=False,
+        tie_word_embeddings=True,
+        bos_token_id=1,
+        eos_token_id=2,
+        pad_token_id=0,
+    )
+    return build_bridge_from_module(
+        CohereForCausalLM(config).eval(),
+        "CohereForCausalLM",
+        hf_config=config,
+        dtype=torch.float32,
+        device="cpu",
+    )
+
+
+def _enable_fold_only_compatibility(bridge: TransformerBridge) -> None:
+    bridge.enable_compatibility_mode(
+        disable_warnings=True,
+        fold_ln=False,
+        center_writing_weights=False,
+        center_unembed=False,
+        fold_value_biases=False,
+    )
+
+
+def _process_only_logit_scale(bridge: TransformerBridge) -> None:
+    bridge.process_weights(
+        fold_ln=False,
+        center_writing_weights=False,
+        center_unembed=False,
+        fold_value_biases=False,
+        refactor_factored_attn_matrices=False,
+    )
 
 
 @pytest.fixture(scope="module")
@@ -256,6 +303,34 @@ class TestCohereLogitScaleEndToEnd:
 
         with pytest.raises(ValueError, match="process_weights"):
             lens.validate_model(cohere_bridge_processed)
+
+    def test_process_weights_preserves_forward_logits(self) -> None:
+        bridge = _tiny_cohere_bridge()
+        tokens = torch.tensor([[1, 2, 3, 4]])
+        raw_embed = bridge.embed.W_E.detach().clone()
+        raw_unembed = bridge.unembed.original_component.weight.detach().clone()
+
+        with torch.no_grad():
+            raw_logits = bridge(tokens)
+            _process_only_logit_scale(bridge)
+            processed_logits = bridge(tokens)
+
+        torch.testing.assert_close(processed_logits, raw_logits)
+        torch.testing.assert_close(bridge.embed.W_E, raw_embed)
+        torch.testing.assert_close(bridge.unembed.original_component.weight, raw_unembed * 0.5)
+        assert bridge.original_model.logit_scale == 1.0
+        assert bridge.cfg.logit_scale == 0.5
+
+    def test_compatibility_mode_preserves_forward_logits(self) -> None:
+        bridge = _tiny_cohere_bridge()
+        tokens = torch.tensor([[1, 2, 3, 4]])
+
+        with torch.no_grad():
+            raw_logits = bridge(tokens)
+            _enable_fold_only_compatibility(bridge)
+            processed_logits = bridge(tokens)
+
+        torch.testing.assert_close(processed_logits, raw_logits)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/model_bridge/test_cohere_adapter.py
+++ b/tests/integration/model_bridge/test_cohere_adapter.py
@@ -332,6 +332,18 @@ class TestCohereLogitScaleEndToEnd:
 
         torch.testing.assert_close(processed_logits, raw_logits)
 
+    def test_process_weights_succeeds_without_model_logit_scale(self) -> None:
+        bridge = _tiny_cohere_bridge()
+        raw_unembed = bridge.unembed.original_component.weight.detach().clone()
+        delattr(bridge.original_model, "logit_scale")
+
+        _process_only_logit_scale(bridge)
+
+        assert bridge._weights_processed
+        assert not hasattr(bridge.original_model, "logit_scale")
+        torch.testing.assert_close(bridge.unembed.original_component.weight, raw_unembed * 0.5)
+        assert bridge.cfg.logit_scale == 0.5
+
 
 # ---------------------------------------------------------------------------
 # 4. Tied embedding preserved — embed.W_E must NOT be scaled

--- a/transformer_lens/model_bridge/architecture_adapter.py
+++ b/transformer_lens/model_bridge/architecture_adapter.py
@@ -300,6 +300,13 @@ class ArchitectureAdapter:
         """
         return state_dict
 
+    def postprocess_weights(self, bridge: Any) -> None:
+        """Apply architecture-specific updates after processed weights are installed.
+
+        Args:
+            bridge: The TransformerBridge whose live source components received the weights.
+        """
+
     def get_component_mapping(self) -> ComponentMapping:
         """Get the full component mapping.
 

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -1261,6 +1261,8 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
             state_dict=state_dict,
             component_mapping=self.real_components,
         )
+        if adapter is not None:
+            adapter.postprocess_weights(self)
 
     def _calculate_loss(self, logits, tokens, loss_per_token=False):
         """Calculate cross-entropy loss."""

--- a/transformer_lens/model_bridge/supported_architectures/AGENTS.md
+++ b/transformer_lens/model_bridge/supported_architectures/AGENTS.md
@@ -117,16 +117,20 @@ Rule of thumb: if the model card or HF source mentions a numerical knob, assume 
 
 Default is a no-op pass-through. Override when a numerical op HF applies natively in forward must also be baked into raw weights — otherwise `bridge.enable_compatibility_mode()` (which calls `process_weights` expecting the math to already be in the weights) diverges.
 
+If HF applies the same factor outside the module whose weight is being folded, `preprocess_weights()` is only half the change: the wrapped HF forward would otherwise apply the factor again. Track whether the fold occurred, then override `postprocess_weights()` to neutralize the outer runtime factor after the processed weights have been installed. If the wrapped model does not expose that runtime attribute, there is no outer factor to neutralize and the fold is already complete.
+
 > **Trigger:** if a config attr changes the forward-pass math AND isn't re-applied by compat-mode weight processing, fold it into the relevant weight in `preprocess_weights()`.
 
 Examples:
 
-- **Cohere** — `cfg.logit_scale` (default `0.0625`) folds into `unembed.weight`. HF forward multiplies logits by `logit_scale`; compat-mode doesn't.
+- **Cohere** — `cfg.logit_scale` (default `0.0625`) folds into `unembed.weight`, then `postprocess_weights()` neutralizes the model-level `logit_scale` that HF forward would otherwise apply again.
 - **Gemma1/2/3** — embedding scale (`√d_model`) folds into `embed.weight`. HF's `GemmaTextScaledWordEmbedding` scales on forward; compat-mode reads raw.
 
 Skeleton:
 
 ```python
+from typing import Any
+
 import torch
 
 def preprocess_weights(self, state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
@@ -135,13 +139,25 @@ def preprocess_weights(self, state_dict: dict[str, torch.Tensor]) -> dict[str, t
     bridge.py clones unembed.weight before calling this, so the scale does not
     leak into the tied embed.weight.
     """
+    self._scale_fold_pending = False
     scale: float = getattr(self.cfg, "<attr>")  # set in __init__
     if scale != 1.0:  # no-op when scale is identity
         key = "unembed.weight"
         if key in state_dict:
             orig_dtype = state_dict[key].dtype
             state_dict[key] = (state_dict[key].float() * scale).to(orig_dtype)
+            self._scale_fold_pending = True
     return state_dict
+
+def postprocess_weights(self, bridge: Any) -> None:
+    """Neutralize the outer runtime factor after installing folded weights."""
+    if not self._scale_fold_pending:
+        return
+
+    model = getattr(bridge, "original_model", None)
+    if model is not None and hasattr(model, "<attr>"):
+        setattr(model, "<attr>", 1.0)
+    self._scale_fold_pending = False
 ```
 
 **Skip the override when:** the op lives inside an HF submodule the bridge delegates to (e.g. RoPE inside `CohereRotaryEmbedding`) — HF forward applies it on both paths, parity is free.

--- a/transformer_lens/model_bridge/supported_architectures/cohere.py
+++ b/transformer_lens/model_bridge/supported_architectures/cohere.py
@@ -94,6 +94,7 @@ class CohereArchitectureAdapter(ArchitectureAdapter):
         # Cohere-specific dynamic attribute accessed later in preprocess_weights.
         _ls = getattr(cfg, "logit_scale", None)
         self.cfg.logit_scale = float(_ls) if _ls is not None else 0.0625  # type: ignore[attr-defined]
+        self._logit_scale_fold_pending = False
 
         # --- RoPE theta (informational metadata) ---
         # CohereRotaryEmbedding reads config.rope_parameters["rope_theta"] directly;
@@ -154,17 +155,30 @@ class CohereArchitectureAdapter(ArchitectureAdapter):
     def preprocess_weights(self, state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Fold logit_scale into unembed weights before ProcessWeights runs.
 
-        bridge.py lines 726-732 clone unembed.weight before calling this, so
+        bridge.py clones unembed.weight before calling this, so
         scaling does not affect the tied embed.weight.
         logit_scale=1.0 is a no-op (skipped for efficiency).
         """
+        self._logit_scale_fold_pending = False
         scale: float = getattr(self.cfg, "logit_scale")  # always set by __init__
         if scale != 1.0:
             for key in ("unembed.weight", "unembed.bias"):
                 if key in state_dict:
                     orig_dtype = state_dict[key].dtype
                     state_dict[key] = (state_dict[key].float() * scale).to(orig_dtype)
+                    self._logit_scale_fold_pending = True
         return state_dict
+
+    def postprocess_weights(self, bridge: Any) -> None:
+        """Disable HF's outer scale after folding it into the live unembed weights."""
+        if not self._logit_scale_fold_pending:
+            return
+
+        model = getattr(bridge, "original_model", None)
+        if model is None or not hasattr(model, "logit_scale"):
+            raise RuntimeError("Cohere weight processing requires a model-level logit_scale")
+        model.logit_scale = 1.0
+        self._logit_scale_fold_pending = False
 
     def apply_output_logits_transform(self, logits: torch.Tensor) -> torch.Tensor:
         """Match Cohere's ``lm_head -> logit_scale -> optional softcap`` path."""

--- a/transformer_lens/model_bridge/supported_architectures/cohere.py
+++ b/transformer_lens/model_bridge/supported_architectures/cohere.py
@@ -175,9 +175,8 @@ class CohereArchitectureAdapter(ArchitectureAdapter):
             return
 
         model = getattr(bridge, "original_model", None)
-        if model is None or not hasattr(model, "logit_scale"):
-            raise RuntimeError("Cohere weight processing requires a model-level logit_scale")
-        model.logit_scale = 1.0
+        if model is not None and hasattr(model, "logit_scale"):
+            model.logit_scale = 1.0
         self._logit_scale_fold_pending = False
 
     def apply_output_logits_transform(self, logits: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
# Description

Fixes #1726

Cohere and Cohere2 weight processing folds `cfg.logit_scale` into the live unembedding weights, but the Hugging Face model forward still applied its model-level scale afterward. As a result, the first valid compatibility-mode conversion produced logits with the scale applied twice.

This change adds an architecture post-install lifecycle hook. The Cohere adapter uses it to neutralize the Hugging Face model-level `logit_scale` only after the scaled unembedding weights have been installed. The Bridge config retains the original scale as metadata, and tied input embeddings remain unscaled.

Network-free tiny-config regressions cover both direct `process_weights()` and the first `enable_compatibility_mode()` call.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

- `tests/integration/model_bridge/test_cohere_adapter.py`: 24 passed
- Cohere/Cohere2 adapter unit surface: 74 passed
- Weight-processing unit surface: 27 passed, 1 skipped
- Full non-slow unit surface: 5,435 passed; the sole nonzero result was a native-Windows GBK decode error in a source-roster test
- The exact roster test passed after enabling Python UTF-8 mode: 1 passed
- `mypy .`: Success, no issues found in 392 source files
- pycln, pinned isort, Black, and `git diff --check`: passed

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (no public documentation change is required; the internal lifecycle hook is documented in code)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility