### PR TITLE
feat(jacobian_lens): anchored J-space coordinate patching (offline primitive)

### DIFF
--- a/docs/source/content/jacobian_lens_fitting.md
+++ b/docs/source/content/jacobian_lens_fitting.md
@@ -331,14 +331,14 @@ and source and target must be distinct.
 Both diagnostics warn but never raise, because an anchored reconstruction needs no inverse:
 
 - **Poor conditioning.** When the column-normalized active-plus-target basis is rank deficient or its
-  `basis_condition_number` exceeds the threshold, coordinate patching emits a `UserWarning` that
-  names the measured condition number; coordinate attribution is then non-unique, but the edit still
-  completes.
+  `basis_condition_number` exceeds `1 / sqrt(float32 eps)` (≈ 2896), coordinate patching emits a
+  `UserWarning` that names the measured condition number; coordinate attribution is then non-unique,
+  but the edit still completes.
 - **Near-parallel source/target.** When the absolute source–target cosine (reported signed in
-  `source_target_cosine`) exceeds the shared `_SWAP_WARN_COSINE` threshold, coordinate patching emits
-  a `UserWarning` that names the measured cosine, since a swap between near-parallel atoms is close to
-  a no-op. Unlike `swap_hooks`, which raises above `_SWAP_ERROR_COSINE`, the patch core only warns at
-  the parallel extreme.
+  `source_target_cosine`) exceeds `_SWAP_WARN_COSINE` (0.99), coordinate patching emits a
+  `UserWarning` that names the measured cosine, since a swap between near-parallel atoms is close to
+  a no-op. Unlike `swap_hooks`, which raises above `_SWAP_ERROR_COSINE` (0.999), the patch core only
+  warns at the parallel extreme.
 
 Read the measured condition number and cosine straight out of each warning message (and from the
 `basis_condition_number` and `source_target_cosine` fields on the returned `CoordinatePatch`) to

--- a/docs/source/content/jacobian_lens_fitting.md
+++ b/docs/source/content/jacobian_lens_fitting.md
@@ -273,8 +273,7 @@ So two vector outputs also need not coincide:
 
 - `reconstruction` -- the nonnegative combination over the active `support`.
 - `j_space_component` (the *J-space component*) -- the orthogonal projection of the activation onto
-  the span of `selected_support` -- with `non_j_space_component = x - j_space_component`, the
-  residual the interventions leave unchanged.
+  the span of `selected_support` -- with `non_j_space_component = x - j_space_component`.
 
 For the default exact NNLS re-solve the `reconstruction` equals the projection onto the *active*
 support (KKT stationarity), so it differs from `j_space_component` exactly when a selected vector
@@ -298,6 +297,57 @@ the paper; its projected step is accepted only when it does not increase the res
 algorithms share the same greedy selection *rule* but, because their coefficient residuals
 differ, may select different vectors at later steps and so return a different `support` and
 `reconstruction`.
+
+### Coordinate patching
+
+`JacobianLens.coordinate_patch` turns a decomposition into an anchored causal edit. Given
+`x = residual + reconstruction`, it changes only named coordinates in the active sparse frame and
+keeps `residual = x - reconstruction` plus every other coordinate fixed. This residual differs from
+`non_j_space_component` when `selected_support` contains zero-coordinate atoms.
+
+```python
+prompt = "The Eiffel Tower is in the city of"
+decomposition = lens.decompose(model, prompt, layer=6, position=-1, k=8)
+source_id = int(decomposition.support[0])
+patch = lens.coordinate_patch(
+    model,
+    prompt,
+    layer=6,
+    source_token=source_id,
+    target_token=" Paris",
+    position=-1,
+    decomposition=decomposition,
+    mode="substitute",
+)
+patched_activation = patch.patched
+```
+
+`substitute` sets the source coordinate to zero and the target to the source value, overwriting an
+existing target coordinate (the discarded value is reported in `overwritten_target_coordinate`).
+`swap` exchanges the two values. An absent target is appended at zero, and `alpha` interpolates
+between the original and edited coordinates (`alpha=0` is an exact no-op). The source must be active
+and source and target must be distinct.
+
+Both diagnostics warn but never raise, because an anchored reconstruction needs no inverse:
+
+- **Poor conditioning.** When the column-normalized active-plus-target basis is rank deficient or its
+  `basis_condition_number` exceeds the threshold, coordinate patching emits a `UserWarning` that
+  names the measured condition number; coordinate attribution is then non-unique, but the edit still
+  completes.
+- **Near-parallel source/target.** When the absolute source–target cosine (reported signed in
+  `source_target_cosine`) exceeds the shared `_SWAP_WARN_COSINE` threshold, coordinate patching emits
+  a `UserWarning` that names the measured cosine, since a swap between near-parallel atoms is close to
+  a no-op. Unlike `swap_hooks`, which raises above `_SWAP_ERROR_COSINE`, the patch core only warns at
+  the parallel extreme.
+
+Read the measured condition number and cosine straight out of each warning message (and from the
+`basis_condition_number` and `source_target_cosine` fields on the returned `CoordinatePatch`) to
+judge how much to trust the edit.
+
+Without `decomposition=`, coordinate patching runs the vocabulary-scale sparse decomposition first.
+Reuse a compatible result for repeated edits to avoid that scan. The method returns an offline
+activation and diagnostics, not forward hooks; applying patches dynamically would otherwise perform
+a vocabulary-scale solve inside the model run.
 
 ### Interpreting the numbers honestly
 

--- a/tests/integration/test_jacobian_lens.py
+++ b/tests/integration/test_jacobian_lens.py
@@ -464,6 +464,60 @@ def test_decompose_gpt2_activation_reconstructs_and_is_orthogonal(published_gpt2
         assert cosine.abs().item() < 1e-3
 
 
+def test_coordinate_patch_gpt2_preserves_anchored_frame(published_gpt2_lens, gpt2_bridge):
+    """A published Bridge lens produces a finite edit while preserving its sparse frame."""
+    layer, k = 6, 8
+    tokens = gpt2_bridge.to_tokens(PROMPT)
+    hook = f"blocks.{layer}.hook_out"
+    _, cache = gpt2_bridge.run_with_cache(tokens, names_filter=lambda name: name == hook)
+    activation = cache[hook][0, -1, :].float()
+    dictionary = published_gpt2_lens.lens_vector_dictionary(gpt2_bridge, layer)
+    decomposition = published_gpt2_lens.decompose(gpt2_bridge, activation, layer=layer, k=k)
+    source_id = int(decomposition.support[0])
+    units = dictionary / dictionary.norm(dim=1, keepdim=True)
+    pair_cosines = (units @ units[source_id]).abs()
+    pair_cosines[source_id] = torch.inf
+    target_id = int(pair_cosines.argmin().item())
+
+    result = published_gpt2_lens.coordinate_patch(
+        gpt2_bridge,
+        PROMPT,
+        layer,
+        source_id,
+        target_id,
+        position=-1,
+        decomposition=decomposition,
+        alpha=0.5,
+    )
+    no_op = published_gpt2_lens.coordinate_patch(
+        gpt2_bridge,
+        activation,
+        layer,
+        source_id,
+        target_id,
+        decomposition=decomposition,
+        alpha=0.0,
+    )
+
+    assert torch.isfinite(result.patched).all()
+    torch.testing.assert_close(
+        result.patched - result.reconstruction_after,
+        result.residual,
+        atol=1e-5,
+        rtol=1e-5,
+    )
+    edited_positions = {
+        result.support_after.tolist().index(source_id),
+        result.support_after.tolist().index(target_id),
+    }
+    for position in range(result.coordinates_before.numel()):
+        if position not in edited_positions:
+            assert torch.equal(
+                result.coordinates_after[position], result.coordinates_before[position]
+            )
+    assert torch.equal(no_op.patched, activation)
+
+
 def test_occupancy_gpt2_activation_is_a_small_positive_integer(published_gpt2_lens, gpt2_bridge):
     """occupancy on a real GPT-2 activation returns a positive integer within ``[1, max_atoms]``,
     with per-step real and control captured-variance curves of the right shape. We assert shape and

--- a/tests/mps/test_mps_basic.py
+++ b/tests/mps/test_mps_basic.py
@@ -18,6 +18,9 @@ import warnings
 import pytest
 import torch
 
+from transformer_lens.tools.analysis.jacobian_lens_coordinate_patch import (
+    solve_coordinate_patch,
+)
 from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
     get_sparse_decomposition,
 )
@@ -109,6 +112,21 @@ def test_mps_jspace_decomposition_moves_before_float64_conversion():
 
     assert result.reconstruction.device.type == "mps"
     torch.testing.assert_close(result.reconstruction, activation)
+    _cleanup()
+
+
+def test_mps_jspace_coordinate_patch_stays_on_device():
+    """Coordinate patching keeps vector outputs on MPS while diagnostics run safely."""
+    dictionary = torch.eye(5, device="mps")[:4]
+    activation = 2.0 * dictionary[0] + 3.0 * dictionary[1]
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+
+    result = solve_coordinate_patch(activation, dictionary, 0, 2, decomposition=decomposition)
+
+    assert result.patched.device.type == "mps"
+    torch.testing.assert_close(
+        result.patched, torch.tensor([0.0, 3.0, 2.0, 0.0, 0.0], device="mps")
+    )
     _cleanup()
 
 

--- a/tests/mps/test_mps_basic.py
+++ b/tests/mps/test_mps_basic.py
@@ -18,6 +18,9 @@ import warnings
 import pytest
 import torch
 
+from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
+    get_sparse_decomposition,
+)
 from transformer_lens.tools.analysis.projection_kernel import (
     SubspaceBasis,
     projection_kernel,
@@ -95,6 +98,18 @@ def test_mps_get_device_falls_back_to_cpu_without_env_var():
     finally:
         if original:
             os.environ["TRANSFORMERLENS_ALLOW_MPS"] = original
+
+
+def test_mps_jspace_decomposition_moves_before_float64_conversion():
+    """The NNLS work moves to CPU before its unsupported float64 conversion."""
+    dictionary = torch.eye(5, device="mps")[:4]
+    activation = 2.0 * dictionary[0] + 3.0 * dictionary[1]
+
+    result = get_sparse_decomposition(activation, dictionary, k=2)
+
+    assert result.reconstruction.device.type == "mps"
+    torch.testing.assert_close(result.reconstruction, activation)
+    _cleanup()
 
 
 def test_mps_warn_if_mps_emits_warning_without_env_var():

--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -930,6 +930,14 @@ def test_lens_vectors_rejects_empty_or_out_of_range_tokens(tokens: list[int]) ->
         _lens().lens_vectors(model, tokens, 0)
 
 
+@pytest.mark.parametrize("token", [True, False])
+def test_to_token_ids_rejects_bool(token: bool) -> None:
+    """A bool token must not silently coerce to id 1/0 via int(token)."""
+    model = _ToyBridge()
+    with pytest.raises(ValueError, match="bool"):
+        jacobian_lens_module._to_token_ids(model, [token])
+
+
 def _intervention_hooks(
     name: str,
     lens: JacobianLens,

--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -19,11 +19,13 @@ from transformer_lens.model_bridge.supported_architectures.deepseek_v4 import (
     DeepseekV4BlockBridge,
 )
 from transformer_lens.tools.analysis import (
+    CoordinatePatch,
     JacobianLens,
     JSpaceDecomposition,
     JSpaceOccupancy,
     JSpaceVarianceProfile,
     get_sparse_decomposition,
+    solve_coordinate_patch,
 )
 from transformer_lens.utilities.activation_functions import apply_softcap
 
@@ -1075,6 +1077,8 @@ def test_exports() -> None:
 
     assert analysis.JacobianLens is JacobianLens
     assert hasattr(analysis, "JacobianLensReadout")
+    assert analysis.CoordinatePatch is CoordinatePatch
+    assert analysis.solve_coordinate_patch is solve_coordinate_patch
 
 
 # ---------------------------------------------------------------------------
@@ -1393,6 +1397,169 @@ def test_decompose_rejects_unfitted_layer(toy_model: _ToyBridge, fitted_lens: Ja
         fitted_lens.decompose(
             toy_model, torch.randn(toy_model.cfg.d_model), layer=N_LAYERS - 1, k=3
         )
+
+
+def test_coordinate_patch_raw_activation_matches_model_free_core(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    layer, source_id, target_id = 0, 3, 5
+    dictionary = fitted_lens.lens_vector_dictionary(toy_model, layer)
+    activation = 2.0 * dictionary[source_id]
+
+    result = fitted_lens.coordinate_patch(toy_model, activation, layer, source_id, target_id, k=1)
+    expected = solve_coordinate_patch(activation, dictionary, source_id, target_id, k=1)
+
+    assert isinstance(result, CoordinatePatch)
+    assert torch.equal(result.support_after, expected.support_after)
+    torch.testing.assert_close(result.coordinates_after, expected.coordinates_after)
+    torch.testing.assert_close(result.patched, expected.patched)
+
+
+def test_coordinate_patch_prompt_matches_manual_activation_and_reuses_decomposition(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    layer, position, k = 0, -1, 3
+    tokens = toy_model.to_tokens("a toy prompt")
+    hook = f"blocks.{layer}.hook_out"
+    _, cache = toy_model.run_with_cache(tokens, names_filter=lambda name: name == hook)
+    activation = cache[hook][0, position, :]
+    dictionary = fitted_lens.lens_vector_dictionary(toy_model, layer)
+    decomposition = get_sparse_decomposition(activation.float(), dictionary, k)
+    source_id = int(decomposition.support[0])
+    target_id = next(token_id for token_id in range(D_VOCAB) if token_id != source_id)
+
+    prompt_result = fitted_lens.coordinate_patch(
+        toy_model,
+        "a toy prompt",
+        layer,
+        source_id,
+        target_id,
+        position=position,
+        decomposition=decomposition,
+    )
+    raw_result = fitted_lens.coordinate_patch(
+        toy_model,
+        activation,
+        layer,
+        source_id,
+        target_id,
+        decomposition=decomposition,
+    )
+
+    assert torch.equal(prompt_result.support_after, raw_result.support_after)
+    torch.testing.assert_close(prompt_result.coordinates_after, raw_result.coordinates_after)
+    torch.testing.assert_close(prompt_result.patched, raw_result.patched)
+
+
+def test_coordinate_patch_resolves_string_tokens(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    layer = 0
+    source_token = "abc"
+    target_token = "abcde"
+    source_id = toy_model.to_single_token(source_token)
+    dictionary = fitted_lens.lens_vector_dictionary(toy_model, layer)
+    activation = dictionary[source_id].clone()
+
+    result = fitted_lens.coordinate_patch(
+        toy_model, activation, layer, source_token, target_token, k=1
+    )
+
+    assert int(result.support_after[result.source_slot]) == source_id
+    assert int(result.support_after[result.target_slot]) == toy_model.to_single_token(target_token)
+
+
+def test_coordinate_patch_reuses_activation_validation(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    with pytest.raises(ValueError, match="raw activation"):
+        fitted_lens.coordinate_patch(toy_model, "a toy prompt", 0, 3, 5, k=1)
+    with pytest.raises(ValueError, match="position is only valid"):
+        fitted_lens.coordinate_patch(toy_model, torch.randn(D_MODEL), 0, 3, 5, position=0, k=1)
+
+
+def test_coordinate_patch_rejects_unfitted_layer(
+    toy_model: _ToyBridge, fitted_lens: JacobianLens
+) -> None:
+    """coordinate_patch shares decompose's resolution: the never-fitted final layer raises."""
+    with pytest.raises(ValueError):
+        fitted_lens.coordinate_patch(
+            toy_model, torch.randn(toy_model.cfg.d_model), N_LAYERS - 1, 3, 5, k=1
+        )
+
+
+def test_coordinate_patch_swap_matches_pseudoinverse_oracle() -> None:
+    """Restricted oracle: a planted two-atom positive swap matches the pseudoinverse intervention
+    swap_hooks performs, ``x + V(sigma(c) - c)`` with ``c = V^+ x``. The pseudoinverse appears only
+    in this test; the core never inverts a basis."""
+    dictionary = torch.tensor([[1.0, 0.0, 0.0], [0.6, 0.8, 0.0]])
+    activation = 2.0 * dictionary[0] + 3.0 * dictionary[1] + torch.tensor([0.0, 0.0, 4.0])
+
+    result = solve_coordinate_patch(
+        activation, dictionary, source_idx=0, target_idx=1, k=2, mode="swap"
+    )
+    basis = dictionary[[0, 1]].T
+    coordinates = torch.linalg.pinv(basis) @ activation
+    expected = activation + basis @ (coordinates[[1, 0]] - coordinates)
+
+    torch.testing.assert_close(result.patched, expected, atol=1e-5, rtol=1e-5)
+
+
+def _fit_lens_with_parallel_target(*, exact: bool) -> tuple["_ToyBridge", JacobianLens]:
+    """Fit a lens on a model whose token-5 unembedding is (near-)parallel to token 3's, so the
+    lens vectors for 3 and 5 collide."""
+    model = _ToyBridge()
+    with torch.no_grad():
+        source = model.unembed.weight[3]
+        if exact:
+            model.unembed.weight[5].copy_(2 * source)
+        else:
+            noise = torch.randn_like(source)
+            noise -= noise.dot(source) / source.square().sum() * source
+            noise *= 0.05 * source.norm() / noise.norm()  # cosine ~= 0.99875
+            model.unembed.weight[5].copy_(source + noise)
+    lens = JacobianLens.fit(
+        model,
+        ["a toy prompt"],
+        corpus=CORPUS,
+        dim_batch=4,
+        skip_first_positions=SKIP_FIRST,
+        show_progress=False,
+    )
+    return model, lens
+
+
+def _pin_source_atom(
+    model: "_ToyBridge", lens: JacobianLens
+) -> tuple[torch.Tensor, JSpaceDecomposition]:
+    """A supplied decomposition that pins atom 3 active, so the near-duplicate atom 5 cannot shadow
+    it during selection. ``activation = 2 * dictionary[3]`` lies exactly in that atom's span."""
+    activation = 2.0 * lens.lens_vector_dictionary(model, 0)[3]
+    decomposition = JSpaceDecomposition(
+        support=torch.tensor([3]),
+        coordinates=torch.tensor([2.0]),
+        selected_support=torch.tensor([3]),
+        reconstruction=activation.clone(),
+        j_space_component=activation.clone(),
+        non_j_space_component=torch.zeros_like(activation),
+    )
+    return activation, decomposition
+
+
+def test_coordinate_patch_propagates_core_near_parallel_warning() -> None:
+    """The wrapper adds no warning handling: the core's near-parallel warning surfaces unchanged."""
+    model, lens = _fit_lens_with_parallel_target(exact=False)
+    activation, decomposition = _pin_source_atom(model, lens)
+    with pytest.warns(UserWarning, match="near-parallel"):
+        lens.coordinate_patch(model, activation, 0, 3, 5, decomposition=decomposition)
+
+
+def test_coordinate_patch_propagates_core_conditioning_warning() -> None:
+    """A colinear target makes the edit basis rank deficient; that core warning must propagate."""
+    model, lens = _fit_lens_with_parallel_target(exact=True)
+    activation, decomposition = _pin_source_atom(model, lens)
+    with pytest.warns(UserWarning, match="rank deficient"):
+        lens.coordinate_patch(model, activation, 0, 3, 5, decomposition=decomposition)
 
 
 def test_occupancy_on_toy_model_raw_activation(

--- a/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
+++ b/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
@@ -416,3 +416,74 @@ def test_well_conditioned_control_emits_no_warning() -> None:
         result = solve_coordinate_patch(activation, dictionary, 0, 2, k=2)
 
     assert torch.isfinite(result.patched).all()
+
+
+def test_large_d_model_full_rank_basis_reports_finite_condition() -> None:
+    """C2: the rank tolerance must scale by the column count, not the d_model row count.
+
+    A full-rank but poorly conditioned edit basis stays finite at model scale. Scaling the
+    rank tolerance by ``max(shape)`` (the d_model row count) instead crosses the smallest
+    singular value once ``d_model >= ~2896``, reporting the basis as rank deficient with an
+    infinite condition number on Llama/Mistral/Gemma-scale dictionaries.
+    """
+    d_model = 3000
+
+    def _atom(*entries: tuple[int, float]) -> torch.Tensor:
+        atom = torch.zeros(d_model)
+        for index, value in entries:
+            atom[index] = value
+        return atom
+
+    dictionary = torch.stack(
+        [_atom((0, 1.0)), _atom((1, 1.0)), _atom((0, 1.0), (1, 1.0), (2, 1e-4)), _atom((3, 1.0))]
+    )
+    activation = dictionary[0] + dictionary[1] + dictionary[2]
+    selected_atoms = dictionary[[0, 1, 2]].T
+    component = selected_atoms @ torch.linalg.pinv(selected_atoms) @ activation
+    decomposition = JSpaceDecomposition(
+        support=torch.tensor([0, 1, 2]),
+        coordinates=torch.ones(3),
+        selected_support=torch.tensor([0, 1, 2]),
+        reconstruction=activation.clone(),
+        j_space_component=component,
+        non_j_space_component=activation - component,
+    )
+
+    with pytest.warns(UserWarning, match="condition number="):
+        result = solve_coordinate_patch(activation, dictionary, 0, 3, decomposition=decomposition)
+
+    assert result.basis_rank == 4
+    assert math.isfinite(result.basis_condition_number)
+
+
+def test_high_condition_decomposition_is_accepted() -> None:
+    """C8: the compatibility tolerance must scale with the selected span's condition number.
+
+    An exactly valid, hand-built decomposition is rejected by a fixed 32-eps tolerance when the
+    activation lies along the near-null direction of an ill-conditioned selected span: the
+    float32 pinv recompute of the projection then diverges by ~cond*eps. Scaling the tolerance
+    with the measured condition number keeps the genuine decomposition valid.
+    """
+    separation = 1e-3  # atom1/atom2 near-parallel; their difference direction is e2
+    atom0 = torch.tensor([1.0, 0.0, 0.0, 0.0])  # active support and edit source
+    atom1 = torch.tensor([0.0, 1.0, 0.0, 0.0])
+    atom2 = torch.tensor([0.0, 1.0, separation, 0.0])
+    atom2 = atom2 / atom2.norm()
+    target_atom = torch.tensor([0.0, 0.0, 0.0, 1.0])  # appended by the edit
+    dictionary = torch.stack([atom0, atom1, atom2, target_atom])
+
+    # The activation sits in the selected span but concentrates on e2, the ill-conditioned
+    # (near-null) direction of the atom1/atom2 pair, so recovering it needs the amplifying inverse.
+    activation = atom0 + torch.tensor([0.0, 0.0, 1.0, 0.0])
+    decomposition = JSpaceDecomposition(
+        support=torch.tensor([0]),
+        coordinates=torch.tensor([1.0]),  # NNLS fit of the activation over the active atom e0
+        selected_support=torch.tensor([0, 1, 2]),
+        reconstruction=atom0.clone(),
+        j_space_component=activation.clone(),  # activation lies entirely in the selected span
+        non_j_space_component=torch.zeros(4),
+    )
+
+    result = solve_coordinate_patch(activation, dictionary, 0, 3, decomposition=decomposition)
+
+    assert torch.isfinite(result.patched).all()

--- a/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
+++ b/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
@@ -41,9 +41,36 @@ def test_substitute_appends_absent_target_and_preserves_frame() -> None:
     torch.testing.assert_close(result.patched, result.residual + result.reconstruction_after)
     torch.testing.assert_close(result.delta, torch.tensor([-2.0, 0.0, 2.0, 0.0, 0.0]))
     assert result.target_was_appended is True
+    assert result.target_was_selected is False
     assert result.overwritten_target_coordinate is None
     assert result.nonedited_coordinate_max_delta == pytest.approx(0.0, abs=1e-6)
     assert result.residual_max_delta == pytest.approx(0.0, abs=1e-6)
+
+
+def test_target_was_selected_true_when_pursuit_drops_it_to_zero() -> None:
+    """Q6: a target selected by pursuit but assigned a zero coordinate is distinguishable from a
+    target pursuit never considered -- both leave ``target_was_appended`` True, but only the
+    former leaves ``target_was_selected`` True."""
+    activation, dictionary = _problem()
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+    # Atom 2 is orthogonal to both selected atoms and to the activation, so folding it into
+    # ``selected_support`` (as if pursuit had picked it and the NNLS re-solve zeroed it) doesn't
+    # perturb ``j_space_component`` or any other validated quantity.
+    selected_with_dropped_target = replace(
+        decomposition,
+        selected_support=torch.cat([decomposition.selected_support, torch.tensor([2])]),
+    )
+
+    result = solve_coordinate_patch(
+        activation,
+        dictionary,
+        source_idx=0,
+        target_idx=2,
+        decomposition=selected_with_dropped_target,
+    )
+
+    assert result.target_was_appended is True
+    assert result.target_was_selected is True
 
 
 def test_active_target_substitute_overwrites_while_swap_exchanges() -> None:
@@ -62,6 +89,8 @@ def test_active_target_substitute_overwrites_while_swap_exchanges() -> None:
     torch.testing.assert_close(swap.patched, torch.tensor([5.0, 2.0, 0.0]))
     assert substitute.target_was_appended is False
     assert swap.target_was_appended is False
+    assert substitute.target_was_selected is True
+    assert swap.target_was_selected is True
 
 
 def test_overwritten_target_coordinate_reports_exact_discarded_value() -> None:
@@ -83,6 +112,23 @@ def test_overwritten_target_coordinate_reports_exact_discarded_value() -> None:
     assert substitute.overwritten_target_coordinate == pytest.approx(7.25)
     assert swap.overwritten_target_coordinate is None
     assert absent.overwritten_target_coordinate is None
+
+
+def test_overwritten_target_coordinate_is_alpha_independent_hypothetical_value() -> None:
+    """Q10: overwritten_target_coordinate reports the coordinate the requested substitute would
+    discard at full strength, independent of alpha -- so at alpha=0, where patched equals the
+    input and nothing is actually discarded, the field is still the hypothetical value rather
+    than None."""
+    dictionary = torch.eye(3)
+    activation = torch.tensor([2.0, 7.25, 0.0])
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+
+    result = solve_coordinate_patch(
+        activation, dictionary, 0, 1, decomposition=decomposition, mode="substitute", alpha=0.0
+    )
+
+    assert torch.equal(result.patched, activation)
+    assert result.overwritten_target_coordinate == pytest.approx(7.25)
 
 
 def test_alpha_interpolates_and_zero_is_bit_exact() -> None:
@@ -114,6 +160,31 @@ def test_small_alpha_delta_is_proportional_not_floored() -> None:
     # delta scales strictly with alpha: no alpha-independent recompute floor survives at 1e-4.
     torch.testing.assert_close(tiny.delta, 1e-4 * full.delta, rtol=1e-3, atol=1e-7)
     assert float(tiny.delta.abs().max()) < 1e-3
+
+
+def test_alpha_within_unit_interval_stays_in_nonnegative_orthant() -> None:
+    """Q5: alpha in [0, 1] never leaves the nonnegative pursuit frame."""
+    activation, dictionary = _problem()
+
+    result = solve_coordinate_patch(activation, dictionary, 0, 2, k=2, alpha=0.5)
+
+    assert result.coordinates_after_nonnegative is True
+    assert bool((result.coordinates_after >= 0).all())
+
+
+def test_alpha_extrapolation_beyond_orthant_warns_and_flags() -> None:
+    """Q5: alpha outside [0, 1] (e.g. 2.0) can drive coordinates_after negative; this must warn
+    and be visible on the result rather than pass silently."""
+    activation, dictionary = _problem()
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+
+    with pytest.warns(UserWarning, match="extrapolat"):
+        result = solve_coordinate_patch(
+            activation, dictionary, 0, 2, decomposition=decomposition, alpha=2.0
+        )
+
+    assert result.coordinates_after_nonnegative is False
+    assert bool((result.coordinates_after < 0).any())
 
 
 def test_preserves_reconstruction_residual_not_selected_span_residual() -> None:

--- a/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
+++ b/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
@@ -212,6 +212,24 @@ def test_rejects_incompatible_precomputed_decomposition() -> None:
         solve_coordinate_patch(activation, changed_dictionary, 0, 2, decomposition=decomposition)
 
 
+def test_rejects_scaled_but_self_consistent_decomposition() -> None:
+    activation, dictionary = _problem()
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+
+    # Scale the (reconstruction, coordinates) pair together. The pair stays internally
+    # consistent with the dictionary and still agrees with the untouched j-space
+    # components, so every self-referential check passes -- but the coordinates are no
+    # longer the NNLS fit of the activation, which the x-coupled stationarity check must
+    # catch instead of silently anchoring the edit to a wrong residual.
+    scaled = replace(
+        decomposition,
+        coordinates=decomposition.coordinates * 2.0,
+        reconstruction=decomposition.reconstruction * 2.0,
+    )
+    with pytest.raises(ValueError, match="activation"):
+        solve_coordinate_patch(activation, dictionary, 0, 1, decomposition=scaled)
+
+
 def test_rejects_malformed_precomputed_decomposition() -> None:
     activation, dictionary = _problem()
     decomposition = get_sparse_decomposition(activation, dictionary, k=2)

--- a/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
+++ b/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
@@ -1,0 +1,387 @@
+"""Model-free tests for anchored J-space coordinate patching."""
+
+import math
+import warnings
+from dataclasses import replace
+
+import pytest
+import torch
+
+from transformer_lens.tools.analysis.jacobian_lens_coordinate_patch import (
+    CoordinatePatch,
+    solve_coordinate_patch,
+)
+from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
+    JSpaceDecomposition,
+    get_sparse_decomposition,
+)
+
+
+def _problem() -> tuple[torch.Tensor, torch.Tensor]:
+    dictionary = torch.eye(5)[:4]
+    residual = torch.tensor([0.0, 0.0, 0.0, 0.0, -4.0])
+    activation = 2.0 * dictionary[0] + 3.0 * dictionary[1] + residual
+    return activation, dictionary
+
+
+def test_substitute_appends_absent_target_and_preserves_frame() -> None:
+    activation, dictionary = _problem()
+
+    result = solve_coordinate_patch(activation, dictionary, source_idx=0, target_idx=2, k=2)
+
+    assert isinstance(result, CoordinatePatch)
+    assert result.support_before.tolist() == [1, 0]
+    assert result.support_after.tolist() == [1, 0, 2]
+    assert result.source_slot == 1
+    assert result.target_slot == 2
+    torch.testing.assert_close(result.coordinates_before, torch.tensor([3.0, 2.0, 0.0]))
+    torch.testing.assert_close(result.coordinates_after, torch.tensor([3.0, 0.0, 2.0]))
+    torch.testing.assert_close(result.residual, torch.tensor([0.0, 0.0, 0.0, 0.0, -4.0]))
+    torch.testing.assert_close(result.reconstruction_after, torch.tensor([0.0, 3.0, 2.0, 0.0, 0.0]))
+    torch.testing.assert_close(result.patched, result.residual + result.reconstruction_after)
+    torch.testing.assert_close(result.delta, torch.tensor([-2.0, 0.0, 2.0, 0.0, 0.0]))
+    assert result.target_was_appended is True
+    assert result.overwritten_target_coordinate is None
+    assert result.nonedited_coordinate_max_delta == pytest.approx(0.0, abs=1e-6)
+    assert result.residual_max_delta == pytest.approx(0.0, abs=1e-6)
+
+
+def test_active_target_substitute_overwrites_while_swap_exchanges() -> None:
+    dictionary = torch.eye(3)
+    activation = torch.tensor([2.0, 5.0, 0.0])
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+
+    substitute = solve_coordinate_patch(
+        activation, dictionary, 0, 1, decomposition=decomposition, mode="substitute"
+    )
+    swap = solve_coordinate_patch(
+        activation, dictionary, 0, 1, decomposition=decomposition, mode="swap"
+    )
+
+    torch.testing.assert_close(substitute.patched, torch.tensor([0.0, 2.0, 0.0]))
+    torch.testing.assert_close(swap.patched, torch.tensor([5.0, 2.0, 0.0]))
+    assert substitute.target_was_appended is False
+    assert swap.target_was_appended is False
+
+
+def test_overwritten_target_coordinate_reports_exact_discarded_value() -> None:
+    """Q2 value-level: substitute onto an active target reports the exact discarded coordinate."""
+    dictionary = torch.eye(3)
+    activation = torch.tensor([2.0, 7.25, 0.0])
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+
+    substitute = solve_coordinate_patch(
+        activation, dictionary, 0, 1, decomposition=decomposition, mode="substitute"
+    )
+    swap = solve_coordinate_patch(
+        activation, dictionary, 0, 1, decomposition=decomposition, mode="swap"
+    )
+    absent = solve_coordinate_patch(
+        activation, dictionary, 0, 2, decomposition=decomposition, mode="substitute"
+    )
+
+    assert substitute.overwritten_target_coordinate == pytest.approx(7.25)
+    assert swap.overwritten_target_coordinate is None
+    assert absent.overwritten_target_coordinate is None
+
+
+def test_alpha_interpolates_and_zero_is_bit_exact() -> None:
+    activation, dictionary = _problem()
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+    full = solve_coordinate_patch(activation, dictionary, 0, 2, decomposition=decomposition)
+    half = solve_coordinate_patch(
+        activation, dictionary, 0, 2, decomposition=decomposition, alpha=0.5
+    )
+    zero = solve_coordinate_patch(
+        activation, dictionary, 0, 2, decomposition=decomposition, alpha=0.0
+    )
+
+    torch.testing.assert_close(half.delta, 0.5 * full.delta)
+    torch.testing.assert_close(half.patched, activation + 0.5 * full.delta)
+    assert torch.equal(zero.patched, activation)
+    assert torch.equal(zero.delta, torch.zeros_like(activation))
+    assert zero.patched.data_ptr() != activation.data_ptr()
+
+
+def test_preserves_reconstruction_residual_not_selected_span_residual() -> None:
+    dictionary = torch.eye(3)
+    activation = torch.tensor([2.0, -1.0, 3.0])
+    decomposition = JSpaceDecomposition(
+        support=torch.tensor([0]),
+        coordinates=torch.tensor([2.0]),
+        selected_support=torch.tensor([0, 1]),
+        reconstruction=torch.tensor([2.0, 0.0, 0.0]),
+        j_space_component=torch.tensor([2.0, -1.0, 0.0]),
+        non_j_space_component=torch.tensor([0.0, 0.0, 3.0]),
+    )
+
+    result = solve_coordinate_patch(activation, dictionary, 0, 2, decomposition=decomposition)
+
+    torch.testing.assert_close(result.residual, torch.tensor([0.0, -1.0, 3.0]))
+    torch.testing.assert_close(result.patched, torch.tensor([0.0, -1.0, 5.0]))
+    assert not torch.equal(result.residual, decomposition.non_j_space_component)
+
+
+def test_witnesses_certify_untouched_coordinates_and_residual() -> None:
+    dictionary = torch.eye(4)
+    activation = torch.tensor([2.0, 3.0, 4.0, 0.0])
+    decomposition = get_sparse_decomposition(activation, dictionary, k=3)
+
+    result = solve_coordinate_patch(activation, dictionary, 0, 3, decomposition=decomposition)
+
+    # Atom 1 and atom 2 are neither source nor target, so their coordinates must be untouched.
+    assert result.nonedited_coordinate_max_delta == pytest.approx(0.0, abs=1e-6)
+    assert result.residual_max_delta == pytest.approx(0.0, abs=1e-6)
+
+
+def test_fresh_and_precomputed_decompositions_match_without_mutating_inputs() -> None:
+    activation, dictionary = _problem()
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+    activation_before = activation.clone()
+    dictionary_before = dictionary.clone()
+    coordinates_before = decomposition.coordinates.clone()
+
+    fresh = solve_coordinate_patch(activation, dictionary, 0, 2, k=2, mode="swap")
+    reused = solve_coordinate_patch(
+        activation, dictionary, 0, 2, decomposition=decomposition, mode="swap"
+    )
+
+    assert torch.equal(fresh.support_after, reused.support_after)
+    torch.testing.assert_close(fresh.coordinates_after, reused.coordinates_after)
+    torch.testing.assert_close(fresh.patched, reused.patched)
+    assert torch.equal(activation, activation_before)
+    assert torch.equal(dictionary, dictionary_before)
+    assert torch.equal(decomposition.coordinates, coordinates_before)
+
+
+def test_repeated_calls_are_deterministic() -> None:
+    activation, dictionary = _problem()
+
+    first = solve_coordinate_patch(activation, dictionary, 0, 2, k=2)
+    second = solve_coordinate_patch(activation, dictionary, 0, 2, k=2)
+
+    assert torch.equal(first.patched, second.patched)
+    assert torch.equal(first.support_after, second.support_after)
+
+
+def test_float64_input_produces_float32_outputs() -> None:
+    activation, dictionary = _problem()
+
+    result = solve_coordinate_patch(activation.double(), dictionary, 0, 2, k=2)
+
+    assert result.patched.dtype == torch.float32
+    assert result.coordinates_after.dtype == torch.float32
+    torch.testing.assert_close(result.patched, torch.tensor([0.0, 3.0, 2.0, 0.0, -4.0]))
+
+
+@pytest.mark.parametrize(
+    "algorithm", ["nonnegative_orthogonal_matching_pursuit", "gradient_pursuit"]
+)
+def test_both_decomposition_algorithms_pass_through(algorithm: str) -> None:
+    activation, dictionary = _problem()
+
+    result = solve_coordinate_patch(activation, dictionary, 0, 2, k=2, algorithm=algorithm)
+
+    torch.testing.assert_close(result.patched, torch.tensor([0.0, 3.0, 2.0, 0.0, -4.0]))
+
+
+def test_rejects_incompatible_precomputed_decomposition() -> None:
+    activation, dictionary = _problem()
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+
+    with pytest.raises(ValueError, match="activation"):
+        solve_coordinate_patch(
+            activation + dictionary[3], dictionary, 0, 2, decomposition=decomposition
+        )
+    changed_dictionary = dictionary.clone()
+    changed_dictionary[0] *= 2
+    with pytest.raises(ValueError, match="dictionary|reconstruction"):
+        solve_coordinate_patch(activation, changed_dictionary, 0, 2, decomposition=decomposition)
+
+
+def test_rejects_malformed_precomputed_decomposition() -> None:
+    activation, dictionary = _problem()
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+
+    duplicate = replace(
+        decomposition, support=torch.tensor([0, 0]), coordinates=torch.tensor([1.0, 1.0])
+    )
+    with pytest.raises(ValueError, match="duplicates"):
+        solve_coordinate_patch(activation, dictionary, 0, 2, decomposition=duplicate)
+    outside = replace(decomposition, selected_support=torch.tensor([0, 1, 9]))
+    with pytest.raises(ValueError, match="outside"):
+        solve_coordinate_patch(activation, dictionary, 0, 2, decomposition=outside)
+    zero_coordinate = replace(
+        decomposition, coordinates=torch.zeros_like(decomposition.coordinates)
+    )
+    with pytest.raises(ValueError, match="positive"):
+        solve_coordinate_patch(activation, dictionary, 0, 2, decomposition=zero_coordinate)
+    bad_shape = replace(decomposition, reconstruction=torch.zeros(2, 5))
+    with pytest.raises(ValueError, match=r"shape \[d_model\]"):
+        solve_coordinate_patch(activation, dictionary, 0, 2, decomposition=bad_shape)
+    nonfinite = replace(
+        decomposition,
+        non_j_space_component=torch.full_like(decomposition.non_j_space_component, torch.nan),
+    )
+    with pytest.raises(ValueError, match="non-finite"):
+        solve_coordinate_patch(activation, dictionary, 0, 2, decomposition=nonfinite)
+
+
+def test_reuse_validates_only_atoms_used_by_the_edit() -> None:
+    dictionary = torch.eye(4)
+    activation = 2.0 * dictionary[0]
+    decomposition = get_sparse_decomposition(activation, dictionary, k=1)
+    dictionary[3] = torch.nan
+
+    reused = solve_coordinate_patch(activation, dictionary, 0, 1, decomposition=decomposition)
+
+    assert torch.isfinite(reused.patched).all()
+    with pytest.raises(ValueError, match="non-finite"):
+        solve_coordinate_patch(activation, dictionary, 0, 1, k=1)
+
+
+def test_tiny_nonzero_atoms_are_valid() -> None:
+    dictionary = torch.tensor([[1e-8, 0.0], [0.0, 1.0]])
+    activation = 2.0 * dictionary[0]
+
+    result = solve_coordinate_patch(activation, dictionary, 0, 1, k=1)
+
+    torch.testing.assert_close(result.patched, torch.tensor([0.0, 2.0]))
+
+
+def test_rejects_zero_norm_target_atom() -> None:
+    # The target atom is edited, so a zero-norm target is rejected once the edit frame is built.
+    dictionary = torch.tensor([[1.0, 0.0], [0.0, 0.0]])
+    activation = torch.tensor([2.0, 0.0])
+
+    with pytest.raises(ValueError, match="zero-norm"):
+        solve_coordinate_patch(activation, dictionary, 0, 1, k=1)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"source_idx": 2, "target_idx": 3}, "active support"),
+        ({"source_idx": 0, "target_idx": 0}, "distinct"),
+        ({"source_idx": -1, "target_idx": 2}, "source_idx"),
+        ({"source_idx": 0, "target_idx": 9}, "target_idx"),
+        ({"source_idx": 0, "target_idx": 2, "mode": "bad"}, "mode"),
+        ({"source_idx": 0, "target_idx": 2, "alpha": math.inf}, "finite"),
+    ],
+)
+def test_rejects_invalid_edit_requests(kwargs: dict[str, object], message: str) -> None:
+    activation, dictionary = _problem()
+    with pytest.raises(ValueError, match=message):
+        solve_coordinate_patch(activation, dictionary, k=2, **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("bad_x", "message"),
+    [
+        (torch.zeros(2, 4), "x must be 1-D"),
+        (torch.zeros(3), "x must be 1-D"),
+        (torch.tensor([2.0, float("nan"), 0.0, 0.0]), "non-finite"),
+    ],
+)
+def test_rejects_malformed_activation(bad_x: torch.Tensor, message: str) -> None:
+    dictionary = torch.eye(4)
+    with pytest.raises(ValueError, match=message):
+        solve_coordinate_patch(bad_x, dictionary, 0, 1, k=1)
+
+
+def test_rejects_malformed_dictionary() -> None:
+    activation = torch.zeros(4)
+    with pytest.raises(ValueError, match="dictionary must be 2-D"):
+        solve_coordinate_patch(activation, torch.zeros(4), 0, 1, k=1)
+    with pytest.raises(ValueError, match="at least one atom"):
+        solve_coordinate_patch(activation, torch.zeros(0, 4), 0, 1, k=1)
+
+
+def test_rejects_device_mismatch_between_activation_and_dictionary() -> None:
+    activation, dictionary = _problem()
+    meta_dictionary = dictionary.to("meta")
+    with pytest.raises(ValueError, match="same device"):
+        solve_coordinate_patch(activation, meta_dictionary, 0, 2, k=2)
+
+
+def test_near_parallel_atoms_warn_but_return_patch() -> None:
+    """Q3-ext: near-parallel source/target warns (naming the cosine) and never raises."""
+    activation = torch.tensor([2.0, 0.0, 0.0])
+    dictionary = torch.tensor([[1.0, 0.0, 0.0], [1.0, 0.05, 0.0], [0.0, 0.0, 1.0]])
+
+    with pytest.warns(UserWarning, match="near-parallel") as record:
+        result = solve_coordinate_patch(activation, dictionary, 0, 1, k=1)
+
+    assert 0.99 <= abs(result.source_target_cosine) < 0.999
+    assert f"{abs(result.source_target_cosine):.6f}" in str(record[0].message)
+    assert torch.isfinite(result.patched).all()
+
+    # The parallel extreme (abs cosine >= 0.999) must still warn-and-complete, not raise.
+    extreme = dictionary.clone()
+    extreme[1] = 2.0 * extreme[0]
+    with pytest.warns(UserWarning, match="near-parallel") as extreme_record:
+        extreme_result = solve_coordinate_patch(activation, extreme, 0, 1, k=1)
+
+    assert abs(extreme_result.source_target_cosine) >= 0.999
+    assert f"{abs(extreme_result.source_target_cosine):.6f}" in str(extreme_record[0].message)
+    assert torch.isfinite(extreme_result.patched).all()
+
+
+def test_rank_deficient_edit_basis_warns_but_returns_patch() -> None:
+    dictionary = torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    activation = torch.tensor([2.0, 3.0, 0.0])
+    decomposition = JSpaceDecomposition(
+        support=torch.tensor([0, 1, 2]),
+        coordinates=torch.tensor([1.0, 2.0, 1.0]),
+        selected_support=torch.tensor([0, 1, 2]),
+        reconstruction=activation.clone(),
+        j_space_component=activation.clone(),
+        non_j_space_component=torch.zeros(3),
+    )
+
+    with pytest.warns(UserWarning, match="rank deficient"):
+        result = solve_coordinate_patch(activation, dictionary, 0, 3, decomposition=decomposition)
+
+    assert result.basis_rank == 3
+    assert math.isinf(result.basis_condition_number)
+    assert torch.isfinite(result.patched).all()
+
+
+def test_poorly_conditioned_full_rank_basis_warns_with_measurement() -> None:
+    dictionary = torch.tensor(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [1.0, 1.0, 1e-4, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    activation = dictionary[0] + dictionary[1] + dictionary[2]
+    selected_atoms = dictionary[[0, 1, 2]].T
+    component = selected_atoms @ torch.linalg.pinv(selected_atoms) @ activation
+    decomposition = JSpaceDecomposition(
+        support=torch.tensor([0, 1, 2]),
+        coordinates=torch.ones(3),
+        selected_support=torch.tensor([0, 1, 2]),
+        reconstruction=activation.clone(),
+        j_space_component=component,
+        non_j_space_component=activation - component,
+    )
+
+    with pytest.warns(UserWarning, match="condition number=") as record:
+        result = solve_coordinate_patch(activation, dictionary, 0, 3, decomposition=decomposition)
+
+    assert result.basis_rank == 4
+    assert math.isfinite(result.basis_condition_number)
+    assert f"{result.basis_condition_number:.6g}" in str(record[0].message)
+
+
+def test_well_conditioned_control_emits_no_warning() -> None:
+    """Over-warning guard: an orthonormal, non-parallel edit must fire no warning at all."""
+    activation, dictionary = _problem()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = solve_coordinate_patch(activation, dictionary, 0, 2, k=2)
+
+    assert torch.isfinite(result.patched).all()

--- a/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
+++ b/tests/unit/tools/test_jacobian_lens_coordinate_patch.py
@@ -103,6 +103,19 @@ def test_alpha_interpolates_and_zero_is_bit_exact() -> None:
     assert zero.patched.data_ptr() != activation.data_ptr()
 
 
+def test_small_alpha_delta_is_proportional_not_floored() -> None:
+    activation, dictionary = _problem()
+    decomposition = get_sparse_decomposition(activation, dictionary, k=2)
+    full = solve_coordinate_patch(activation, dictionary, 0, 2, decomposition=decomposition)
+    tiny = solve_coordinate_patch(
+        activation, dictionary, 0, 2, decomposition=decomposition, alpha=1e-4
+    )
+
+    # delta scales strictly with alpha: no alpha-independent recompute floor survives at 1e-4.
+    torch.testing.assert_close(tiny.delta, 1e-4 * full.delta, rtol=1e-3, atol=1e-7)
+    assert float(tiny.delta.abs().max()) < 1e-3
+
+
 def test_preserves_reconstruction_residual_not_selected_span_residual() -> None:
     dictionary = torch.eye(3)
     activation = torch.tensor([2.0, -1.0, 3.0])

--- a/transformer_lens/tools/analysis/__init__.py
+++ b/transformer_lens/tools/analysis/__init__.py
@@ -11,7 +11,8 @@ Tools:
       analysis.
     - jacobian_lens: The Jacobian lens (J-lens) — per-layer causal transport to
       the output vocabulary basis, with loading of published lens artifacts,
-      native fitting, readouts, interventions, and J-space sparse decomposition.
+      native fitting, readouts, interventions, J-space sparse decomposition, and
+      anchored coordinate patching.
     - projection_kernel: Basis-invariant subspace overlap and TransformerBridge
       attention-head OQ/OK/OV affinity.
 """
@@ -27,6 +28,10 @@ from transformer_lens.tools.analysis.direct_path_patching import (
 from transformer_lens.tools.analysis.jacobian_lens import (
     JacobianLens,
     JacobianLensReadout,
+)
+from transformer_lens.tools.analysis.jacobian_lens_coordinate_patch import (
+    CoordinatePatch,
+    solve_coordinate_patch,
 )
 from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
     JSpaceDecomposition,
@@ -50,6 +55,7 @@ from transformer_lens.tools.analysis.projection_kernel import (
 
 __all__ = [
     "AttentionHeadRef",
+    "CoordinatePatch",
     "DirectLogitAttribution",
     "HeadAffinityPair",
     "HeadAffinityResult",
@@ -70,4 +76,5 @@ __all__ = [
     "orthonormal_subspace",
     "projection_kernel",
     "random_projection_kernel_moments",
+    "solve_coordinate_patch",
 ]

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -60,7 +60,6 @@ Example::
     print(result.top_tokens(model.tokenizer, k=5)[8][-1])  # layer 8, final position
 """
 
-import math
 import warnings
 from dataclasses import dataclass
 from importlib.metadata import version
@@ -70,11 +69,16 @@ import torch
 from jaxtyping import Float, Int
 from tqdm.auto import tqdm
 
+from transformer_lens.tools.analysis.jacobian_lens_coordinate_patch import (
+    CoordinatePatch,
+    solve_coordinate_patch,
+)
 from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
     DEFAULT_K,
     JSpaceDecomposition,
     JSpaceOccupancy,
     JSpaceVarianceProfile,
+    _diagnose_intervention_pair,
     estimate_occupancy,
     get_sparse_decomposition,
 )
@@ -126,8 +130,6 @@ def _resolve_registry_entry(name_or_path: str) -> Optional[Tuple[str, str]]:
 # and the final position (no next-token target), matching the reference implementation.
 DEFAULT_SKIP_FIRST_POSITIONS = 16
 DEFAULT_TOP_K = 10
-_SWAP_WARN_COSINE = 0.99
-_SWAP_ERROR_COSINE = 0.999
 
 # Keys written by fit() that must not appear in converted-lens metadata so that
 # merge() can refuse to mix TL-fitted lenses with externally converted ones.
@@ -910,6 +912,65 @@ class JacobianLens:
             activation.float().to(dictionary.device), dictionary, k, algorithm=algorithm
         )
 
+    @torch.no_grad()
+    def coordinate_patch(
+        self,
+        model: Any,
+        activation_or_prompt: Union[torch.Tensor, str],
+        layer: int,
+        source_token: TokenInput,
+        target_token: TokenInput,
+        *,
+        position: Optional[int] = None,
+        decomposition: Optional[JSpaceDecomposition] = None,
+        k: int = DEFAULT_K,
+        mode: str = "substitute",
+        alpha: float = 1.0,
+        algorithm: str = "nonnegative_orthogonal_matching_pursuit",
+    ) -> CoordinatePatch:
+        """Patch sparse J-space coordinates for an activation at ``layer``.
+
+        The activation may be a raw ``[d_model]`` vector or a prompt paired with ``position``,
+        exactly as in :meth:`decompose`. ``source_token`` must occur in the active sparse support.
+        ``substitute`` replaces the target coordinate with the source coordinate and zeros the
+        source; ``swap`` exchanges them. Other coordinates and ``x - reconstruction`` are fixed.
+
+        A supplied ``decomposition`` avoids repeating the vocabulary-scale sparse solve after its
+        activation and dictionary compatibility have been validated.
+
+        Args:
+            model: A raw ``TransformerBridge``.
+            activation_or_prompt: An activation vector, or a prompt (string / token tensor).
+            layer: Source layer (must be a fitted source layer).
+            source_token: Active source concept, as a single-token string or token id.
+            target_token: Distinct target concept, as a single-token string or token id.
+            position: Token position when a prompt is given; ``None`` for a raw activation.
+            decomposition: Optional compatible decomposition of this activation and dictionary.
+            k: Sparse-solver upper bound when ``decomposition`` is not supplied.
+            mode: ``"substitute"`` or ``"swap"``.
+            alpha: Finite interpolation strength; zero is an exact no-op.
+            algorithm: Sparse coefficient-update rule when solving a fresh decomposition.
+
+        Returns:
+            A :class:`CoordinatePatch` containing the edited frame, diagnostics, and activation.
+        """
+        activation, resolved_layer = self._resolve_activation(
+            model, activation_or_prompt, layer, position
+        )
+        dictionary = self.lens_vector_dictionary(model, resolved_layer)
+        source_id, target_id = _to_token_ids(model, [source_token, target_token])
+        return solve_coordinate_patch(
+            activation.float().to(dictionary.device),
+            dictionary,
+            source_id,
+            target_id,
+            decomposition=decomposition,
+            k=k,
+            mode=mode,
+            alpha=alpha,
+            algorithm=algorithm,
+        )
+
     def _resolve_activation(
         self,
         model: Any,
@@ -920,8 +981,9 @@ class JacobianLens:
         """Validate the model and layer, then resolve either a raw ``[d_model]`` activation or a
         prompt plus ``position`` to the activation vector to analyse.
 
-        Returns ``(activation, resolved_layer)``. Shared by :meth:`decompose` and
-        :meth:`occupancy` so both accept the same input forms with identical validation.
+        Returns ``(activation, resolved_layer)``. Shared by :meth:`decompose`,
+        :meth:`coordinate_patch`, and :meth:`occupancy` so all accept the same input forms with
+        identical validation.
         """
         self.validate_model(model)
         resolved_layer = _normalize_layer(layer, model.cfg.n_layers)
@@ -934,8 +996,8 @@ class JacobianLens:
         if position is None:
             if not isinstance(activation_or_prompt, torch.Tensor):
                 raise ValueError(
-                    "decompose expects a raw activation tensor when position is None; pass a "
-                    "prompt together with a position to decompose a model activation"
+                    "analysis expects a raw activation tensor when position is None; pass a "
+                    "prompt together with a position to analyze a model activation"
                 )
             activation = activation_or_prompt
             if activation.ndim != 1 or activation.shape[0] != self.d_model:
@@ -956,7 +1018,7 @@ class JacobianLens:
             )
             if tokens.ndim != 2 or tokens.shape[0] != 1:
                 raise ValueError(
-                    f"decompose expects a single prompt; got shape {tuple(tokens.shape)}"
+                    f"analysis expects a single prompt; got shape {tuple(tokens.shape)}"
                 )
             hook_name = _resid_post_hook_name(resolved_layer)
             _, cache = model.run_with_cache(tokens, names_filter=lambda name: name == hook_name)
@@ -1284,19 +1346,9 @@ class JacobianLens:
         for layer in [_normalize_layer(layer, model.cfg.n_layers) for layer in layers]:
             vectors = self.lens_vectors(model, [source_id, target_id], layer)
             units = _unit_rows(vectors, layer=layer)
-            cosine = abs(float((units[0] @ units[1]).item()))
-            if not math.isfinite(cosine) or cosine >= _SWAP_ERROR_COSINE:
-                raise ValueError(
-                    f"swap vectors at layer {layer} are numerically near-parallel "
-                    f"(abs cosine={cosine:.6f}); choose better-separated concepts"
-                )
-            if cosine >= _SWAP_WARN_COSINE:
-                warnings.warn(
-                    f"swap vectors at layer {layer} are poorly conditioned "
-                    f"(abs cosine={cosine:.6f}); the intervention may be amplified",
-                    UserWarning,
-                    stacklevel=2,
-                )
+            _diagnose_intervention_pair(
+                units, description=f"swap vectors at layer {layer}", stacklevel=3
+            )
             basis = vectors.T  # [d, 2]
             pinv = torch.linalg.pinv(basis)  # [2, d]
             device_basis: Dict[torch.device, torch.Tensor] = {}

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -1748,6 +1748,8 @@ def _to_token_ids(model: Any, tokens: Union[TokenInput, Sequence[TokenInput]]) -
     for token in tokens:
         if isinstance(token, str):
             ids.append(model.to_single_token(token))
+        elif isinstance(token, bool):
+            raise ValueError(f"token {token!r} must be a string or integer token id, not bool")
         else:
             ids.append(int(token))
     if not ids:

--- a/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
@@ -1,0 +1,434 @@
+"""Anchored coordinate edits over sparse Jacobian-lens decompositions."""
+
+from __future__ import annotations
+
+import math
+import warnings
+from dataclasses import dataclass
+from numbers import Integral, Real
+from typing import Optional
+
+import torch
+
+from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
+    _SWAP_WARN_COSINE,
+    DEFAULT_K,
+    JSpaceDecomposition,
+    get_sparse_decomposition,
+)
+
+#: Above this condition number the column-normalized edit basis is treated as ill-conditioned and
+#: the patch warns. It sits at the inverse square-root of float32 epsilon so a benign, well-scaled
+#: basis (condition number of order one) never trips the warning.
+_BASIS_CONDITION_WARNING = 1.0 / math.sqrt(torch.finfo(torch.float32).eps)
+
+
+@dataclass(frozen=True)
+class CoordinatePatch:
+    """Result of an anchored edit to sparse J-space coordinates.
+
+    All tensors are detached. Vector outputs use float32 on the dictionary device; the two support
+    tensors are ``torch.long`` on CPU. This is a report only: it retains no model, lens, tokenizer,
+    hook, or full dictionary.
+
+    Attributes:
+        support_before: Active support from the sparse decomposition, in decomposition order.
+        support_after: The coordinate frame the edit acts on: ``support_before`` in the same order,
+            with an absent target appended. Both coordinate tensors align with this frame.
+        coordinates_before: Original coordinates in ``support_after``, including an appended zero
+            when the target was absent.
+        coordinates_after: Coordinates after applying ``mode`` and ``alpha``.
+        source_slot: Position of the source atom within ``support_after``.
+        target_slot: Position of the target atom within ``support_after``.
+        target_was_appended: Whether the target was absent and appended to ``support_after``.
+        overwritten_target_coordinate: The discarded old target coordinate when a ``substitute``
+            overwrites an already-active target; ``None`` when the target was absent or ``mode`` is
+            ``"swap"`` (a swap relocates a coordinate and discards nothing).
+        reconstruction_before: Sparse reconstruction from ``support_before``.
+        reconstruction_after: Reconstruction from ``support_after`` and ``coordinates_after``.
+        residual: Anchored residual ``x - reconstruction_before``. This is not necessarily the
+            decomposition's orthogonal ``non_j_space_component``.
+        delta: ``reconstruction_after - reconstruction_before``.
+        patched: ``x + delta``; an unchanged clone of the float32 input when ``alpha`` is zero.
+        nonedited_coordinate_max_delta: Maximum absolute change across every coordinate that is
+            neither source nor target. A postcondition witness: it must be numerically zero.
+        residual_max_delta: Maximum absolute difference between ``patched - reconstruction_after``
+            and ``residual``. A postcondition witness: the anchored residual must be preserved.
+        source_target_cosine: Signed cosine between the source and target atoms.
+        basis_rank: Numerical rank of the column-normalized edit basis at float32 precision.
+        basis_condition_number: Condition number of that basis, or infinity when rank deficient.
+    """
+
+    support_before: torch.Tensor
+    support_after: torch.Tensor
+    coordinates_before: torch.Tensor
+    coordinates_after: torch.Tensor
+    source_slot: int
+    target_slot: int
+    target_was_appended: bool
+    overwritten_target_coordinate: Optional[float]
+    reconstruction_before: torch.Tensor
+    reconstruction_after: torch.Tensor
+    residual: torch.Tensor
+    delta: torch.Tensor
+    patched: torch.Tensor
+    nonedited_coordinate_max_delta: float
+    residual_max_delta: float
+    source_target_cosine: float
+    basis_rank: int
+    basis_condition_number: float
+
+
+def _validate_inputs(
+    x: torch.Tensor, dictionary: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if dictionary.ndim != 2:
+        raise ValueError(
+            f"dictionary must be 2-D [num_atoms, d_model], got shape {tuple(dictionary.shape)}"
+        )
+    num_atoms, d_model = dictionary.shape
+    if x.ndim != 1 or x.shape[0] != d_model:
+        raise ValueError(f"x must be 1-D of length d_model={d_model}, got shape {tuple(x.shape)}")
+    if num_atoms == 0:
+        raise ValueError("dictionary must contain at least one atom")
+    if torch.is_complex(x) or torch.is_complex(dictionary):
+        raise ValueError("x and dictionary must be real-valued")
+    if x.device != dictionary.device:
+        raise ValueError("x and dictionary must be on the same device")
+    target = x.float()
+    if not bool(torch.isfinite(target).all()):
+        raise ValueError("x contains non-finite entries")
+    return target, dictionary
+
+
+def _validate_atom_rows(
+    dictionary: torch.Tensor, indices: torch.Tensor, *, context: str
+) -> torch.Tensor:
+    atoms = dictionary[indices].float()
+    if not bool(torch.isfinite(atoms).all()):
+        raise ValueError(f"{context} contains a non-finite dictionary atom")
+    if bool((torch.linalg.vector_norm(atoms, dim=1) == 0).any()):
+        raise ValueError(f"{context} contains a zero-norm dictionary atom")
+    return atoms
+
+
+def _validate_index(name: str, value: int, num_atoms: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer atom index")
+    index = int(value)
+    if not 0 <= index < num_atoms:
+        raise ValueError(f"{name}={index} out of range for dictionary with {num_atoms} atoms")
+    return index
+
+
+def _close(actual: torch.Tensor, expected: torch.Tensor) -> bool:
+    if actual.shape != expected.shape:
+        return False
+    magnitude = torch.stack([actual.abs().max(), expected.abs().max()]).max()
+    tolerance = 32 * torch.finfo(torch.float32).eps
+    return bool(
+        torch.allclose(actual, expected, rtol=tolerance, atol=tolerance * float(magnitude.item()))
+    )
+
+
+def _validate_decomposition(
+    decomposition: JSpaceDecomposition,
+    target: torch.Tensor,
+    dictionary: torch.Tensor,
+    target_idx: int,
+) -> None:
+    num_atoms, d_model = dictionary.shape
+    support = decomposition.support
+    selected = decomposition.selected_support
+    if support.ndim != 1 or selected.ndim != 1:
+        raise ValueError("precomputed decomposition supports must be 1-D")
+    if support.dtype != torch.long or selected.dtype != torch.long:
+        raise ValueError("precomputed decomposition supports must have dtype torch.long")
+    support_cpu = support.detach().cpu()
+    selected_cpu = selected.detach().cpu()
+    if (
+        support_cpu.unique().numel() != support_cpu.numel()
+        or selected_cpu.unique().numel() != selected_cpu.numel()
+    ):
+        raise ValueError("precomputed decomposition supports must not contain duplicates")
+    if bool(((support_cpu < 0) | (support_cpu >= num_atoms)).any()) or bool(
+        ((selected_cpu < 0) | (selected_cpu >= num_atoms)).any()
+    ):
+        raise ValueError("precomputed decomposition support is outside the dictionary")
+    if not set(support_cpu.tolist()).issubset(set(selected_cpu.tolist())):
+        raise ValueError("precomputed active support must be a subset of selected_support")
+    referenced = torch.unique(
+        torch.cat([support_cpu, selected_cpu, torch.tensor([target_idx], dtype=torch.long)])
+    )
+    _validate_atom_rows(dictionary, referenced, context="precomputed decomposition")
+    coordinates = decomposition.coordinates.float().to(dictionary.device)
+    if coordinates.ndim != 1 or coordinates.numel() != support_cpu.numel():
+        raise ValueError("precomputed decomposition coordinates must align with active support")
+    if not bool(torch.isfinite(coordinates).all()) or bool((coordinates <= 0).any()):
+        raise ValueError("precomputed decomposition active coordinates must be finite and positive")
+    vectors = (
+        decomposition.reconstruction,
+        decomposition.j_space_component,
+        decomposition.non_j_space_component,
+    )
+    if any(vector.ndim != 1 or vector.shape[0] != d_model for vector in vectors):
+        raise ValueError("precomputed decomposition vector outputs must have shape [d_model]")
+    local_vectors = [vector.float().to(dictionary.device) for vector in vectors]
+    if not all(bool(torch.isfinite(vector).all()) for vector in local_vectors):
+        raise ValueError("precomputed decomposition contains non-finite vector outputs")
+    support_atoms = dictionary[support_cpu].float()
+    expected_reconstruction = support_atoms.T @ coordinates
+    if not _close(local_vectors[0], expected_reconstruction):
+        raise ValueError("precomputed decomposition reconstruction is incompatible with dictionary")
+    if not _close(local_vectors[1] + local_vectors[2], target):
+        raise ValueError("precomputed decomposition is incompatible with activation")
+    if selected_cpu.numel():
+        selected_atoms = dictionary[selected_cpu].float().T
+        if target.device.type == "mps":
+            work_atoms = selected_atoms.cpu()
+            work_target = target.cpu()
+            expected_component = (work_atoms @ (torch.linalg.pinv(work_atoms) @ work_target)).to(
+                target.device
+            )
+        else:
+            expected_component = selected_atoms @ (torch.linalg.pinv(selected_atoms) @ target)
+    else:
+        expected_component = torch.zeros_like(target)
+    if not _close(local_vectors[1], expected_component):
+        raise ValueError("precomputed decomposition selected span is incompatible with dictionary")
+
+
+def _basis_diagnostics(basis: torch.Tensor) -> tuple[int, float]:
+    """Rank and condition number of the column-normalized edit basis, warning when ill-conditioned.
+
+    Both warnings are non-fatal: the anchored edit performs no inverse of ``basis``, so a
+    rank-deficient or poorly conditioned basis only means coordinate attribution is non-unique.
+    """
+    normalized = basis / torch.linalg.vector_norm(basis, dim=0, keepdim=True)
+    diagnostic_basis = normalized.detach().cpu().double()
+    rank_rtol = torch.finfo(torch.float32).eps * max(diagnostic_basis.shape)
+    rank = int(torch.linalg.matrix_rank(diagnostic_basis, rtol=rank_rtol).item())
+    if rank < diagnostic_basis.shape[1]:
+        condition = math.inf
+        warnings.warn(
+            "coordinate-patch basis is rank deficient (condition number=inf); "
+            "coordinate attribution may be non-unique",
+            UserWarning,
+            stacklevel=3,
+        )
+    else:
+        singular_values = torch.linalg.svdvals(diagnostic_basis)
+        condition = float((singular_values.max() / singular_values.min()).item())
+        if condition >= _BASIS_CONDITION_WARNING:
+            warnings.warn(
+                f"coordinate-patch basis is poorly conditioned (condition number={condition:.6g}); "
+                "coordinate attribution may be non-unique",
+                UserWarning,
+                stacklevel=3,
+            )
+    return rank, condition
+
+
+def _warn_if_near_parallel(pair_units: torch.Tensor) -> float:
+    """Warn (never raise) when the source and target atoms are near-parallel; return their cosine.
+
+    A swap or substitution between near-parallel atoms is approximately a no-op, so the user should
+    hear it. Unlike ``JacobianLens.swap_hooks`` (which inverts a two-atom basis and therefore raises
+    at the parallel extreme), the anchored patch performs no inverse and stays non-fatal.
+    """
+    cosine = float((pair_units[0] @ pair_units[1]).item())
+    abs_cosine = abs(cosine)
+    if abs_cosine >= _SWAP_WARN_COSINE:
+        warnings.warn(
+            f"coordinate-patch source and target atoms are near-parallel "
+            f"(abs cosine={abs_cosine:.6f}); the edit is approximately a no-op",
+            UserWarning,
+            stacklevel=3,
+        )
+    return cosine
+
+
+def solve_coordinate_patch(
+    x: torch.Tensor,
+    dictionary: torch.Tensor,
+    source_idx: int,
+    target_idx: int,
+    *,
+    decomposition: Optional[JSpaceDecomposition] = None,
+    k: int = DEFAULT_K,
+    mode: str = "substitute",
+    alpha: float = 1.0,
+    algorithm: str = "nonnegative_orthogonal_matching_pursuit",
+) -> CoordinatePatch:
+    """Edit one sparse J-space coordinate while preserving its recovered frame.
+
+    ``substitute`` zeros the source and replaces the target coordinate with the source value;
+    ``swap`` exchanges the two values. An absent target is appended at zero. The edit is blended
+    by ``alpha`` and reconstructed over the original residual ``x - reconstruction``.
+
+    Args:
+        x: Activation vector with shape ``[d_model]``.
+        dictionary: Atom matrix with shape ``[num_atoms, d_model]``; rows are atoms.
+        source_idx: Atom index that must occur in the decomposition's active support.
+        target_idx: Distinct atom index to receive or exchange the source coordinate.
+        decomposition: Optional decomposition of ``x`` under ``dictionary``. Reuse validates only
+            the selected and edited rows, avoiding another full-dictionary scan.
+        k: Sparse-solver upper bound when no decomposition is supplied.
+        mode: ``"substitute"`` to overwrite the target, or ``"swap"`` to exchange coordinates.
+        alpha: Finite interpolation strength. Zero returns an unchanged float32 clone.
+        algorithm: Sparse coefficient-update rule when no decomposition is supplied.
+
+    Returns:
+        A :class:`CoordinatePatch` with the anchored edit and numerical diagnostics.
+
+    Raises:
+        ValueError: If tensors, indices, edit arguments, atoms, or a supplied decomposition are
+            invalid or incompatible.
+        RuntimeError: If a fresh default NNLS decomposition fails its KKT certification, or an
+            edit postcondition is violated.
+
+    Warns:
+        UserWarning: If the source/target pair is near-parallel, or the normalized edit basis is
+            rank deficient or poorly conditioned. Both are non-fatal.
+    """
+    target, dictionary = _validate_inputs(x, dictionary)
+    source_idx = _validate_index("source_idx", source_idx, dictionary.shape[0])
+    target_idx = _validate_index("target_idx", target_idx, dictionary.shape[0])
+    if source_idx == target_idx:
+        raise ValueError("source_idx and target_idx must be distinct")
+    if mode not in ("substitute", "swap"):
+        raise ValueError(f"mode must be 'substitute' or 'swap', got {mode!r}")
+    if isinstance(alpha, bool) or not isinstance(alpha, Real) or not math.isfinite(float(alpha)):
+        raise ValueError("alpha must be a finite real number")
+
+    if decomposition is None:
+        decomposition = get_sparse_decomposition(target, dictionary, k, algorithm=algorithm)
+    elif not isinstance(decomposition, JSpaceDecomposition):
+        raise ValueError("decomposition must be a JSpaceDecomposition")
+    else:
+        _validate_decomposition(decomposition, target, dictionary, target_idx)
+
+    support_before = decomposition.support.detach().cpu().clone()
+    support_ids = support_before.tolist()
+    if source_idx not in support_ids:
+        raise ValueError(f"source_idx={source_idx} is not in the decomposition's active support")
+    target_was_active = target_idx in support_ids
+    if target_was_active:
+        support_after = support_before.clone()
+        coordinates_before = decomposition.coordinates.float().to(dictionary.device).clone()
+    else:
+        support_after = torch.cat([support_before, torch.tensor([target_idx], dtype=torch.long)])
+        coordinates_before = torch.cat(
+            [decomposition.coordinates.float().to(dictionary.device).clone(), target.new_zeros(1)]
+        )
+
+    frame = support_after.tolist()
+    source_slot = frame.index(source_idx)
+    target_slot = frame.index(target_idx)
+    edit_coordinates = coordinates_before.clone()
+    source_coordinate = coordinates_before[source_slot].clone()
+    target_coordinate = coordinates_before[target_slot].clone()
+    if mode == "swap":
+        edit_coordinates[source_slot] = target_coordinate
+        overwritten_target_coordinate: Optional[float] = None
+    else:
+        edit_coordinates[source_slot] = 0.0
+        overwritten_target_coordinate = (
+            float(target_coordinate.item()) if target_was_active else None
+        )
+    edit_coordinates[target_slot] = source_coordinate
+    coordinates_after = coordinates_before + float(alpha) * (edit_coordinates - coordinates_before)
+
+    pair = _validate_atom_rows(
+        dictionary,
+        torch.tensor([source_idx, target_idx], dtype=torch.long),
+        context="coordinate patch",
+    )
+    pair_units = pair / torch.linalg.vector_norm(pair, dim=1, keepdim=True)
+    cosine = _warn_if_near_parallel(pair_units)
+    basis = dictionary[support_after].float().T
+    rank, condition = _basis_diagnostics(basis)
+
+    reconstruction_before = decomposition.reconstruction.float().to(dictionary.device).clone()
+    residual = target - reconstruction_before
+    if float(alpha) == 0.0:
+        reconstruction_after = reconstruction_before.clone()
+        delta = torch.zeros_like(target)
+        patched = target.clone()
+    else:
+        reconstruction_after = basis @ coordinates_after
+        delta = reconstruction_after - reconstruction_before
+        patched = target + delta
+
+    nonedited_max, residual_max = _postcondition_witnesses(
+        coordinates_before,
+        coordinates_after,
+        source_slot,
+        target_slot,
+        patched,
+        reconstruction_after,
+        residual,
+    )
+    return CoordinatePatch(
+        support_before=support_before,
+        support_after=support_after,
+        coordinates_before=coordinates_before.detach(),
+        coordinates_after=coordinates_after.detach(),
+        source_slot=source_slot,
+        target_slot=target_slot,
+        target_was_appended=not target_was_active,
+        overwritten_target_coordinate=overwritten_target_coordinate,
+        reconstruction_before=reconstruction_before.detach(),
+        reconstruction_after=reconstruction_after.detach(),
+        residual=residual.detach(),
+        delta=delta.detach(),
+        patched=patched.detach(),
+        nonedited_coordinate_max_delta=nonedited_max,
+        residual_max_delta=residual_max,
+        source_target_cosine=cosine,
+        basis_rank=rank,
+        basis_condition_number=condition,
+    )
+
+
+def _postcondition_witnesses(
+    coordinates_before: torch.Tensor,
+    coordinates_after: torch.Tensor,
+    source_slot: int,
+    target_slot: int,
+    patched: torch.Tensor,
+    reconstruction_after: torch.Tensor,
+    residual: torch.Tensor,
+) -> tuple[float, float]:
+    """Measure — and enforce — that the edit only moved the source/target coordinates.
+
+    Diagnostic reductions run in float64 on CPU (the decomposition module's convention). Returns
+    ``(nonedited_coordinate_max_delta, residual_max_delta)``; raises if either exceeds a float32
+    tolerance, since the anchored edit must leave every other coordinate and the residual intact.
+    """
+    before = coordinates_before.detach().cpu().double()
+    after = coordinates_after.detach().cpu().double()
+    keep = torch.ones(before.numel(), dtype=torch.bool)
+    keep[source_slot] = False
+    keep[target_slot] = False
+    nonedited_max = (
+        float((after[keep] - before[keep]).abs().max().item()) if bool(keep.any()) else 0.0
+    )
+
+    residual64 = residual.detach().cpu().double()
+    recovered_residual = (
+        patched.detach().cpu().double() - reconstruction_after.detach().cpu().double()
+    )
+    residual_max = float((recovered_residual - residual64).abs().max().item())
+
+    magnitude = max(1.0, float(residual64.abs().max().item()), float(before.abs().max().item()))
+    tolerance = 256 * float(torch.finfo(torch.float32).eps) * magnitude
+    if nonedited_max > tolerance:
+        raise RuntimeError(
+            f"coordinate patch changed a non-edited coordinate (max delta={nonedited_max:.3g})"
+        )
+    if residual_max > tolerance:
+        raise RuntimeError(
+            f"coordinate patch did not preserve the anchored residual (max delta={residual_max:.3g})"
+        )
+    return nonedited_max, residual_max

--- a/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
@@ -14,6 +14,7 @@ from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
     _SWAP_WARN_COSINE,
     DEFAULT_K,
     JSpaceDecomposition,
+    _linalg_on_cpu_if_mps,
     get_sparse_decomposition,
 )
 
@@ -190,14 +191,11 @@ def _validate_decomposition(
         raise ValueError("precomputed decomposition is incompatible with activation")
     if selected_cpu.numel():
         selected_atoms = dictionary[selected_cpu].float().T
-        if target.device.type == "mps":
-            work_atoms = selected_atoms.cpu()
-            work_target = target.cpu()
-            expected_component = (work_atoms @ (torch.linalg.pinv(work_atoms) @ work_target)).to(
-                target.device
-            )
-        else:
-            expected_component = selected_atoms @ (torch.linalg.pinv(selected_atoms) @ target)
+        expected_component = _linalg_on_cpu_if_mps(
+            lambda atoms, vector: atoms @ (torch.linalg.pinv(atoms) @ vector),
+            selected_atoms,
+            target,
+        )
     else:
         expected_component = torch.zeros_like(target)
     if not _close(local_vectors[1], expected_component):

--- a/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
@@ -129,14 +129,28 @@ def _validate_index(name: str, value: int, num_atoms: int) -> int:
     return index
 
 
-def _close(actual: torch.Tensor, expected: torch.Tensor) -> bool:
+def _close(actual: torch.Tensor, expected: torch.Tensor, condition_number: float = 1.0) -> bool:
+    # The base tolerance certifies a well-conditioned comparison. When ``expected`` is recomputed
+    # through an ill-conditioned span (a pinv projection), the float32 recompute error grows with
+    # the span's condition number, so scale the tolerance by it: a fixed 32-eps floor otherwise
+    # rejects an exactly-valid hand-built decomposition whose activation lies near the span's
+    # null direction. ``condition_number`` clamps to one so well-conditioned checks stay strict.
     if actual.shape != expected.shape:
         return False
     magnitude = torch.stack([actual.abs().max(), expected.abs().max()]).max()
-    tolerance = 32 * torch.finfo(torch.float32).eps
+    tolerance = 32 * torch.finfo(torch.float32).eps * max(condition_number, 1.0)
     return bool(
         torch.allclose(actual, expected, rtol=tolerance, atol=tolerance * float(magnitude.item()))
     )
+
+
+def _condition_number(atoms: torch.Tensor) -> float:
+    """Condition number of a column matrix, on CPU when the device lacks an ``svdvals`` kernel."""
+    singular_values = _linalg_on_cpu_if_mps(torch.linalg.svdvals, atoms)
+    smallest = float(singular_values.min().item())
+    if smallest <= 0.0:
+        return math.inf
+    return float(singular_values.max().item()) / smallest
 
 
 def _validate_decomposition(
@@ -185,8 +199,18 @@ def _validate_decomposition(
     if not all(bool(torch.isfinite(vector).all()) for vector in local_vectors):
         raise ValueError("precomputed decomposition contains non-finite vector outputs")
     support_atoms = dictionary[support_cpu].float()
+    # Measure the selected span's conditioning once and relax the compatibility checks by it: the
+    # pinv projection recompute below (and the dictionary reconstruction) inherit float32 error
+    # that grows with this condition number, so a fixed tolerance would reject a genuinely valid
+    # decomposition on an ill-conditioned span (see ``_close``).
+    if selected_cpu.numel():
+        selected_atoms = dictionary[selected_cpu].float().T
+        span_condition = _condition_number(selected_atoms)
+    else:
+        selected_atoms = None
+        span_condition = 1.0
     expected_reconstruction = support_atoms.T @ coordinates
-    if not _close(local_vectors[0], expected_reconstruction):
+    if not _close(local_vectors[0], expected_reconstruction, span_condition):
         raise ValueError("precomputed decomposition reconstruction is incompatible with dictionary")
     # Couple the coordinates to ``target`` (the activation), not just to the dictionary: the
     # reconstruction/dictionary check above passes for any self-consistently scaled pair, so a
@@ -209,10 +233,9 @@ def _validate_decomposition(
         raise ValueError(
             f"precomputed decomposition coordinates do not fit the activation ({error})"
         ) from error
-    if not _close(local_vectors[1] + local_vectors[2], target):
+    if not _close(local_vectors[1] + local_vectors[2], target, span_condition):
         raise ValueError("precomputed decomposition is incompatible with activation")
-    if selected_cpu.numel():
-        selected_atoms = dictionary[selected_cpu].float().T
+    if selected_atoms is not None:
         expected_component = _linalg_on_cpu_if_mps(
             lambda atoms, vector: atoms @ (torch.linalg.pinv(atoms) @ vector),
             selected_atoms,
@@ -220,7 +243,7 @@ def _validate_decomposition(
         )
     else:
         expected_component = torch.zeros_like(target)
-    if not _close(local_vectors[1], expected_component):
+    if not _close(local_vectors[1], expected_component, span_condition):
         raise ValueError("precomputed decomposition selected span is incompatible with dictionary")
 
 
@@ -232,7 +255,12 @@ def _basis_diagnostics(basis: torch.Tensor) -> tuple[int, float]:
     """
     normalized = basis / torch.linalg.vector_norm(basis, dim=0, keepdim=True)
     diagnostic_basis = normalized.detach().cpu().double()
-    rank_rtol = torch.finfo(torch.float32).eps * max(diagnostic_basis.shape)
+    # Scale the rank tolerance by the column count (the number of edit atoms), not ``max(shape)``.
+    # ``basis`` is ``[d_model, num_atoms]`` with ``d_model >> num_atoms``, so ``max(shape)`` is the
+    # d_model row count; for ``d_model >= ~2896`` its ``eps * d_model`` tolerance exceeds the
+    # smallest singular value of a genuinely full-rank basis, mislabelling it rank deficient
+    # (condition number=inf) at model scale. Column count is the dimension that bounds the rank.
+    rank_rtol = torch.finfo(torch.float32).eps * diagnostic_basis.shape[1]
     rank = int(torch.linalg.matrix_rank(diagnostic_basis, rtol=rank_rtol).item())
     if rank < diagnostic_basis.shape[1]:
         condition = math.inf

--- a/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
@@ -45,15 +45,21 @@ class CoordinatePatch:
             overwrites an already-active target; ``None`` when the target was absent or ``mode`` is
             ``"swap"`` (a swap relocates a coordinate and discards nothing).
         reconstruction_before: Sparse reconstruction from ``support_before``.
-        reconstruction_after: Reconstruction from ``support_after`` and ``coordinates_after``.
+        reconstruction_after: ``reconstruction_before + delta``, the anchored reconstruction after
+            the edit.
         residual: Anchored residual ``x - reconstruction_before``. This is not necessarily the
             decomposition's orthogonal ``non_j_space_component``.
-        delta: ``reconstruction_after - reconstruction_before``.
-        patched: ``x + delta``; an unchanged clone of the float32 input when ``alpha`` is zero.
+        delta: ``basis @ (coordinates_after - coordinates_before)``; equivalently
+            ``reconstruction_after - reconstruction_before``. Exactly zero and proportional to
+            ``alpha``, so it carries no recompute floor.
+        patched: ``x + delta``; equal to the float32 input when ``alpha`` is zero, where ``delta``
+            is then exactly zero.
         nonedited_coordinate_max_delta: Maximum absolute change across every coordinate that is
             neither source nor target. A postcondition witness: it must be numerically zero.
-        residual_max_delta: Maximum absolute difference between ``patched - reconstruction_after``
-            and ``residual``. A postcondition witness: the anchored residual must be preserved.
+        residual_max_delta: Maximum absolute difference between ``residual`` and
+            ``patched - dictionary[support_after].T @ coordinates_after``, the reconstruction
+            recomputed independently from the dictionary rows. A postcondition witness: the
+            anchored residual must be preserved.
         source_target_cosine: Signed cosine between the source and target atoms.
         basis_rank: Numerical rank of the column-normalized edit basis at float32 precision.
         basis_condition_number: Condition number of that basis, or infinity when rank deficient.
@@ -351,14 +357,13 @@ def solve_coordinate_patch(
 
     reconstruction_before = decomposition.reconstruction.float().to(dictionary.device).clone()
     residual = target - reconstruction_before
-    if float(alpha) == 0.0:
-        reconstruction_after = reconstruction_before.clone()
-        delta = torch.zeros_like(target)
-        patched = target.clone()
-    else:
-        reconstruction_after = basis @ coordinates_after
-        delta = reconstruction_after - reconstruction_before
-        patched = target + delta
+    # Move the reconstruction by the coordinate change alone. This is exactly zero at alpha=0
+    # (no special case) and strictly proportional to alpha, so ``patched`` has no recompute floor
+    # and is continuous through the origin. ``reconstruction_after`` stays anchored to the stored
+    # ``reconstruction_before`` so the residual ``x - reconstruction_before`` is preserved exactly.
+    delta = basis @ (coordinates_after - coordinates_before)
+    reconstruction_after = reconstruction_before + delta
+    patched = target + delta
 
     nonedited_max, residual_max = _postcondition_witnesses(
         coordinates_before,
@@ -366,7 +371,7 @@ def solve_coordinate_patch(
         source_slot,
         target_slot,
         patched,
-        reconstruction_after,
+        basis,
         residual,
     )
     return CoordinatePatch(
@@ -397,7 +402,7 @@ def _postcondition_witnesses(
     source_slot: int,
     target_slot: int,
     patched: torch.Tensor,
-    reconstruction_after: torch.Tensor,
+    basis: torch.Tensor,
     residual: torch.Tensor,
 ) -> tuple[float, float]:
     """Measure — and enforce — that the edit only moved the source/target coordinates.
@@ -405,6 +410,11 @@ def _postcondition_witnesses(
     Diagnostic reductions run in float64 on CPU (the decomposition module's convention). Returns
     ``(nonedited_coordinate_max_delta, residual_max_delta)``; raises if either exceeds a float32
     tolerance, since the anchored edit must leave every other coordinate and the residual intact.
+
+    The residual witness recomputes the reconstruction independently from the dictionary rows
+    (``basis @ coordinates_after``) rather than reusing the ``delta`` that built ``patched``, so a
+    basis/coordinate misalignment surfaces as ``patched - basis @ coordinates_after`` drifting from
+    ``residual`` instead of cancelling as an algebraic identity of the construction.
     """
     before = coordinates_before.detach().cpu().double()
     after = coordinates_after.detach().cpu().double()
@@ -416,9 +426,8 @@ def _postcondition_witnesses(
     )
 
     residual64 = residual.detach().cpu().double()
-    recovered_residual = (
-        patched.detach().cpu().double() - reconstruction_after.detach().cpu().double()
-    )
+    independent_reconstruction = (basis @ coordinates_after).detach().cpu().double()
+    recovered_residual = patched.detach().cpu().double() - independent_reconstruction
     residual_max = float((recovered_residual - residual64).abs().max().item())
 
     magnitude = max(1.0, float(residual64.abs().max().item()), float(before.abs().max().item()))

--- a/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
@@ -15,6 +15,7 @@ from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
     DEFAULT_K,
     JSpaceDecomposition,
     _linalg_on_cpu_if_mps,
+    _validate_nnls_kkt,
     get_sparse_decomposition,
 )
 
@@ -187,6 +188,27 @@ def _validate_decomposition(
     expected_reconstruction = support_atoms.T @ coordinates
     if not _close(local_vectors[0], expected_reconstruction):
         raise ValueError("precomputed decomposition reconstruction is incompatible with dictionary")
+    # Couple the coordinates to ``target`` (the activation), not just to the dictionary: the
+    # reconstruction/dictionary check above passes for any self-consistently scaled pair, so a
+    # wrongly-scaled decomposition would slip through and silently anchor the edit to a bogus
+    # residual. Reuse the solver's NNLS KKT stationarity test -- the active coordinates are all
+    # strictly positive (validated above), so stationarity ``A^T (target - A c) == 0`` is the
+    # exact condition for ``c`` being the nonnegative fit of ``target`` over the active support.
+    # Tolerances mirror the solver's result-dtype certification (sqrt(eps) of the float32
+    # coordinates) so genuine float32-rounded decompositions are not falsely rejected.
+    active_atoms = support_atoms.T
+    tiny = torch.finfo(target.dtype).tiny
+    relative_tolerance = math.sqrt(torch.finfo(target.dtype).eps)
+    atom_norms = active_atoms.norm(dim=0).clamp_min(tiny)
+    scale = (target.norm() + (active_atoms.abs() @ coordinates.abs()).norm()).clamp_min(tiny)
+    dual_tol = relative_tolerance * atom_norms * scale
+    coefficient_tol = relative_tolerance * scale / atom_norms
+    try:
+        _validate_nnls_kkt(active_atoms, target, coordinates, dual_tol, coefficient_tol)
+    except RuntimeError as error:
+        raise ValueError(
+            f"precomputed decomposition coordinates do not fit the activation ({error})"
+        ) from error
     if not _close(local_vectors[1] + local_vectors[2], target):
         raise ValueError("precomputed decomposition is incompatible with activation")
     if selected_cpu.numel():

--- a/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py
@@ -42,10 +42,22 @@ class CoordinatePatch:
         coordinates_after: Coordinates after applying ``mode`` and ``alpha``.
         source_slot: Position of the source atom within ``support_after``.
         target_slot: Position of the target atom within ``support_after``.
-        target_was_appended: Whether the target was absent and appended to ``support_after``.
-        overwritten_target_coordinate: The discarded old target coordinate when a ``substitute``
-            overwrites an already-active target; ``None`` when the target was absent or ``mode`` is
-            ``"swap"`` (a swap relocates a coordinate and discards nothing).
+        target_was_appended: Whether the target was absent from the active support and appended
+            to ``support_after``. ``target_was_selected`` disambiguates why: pursuit may never
+            have considered the target at all, or may have selected it and then assigned it a
+            zero coordinate.
+        target_was_selected: Whether the target atom was selected by pursuit
+            (``decomposition.selected_support``), whether or not it ended up numerically active.
+            ``target_was_appended and not target_was_selected`` means pursuit never considered the
+            target; ``target_was_appended and target_was_selected`` means pursuit selected it but
+            assigned it a zero coordinate. Always ``True`` when ``target_was_appended`` is
+            ``False``, since the active support is a subset of the selected support.
+        overwritten_target_coordinate: The old target coordinate that a ``substitute`` discards
+            when it overwrites an already-active target; ``None`` when the target was absent or
+            ``mode`` is ``"swap"`` (a swap relocates a coordinate and discards nothing).
+            Alpha-independent by design, like ``target_was_appended`` and the support fields: it
+            reports the coordinate the requested edit targets for replacement, not the blended
+            outcome, so it is non-``None`` even at ``alpha=0`` where nothing is actually discarded.
         reconstruction_before: Sparse reconstruction from ``support_before``.
         reconstruction_after: ``reconstruction_before + delta``, the anchored reconstruction after
             the edit.
@@ -65,6 +77,11 @@ class CoordinatePatch:
         source_target_cosine: Signed cosine between the source and target atoms.
         basis_rank: Numerical rank of the column-normalized edit basis at float32 precision.
         basis_condition_number: Condition number of that basis, or infinity when rank deficient.
+        coordinates_after_nonnegative: Whether every entry of ``coordinates_after`` is ``>= 0``.
+            ``alpha`` in ``[0, 1]`` interpolates within the nonnegative pursuit frame and always
+            leaves this ``True``; an ``alpha`` outside that range (e.g. ``2.0`` or ``-1.0``)
+            extrapolates and can drive a coordinate negative, in which case this is ``False`` and
+            a warning is raised.
     """
 
     support_before: torch.Tensor
@@ -74,6 +91,7 @@ class CoordinatePatch:
     source_slot: int
     target_slot: int
     target_was_appended: bool
+    target_was_selected: bool
     overwritten_target_coordinate: Optional[float]
     reconstruction_before: torch.Tensor
     reconstruction_after: torch.Tensor
@@ -85,6 +103,7 @@ class CoordinatePatch:
     source_target_cosine: float
     basis_rank: int
     basis_condition_number: float
+    coordinates_after_nonnegative: bool
 
 
 def _validate_inputs(
@@ -302,6 +321,27 @@ def _warn_if_near_parallel(pair_units: torch.Tensor) -> float:
     return cosine
 
 
+def _warn_if_alpha_extrapolates(coordinates_after: torch.Tensor, alpha: float) -> bool:
+    """Warn (never raise) when ``alpha`` pushes ``coordinates_after`` outside ``c >= 0``.
+
+    ``alpha`` in ``[0, 1]`` interpolates within the nonnegative pursuit frame, but a caller passing
+    ``alpha`` outside that range (e.g. ``2.0`` or ``-1.0``) extrapolates past it and can leave a
+    coordinate negative -- meaningful only as an explicit extrapolation, not a fitted
+    decomposition. Non-fatal, matching ``_warn_if_near_parallel`` and ``_basis_diagnostics``: the
+    edit still completes and the caller can inspect the returned flag.
+    """
+    nonnegative = bool((coordinates_after >= 0).all().item())
+    if not nonnegative:
+        warnings.warn(
+            f"coordinate-patch alpha={alpha:g} extrapolates coordinates_after outside the "
+            "nonnegative pursuit frame (a coordinate is negative); treat the patch as an "
+            "extrapolation, not a fitted decomposition",
+            UserWarning,
+            stacklevel=3,
+        )
+    return nonnegative
+
+
 def solve_coordinate_patch(
     x: torch.Tensor,
     dictionary: torch.Tensor,
@@ -342,8 +382,9 @@ def solve_coordinate_patch(
             edit postcondition is violated.
 
     Warns:
-        UserWarning: If the source/target pair is near-parallel, or the normalized edit basis is
-            rank deficient or poorly conditioned. Both are non-fatal.
+        UserWarning: If the source/target pair is near-parallel, the normalized edit basis is
+            rank deficient or poorly conditioned, or ``alpha`` extrapolates ``coordinates_after``
+            outside the nonnegative pursuit frame. All three are non-fatal.
     """
     target, dictionary = _validate_inputs(x, dictionary)
     source_idx = _validate_index("source_idx", source_idx, dictionary.shape[0])
@@ -367,6 +408,9 @@ def solve_coordinate_patch(
     if source_idx not in support_ids:
         raise ValueError(f"source_idx={source_idx} is not in the decomposition's active support")
     target_was_active = target_idx in support_ids
+    target_was_selected = target_was_active or (
+        target_idx in decomposition.selected_support.detach().cpu().tolist()
+    )
     if target_was_active:
         support_after = support_before.clone()
         coordinates_before = decomposition.coordinates.float().to(dictionary.device).clone()
@@ -392,6 +436,7 @@ def solve_coordinate_patch(
         )
     edit_coordinates[target_slot] = source_coordinate
     coordinates_after = coordinates_before + float(alpha) * (edit_coordinates - coordinates_before)
+    coordinates_after_nonnegative = _warn_if_alpha_extrapolates(coordinates_after, float(alpha))
 
     pair = _validate_atom_rows(
         dictionary,
@@ -430,6 +475,7 @@ def solve_coordinate_patch(
         source_slot=source_slot,
         target_slot=target_slot,
         target_was_appended=not target_was_active,
+        target_was_selected=target_was_selected,
         overwritten_target_coordinate=overwritten_target_coordinate,
         reconstruction_before=reconstruction_before.detach(),
         reconstruction_after=reconstruction_after.detach(),
@@ -441,6 +487,7 @@ def solve_coordinate_patch(
         source_target_cosine=cosine,
         basis_rank=rank,
         basis_condition_number=condition,
+        coordinates_after_nonnegative=coordinates_after_nonnegative,
     )
 
 

--- a/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
@@ -60,6 +60,7 @@ References:
 from __future__ import annotations
 
 import math
+import warnings
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
@@ -98,6 +99,37 @@ _CORRELATION_RELATIVE_TOLERANCE = math.sqrt(torch.finfo(torch.float32).eps)
 #: approximately a no-op. Both the anchored coordinate patch and ``JacobianLens.swap_hooks``
 #: read this one definition so their near-parallel diagnostics never drift apart.
 _SWAP_WARN_COSINE = 0.99
+#: Above this cosine ``swap_hooks`` refuses the intervention: inverting a two-atom basis whose
+#: columns are near-collinear is numerically hopeless. The anchored coordinate patch inverts
+#: nothing, so it only reads ``_SWAP_WARN_COSINE`` and never raises on this threshold.
+_SWAP_ERROR_COSINE = 0.999
+
+
+def _diagnose_intervention_pair(
+    unit_vectors: torch.Tensor, *, description: str, stacklevel: int
+) -> float:
+    """Apply the shared near-parallel warn/raise policy to two unit-normalized vectors.
+
+    Returns the signed cosine. Warns above :data:`_SWAP_WARN_COSINE` and raises above
+    :data:`_SWAP_ERROR_COSINE`. Used by interventions that invert a two-atom basis (e.g.
+    ``swap_hooks``); the anchored coordinate patch, which performs no inverse, warns without
+    raising and does not call this helper.
+    """
+    cosine = float((unit_vectors[0] @ unit_vectors[1]).item())
+    abs_cosine = abs(cosine)
+    if not math.isfinite(abs_cosine) or abs_cosine >= _SWAP_ERROR_COSINE:
+        raise ValueError(
+            f"{description} are numerically near-parallel "
+            f"(abs cosine={abs_cosine:.6f}); choose better-separated concepts"
+        )
+    if abs_cosine >= _SWAP_WARN_COSINE:
+        warnings.warn(
+            f"{description} are poorly conditioned "
+            f"(abs cosine={abs_cosine:.6f}); the intervention may be amplified",
+            UserWarning,
+            stacklevel=stacklevel,
+        )
+    return cosine
 
 
 @dataclass

--- a/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
@@ -201,8 +201,8 @@ def _nonnegative_least_squares(active_atoms: torch.Tensor, target: torch.Tensor)
     result_dtype = target.dtype
     result_device = target.device
     work_device = torch.device("cpu") if target.device.type == "mps" else target.device
-    work_atoms = active_atoms.to(device=work_device, dtype=torch.float64)
-    work_target = target.to(device=work_device, dtype=torch.float64)
+    work_atoms = active_atoms.to(device=work_device).to(dtype=torch.float64)
+    work_target = target.to(device=work_device).to(dtype=torch.float64)
     if not bool(torch.isfinite(work_atoms).all()) or not bool(torch.isfinite(work_target).all()):
         raise ValueError("active_atoms and target must contain only finite values")
 
@@ -435,7 +435,14 @@ def get_sparse_decomposition(
     # swap_hooks. That span can be larger than the active support when a selected coordinate is
     # zero, so the projection differs from the nonnegative reconstruction in that case.
     if selected:
-        j_space_component = selected_atoms @ (torch.linalg.pinv(selected_atoms) @ target)
+        if target.device.type == "mps":
+            work_atoms = selected_atoms.cpu()
+            work_target = target.cpu()
+            j_space_component = (work_atoms @ (torch.linalg.pinv(work_atoms) @ work_target)).to(
+                target.device
+            )
+        else:
+            j_space_component = selected_atoms @ (torch.linalg.pinv(selected_atoms) @ target)
     else:
         j_space_component = target.new_zeros(d_model)
     non_j_space_component = target - j_space_component

--- a/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
@@ -93,6 +93,12 @@ _GRADIENT_BACKTRACK_STEPS = 20
 #: selection is a float32 correlation decision, activity a check against the float64 solve.
 _CORRELATION_RELATIVE_TOLERANCE = math.sqrt(torch.finfo(torch.float32).eps)
 
+#: Shared near-parallel policy for lens-space interventions. Two atoms whose absolute cosine
+#: reaches this threshold span an ill-conditioned pair: a coordinate swap between them is
+#: approximately a no-op. Both the anchored coordinate patch and ``JacobianLens.swap_hooks``
+#: read this one definition so their near-parallel diagnostics never drift apart.
+_SWAP_WARN_COSINE = 0.99
+
 
 @dataclass
 class JSpaceDecomposition:

--- a/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
+++ b/transformer_lens/tools/analysis/jacobian_lens_decomposition.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 import math
 import warnings
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
 
 import torch
 
@@ -103,6 +103,21 @@ _SWAP_WARN_COSINE = 0.99
 #: columns are near-collinear is numerically hopeless. The anchored coordinate patch inverts
 #: nothing, so it only reads ``_SWAP_WARN_COSINE`` and never raises on this threshold.
 _SWAP_ERROR_COSINE = 0.999
+
+
+def _linalg_on_cpu_if_mps(op: Callable[..., torch.Tensor], *tensors: torch.Tensor) -> torch.Tensor:
+    """Run a linear-algebra op that MPS lacks a kernel for, restoring the input device.
+
+    Several LAPACK-backed ``torch.linalg`` routines (``pinv``, ``svdvals``) are unimplemented on
+    the MPS backend, so callers must round-trip through CPU. This centralizes the shared
+    detect-device -> ``.cpu()`` -> op -> restore idiom: off MPS ``op`` is called on the input
+    tensors unchanged, and on MPS it is called on their CPU copies with the result moved back to
+    the input device. All inputs must share one device.
+    """
+    device = tensors[0].device
+    if device.type == "mps":
+        return op(*(tensor.cpu() for tensor in tensors)).to(device)
+    return op(*tensors)
 
 
 def _diagnose_intervention_pair(
@@ -473,14 +488,11 @@ def get_sparse_decomposition(
     # swap_hooks. That span can be larger than the active support when a selected coordinate is
     # zero, so the projection differs from the nonnegative reconstruction in that case.
     if selected:
-        if target.device.type == "mps":
-            work_atoms = selected_atoms.cpu()
-            work_target = target.cpu()
-            j_space_component = (work_atoms @ (torch.linalg.pinv(work_atoms) @ work_target)).to(
-                target.device
-            )
-        else:
-            j_space_component = selected_atoms @ (torch.linalg.pinv(selected_atoms) @ target)
+        j_space_component = _linalg_on_cpu_if_mps(
+            lambda atoms, vector: atoms @ (torch.linalg.pinv(atoms) @ vector),
+            selected_atoms,
+            target,
+        )
     else:
         j_space_component = target.new_zeros(d_model)
     non_j_space_component = target - j_space_component

--- a/transformer_lens/tools/analysis/projection_kernel.py
+++ b/transformer_lens/tools/analysis/projection_kernel.py
@@ -15,6 +15,10 @@ from typing import Any, List, Literal, Optional, Sequence, Tuple, cast
 import torch
 from jaxtyping import Bool, Float, Int
 
+from transformer_lens.tools.analysis.jacobian_lens_decomposition import (
+    _linalg_on_cpu_if_mps,
+)
+
 AttentionRole = Literal["Q", "K", "V", "O"]
 LayerOrder = Literal["forward", "all"]
 HeadKind = Literal["query", "kv"]
@@ -365,9 +369,7 @@ def _clamp_principal_cosines(cosines: torch.Tensor) -> torch.Tensor:
 
 def _singular_values(matrix: torch.Tensor) -> torch.Tensor:
     """Compute singular values with an explicit MPS CPU fallback."""
-    if matrix.device.type == "mps":
-        return torch.linalg.svdvals(matrix.cpu()).to(device=matrix.device)
-    return torch.linalg.svdvals(matrix)
+    return _linalg_on_cpu_if_mps(torch.linalg.svdvals, matrix)
 
 
 def projection_kernel(


### PR DESCRIPTION
### Summary

Adds an **offline, model-free coordinate-patching primitive** on top of the shipped J-space sparse
decomposition, plus a thin `JacobianLens` wrapper. Given `x = residual + reconstruction`, it edits
only named coordinates in the active sparse frame and holds `residual = x - reconstruction` and
every other coordinate fixed. `substitute` moves the source coordinate onto the target (zeroing the
source); `swap` exchanges them; an absent target is appended at zero; `alpha` interpolates, with
`alpha=0` an exact no-op.

The edit **inverts nothing** — coordinates come from the anchored decomposition chart, and
`patched = residual + B @ coordinates_after`. The two numerical diagnostics (basis conditioning and
source/target near-parallelism) therefore **warn but never raise**.

This is PR1 of the plan: the offline primitive. Dynamic forward hooks, a causal-swap benchmark, a
notebook, arbitrary multi-slot permutations, and HookedTransformer support are explicitly deferred
to a follow-up.

Fixes #1739 

### Motivation

Sparse decomposition identifies which J-space concepts are active in an activation; nothing yet
edits one of those coordinates while preserving the rest of the recovered frame and the residual.
Coordinate patching returns an activation suitable for intervention studies without silently
re-solving `B⁺x` (which would perturb every coordinate when a target atom is appended).

### What ships (commit by commit)

The plan called for three reviewable units; a fourth prerequisite fix rides along (see "Note on the
MPS commit").

1. **`fix(jacobian_lens): support sparse decomposition on MPS`**
   Stages the selected-span pseudoinverse and the NNLS solve on CPU before their unsupported float64
   conversion, keeping vector outputs on the MPS device. Required for the coordinate patch (and the
   existing decomposition) to run on Apple Silicon. Adds two `tests/mps` cases.

2. **`feat(jacobian_lens): add anchored coordinate-patching core`**
   New `transformer_lens/tools/analysis/jacobian_lens_coordinate_patch.py`: the `CoordinatePatch`
   frozen dataclass (report-only, all tensors detached — retains no model/lens/tokenizer/hook/full
   dictionary) and `solve_coordinate_patch(...)`. Includes the Q2 overwrite field, the Q3/Q3-ext
   real warnings, the Q4 precomputed-reuse path with strict validation, and postcondition witnesses.
   Model-free tests first.

3. **`feat(jacobian_lens): expose coordinate patching on the Bridge`**
   `JacobianLens.coordinate_patch(...)` resolves a raw activation or prompt+position exactly like
   `decompose(...)`, resolves token inputs to dictionary rows, then calls the core. **No forward
   hooks.** Also performs the shared near-parallel policy refactor: `_SWAP_WARN_COSINE` /
   `_SWAP_ERROR_COSINE` and a `_diagnose_intervention_pair` helper move into
   `jacobian_lens_decomposition.py`; `swap_hooks` re-points to them with **byte-identical** warn/raise
   behavior.

4. **`feat(jacobian_lens): export coordinate patching with docs and integration test`**
   Exports `CoordinatePatch` and `solve_coordinate_patch` from `transformer_lens.tools.analysis`,
   extends the package docstring, documents the API and warning policy in `jacobian_lens_fitting.md`,
   and adds one cached-model integration test asserting **algebraic invariants only** (no-op at
   `alpha=0`, residual preservation, finite output, unchanged non-edited coordinates) — not a
   token-flip.

### Reviewer decision ledger

| # | Decision | How it's satisfied |
|---|----------|--------------------|
| Q1 | Offline primitive + wrapper; dynamic hooks deferred | Core and wrapper land as separate, independently reviewable commits. |
| Q2 | `substitute` overwrites, `swap` exchanges, overwritten value reported | `overwritten_target_coordinate: float \| None` (`None` for absent target or `swap`); a value-level test asserts the **exact** discarded coordinate, not just field presence. |
| Q3 | Rank-deficient / high-condition basis warns, non-fatal | Real `warnings.warn` naming the **measured condition number**; warn-path test + over-warning control. |
| Q3-ext | Near-parallel source/target warns, non-fatal | Real `warnings.warn` naming the **measured cosine**; warn-path test. Patch warns (never raises) at the parallel extreme because it performs no inverse. |
| Q4 | Optional precomputed `JSpaceDecomposition` | Accepted with strict compatibility validation before reuse; a fresh and a validated-supplied decomposition produce identical patches. |

### Testing

- `tests/unit/tools/test_jacobian_lens_coordinate_patch.py` — model-free core (exact expected
  outputs, alpha semantics, error paths, malformed activation/dictionary, Q2/Q3/Q3-ext/Q4, no-mutation,
  determinism, both decomposition algorithms).
- `tests/unit/tools/test_jacobian_lens.py` — wrapper: raw vs prompt agreement, token resolution,
  restricted `swap_hooks` pseudoinverse oracle, unfitted-layer rejection, warning propagation,
  `swap_hooks` regression after the constant move.
- `tests/integration/test_jacobian_lens.py` — one published-GPT-2 algebraic-invariant test.
- `tests/mps/test_mps_basic.py` — decomposition and patch stay on the MPS device.

Local gates green: unit tier passes; `black`, `isort`, `mypy` clean on touched sources
(`tests/` are excluded from mypy per `pyproject.toml`).

### Out of scope (deferred to a follow-up PR)

Dynamic `coordinate_patch_hooks(...)`, the causal-swap benchmark and any notebook, arbitrary
multi-slot permutations, and HookedTransformer support.

### Note on the MPS commit

Commit 1 (`fix ... support sparse decomposition on MPS`) is a prerequisite, not part of the
reviewer's original three-unit scope. It is kept in this PR because the coordinate patch depends on
it on Apple Silicon and splitting it would introduce a merge-order dependency between two PRs. It is
isolated in its own commit and can be cherry-picked out into a standalone PR on request.

### Checklist

- [x] Base set to `dev`.
- [x] Full `make test-pr` run attached (unit + docstring + acceptance + integration).
- [x] Integration test run against a cached GPT-2 with `.env` sourced.
- [ ] Reviewer sign-off on keeping the MPS fix in-PR vs. splitting it.
