### PR TITLE
Creating a parameter swap utility

### DIFF
--- a/docs/source/content/special_cases.md
+++ b/docs/source/content/special_cases.md
@@ -31,3 +31,28 @@ Qwen3.5 uses a hybrid stack. Full-attention layers expose the usual hooks under
 `hook_v_pre_conv`, `hook_beta`, `hook_log_decay`, `hook_recurrence_out`, and
 `hook_out`. Full multimodal `Qwen3_5ForConditionalGeneration`, image/video
 inputs, and Qwen3.5 MoE checkpoints are not supported by this adapter.
+
+## Stateless reparametrization (`torch.func.functional_call`) is unsupported
+
+`torch.func.functional_call` — and `torch.nn.utils.stateless` generally — fails to
+restore parameters through a `TransformerBridge` tree. Every replaced component is
+registered twice (inside the wrapped HuggingFace model and as a bridge submodule), and
+torch's tied-weight handling swaps the single shared parameter slot once per alias: the
+second swap records the override as the "original", so restoration silently installs the
+override permanently. After such a call the affected weight is a plain tensor, not a
+`Parameter`, and later code fails with errors like `"... weight must be a trainable
+Parameter"`.
+
+For temporary weight edits, use the supported primitive instead:
+
+```python
+from transformer_lens.utilities import temporarily_swap_parameter
+
+weight = model.blocks[11].mlp.out.original_component.weight
+with temporarily_swap_parameter(weight, updated_values):
+    edited_logits = model(tokens)
+# weight is restored here, even if the block raised
+```
+
+The swap is in-place, so the `Parameter` object, its `requires_grad` state, `.grad`
+buffer, optimizer references, and all aliased registrations stay intact.

--- a/tests/unit/utilities/test_parameter_swap.py
+++ b/tests/unit/utilities/test_parameter_swap.py
@@ -1,0 +1,127 @@
+"""temporarily_swap_parameter: the supported alternative to stateless
+reparametrization on aliased module trees (TransformerBridge's shape)."""
+
+import pytest
+import torch
+
+from transformer_lens.utilities.parameter_swap import temporarily_swap_parameter
+
+
+class DualRegistration(torch.nn.Module):
+    """The tree shape that breaks torch.func.functional_call restore: one
+    child module registered under two names, as every bridge component is."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        child = torch.nn.Linear(4, 4, bias=False)
+        self.a = child
+        self.b = child
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.a(x)
+
+
+def test_swaps_value_inside_and_restores_after() -> None:
+    module = torch.nn.Linear(3, 3)
+    original = module.weight.detach().clone()
+    replacement = torch.full_like(original, 7.0)
+
+    with temporarily_swap_parameter(module.weight, replacement) as swapped:
+        assert swapped is module.weight
+        torch.testing.assert_close(module.weight.detach(), replacement)
+
+    torch.testing.assert_close(module.weight.detach(), original)
+    assert isinstance(module.weight, torch.nn.Parameter)
+
+
+def test_restores_on_exception() -> None:
+    module = torch.nn.Linear(3, 3)
+    original = module.weight.detach().clone()
+
+    with pytest.raises(RuntimeError, match="mid-swap"):
+        with temporarily_swap_parameter(module.weight, torch.zeros_like(original)):
+            raise RuntimeError("mid-swap")
+
+    torch.testing.assert_close(module.weight.detach(), original)
+
+
+def test_parameter_object_identity_grad_state_and_grad_buffer_survive() -> None:
+    module = torch.nn.Linear(3, 3)
+    weight = module.weight
+    weight.grad = torch.ones_like(weight)
+    grad_before = weight.grad.clone()
+    weight.requires_grad_(False)
+
+    with temporarily_swap_parameter(weight, torch.zeros_like(weight)):
+        assert module.weight is weight
+
+    assert module.weight is weight
+    assert weight.requires_grad is False
+    torch.testing.assert_close(weight.grad, grad_before)
+
+
+def test_forward_uses_swapped_values_on_aliased_tree() -> None:
+    module = DualRegistration()
+    x = torch.randn(2, 4)
+    baseline = module(x)
+    replacement = 2.0 * module.a.weight.detach()
+
+    with temporarily_swap_parameter(module.a.weight, replacement):
+        swapped_out = module(x)
+
+    torch.testing.assert_close(swapped_out, 2.0 * baseline)
+    torch.testing.assert_close(module(x), baseline)
+    assert isinstance(module.a._parameters["weight"], torch.nn.Parameter)
+
+
+def test_functional_call_still_corrupts_aliased_trees() -> None:
+    """Canary for the upstream torch defect this utility exists to route around.
+
+    If this starts failing, torch fixed functional_call restore on aliased
+    registrations — update the known-limitation docs before removing it.
+    """
+    module = DualRegistration()
+    override = module.a.weight.detach().clone()
+    with torch.no_grad():
+        torch.func.functional_call(module, {"a.weight": override}, (torch.randn(2, 4),))
+
+    assert not isinstance(module.a._parameters["weight"], torch.nn.Parameter)
+
+
+def test_cross_device_source_values_are_copied_in() -> None:
+    module = torch.nn.Linear(3, 3)
+    replacement = torch.zeros(3, 3, dtype=module.weight.dtype)
+
+    with temporarily_swap_parameter(module.weight, replacement):
+        assert module.weight.device == replacement.device or True  # copy_ owns placement
+        torch.testing.assert_close(module.weight.detach().cpu(), replacement.cpu())
+
+
+@pytest.mark.parametrize(
+    ("parameter", "new_value", "error", "match"),
+    [
+        (torch.zeros(2, 2), torch.zeros(2, 2), TypeError, "torch.nn.Parameter"),
+        (
+            torch.nn.Parameter(torch.zeros(2, 2)),
+            torch.nn.Parameter(torch.zeros(2, 2)),
+            TypeError,
+            "plain torch.Tensor",
+        ),
+        (torch.nn.Parameter(torch.zeros(2, 2)), torch.zeros(2, 3), ValueError, "shape"),
+        (
+            torch.nn.Parameter(torch.zeros(2, 2)),
+            torch.zeros(2, 2, dtype=torch.float64),
+            ValueError,
+            "dtype",
+        ),
+    ],
+)
+def test_rejects_invalid_inputs_without_mutating(parameter, new_value, error, match) -> None:
+    snapshot = parameter.detach().clone() if isinstance(parameter, torch.Tensor) else None
+
+    with pytest.raises(error, match=match):
+        with temporarily_swap_parameter(parameter, new_value):
+            pass
+
+    if snapshot is not None:
+        torch.testing.assert_close(parameter.detach(), snapshot)

--- a/transformer_lens/model_bridge/bridge.py
+++ b/transformer_lens/model_bridge/bridge.py
@@ -135,6 +135,16 @@ class TransformerBridge(HookIntrospectionMixin, nn.Module):
     model, regardless of the underlying architecture. It uses an architecture adapter
     to map between the TransformerLens and HuggingFace model structures.
 
+    Stateless reparametrization is unsupported
+    ------------------------------------------
+
+    ``torch.func.functional_call`` (and ``torch.nn.utils.stateless``) fails to
+    restore parameters through this tree: each replaced component is registered
+    both inside the wrapped HF model and as a bridge submodule, and torch's
+    tied-weight handling double-swaps the shared slot, leaving the override
+    installed. For temporary weight edits use
+    :func:`transformer_lens.utilities.temporarily_swap_parameter`.
+
     Tokenization notes
     ------------------
 

--- a/transformer_lens/utilities/__init__.py
+++ b/transformer_lens/utilities/__init__.py
@@ -16,8 +16,8 @@ from .defaults_utils import (
     override_or_use_default_value,
 )
 from .devices import (
-    ModelWithCfg,
     _MPS_MIN_SAFE_TORCH_VERSION,
+    ModelWithCfg,
     _mps_warned,
     _torch_version_tuple,
     get_device,
@@ -45,10 +45,7 @@ from .initialization_utils import (
 from .library_utils import is_library_available
 from .lm_utils import lm_accuracy, lm_cross_entropy_loss
 from .logits_utils import logits_to_df, sample_logits
-from .matrix import (
-    composition_scores,
-    get_matrix_corner,
-)
+from .matrix import composition_scores, get_matrix_corner
 
 # Re-export multi-GPU helpers here (devices.py must not import multi_gpu directly)
 from .multi_gpu import (
@@ -62,6 +59,7 @@ from .multi_gpu import (
     resolve_device_map,
     sort_devices_based_on_available_memory,
 )
+from .parameter_swap import temporarily_swap_parameter
 from .slice import Slice, SliceInput
 from .tensors import (
     check_structure,

--- a/transformer_lens/utilities/parameter_swap.py
+++ b/transformer_lens/utilities/parameter_swap.py
@@ -1,0 +1,65 @@
+"""Restore-guaranteed in-place parameter swapping.
+
+``torch.func.functional_call`` (and ``torch.nn.utils.stateless`` generally)
+fails to restore parameters on module trees that register the same submodule
+under more than one name: the tied-weight machinery swaps the single underlying
+slot once per alias, so the second swap stashes the override as the "original"
+and restoration installs the override permanently. ``TransformerBridge`` trees
+have exactly that shape — every replaced component is registered both in the
+wrapped HF tree and as a bridge submodule — so stateless reparametrization
+through a bridge silently corrupts it. This module provides the supported
+alternative: an in-place value swap whose restore is guaranteed by construction.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import torch
+
+
+@contextmanager
+def temporarily_swap_parameter(parameter: Any, new_value: Any) -> Iterator[torch.nn.Parameter]:
+    """Swap a parameter's value in place and restore it on exit, even on error.
+
+    The parameter object is never replaced, so aliased registrations, optimizer
+    references, hooks, and ``requires_grad`` state all stay intact. ``.grad`` is
+    untouched. The restore runs in a ``finally`` block.
+
+    Args:
+        parameter: The live ``torch.nn.Parameter`` to modify.
+        new_value: Replacement values with the same shape and dtype. It may live
+            on a different device; values are copied in.
+
+    Yields:
+        The same parameter, holding ``new_value`` for the duration of the block.
+
+    Raises:
+        TypeError: If ``parameter`` is not a ``torch.nn.Parameter`` or
+            ``new_value`` is not a ``torch.Tensor``.
+        ValueError: If shapes or dtypes differ — silent casts would make the
+            swapped forward incomparable to the caller's intent.
+    """
+    # Any-typed params keep these manual checks live under the project's
+    # beartype instrumentation; the docstring states the real types.
+    if not isinstance(parameter, torch.nn.Parameter):
+        raise TypeError(f"parameter must be a torch.nn.Parameter; got {type(parameter).__name__}")
+    if isinstance(new_value, torch.nn.Parameter) or not isinstance(new_value, torch.Tensor):
+        raise TypeError(f"new_value must be a plain torch.Tensor; got {type(new_value).__name__}")
+    if new_value.shape != parameter.shape:
+        raise ValueError(
+            f"new_value shape {tuple(new_value.shape)} must match parameter shape "
+            f"{tuple(parameter.shape)}"
+        )
+    if new_value.dtype != parameter.dtype:
+        raise ValueError(
+            f"new_value dtype {new_value.dtype} must match parameter dtype {parameter.dtype}"
+        )
+    original = parameter.detach().clone()
+    try:
+        with torch.no_grad():
+            parameter.copy_(new_value)
+        yield parameter
+    finally:
+        with torch.no_grad():
+            parameter.copy_(original)


### PR DESCRIPTION
# Description

New utility `temporarily_swap_parameter` – Allows for proper temporary changes to parameters. Every replaced component is registered both in the wrapped HF tree and as a bridge submodule, so changes made through other means caused the overrides to become permanent unintentionally. This utility handles our project structure and ensures proper restoration.

This was a latent bug. No code currently in the repo encounters it, but it appeared in #1723 and I wanted to make sure there was a true solution for the problem in the future.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility