### PR TITLE
Fixes to moe and composition scores

### DIFF
--- a/tests/unit/model_bridge/supported_architectures/test_moe_routing_hooks.py
+++ b/tests/unit/model_bridge/supported_architectures/test_moe_routing_hooks.py
@@ -157,3 +157,47 @@ def test_rerouting_picks_up_the_weight_at_the_newly_selected_expert():
         "weights must be gathered at the edited indices, so a re-route to an "
         f"unselected expert yields 0; got {out_weights.tolist()}"
     )
+
+
+def test_boosting_a_suppressed_expert_reroutes_the_selection():
+    """A weight edit outside the top-k re-derives the selection from the edited
+    tensor — HT's pre-top-k contract — instead of being discarded by the gather.
+    """
+    from transformer_lens.model_bridge.generalized_components.moe import MoERouterBridge
+
+    logits = torch.zeros(1, NUM_EXPERTS)
+    weights = torch.tensor([[0.7, 0.3]])
+    indices = torch.tensor([[1, 2]])
+
+    router = MoERouterBridge(name="router")
+    router.set_original_component(_StubRouter(logits, weights, indices))
+
+    def boost_expert_zero(t, hook=None):
+        t = t.clone()
+        t[:, 0] = 5.0  # expert 0 held no weight in the original top-k
+        return t
+
+    router.hook_expert_weights.add_hook(boost_expert_zero)
+    _, out_weights, out_indices = router(torch.zeros(1, 8))
+
+    assert out_indices[0].tolist() == [0, 1], out_indices
+    assert torch.allclose(out_weights, torch.tensor([[5.0, 0.7]])), out_weights
+
+
+def test_suppressed_expert_boost_reaches_the_model_output():
+    """End-to-end: the edit changes logits, where the pre-fix gather no-opped it."""
+    bridge = _tiny_bridge()
+    tokens = torch.tensor([[3, 17, 42, 9]])
+
+    with torch.no_grad():
+        base = bridge(tokens, return_type="logits")
+
+    def boost_all_nonselected(t, hook=None):
+        t = t.clone()
+        t[t == 0.0] = 100.0
+        return t
+
+    with torch.no_grad():
+        edited = bridge.run_with_hooks(tokens, fwd_hooks=[(WEIGHTS, boost_all_nonselected)])
+
+    assert not torch.allclose(edited, base), "off-top-k weight edit must reach the model"

--- a/tests/unit/model_bridge/test_encdec_weight_stacking.py
+++ b/tests/unit/model_bridge/test_encdec_weight_stacking.py
@@ -92,9 +92,20 @@ def test_all_head_labels_uses_the_encoder_decoder_scheme(t5_bridge):
     assert sum(label.startswith("EL") for label in labels) == N_LAYERS * N_HEADS
 
 
-def test_attn_head_labels_cover_both_stacks(t5_bridge):
-    """Derives from composition_layer_indices, which routes through blocks_with."""
-    assert len(t5_bridge.attn_head_labels) == 2 * N_LAYERS * N_HEADS
+def test_composition_surfaces_refuse_encoder_decoder(t5_bridge):
+    """Composition scores live in one residual stream; enc-dec models have two.
+
+    The labels must refuse alongside the scores — advertising 2*L*H heads for
+    dims that all_composition_scores can never produce is worse than raising.
+    """
+    import pytest
+
+    with pytest.raises(NotImplementedError, match="residual streams"):
+        _ = t5_bridge.attn_head_labels
+    with pytest.raises(NotImplementedError, match="residual streams"):
+        t5_bridge.composition_layer_indices()
+    with pytest.raises(NotImplementedError, match="residual streams"):
+        t5_bridge.all_composition_scores("Q")
 
 
 def test_cross_attention_is_excluded_from_stacking(t5_bridge):

--- a/transformer_lens/model_bridge/generalized_components/moe.py
+++ b/transformer_lens/model_bridge/generalized_components/moe.py
@@ -356,7 +356,11 @@ class MoERouterBridge(LinearBridge):
     MoE routing hooks. HF routers hand back top-k-shaped weights
     ``[tokens, top_k]``, so the weights are scattered to HT's
     ``[tokens, num_experts]`` before firing and gathered back afterwards — an
-    unedited round trip returns the values bit-for-bit, and an edit reaches HF.
+    unedited round trip returns the values bit-for-bit. Any weight edit
+    re-derives the top-k selection from the edited tensor, so boosting a
+    suppressed expert re-routes the token (HT's pre-top-k contract); unlike
+    HT's mixtral component, edited weights are used as-is with no
+    renormalization after the hook.
     """
 
     def __init__(
@@ -401,8 +405,23 @@ class MoERouterBridge(LinearBridge):
         indices = None if indices_at is None else parts[indices_at]
         expanded = None
         if weights_at is not None:
-            expanded = self._expand_expert_weights(parts[weights_at], indices, parts[logits_at])
-            expanded = self.hook_expert_weights(expanded)
+            scattered = self._expand_expert_weights(parts[weights_at], indices, parts[logits_at])
+            expanded = self.hook_expert_weights(scattered)
+            if (
+                indices is not None
+                and expanded.shape != parts[weights_at].shape
+                and not torch.equal(expanded, scattered)
+            ):
+                # An edit outside the current top-k would otherwise be discarded
+                # by the gather below (those columns have no downstream reader in
+                # the [tokens, top_k] layout). Re-derive the selection from the
+                # edited tensor so boosting a suppressed expert re-routes, as it
+                # does on HookedTransformer's pre-top-k hook. The edited values
+                # are used as-is — no per-arch renormalization is re-applied.
+                _, new_indices = torch.topk(expanded, indices.shape[-1], dim=-1)
+                indices = new_indices.to(indices.dtype)
+                if indices_at is not None:
+                    parts[indices_at] = indices
         if indices_at is not None:
             indices = self.hook_expert_indices(indices)
             parts[indices_at] = indices

--- a/transformer_lens/model_bridge/transformer_bridge.py
+++ b/transformer_lens/model_bridge/transformer_bridge.py
@@ -1540,6 +1540,7 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
         On hybrid models, only attention layers are included; layer_indices
         maps tensor position i to original layer number.
         """
+        self._reject_encoder_decoder_composition()
         attn_blocks = self.blocks_with("attn")
         if not attn_blocks:
             raise ValueError("No attention layers found — cannot compute composition scores.")
@@ -1591,8 +1592,18 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
         labels = [f"L{l}H{h}" for l in indices for h in range(self.cfg.n_heads)]
         return CompositionScores(scores=scores, layer_indices=indices, head_labels=labels)
 
+    def _reject_encoder_decoder_composition(self) -> None:
+        """Composition scores live in one residual stream; enc-dec models have two."""
+        if any(hasattr(self, a) for a in ("encoder_blocks", "decoder_blocks")):
+            raise NotImplementedError(
+                "Composition scores are not defined across an encoder-decoder "
+                "model's two residual streams (HookedTransformer never "
+                "supported them there either)."
+            )
+
     def composition_layer_indices(self) -> List[int]:
         """Original layer indices for attention layers (maps composition score positions)."""
+        self._reject_encoder_decoder_composition()
         return [idx for idx, _ in self.blocks_with("attn")]
 
     def block_hooks(self, layer_idx: int) -> List[str]:
@@ -1641,6 +1652,7 @@ class TransformerBridge(BridgeCore, HookIntrospectionMixin, nn.Module):
     @property
     def attn_head_labels(self) -> list[str]:
         """Head labels for attention layers only — matches all_composition_scores() dims."""
+        self._reject_encoder_decoder_composition()
         return [
             f"L{l}H{h}" for l in self.composition_layer_indices() for h in range(self.cfg.n_heads)
         ]


### PR DESCRIPTION
# Description

- ensuring MoE edits are properly connected to future experts
- `_reject_encoder_decoder_composition` ensures HookedAudioEncoder properly avoids doing a composition score

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility