### PR TITLE
feat(attribution_patching): node attribution-patching substrate on TransformerBridge

### DIFF
--- a/tests/integration/test_attribution_patching.py
+++ b/tests/integration/test_attribution_patching.py
@@ -1,0 +1,73 @@
+"""Integration guard: ``attribution_patch`` yields finite node scores on a real Bridge.
+
+The model-free unit suite runs against ``_LinearToyBridge``, which overrides
+``hook_dict``, ``hooks()``, and ``check_hooks_to_add`` — the three behaviours the
+two real-Bridge failures depend on. Its hook points have no conversion and its
+gate check is a no-op, so a green unit suite says nothing about a real Bridge.
+
+This test boots a real GPT-2 Bridge and exercises the two paths the toy bridge
+hides:
+
+- gradients captured *through* hook conversions — ``blocks.*.attn.hook_z`` hands a
+  reshaped ``[batch, seq, n_heads, d_head]`` view to the forward hook, so the
+  ``attn_head_out`` family only scores if the backward hook delivers the gradient
+  in that converted shape; and
+- the default ``names_filter`` (``None``) falling back to the node hook set on a
+  real ``hook_dict``, which also exposes gated points (``hook_mlp_in``,
+  ``attn.hook_result``, split-QKV inputs) that ``add_hook`` would reject.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from transformer_lens.model_bridge import TransformerBridge
+from transformer_lens.tools.analysis.attribution_patching import attribution_patch
+
+CLEAN_PROMPT = "The capital of France is"
+CORRUPT_PROMPT = "The capital of Russia is"
+
+
+@pytest.fixture(scope="module")
+def gpt2_bridge():
+    return TransformerBridge.boot_transformers("gpt2", device="cpu", dtype=torch.float32)
+
+
+def _logit_diff_metric(answer_id: int, wrong_id: int):
+    def metric(logits: torch.Tensor) -> torch.Tensor:
+        return logits[0, -1, answer_id] - logits[0, -1, wrong_id]
+
+    return metric
+
+
+def test_attribution_patch_scores_every_node_finite_on_real_bridge(gpt2_bridge) -> None:
+    clean = gpt2_bridge.to_tokens(CLEAN_PROMPT)
+    corrupt = gpt2_bridge.to_tokens(CORRUPT_PROMPT)
+    assert clean.shape == corrupt.shape, "prompts must tokenize to the same length"
+
+    answer_id = int(gpt2_bridge.to_tokens(" Paris")[0, -1].item())
+    wrong_id = int(gpt2_bridge.to_tokens(" Moscow")[0, -1].item())
+    metric_fn = _logit_diff_metric(answer_id, wrong_id)
+
+    # Default config, no explicit names_filter: exercises the node-hook-set fallback.
+    result = attribution_patch(gpt2_bridge, clean, corrupt, metric_fn)
+
+    # Scores exactly the node graph: embed at every position, plus per-layer
+    # per-head attention outputs and per-layer MLP outputs.
+    seq_len = int(clean.shape[1])
+    n_layers = int(gpt2_bridge.cfg.n_layers)
+    n_heads = int(gpt2_bridge.cfg.n_heads)
+    expected_count = seq_len * (1 + n_layers * (n_heads + 1))
+    assert len(result.node_scores) == expected_count
+    assert result.edge_scores == {}
+
+    for node, score in result.node_scores.items():
+        assert math.isfinite(score), f"non-finite score for {node}"
+
+    # All three node families are present — attn_head_out is the family the hook
+    # conversion bug broke, mlp_out and embed round out the node graph.
+    families = {node.kind for node in result.node_scores}
+    assert families == {"embed", "attn_head_out", "mlp_out"}

--- a/tests/unit/tools/test_attribution_patching.py
+++ b/tests/unit/tools/test_attribution_patching.py
@@ -19,6 +19,8 @@ import torch.nn as nn
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge import TransformerBridge
 from transformer_lens.tools.analysis.attribution_patching import (
+    AttributionResult,
+    EdgeAttributionConfig,
     GradientCache,
     Node,
     cache_activation_and_gradient,
@@ -275,3 +277,48 @@ def test_enumerate_nodes_raises_on_missing_hook() -> None:
 
     with pytest.raises(ValueError, match="blocks.1.hook_mlp_out"):
         enumerate_nodes(_cfg_stub(), cache)
+
+
+# ---------------------------------------------------------------------------
+# Commit 3 — config + result API
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults_are_the_supported_node_sweep() -> None:
+    config = EdgeAttributionConfig()
+    assert config.granularity == "node"
+    assert config.ig_steps == 1
+
+
+def test_config_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError, match="ig_steps"):
+        EdgeAttributionConfig(ig_steps=0)
+
+
+def test_config_unsupported_paths_raise_not_implemented() -> None:
+    with pytest.raises(NotImplementedError, match="PR2"):
+        EdgeAttributionConfig(granularity="edge")
+    with pytest.raises(NotImplementedError, match="PR3"):
+        EdgeAttributionConfig(ig_steps=5)
+
+
+def test_top_nodes_ranks_by_effect_magnitude() -> None:
+    small = Node(kind="embed", position=0)
+    big_negative = Node(kind="mlp_out", layer=0, position=1)
+    medium = Node(kind="attn_head_out", layer=1, head=0, position=2)
+    result = AttributionResult(
+        node_scores={small: 0.1, big_negative: -5.0, medium: 2.0},
+    )
+
+    ranked = result.top_nodes(k=2)
+    assert [node for node, _ in ranked] == [big_negative, medium]
+
+    # k beyond the node count returns every node, still magnitude-ordered.
+    assert [node for node, _ in result.top_nodes(k=10)] == [big_negative, medium, small]
+
+
+def test_top_edges_not_implemented_until_pr2() -> None:
+    result = AttributionResult(node_scores={})
+    assert result.edge_scores == {}
+    with pytest.raises(NotImplementedError, match="PR2"):
+        result.top_edges()

--- a/tests/unit/tools/test_attribution_patching.py
+++ b/tests/unit/tools/test_attribution_patching.py
@@ -256,7 +256,7 @@ def test_node_hook_name_and_key_validation() -> None:
     )
     assert Node(kind="mlp_out", layer=0, position=1).hook_name == "blocks.0.hook_mlp_out"
 
-    # The typed key rejects malformed nodes (Risk 1: explicit graph).
+    # The typed key rejects malformed nodes rather than building a wrong graph.
     with pytest.raises(ValueError):
         Node(kind="embed", position=0, layer=0)
     with pytest.raises(ValueError):
@@ -314,9 +314,9 @@ def test_config_rejects_invalid_values() -> None:
 
 
 def test_config_unsupported_paths_raise_not_implemented() -> None:
-    with pytest.raises(NotImplementedError, match="PR2"):
+    with pytest.raises(NotImplementedError, match="edge"):
         EdgeAttributionConfig(granularity="edge")
-    with pytest.raises(NotImplementedError, match="PR3"):
+    with pytest.raises(NotImplementedError, match="integrated gradient"):
         EdgeAttributionConfig(ig_steps=5)
 
 
@@ -335,10 +335,10 @@ def test_top_nodes_ranks_by_effect_magnitude() -> None:
     assert [node for node, _ in result.top_nodes(k=10)] == [big_negative, medium, small]
 
 
-def test_top_edges_not_implemented_until_pr2() -> None:
+def test_top_edges_not_implemented() -> None:
     result = AttributionResult(node_scores={})
     assert result.edge_scores == {}
-    with pytest.raises(NotImplementedError, match="PR2"):
+    with pytest.raises(NotImplementedError, match="edge"):
         result.top_edges()
 
 
@@ -516,9 +516,9 @@ def test_attribution_patch_raises_on_batch_size_mismatch() -> None:
 # Commit 5 — linear-model reconstruction identity
 # ---------------------------------------------------------------------------
 #
-# ``_NodeGraphToyBridge`` is fully linear by construction — the plan's
-# "neutralize the remaining nonlinearities on the residual->metric path"
-# conditions hold without extra freezing: ``ln_final`` is ``nn.Identity``, the
+# ``_NodeGraphToyBridge`` is fully linear by construction — the remaining
+# nonlinearities on the residual->metric path are neutralized without extra
+# freezing: ``ln_final`` is ``nn.Identity``, the
 # attention projection is a plain linear map with no softmax pattern, the MLP has
 # no activation, and ``_metric_fn`` is linear in the logits. The first-order
 # Taylor estimate each node score uses is therefore *exact*, so the reconstruction

--- a/tests/unit/tools/test_attribution_patching.py
+++ b/tests/unit/tools/test_attribution_patching.py
@@ -1,0 +1,189 @@
+"""Model-free unit tests for the attribution-patching substrate.
+
+These tests target the ``TransformerBridge`` API exclusively (TransformerLens v4
+deprecates ``HookedTransformer``). They use a tiny, deliberately *linear*
+``TransformerBridge`` subclass so gradients have a closed form and, later, the
+first-order attribution identity holds exactly.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any, Callable, Iterator
+
+import torch
+import torch.nn as nn
+
+from transformer_lens.hook_points import HookPoint
+from transformer_lens.model_bridge import TransformerBridge
+from transformer_lens.tools.analysis.attribution_patching import (
+    cache_activation_and_gradient,
+)
+
+D_MODEL = 4
+D_VOCAB = 6
+N_LAYERS = 2
+SEQ_LEN = 3
+
+
+class _LinearBlock(nn.Module):
+    """Position-wise residual-linear block with a single output hook point."""
+
+    def __init__(self, d_model: int, layer: int, dtype: torch.dtype) -> None:
+        super().__init__()
+        self.linear = nn.Linear(d_model, d_model, bias=False, dtype=dtype)
+        nn.init.normal_(self.linear.weight, std=0.2)
+        self.hook_out = HookPoint()
+        self.hook_out.name = f"blocks.{layer}.hook_out"
+
+    def forward(self, residual: torch.Tensor) -> torch.Tensor:
+        return self.hook_out(residual + self.linear(residual))
+
+
+class _LinearToyBridge(TransformerBridge):
+    """Tiny fully-linear ``TransformerBridge`` with Bridge-native hook points.
+
+    The production constructor needs a Hugging Face model and an architecture
+    adapter; unit tests only need the hook graph, a forward pass, and the
+    ``hooks()`` context, so this subclass initializes ``nn.Module`` directly while
+    keeping the concrete ``TransformerBridge`` isinstance contract. Every layer is
+    linear and ``ln_final`` is the identity, so the residual->metric map is linear.
+    """
+
+    def __init__(self, *, dtype: torch.dtype = torch.float32) -> None:
+        nn.Module.__init__(self)
+        # TransformerBridge.__setattr__ registers HookPoints here; create it before
+        # any HookPoint attribute is assigned.
+        self._hook_registry: dict[str, HookPoint] = {}
+        self.context_level = 0
+        torch.manual_seed(0)
+        self.cfg = SimpleNamespace(
+            n_layers=N_LAYERS,
+            d_model=D_MODEL,
+            d_vocab=D_VOCAB,
+            d_vocab_out=D_VOCAB,
+            model_name="linear-toy-bridge",
+            dtype=dtype,
+            device="cpu",
+        )
+        self.compatibility_mode = False
+        self._weights_processed = False
+        self.embed = nn.Embedding(D_VOCAB, D_MODEL, dtype=dtype)
+        nn.init.normal_(self.embed.weight, std=0.2)
+        self.hook_embed = HookPoint()
+        self.hook_embed.name = "hook_embed"
+        self.blocks = nn.ModuleList(
+            [_LinearBlock(D_MODEL, layer, dtype) for layer in range(N_LAYERS)]
+        )
+        self.ln_final = nn.Identity()
+        self.unembed = nn.Linear(D_MODEL, D_VOCAB, bias=False, dtype=dtype)
+        nn.init.normal_(self.unembed.weight, std=0.2)
+
+    @property
+    def hook_dict(self) -> dict[str, HookPoint]:
+        hooks: dict[str, HookPoint] = {"hook_embed": self.hook_embed}
+        for layer, block in enumerate(self.blocks):
+            hooks[f"blocks.{layer}.hook_out"] = block.hook_out
+        return hooks
+
+    def check_hooks_to_add(self, name: str) -> None:  # pragma: no cover - trivial
+        del name
+
+    def parameters(self, recurse: bool = True):  # type: ignore[override]
+        # A production bridge delegates this to its wrapped HF model; this toy owns
+        # its small modules directly, so enumerate the nn.Module tree.
+        return nn.Module.parameters(self, recurse=recurse)
+
+    def named_parameters(  # type: ignore[override]
+        self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
+    ):
+        return nn.Module.named_parameters(
+            self, prefix=prefix, recurse=recurse, remove_duplicate=remove_duplicate
+        )
+
+    def to_tokens(self, prompt: str) -> torch.Tensor:
+        ids = [(3 * index + len(prompt)) % D_VOCAB for index in range(SEQ_LEN)]
+        return torch.tensor([ids], dtype=torch.long)
+
+    def forward(
+        self, tokens: torch.Tensor, return_type: str | None = "logits"
+    ) -> torch.Tensor | None:
+        residual = self.hook_embed(self.embed(tokens))
+        for block in self.blocks:
+            residual = block(residual)
+        if return_type is None:
+            return None
+        return self.unembed(self.ln_final(residual))
+
+    @contextmanager
+    def hooks(
+        self,
+        fwd_hooks: list[tuple[str, Any]] = [],
+        bwd_hooks: list[tuple[str, Any]] = [],
+        reset_hooks_end: bool = True,
+        clear_contexts: bool = False,
+    ) -> Iterator["_LinearToyBridge"]:
+        del clear_contexts
+        added: list[tuple[HookPoint, str, Any]] = []
+        for direction, specs in (("fwd", fwd_hooks), ("bwd", bwd_hooks)):
+            for name, hook_fn in specs:
+                hook_point = self.hook_dict[name]
+                hook_point.add_hook(hook_fn, dir=direction)
+                handles = hook_point.fwd_hooks if direction == "fwd" else hook_point.bwd_hooks
+                added.append((hook_point, direction, handles[-1]))
+        try:
+            yield self
+        finally:
+            if reset_hooks_end:
+                for hook_point, direction, handle in added:
+                    handle.hook.remove()
+                    handles = hook_point.fwd_hooks if direction == "fwd" else hook_point.bwd_hooks
+                    if handle in handles:
+                        handles.remove(handle)
+
+
+def _metric_fn(answer: int, wrong: int) -> Callable[[torch.Tensor], torch.Tensor]:
+    def metric(logits: torch.Tensor) -> torch.Tensor:
+        return logits[0, -1, answer] - logits[0, -1, wrong]
+
+    return metric
+
+
+def test_gradient_cache_only_covers_filtered_names() -> None:
+    model = _LinearToyBridge()
+    tokens = model.to_tokens("prompt")
+    metric = _metric_fn(answer=1, wrong=2)
+
+    result = cache_activation_and_gradient(
+        model, tokens, metric, names_filter=["blocks.0.hook_out"]
+    )
+
+    assert set(result.activations) == {"blocks.0.hook_out"}
+    assert set(result.gradients) == {"blocks.0.hook_out"}
+    grad = result.gradients["blocks.0.hook_out"]
+    assert grad is not None
+    assert grad.shape == result.activations["blocks.0.hook_out"].shape
+    assert torch.isfinite(grad).all()
+
+
+def test_gradient_cache_matches_closed_form_linear_gradient() -> None:
+    model = _LinearToyBridge()
+    tokens = model.to_tokens("prompt")
+    answer, wrong = 1, 2
+    metric = _metric_fn(answer, wrong)
+
+    result = cache_activation_and_gradient(
+        model, tokens, metric, names_filter=["blocks.0.hook_out"]
+    )
+    grad = result.gradients["blocks.0.hook_out"]
+
+    # Closed form: metric = (u_a - u_b) . (I + W1) h0[-1]; blocks are position-wise
+    # so the gradient is zero except at the final position.
+    direction = model.unembed.weight[answer] - model.unembed.weight[wrong]  # [d_model]
+    jac = torch.eye(D_MODEL) + model.blocks[1].linear.weight  # d h1 / d h0
+    expected_last = jac.T @ direction
+    expected = torch.zeros(1, SEQ_LEN, D_MODEL)
+    expected[0, -1] = expected_last
+
+    torch.testing.assert_close(grad, expected)

--- a/tests/unit/tools/test_attribution_patching.py
+++ b/tests/unit/tools/test_attribution_patching.py
@@ -24,6 +24,7 @@ from transformer_lens.tools.analysis.attribution_patching import (
     EdgeAttributionConfig,
     GradientCache,
     Node,
+    _node_effects,
     attribution_patch,
     cache_activation_and_gradient,
     enumerate_nodes,
@@ -615,3 +616,123 @@ def test_linear_single_node_patch_matches_score_and_sign() -> None:
         covered.add(node.kind)
 
     assert covered == {"embed", "attn_head_out", "mlp_out"}
+
+
+# ---------------------------------------------------------------------------
+# The denoising convention on a nonlinear model
+# ---------------------------------------------------------------------------
+#
+# Every toy bridge above is linear, so its Jacobian is input-independent and the
+# clean and corrupt runs share a gradient. That hides the "gradient is taken from
+# the corrupt run" half of the denoising convention: repointing ``_node_effects``
+# at ``clean_cache.gradients`` would leave every linear test green.
+# ``_NonlinearNodeGraphToyBridge`` adds a GELU MLP so the two runs' gradients
+# diverge, which makes the corrupt-vs-clean choice observable.
+
+
+class _NonlinearAttnMlpBlock(_AttnMlpBlock):
+    """``_AttnMlpBlock`` with a GELU MLP so the residual->metric map is nonlinear.
+
+    The extra ``w_mlp_in`` + GELU make ``d(metric)/d(activation)`` input-dependent,
+    so the clean and corrupt runs no longer share a Jacobian. Without a
+    nonlinearity the two caches hold identical gradients and which run the score
+    reads from cannot be told apart.
+    """
+
+    def __init__(self, d_model: int, n_heads: int, d_head: int, layer: int, dtype: torch.dtype):
+        super().__init__(d_model, n_heads, d_head, layer, dtype)
+        self.w_mlp_in = nn.Linear(d_model, d_model, bias=False, dtype=dtype)
+        nn.init.normal_(self.w_mlp_in.weight, std=0.6)
+
+    def forward(self, residual: torch.Tensor) -> torch.Tensor:
+        batch, seq, _ = residual.shape
+        z = self.hook_z(self.w_z(residual).reshape(batch, seq, self.n_heads, self.d_head))
+        residual = residual + self.w_o(z.reshape(batch, seq, self.n_heads * self.d_head))
+        hidden = torch.nn.functional.gelu(self.w_mlp_in(residual))
+        mlp_out = self.hook_mlp_out(self.w_mlp(hidden))
+        return residual + mlp_out
+
+
+class _NonlinearNodeGraphToyBridge(_NodeGraphToyBridge):
+    """``_NodeGraphToyBridge`` whose MLPs carry a GELU, so gradients are input-dependent.
+
+    Reuses the parent's hook graph and ``hooks()`` plumbing but swaps the linear
+    blocks for :class:`_NonlinearAttnMlpBlock`, giving the clean and corrupt runs
+    genuinely different gradients.
+    """
+
+    def __init__(self, *, dtype: torch.dtype = torch.float32) -> None:
+        super().__init__(dtype=dtype)
+        torch.manual_seed(1)
+        self.blocks = nn.ModuleList(
+            [
+                _NonlinearAttnMlpBlock(D_MODEL, N_HEADS, D_HEAD, layer, dtype)
+                for layer in range(N_LAYERS)
+            ]
+        )
+
+
+def test_nonlinear_node_scores_read_the_corrupt_run_gradient() -> None:
+    """On a nonlinear model the score reads the corrupt run's gradient, not the clean one.
+
+    With an input-dependent Jacobian the clean and corrupt caches hold *different*
+    gradients, so pairing the clean-activation delta with the clean gradient (the
+    reversed convention) yields different scores from the corrupt-gradient one the
+    docstring promises. This pins ``attribution_patch`` to the corrupt gradient — a
+    guard the linear tests structurally cannot provide.
+    """
+    model = _NonlinearNodeGraphToyBridge()
+    clean = torch.tensor([[1, 2, 3]])
+    corrupt = torch.tensor([[3, 2, 1]])
+    metric = _metric_fn(answer=1, wrong=2)
+
+    # Both caches carry gradients so the two conventions can be contrasted directly.
+    clean_cache = cache_activation_and_gradient(model, clean, metric)
+    corrupt_cache = cache_activation_and_gradient(model, corrupt, metric)
+    nodes = enumerate_nodes(model, corrupt_cache)
+
+    # Fixture guard: the nonlinearity must actually make the runs' gradients differ,
+    # otherwise this test would silently pass on a still-linear model.
+    assert any(
+        not torch.allclose(clean_cache.gradients[name], corrupt_cache.gradients[name])
+        for name in corrupt_cache.gradients
+    )
+
+    result = attribution_patch(model, clean, corrupt, metric)
+
+    # attribution_patch scores the corrupt-gradient convention...
+    corrupt_grad_scores = _node_effects(clean_cache, corrupt_cache, nodes)
+    for node in nodes:
+        assert result.node_scores[node] == pytest.approx(corrupt_grad_scores[node])
+
+    # ...which genuinely diverges from the clean-gradient convention (same delta,
+    # clean run's gradient). If _node_effects read the clean gradient instead, the
+    # two would coincide and this assertion would fail.
+    clean_grad_scores = _node_effects(
+        clean_cache,
+        GradientCache(
+            activations=corrupt_cache.activations,
+            gradients=clean_cache.gradients,
+            metric=corrupt_cache.metric,
+        ),
+        nodes,
+    )
+    assert any(
+        corrupt_grad_scores[node] != pytest.approx(clean_grad_scores[node]) for node in nodes
+    )
+
+    # Behavioural pin, independent of _node_effects: a single-node corrupt->clean
+    # patch moves the metric in the score's direction. The estimate is first-order
+    # on a nonlinear model, so assert the sign (not the exact value) across every
+    # non-negligible node and confirm at least one was actually checked.
+    with torch.no_grad():
+        m_corrupt = float(metric(model(corrupt)))
+    checked = 0
+    for node, score in result.top_nodes(k=len(result.node_scores)):
+        if abs(score) < 1e-3:
+            continue
+        delta_m = _patch_node_toward_clean(model, corrupt, node, clean_cache.activations, metric)
+        delta_m -= m_corrupt
+        assert (delta_m > 0) == (score > 0)  # denoising sign convention
+        checked += 1
+    assert checked > 0

--- a/tests/unit/tools/test_attribution_patching.py
+++ b/tests/unit/tools/test_attribution_patching.py
@@ -12,13 +12,17 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any, Callable, Iterator
 
+import pytest
 import torch
 import torch.nn as nn
 
 from transformer_lens.hook_points import HookPoint
 from transformer_lens.model_bridge import TransformerBridge
 from transformer_lens.tools.analysis.attribution_patching import (
+    GradientCache,
+    Node,
     cache_activation_and_gradient,
+    enumerate_nodes,
 )
 
 D_MODEL = 4
@@ -187,3 +191,87 @@ def test_gradient_cache_matches_closed_form_linear_gradient() -> None:
     expected[0, -1] = expected_last
 
     torch.testing.assert_close(grad, expected)
+
+
+# ---------------------------------------------------------------------------
+# Commit 2 — typed computational-graph node model
+# ---------------------------------------------------------------------------
+
+N_HEADS = 2
+D_HEAD = 2
+
+
+def _synthetic_node_cache(
+    n_layers: int = N_LAYERS,
+    seq_len: int = SEQ_LEN,
+    n_heads: int = N_HEADS,
+    d_head: int = D_HEAD,
+    d_model: int = D_MODEL,
+) -> GradientCache:
+    """A cache whose keys/shapes carry the standard node-granularity hook points.
+
+    Node enumeration only reads hook names and tensor shapes, so the contents can
+    be zeros; this keeps the graph test model-free and independent of any forward
+    pass.
+    """
+    activations: dict[str, torch.Tensor] = {"hook_embed": torch.zeros(1, seq_len, d_model)}
+    for layer in range(n_layers):
+        activations[f"blocks.{layer}.attn.hook_z"] = torch.zeros(1, seq_len, n_heads, d_head)
+        activations[f"blocks.{layer}.hook_mlp_out"] = torch.zeros(1, seq_len, d_model)
+    return GradientCache(
+        activations=activations,
+        gradients={name: None for name in activations},
+        metric=torch.tensor(0.0),
+    )
+
+
+def _cfg_stub(n_layers: int = N_LAYERS) -> SimpleNamespace:
+    return SimpleNamespace(cfg=SimpleNamespace(n_layers=n_layers))
+
+
+def test_node_hook_name_and_key_validation() -> None:
+    assert Node(kind="embed", position=0).hook_name == "hook_embed"
+    assert (
+        Node(kind="attn_head_out", layer=1, head=0, position=2).hook_name == "blocks.1.attn.hook_z"
+    )
+    assert Node(kind="mlp_out", layer=0, position=1).hook_name == "blocks.0.hook_mlp_out"
+
+    # The typed key rejects malformed nodes (Risk 1: explicit graph).
+    with pytest.raises(ValueError):
+        Node(kind="embed", position=0, layer=0)
+    with pytest.raises(ValueError):
+        Node(kind="attn_head_out", layer=0, position=0)  # head missing
+    with pytest.raises(ValueError):
+        Node(kind="mlp_out", layer=0, head=0, position=0)  # head not allowed
+
+
+def test_enumerate_nodes_returns_expected_keys() -> None:
+    nodes = enumerate_nodes(_cfg_stub(), _synthetic_node_cache())
+
+    # embed(pos) + per layer [head*pos attn-head-out + pos mlp-out]
+    expected = SEQ_LEN + N_LAYERS * (N_HEADS * SEQ_LEN + SEQ_LEN)
+    assert len(nodes) == expected
+    assert len(set(nodes)) == expected  # nodes are unique + hashable
+
+    embed_nodes = [n for n in nodes if n.kind == "embed"]
+    assert {n.position for n in embed_nodes} == set(range(SEQ_LEN))
+    assert all(n.layer is None and n.head is None for n in embed_nodes)
+
+    attn_nodes = [n for n in nodes if n.kind == "attn_head_out"]
+    assert {(n.layer, n.head) for n in attn_nodes} == {
+        (layer, head) for layer in range(N_LAYERS) for head in range(N_HEADS)
+    }
+
+    mlp_nodes = [n for n in nodes if n.kind == "mlp_out"]
+    assert {(n.layer, n.position) for n in mlp_nodes} == {
+        (layer, pos) for layer in range(N_LAYERS) for pos in range(SEQ_LEN)
+    }
+    assert all(n.head is None for n in mlp_nodes)
+
+
+def test_enumerate_nodes_raises_on_missing_hook() -> None:
+    cache = _synthetic_node_cache()
+    del cache.activations["blocks.1.hook_mlp_out"]
+
+    with pytest.raises(ValueError, match="blocks.1.hook_mlp_out"):
+        enumerate_nodes(_cfg_stub(), cache)

--- a/tests/unit/tools/test_attribution_patching.py
+++ b/tests/unit/tools/test_attribution_patching.py
@@ -197,6 +197,22 @@ def test_gradient_cache_matches_closed_form_linear_gradient() -> None:
     torch.testing.assert_close(grad, expected)
 
 
+def test_gradient_cache_activation_only_skips_gradients() -> None:
+    model = _LinearToyBridge()
+    tokens = model.to_tokens("prompt")
+    metric = _metric_fn(answer=1, wrong=2)
+
+    result = cache_activation_and_gradient(
+        model, tokens, metric, names_filter=["blocks.0.hook_out"], compute_gradient=False
+    )
+
+    # Activation-only pass: activations populated, every gradient left None.
+    assert set(result.activations) == {"blocks.0.hook_out"}
+    assert torch.isfinite(result.activations["blocks.0.hook_out"]).all()
+    assert set(result.gradients) == {"blocks.0.hook_out"}
+    assert result.gradients["blocks.0.hook_out"] is None
+
+
 # ---------------------------------------------------------------------------
 # Commit 2 — typed computational-graph node model
 # ---------------------------------------------------------------------------

--- a/tests/unit/tools/test_attribution_patching.py
+++ b/tests/unit/tools/test_attribution_patching.py
@@ -469,3 +469,108 @@ def test_attribution_patch_raises_on_batch_size_mismatch() -> None:
 
     with pytest.raises(ValueError, match="same number of prompt pairs"):
         attribution_patch(model, clean, corrupt, _metric_fn(answer=1, wrong=2))
+
+
+# ---------------------------------------------------------------------------
+# Commit 5 — linear-model reconstruction identity
+# ---------------------------------------------------------------------------
+#
+# ``_NodeGraphToyBridge`` is fully linear by construction — the plan's
+# "neutralize the remaining nonlinearities on the residual->metric path"
+# conditions hold without extra freezing: ``ln_final`` is ``nn.Identity``, the
+# attention projection is a plain linear map with no softmax pattern, the MLP has
+# no activation, and ``_metric_fn`` is linear in the logits. The first-order
+# Taylor estimate each node score uses is therefore *exact*, so the reconstruction
+# and single-node identities below hold under equality (tight ``atol``) rather than
+# the ``atol``-slack approximation a stock nonlinear model would require.
+
+
+def _metric_delta(
+    model: _NodeGraphToyBridge,
+    clean: torch.Tensor,
+    corrupt: torch.Tensor,
+    metric_fn: Callable[[torch.Tensor], torch.Tensor],
+) -> float:
+    with torch.no_grad():
+        return float(metric_fn(model(clean)) - metric_fn(model(corrupt)))
+
+
+def _patch_node_toward_clean(
+    model: _NodeGraphToyBridge,
+    corrupt: torch.Tensor,
+    node: Node,
+    clean_activations: dict[str, torch.Tensor],
+    metric_fn: Callable[[torch.Tensor], torch.Tensor],
+) -> float:
+    """Run the corrupt forward with ``node``'s activation replaced by its clean value."""
+    clean_value = clean_activations[node.hook_name]
+
+    def hook(tensor: torch.Tensor, *, hook: Any) -> torch.Tensor:
+        del hook
+        if node.kind == "attn_head_out":
+            tensor[0, node.position, node.head] = clean_value[0, node.position, node.head]
+        else:
+            tensor[0, node.position] = clean_value[0, node.position]
+        return tensor
+
+    with torch.no_grad(), model.hooks(fwd_hooks=[(node.hook_name, hook)]):
+        return float(metric_fn(model(corrupt)))
+
+
+def test_linear_reconstruction_identity_holds_on_a_complete_cut() -> None:
+    """Node attribution reconstructs ``m(clean) - m(corrupt)`` exactly on a complete cut.
+
+    The identity holds over a **complete cut** of the graph, not the full node set.
+    Each residual write flows through the writes downstream of it (the MLP reads the
+    post-attention residual, which already contains the embed and attention writes),
+    so a node's full-model gradient re-counts the paths of every node upstream of
+    it: summing embed + attention + MLP scores overcounts. The embed layer is the
+    input-side complete cut — every path to the metric passes through exactly one
+    embed position — so its scores alone reconstruct the exact metric delta for a
+    linear model.
+    """
+    model = _NodeGraphToyBridge()
+    clean = torch.tensor([[1, 2, 3]])
+    corrupt = torch.tensor([[3, 2, 1]])
+    metric = _metric_fn(answer=1, wrong=2)
+
+    result = attribution_patch(model, clean, corrupt, metric)
+    embed_reconstruction = sum(
+        score for node, score in result.node_scores.items() if node.kind == "embed"
+    )
+
+    assert embed_reconstruction == pytest.approx(
+        _metric_delta(model, clean, corrupt, metric), abs=1e-6
+    )
+
+
+def test_linear_single_node_patch_matches_score_and_sign() -> None:
+    """Patching one node corrupt->clean moves the metric by exactly its score.
+
+    For a linear model the first-order attribution of a single node equals the exact
+    effect of patching only that node from its corrupt value to its clean value
+    (everything upstream held at corrupt). This pins the sign/direction convention
+    end to end across all three node families: a positive score corresponds to the
+    metric moving in the positive direction under the denoising patch.
+    """
+    model = _NodeGraphToyBridge()
+    clean = torch.tensor([[1, 2, 3]])
+    corrupt = torch.tensor([[3, 2, 1]])
+    metric = _metric_fn(answer=1, wrong=2)
+
+    # names_filter=None caches every hook, which for this toy is exactly the node graph.
+    clean_cache = cache_activation_and_gradient(model, clean, metric)
+    result = attribution_patch(model, clean, corrupt, metric)
+    with torch.no_grad():
+        m_corrupt = float(metric(model(corrupt)))
+
+    covered: set[str] = set()
+    for node, score in result.top_nodes(k=len(result.node_scores)):
+        delta_m = _patch_node_toward_clean(model, corrupt, node, clean_cache.activations, metric)
+        delta_m -= m_corrupt
+        assert delta_m == pytest.approx(score, abs=1e-6)
+        if abs(score) > 1e-6:
+            assert (delta_m > 0) == (score > 0)  # denoising sign convention
+        covered.add(node.kind)
+
+    assert covered == {"embed", "attn_head_out", "mlp_out"}

--- a/tests/unit/tools/test_attribution_patching.py
+++ b/tests/unit/tools/test_attribution_patching.py
@@ -436,6 +436,31 @@ def _expected_node_count() -> int:
     return SEQ_LEN + N_LAYERS * (N_HEADS * SEQ_LEN + SEQ_LEN)
 
 
+def test_gradient_cache_defaults_to_the_node_hook_set() -> None:
+    """``names_filter=None`` caches the node hook set, not every hook point.
+
+    On a real Bridge, "every hook point" raises: ``hook_dict`` exposes gated points
+    (``hook_mlp_in``, ``attn.hook_result``, split-QKV inputs) that ``add_hook``
+    rejects unless the matching ``set_use_*`` flag is on. The default filter falls
+    back to the node graph's hook set so it works out of the box.
+    """
+    model = _NodeGraphToyBridge()
+    tokens = torch.tensor([[1, 2, 3]])
+    metric = _metric_fn(answer=1, wrong=2)
+
+    result = cache_activation_and_gradient(model, tokens, metric)
+
+    expected = {
+        "hook_embed",
+        "blocks.0.attn.hook_z",
+        "blocks.0.hook_mlp_out",
+        "blocks.1.attn.hook_z",
+        "blocks.1.hook_mlp_out",
+    }
+    assert set(result.activations) == expected
+    assert set(result.gradients) == expected
+
+
 def test_attribution_patch_scores_every_node_with_finite_values() -> None:
     model = _NodeGraphToyBridge()
     clean = torch.tensor([[1, 2, 3]])
@@ -574,7 +599,7 @@ def test_linear_single_node_patch_matches_score_and_sign() -> None:
     corrupt = torch.tensor([[3, 2, 1]])
     metric = _metric_fn(answer=1, wrong=2)
 
-    # names_filter=None caches every hook, which for this toy is exactly the node graph.
+    # names_filter=None defaults to the node hook set, which for this toy is every hook.
     clean_cache = cache_activation_and_gradient(model, clean, metric)
     result = attribution_patch(model, clean, corrupt, metric)
     with torch.no_grad():

--- a/tests/unit/tools/test_attribution_patching.py
+++ b/tests/unit/tools/test_attribution_patching.py
@@ -8,6 +8,7 @@ first-order attribution identity holds exactly.
 
 from __future__ import annotations
 
+import math
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any, Callable, Iterator
@@ -23,6 +24,7 @@ from transformer_lens.tools.analysis.attribution_patching import (
     EdgeAttributionConfig,
     GradientCache,
     Node,
+    attribution_patch,
     cache_activation_and_gradient,
     enumerate_nodes,
 )
@@ -322,3 +324,148 @@ def test_top_edges_not_implemented_until_pr2() -> None:
     assert result.edge_scores == {}
     with pytest.raises(NotImplementedError, match="PR2"):
         result.top_edges()
+
+
+# ---------------------------------------------------------------------------
+# Commit 4 — node attribution_patch entry point
+# ---------------------------------------------------------------------------
+
+
+class _AttnMlpBlock(nn.Module):
+    """A block exposing the standard node-granularity hook points.
+
+    ``hook_z`` carries the per-head output ``[batch, seq, n_heads, d_head]`` and
+    ``hook_mlp_out`` the MLP write ``[batch, seq, d_model]`` — the two per-layer
+    hook families ``enumerate_nodes`` reads. The block is linear; the test only
+    needs a real hook graph with gradients flowing to those points, not attention.
+    """
+
+    def __init__(self, d_model: int, n_heads: int, d_head: int, layer: int, dtype: torch.dtype):
+        super().__init__()
+        self.n_heads = n_heads
+        self.d_head = d_head
+        self.w_z = nn.Linear(d_model, n_heads * d_head, bias=False, dtype=dtype)
+        self.w_o = nn.Linear(n_heads * d_head, d_model, bias=False, dtype=dtype)
+        self.w_mlp = nn.Linear(d_model, d_model, bias=False, dtype=dtype)
+        for linear in (self.w_z, self.w_o, self.w_mlp):
+            nn.init.normal_(linear.weight, std=0.2)
+        self.hook_z = HookPoint()
+        self.hook_z.name = f"blocks.{layer}.attn.hook_z"
+        self.hook_mlp_out = HookPoint()
+        self.hook_mlp_out.name = f"blocks.{layer}.hook_mlp_out"
+
+    def forward(self, residual: torch.Tensor) -> torch.Tensor:
+        batch, seq, _ = residual.shape
+        z = self.hook_z(self.w_z(residual).reshape(batch, seq, self.n_heads, self.d_head))
+        residual = residual + self.w_o(z.reshape(batch, seq, self.n_heads * self.d_head))
+        mlp_out = self.hook_mlp_out(self.w_mlp(residual))
+        return residual + mlp_out
+
+
+class _NodeGraphToyBridge(_LinearToyBridge):
+    """A tiny ``TransformerBridge`` carrying the full node-granularity hook graph.
+
+    Inherits ``_LinearToyBridge``'s ``hooks()`` / parameter plumbing but swaps in
+    blocks with ``attn.hook_z`` + ``hook_mlp_out`` so ``attribution_patch`` can
+    enumerate and score every node.
+    """
+
+    def __init__(self, *, dtype: torch.dtype = torch.float32) -> None:
+        nn.Module.__init__(self)
+        self._hook_registry: dict[str, HookPoint] = {}
+        self.context_level = 0
+        torch.manual_seed(0)
+        self.cfg = SimpleNamespace(
+            n_layers=N_LAYERS,
+            d_model=D_MODEL,
+            d_vocab=D_VOCAB,
+            d_vocab_out=D_VOCAB,
+            model_name="node-graph-toy-bridge",
+            dtype=dtype,
+            device="cpu",
+        )
+        self.compatibility_mode = False
+        self._weights_processed = False
+        self.embed = nn.Embedding(D_VOCAB, D_MODEL, dtype=dtype)
+        nn.init.normal_(self.embed.weight, std=0.2)
+        self.hook_embed = HookPoint()
+        self.hook_embed.name = "hook_embed"
+        self.blocks = nn.ModuleList(
+            [_AttnMlpBlock(D_MODEL, N_HEADS, D_HEAD, layer, dtype) for layer in range(N_LAYERS)]
+        )
+        self.ln_final = nn.Identity()
+        self.unembed = nn.Linear(D_MODEL, D_VOCAB, bias=False, dtype=dtype)
+        nn.init.normal_(self.unembed.weight, std=0.2)
+
+    @property
+    def hook_dict(self) -> dict[str, HookPoint]:
+        hooks: dict[str, HookPoint] = {"hook_embed": self.hook_embed}
+        for layer, block in enumerate(self.blocks):
+            hooks[f"blocks.{layer}.attn.hook_z"] = block.hook_z
+            hooks[f"blocks.{layer}.hook_mlp_out"] = block.hook_mlp_out
+        return hooks
+
+    def forward(
+        self, tokens: torch.Tensor, return_type: str | None = "logits"
+    ) -> torch.Tensor | None:
+        residual = self.hook_embed(self.embed(tokens))
+        for block in self.blocks:
+            residual = block(residual)
+        if return_type is None:
+            return None
+        return self.unembed(self.ln_final(residual))
+
+
+def _expected_node_count() -> int:
+    return SEQ_LEN + N_LAYERS * (N_HEADS * SEQ_LEN + SEQ_LEN)
+
+
+def test_attribution_patch_scores_every_node_with_finite_values() -> None:
+    model = _NodeGraphToyBridge()
+    clean = torch.tensor([[1, 2, 3]])
+    corrupt = torch.tensor([[3, 2, 1]])
+
+    result = attribution_patch(model, clean, corrupt, _metric_fn(answer=1, wrong=2))
+
+    assert isinstance(result, AttributionResult)
+    assert len(result.node_scores) == _expected_node_count()
+    assert all(isinstance(score, float) for score in result.node_scores.values())
+    assert all(math.isfinite(score) for score in result.node_scores.values())
+    assert result.edge_scores == {}
+    # top_nodes ranks the scored graph by magnitude.
+    assert len(result.top_nodes(k=3)) == 3
+
+
+def test_attribution_patch_averages_scores_across_the_batch() -> None:
+    model = _NodeGraphToyBridge()
+    clean = torch.tensor([[1, 2, 3], [0, 4, 5]])
+    corrupt = torch.tensor([[3, 2, 1], [5, 4, 0]])
+    metric = _metric_fn(answer=1, wrong=2)
+
+    batched = attribution_patch(model, clean, corrupt, metric)
+    per_example = [
+        attribution_patch(model, clean[i : i + 1], corrupt[i : i + 1], metric) for i in range(2)
+    ]
+
+    assert set(batched.node_scores) == set(per_example[0].node_scores)
+    for node in batched.node_scores:
+        expected = (per_example[0].node_scores[node] + per_example[1].node_scores[node]) / 2
+        assert batched.node_scores[node] == pytest.approx(expected)
+
+
+def test_attribution_patch_raises_on_token_length_mismatch() -> None:
+    model = _NodeGraphToyBridge()
+    clean = torch.tensor([[1, 2, 3]])
+    corrupt = torch.tensor([[1, 2]])
+
+    with pytest.raises(ValueError, match="same length"):
+        attribution_patch(model, clean, corrupt, _metric_fn(answer=1, wrong=2))
+
+
+def test_attribution_patch_raises_on_batch_size_mismatch() -> None:
+    model = _NodeGraphToyBridge()
+    clean = torch.tensor([[1, 2, 3], [3, 2, 1]])
+    corrupt = torch.tensor([[3, 2, 1]])
+
+    with pytest.raises(ValueError, match="same number of prompt pairs"):
+        attribution_patch(model, clean, corrupt, _metric_fn(answer=1, wrong=2))

--- a/transformer_lens/tools/analysis/__init__.py
+++ b/transformer_lens/tools/analysis/__init__.py
@@ -5,6 +5,11 @@ sit on top of the hook/cache system. Model support is documented per tool;
 new analyses may target the ``TransformerBridge`` API exclusively.
 
 Tools:
+    - attribution_patching: Attribution patching (gradient-linearized activation
+      patching) over residual-stream nodes — typed computational graph, a
+      names-filtered manual-backward gradient cache, and signed node scores. Edge
+      scoring (EAP), integrated gradients (EAP-IG), and faithfulness land in
+      follow-on PRs.
     - backward_lens: GPT-2 MLP weight-gradient factors projected into vocabulary
       space with explicit raw-gradient sign semantics.
     - direct_logit_attribution: Direct Logit Attribution (DLA) over components,
@@ -19,6 +24,12 @@ Tools:
       attention-head OQ/OK/OV affinity.
 """
 
+from transformer_lens.tools.analysis.attribution_patching import (
+    AttributionResult,
+    EdgeAttributionConfig,
+    Node,
+    attribution_patch,
+)
 from transformer_lens.tools.analysis.backward_lens import (
     BackwardLens,
     BackwardLensLayerResult,
@@ -67,12 +78,14 @@ from transformer_lens.tools.analysis.projection_kernel import (
 
 __all__ = [
     "AttentionHeadRef",
+    "AttributionResult",
     "BackwardLens",
     "BackwardLensLayerResult",
     "BackwardLensMatrixResult",
     "BackwardLensResult",
     "CoordinatePatch",
     "DirectLogitAttribution",
+    "EdgeAttributionConfig",
     "HeadAffinityPair",
     "HeadAffinityResult",
     "JSpaceDecomposition",
@@ -81,6 +94,7 @@ __all__ = [
     "JacobianLens",
     "JacobianLensReadout",
     "LinearGradientFactors",
+    "Node",
     "ProjectedFactor",
     "ProjectionKernelResult",
     "RandomSubspaceReference",
@@ -88,6 +102,7 @@ __all__ = [
     "VocabularyRanking",
     "WeightLayout",
     "attention_head_subspace_affinity",
+    "attribution_patch",
     "direct_logit_attribution",
     "estimate_occupancy",
     "get_act_patch_direct_path",

--- a/transformer_lens/tools/analysis/attribution_patching.py
+++ b/transformer_lens/tools/analysis/attribution_patching.py
@@ -1,21 +1,32 @@
 """Attribution patching — linearized activation patching on ``TransformerBridge``.
 
-This module estimates the causal effect of model components on a task metric with
-a *gradient-based linearization* of activation patching: instead of one forward
-pass per intervention, it reads a single gradient cache. This first commit ships
-only the substrate — a names-filtered forward pass that caches activations
-together with the gradient of a custom metric with respect to each of them.
+Attribution patching estimates the causal effect of every model component on a
+task metric with a *gradient-based linearization* of activation patching: rather
+than one forward pass per intervention, it reads a single gradient cache. For a
+clean/corrupt prompt pair it runs a clean forward (for ``a_clean``), a corrupt
+forward with retained gradients plus a manual ``metric.backward()`` (for
+``a_corrupt`` and ``g = d(metric)/d(a)``), and scores each node with the
+first-order Taylor estimate ``effect(node) = (a_clean - a_corrupt) . g``. Scores
+over a batch of clean/corrupt pairs are averaged before ranking.
 
 Only the ``TransformerBridge`` API is targeted; TransformerLens v4 deprecates
 ``HookedTransformer``.
 
 Sign/direction convention (denoising form): the gradient is taken on the
-*corrupt* run and the estimate points *toward* the clean activation. Node/edge
-scoring built on top of this substrate lands in follow-on commits.
+*corrupt* run and the estimate points *toward* the clean activation, so a
+positive score means patching that node from corrupt toward clean moves the
+metric in the positive direction. The oracle-parity test (PR5) maps this
+convention onto the pinned reference rather than assuming the two agree.
 
 Memory note: gradients are retained only for hook points passing ``names_filter``.
 Retaining gradients at every hook point roughly doubles cache memory, so callers
 should filter to the hook families their analysis actually reads.
+
+Scope: this PR ships node granularity with plain attribution (``ig_steps=1``).
+Edge scoring (EAP), the integrated-gradient path (EAP-IG, ``ig_steps>1``), and
+ablate-outside faithfulness land in follow-on PRs; their API is declared here —
+``granularity="edge"`` and ``ig_steps>1`` raise :class:`NotImplementedError` — so
+downstream code can pin against a stable surface now.
 """
 
 from __future__ import annotations

--- a/transformer_lens/tools/analysis/attribution_patching.py
+++ b/transformer_lens/tools/analysis/attribution_patching.py
@@ -1,0 +1,121 @@
+"""Attribution patching — linearized activation patching on ``TransformerBridge``.
+
+This module estimates the causal effect of model components on a task metric with
+a *gradient-based linearization* of activation patching: instead of one forward
+pass per intervention, it reads a single gradient cache. This first commit ships
+only the substrate — a names-filtered forward pass that caches activations
+together with the gradient of a custom metric with respect to each of them.
+
+Only the ``TransformerBridge`` API is targeted; TransformerLens v4 deprecates
+``HookedTransformer``.
+
+Sign/direction convention (denoising form): the gradient is taken on the
+*corrupt* run and the estimate points *toward* the clean activation. Node/edge
+scoring built on top of this substrate lands in follow-on commits.
+
+Memory note: gradients are retained only for hook points passing ``names_filter``.
+Retaining gradients at every hook point roughly doubles cache memory, so callers
+should filter to the hook families their analysis actually reads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Sequence, Union
+
+import torch
+
+MetricFn = Callable[[torch.Tensor], torch.Tensor]
+NamesFilter = Union[str, Sequence[str], Callable[[str], bool], None]
+
+
+@dataclass
+class GradientCache:
+    """Activations and their metric-gradients from one forward + backward pass.
+
+    Attributes:
+        activations: Detached activation tensor per cached hook name.
+        gradients: ``d(metric)/d(activation)`` per cached hook name.
+        metric: The scalar metric value at this run (detached).
+    """
+
+    activations: dict[str, torch.Tensor]
+    gradients: dict[str, Optional[torch.Tensor]]
+    metric: torch.Tensor
+
+
+def _as_predicate(names_filter: NamesFilter) -> Callable[[str], bool]:
+    if names_filter is None:
+        return lambda name: True
+    if isinstance(names_filter, str):
+        target = names_filter
+        return lambda name: name == target
+    if callable(names_filter):
+        return names_filter
+    wanted = set(names_filter)
+    return lambda name: name in wanted
+
+
+def cache_activation_and_gradient(
+    model: Any,
+    tokens: torch.Tensor,
+    metric_fn: MetricFn,
+    names_filter: NamesFilter = None,
+) -> GradientCache:
+    """Run one forward + one manual backward, caching activations and gradients.
+
+    ``run_with_cache(..., incl_bwd=True)`` only backpropagates the model's own
+    scalar output, so a custom (non-scalar-output) metric such as a logit-diff
+    needs the backward call done by hand — that is what this helper does.
+
+    Args:
+        model: A ``TransformerBridge`` (or compatible) exposing ``hook_dict`` and
+            the ``hooks()`` context manager.
+        tokens: Input token ids for a single forward pass.
+        metric_fn: Maps the model logits to a scalar to differentiate.
+        names_filter: Restricts which hook points are cached (and have gradients
+            retained). ``None`` caches every hook point.
+
+    Returns:
+        A :class:`GradientCache` with per-hook activations and gradients.
+    """
+    if not torch.is_grad_enabled():
+        raise ValueError(
+            "cache_activation_and_gradient needs autograd, but gradient tracking "
+            "is off (torch.no_grad(), set_grad_enabled(False), or inference mode)."
+        )
+
+    predicate = _as_predicate(names_filter)
+    names = [name for name in model.hook_dict if predicate(name)]
+    if not names:
+        raise ValueError("names_filter matched no hook points")
+
+    live: dict[str, torch.Tensor] = {}
+    activations: dict[str, torch.Tensor] = {}
+
+    def make_hook(name: str) -> Callable[..., None]:
+        def hook(tensor: torch.Tensor, *, hook: Any) -> None:
+            del hook
+            if isinstance(tensor, torch.Tensor):
+                tensor.retain_grad()
+                live[name] = tensor
+                activations[name] = tensor.detach().clone()
+            return None
+
+        return hook
+
+    fwd_hooks = [(name, make_hook(name)) for name in names]
+
+    model.zero_grad(set_to_none=True)
+    with model.hooks(fwd_hooks=fwd_hooks):
+        logits = model(tokens)
+
+    metric = metric_fn(logits)
+    if metric.dim() != 0:
+        raise ValueError(f"metric_fn must return a scalar tensor, got shape {tuple(metric.shape)}")
+    metric.backward()
+
+    gradients: dict[str, Optional[torch.Tensor]] = {
+        name: live[name].grad for name in names if name in live
+    }
+    return GradientCache(activations=activations, gradients=gradients, metric=metric.detach())

--- a/transformer_lens/tools/analysis/attribution_patching.py
+++ b/transformer_lens/tools/analysis/attribution_patching.py
@@ -21,12 +21,14 @@ should filter to the hook families their analysis actually reads.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Literal, Optional, Sequence, Union
 
 import torch
 
 MetricFn = Callable[[torch.Tensor], torch.Tensor]
 NamesFilter = Union[str, Sequence[str], Callable[[str], bool], None]
+
+NodeKind = Literal["embed", "attn_head_out", "mlp_out"]
 
 
 @dataclass
@@ -42,6 +44,109 @@ class GradientCache:
     activations: dict[str, torch.Tensor]
     gradients: dict[str, Optional[torch.Tensor]]
     metric: torch.Tensor
+
+
+@dataclass(frozen=True)
+class Node:
+    """A node in the residual-stream computational graph at node granularity.
+
+    Nodes are the typed, hashable keys the attribution sweep scores. Each node
+    is identified by ``(kind, layer, position, head)``; ``kind`` selects the node
+    family and constrains which of ``layer``/``head`` apply:
+
+    - ``"embed"``: the token embedding write. ``layer`` and ``head`` are ``None``.
+    - ``"attn_head_out"``: one attention head's output. ``layer`` and ``head`` set.
+    - ``"mlp_out"``: one layer's MLP output. ``layer`` set, ``head`` is ``None``.
+
+    ``position`` is the sequence index the node is read at. The invariants above
+    are enforced in ``__post_init__`` so a malformed key raises rather than
+    silently producing a wrong graph (Risk 1: the explicit-graph guard).
+    """
+
+    kind: NodeKind
+    position: int
+    layer: Optional[int] = None
+    head: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.kind == "embed":
+            if self.layer is not None or self.head is not None:
+                raise ValueError("embed nodes take neither layer nor head")
+        elif self.kind == "attn_head_out":
+            if self.layer is None or self.head is None:
+                raise ValueError("attn_head_out nodes need both layer and head")
+        elif self.kind == "mlp_out":
+            if self.layer is None:
+                raise ValueError("mlp_out nodes need a layer")
+            if self.head is not None:
+                raise ValueError("mlp_out nodes take no head")
+        else:
+            raise ValueError(f"unknown node kind {self.kind!r}")
+
+    @property
+    def hook_name(self) -> str:
+        """The cache hook point this node reads from.
+
+        Uses the standard ``TransformerBridge`` alias names (``hook_embed``,
+        ``blocks.{l}.attn.hook_z``, ``blocks.{l}.hook_mlp_out``); the per-head
+        ``attn_head_out`` node slices head ``self.head`` out of the shared
+        ``hook_z`` tensor.
+        """
+        if self.kind == "embed":
+            return "hook_embed"
+        if self.kind == "attn_head_out":
+            return f"blocks.{self.layer}.attn.hook_z"
+        return f"blocks.{self.layer}.hook_mlp_out"
+
+
+def _required_hook_names(n_layers: int) -> list[str]:
+    """Hook points the node graph reads: embed plus per-layer attn-z and mlp-out."""
+    names = ["hook_embed"]
+    for layer in range(n_layers):
+        names.append(f"blocks.{layer}.attn.hook_z")
+        names.append(f"blocks.{layer}.hook_mlp_out")
+    return names
+
+
+def enumerate_nodes(model: Any, cache: GradientCache) -> list[Node]:
+    """Enumerate the full node-granularity graph from the Bridge hook graph.
+
+    The graph is *explicit*: for ``n_layers`` layers it always contains the embed
+    write, every attention head's output, and every layer's MLP output, at every
+    sequence position. Sequence length and head count are read from the cached
+    tensor shapes; ``n_layers`` from ``model.cfg``.
+
+    Args:
+        model: A ``TransformerBridge`` (or compatible) exposing ``cfg.n_layers``.
+        cache: A :class:`GradientCache` holding at least the required hook points.
+
+    Returns:
+        The node list, ordered embed-then-layerwise for deterministic ranking.
+
+    Raises:
+        ValueError: if any required hook point is absent from ``cache`` — the
+            graph is never silently truncated (Risk 1).
+    """
+    n_layers = int(model.cfg.n_layers)
+    missing = [name for name in _required_hook_names(n_layers) if name not in cache.activations]
+    if missing:
+        raise ValueError(
+            "node graph requires hook points missing from the cache: "
+            + ", ".join(missing)
+            + ". Cache with a names_filter that keeps hook_embed, "
+            "blocks.*.attn.hook_z, and blocks.*.hook_mlp_out."
+        )
+
+    seq_len = cache.activations["hook_embed"].shape[1]
+
+    nodes: list[Node] = [Node(kind="embed", position=position) for position in range(seq_len)]
+    for layer in range(n_layers):
+        n_heads = cache.activations[f"blocks.{layer}.attn.hook_z"].shape[2]
+        for position in range(seq_len):
+            for head in range(n_heads):
+                nodes.append(Node(kind="attn_head_out", layer=layer, head=head, position=position))
+            nodes.append(Node(kind="mlp_out", layer=layer, position=position))
+    return nodes
 
 
 def _as_predicate(names_filter: NamesFilter) -> Callable[[str], bool]:

--- a/transformer_lens/tools/analysis/attribution_patching.py
+++ b/transformer_lens/tools/analysis/attribution_patching.py
@@ -294,12 +294,18 @@ def cache_activation_and_gradient(
     use this to run a plain forward instead of a needless forward + backward.
 
     Args:
-        model: A ``TransformerBridge`` (or compatible) exposing ``hook_dict`` and
-            the ``hooks()`` context manager.
+        model: A ``TransformerBridge`` (or compatible) exposing ``cfg.n_layers``,
+            ``hook_dict``, and the ``hooks()`` context manager.
         tokens: Input token ids for a single forward pass.
         metric_fn: Maps the model logits to a scalar to differentiate.
         names_filter: Restricts which hook points are cached (and have gradients
-            retained). ``None`` caches every hook point.
+            retained). ``None`` (the default) caches the node-granularity hook set —
+            ``hook_embed`` plus each layer's ``attn.hook_z`` and ``hook_mlp_out``;
+            pass an explicit filter to cache any hook point outside that set. On a
+            real Bridge, ``None`` cannot mean "every hook point": the gated points
+            (``hook_mlp_in``, ``attn.hook_result``, the split-QKV inputs) that
+            ``hook_dict`` exposes raise in ``add_hook`` unless their ``set_use_*``
+            flag is on.
         compute_gradient: When ``True`` (default) capture gradients via backward
             hooks. When ``False`` run an activation-only forward and leave every
             gradient ``None``.
@@ -314,6 +320,12 @@ def cache_activation_and_gradient(
             "is off (torch.no_grad(), set_grad_enabled(False), or inference mode)."
         )
 
+    if names_filter is None:
+        # Default to the node-granularity hook set rather than every hook point: a
+        # real Bridge's hook_dict holds gated points (hook_mlp_in, attn.hook_result,
+        # the split-QKV inputs) that add_hook rejects unless their set_use_* flag is
+        # on, so caching "everything" raises. Pass an explicit filter to reach them.
+        names_filter = _required_hook_names(int(model.cfg.n_layers))
     predicate = _as_predicate(names_filter)
     names = [name for name in model.hook_dict if predicate(name)]
     if not names:

--- a/transformer_lens/tools/analysis/attribution_patching.py
+++ b/transformer_lens/tools/analysis/attribution_patching.py
@@ -20,7 +20,7 @@ should filter to the hook families their analysis actually reads.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Literal, Optional, Sequence, Union
 
 import torch
@@ -29,6 +29,7 @@ MetricFn = Callable[[torch.Tensor], torch.Tensor]
 NamesFilter = Union[str, Sequence[str], Callable[[str], bool], None]
 
 NodeKind = Literal["embed", "attn_head_out", "mlp_out"]
+Granularity = Literal["node", "edge"]
 
 
 @dataclass
@@ -97,6 +98,94 @@ class Node:
         if self.kind == "attn_head_out":
             return f"blocks.{self.layer}.attn.hook_z"
         return f"blocks.{self.layer}.hook_mlp_out"
+
+
+@dataclass(frozen=True)
+class EdgeAttributionConfig:
+    """Configuration for an attribution-patching sweep.
+
+    The two axes are deliberately orthogonal:
+
+    - ``granularity`` selects what is scored: ``"node"`` scores each residual-stream
+      write, ``"edge"`` scores each ``(source, destination)`` write->read pair.
+    - ``ig_steps`` selects gradient fidelity. ``ig_steps=1`` is plain attribution
+      patching / EAP: a single first-order Taylor gradient taken at the corrupt
+      point. ``ig_steps>1`` is EAP-IG: the integrated gradient averaged over that
+      many points along the corrupt->clean path, which corrects the gradient
+      saturation that makes plain attribution unfaithful.
+
+    There is intentionally **no** ``method`` field. An earlier design had both a
+    ``method`` enum (``"attribution"``/``"EAP"``/``"EAP-IG"``) and ``ig_steps``,
+    which overlap: the method is fully determined by ``granularity`` and whether
+    ``ig_steps`` exceeds 1. Collapsing them removes the invalid states (e.g.
+    ``method="attribution", ig_steps=5``).
+
+    This substrate PR implements node granularity with plain attribution only.
+    ``granularity="edge"`` and ``ig_steps>1`` are accepted by the type but raise
+    :class:`NotImplementedError` at construction, so downstream code can import and
+    reference this API now while the edge sweep (PR2) and the integrated-gradient
+    path (PR3) land later. When PR3 ships EAP-IG, the default flips to the
+    proposal's ``ig_steps=5`` (EAP-IG is the faithful default); until then the
+    default is the only executable value, ``ig_steps=1``.
+
+    Attributes:
+        granularity: ``"node"`` or ``"edge"``. Defaults to ``"node"``.
+        ig_steps: Integrated-gradient path steps (``>=1``). Defaults to ``1``.
+    """
+
+    granularity: Granularity = "node"
+    ig_steps: int = 1
+
+    def __post_init__(self) -> None:
+        if self.ig_steps < 1:
+            raise ValueError(f"ig_steps must be >= 1, got {self.ig_steps}")
+        if self.granularity == "edge":
+            raise NotImplementedError(
+                "granularity='edge' (EAP edge scoring) lands in PR2; this substrate "
+                "PR implements granularity='node' only."
+            )
+        if self.ig_steps > 1:
+            raise NotImplementedError(
+                "ig_steps>1 (EAP-IG integrated gradients) lands in PR3; this substrate "
+                "PR implements ig_steps=1 (plain attribution) only."
+            )
+
+
+@dataclass
+class AttributionResult:
+    """Scored output of an attribution-patching sweep.
+
+    Attributes:
+        node_scores: Signed first-order effect estimate per node,
+            ``(a_clean - a_corrupt) . d(metric)/d(a)``. A positive score means
+            patching that node from corrupt toward clean moves the metric in the
+            positive direction (the denoising convention pinned in the module
+            docstring).
+        edge_scores: Per-edge effect estimate keyed by ``(source, destination)``.
+            Declared here so the result API is stable across the PR series; it is
+            populated only from PR2 (edge sweep) and is empty for a node sweep.
+    """
+
+    node_scores: dict[Node, float]
+    edge_scores: dict[tuple[Node, Node], float] = field(default_factory=dict)
+
+    def top_nodes(self, k: int = 10) -> list[tuple[Node, float]]:
+        """The ``k`` nodes with the largest effect magnitude, strongest first.
+
+        Ranking is by absolute score: a node with a large negative effect is as
+        causally important as one with a large positive effect, so magnitude — not
+        signed value — orders the circuit. Ties keep enumeration order (stable
+        sort). Requesting more than the available nodes returns all of them.
+        """
+        ranked = sorted(self.node_scores.items(), key=lambda item: abs(item[1]), reverse=True)
+        return ranked[:k]
+
+    def top_edges(self, k: int = 10) -> list[tuple[Node, Node, float]]:
+        """The ``k`` highest-magnitude edges — populated from PR2's edge sweep."""
+        raise NotImplementedError(
+            "edge scoring lands in PR2; run a node-granularity sweep and use "
+            "top_nodes() in this PR."
+        )
 
 
 def _required_hook_names(n_layers: int) -> list[str]:

--- a/transformer_lens/tools/analysis/attribution_patching.py
+++ b/transformer_lens/tools/analysis/attribution_patching.py
@@ -313,3 +313,115 @@ def cache_activation_and_gradient(
         name: live[name].grad for name in names if name in live
     }
     return GradientCache(activations=activations, gradients=gradients, metric=metric.detach())
+
+
+def _node_effects(
+    clean_cache: GradientCache,
+    corrupt_cache: GradientCache,
+    nodes: Sequence[Node],
+) -> dict[Node, float]:
+    """Score every node with the first-order attribution ``(a_clean - a_corrupt) . g``.
+
+    The gradient ``g`` is taken from the corrupt cache (denoising convention). For
+    each node the feature dimension (``d_model``, or ``d_head`` for an attention
+    head) is contracted at the node's position/head, giving one signed scalar.
+    """
+    scores: dict[Node, float] = {}
+    for node in nodes:
+        name = node.hook_name
+        grad = corrupt_cache.gradients.get(name)
+        if grad is None:
+            raise ValueError(
+                f"node {node} reads {name!r}, but the corrupt cache holds no gradient "
+                "there; cache with a names_filter that retains this hook point."
+            )
+        delta = clean_cache.activations[name] - corrupt_cache.activations[name]
+        contribution = delta * grad
+        if node.kind == "attn_head_out":
+            value = contribution[0, node.position, node.head].sum()
+        else:
+            value = contribution[0, node.position].sum()
+        scores[node] = float(value)
+    return scores
+
+
+def attribution_patch(
+    model: Any,
+    clean: torch.Tensor,
+    corrupt: torch.Tensor,
+    metric_fn: MetricFn,
+    config: EdgeAttributionConfig = EdgeAttributionConfig(),
+) -> AttributionResult:
+    """Estimate every node's causal effect on ``metric_fn`` in two forwards + one backward.
+
+    For each clean/corrupt pair this runs a clean forward (for ``a_clean``) and a
+    corrupt forward with retained gradients plus a manual ``metric.backward()`` (for
+    ``a_corrupt`` and ``g = d(metric)/d(a)``), then scores each node with the
+    first-order Taylor estimate ``effect(node) = (a_clean - a_corrupt) . g``.
+
+    Sign/direction convention (denoising form): gradients are taken on the *corrupt*
+    run and the estimate points *toward* the clean activation, so a positive score
+    means patching that node from corrupt toward clean moves the metric in the
+    positive direction. PR5's oracle-parity test maps this convention onto the
+    pinned reference rather than assuming the two agree.
+
+    Dataset averaging: ``clean``/``corrupt`` may hold a batch of prompt pairs. Each
+    pair is scored independently (per-example forward/backward, so its own
+    reconstruction identity holds) and per-node scores are averaged across the batch
+    before ranking (proposal step 6).
+
+    Args:
+        model: A ``TransformerBridge`` (or compatible) exposing ``cfg.n_layers``,
+            ``hook_dict``, and ``hooks()``.
+        clean: Clean token ids, shape ``[batch, seq]``.
+        corrupt: Corrupt token ids, shape ``[batch, seq]``, paired row-by-row with
+            ``clean``.
+        metric_fn: Maps single-example logits to a scalar to differentiate.
+        config: Sweep configuration. This PR supports node granularity with plain
+            attribution (``ig_steps=1``) only; other values raise at construction.
+
+    Returns:
+        An :class:`AttributionResult` whose ``node_scores`` are averaged over the
+        batch. ``edge_scores`` stays empty until PR2.
+
+    Raises:
+        ValueError: if ``clean``/``corrupt`` are not 2D, hold a different number of
+            pairs, or a pair tokenizes to different lengths (activations must align
+            position-by-position).
+    """
+    del config  # node granularity + ig_steps=1 only this PR; enforced at construction.
+
+    if clean.ndim != 2 or corrupt.ndim != 2:
+        raise ValueError(
+            "attribution_patch expects 2D [batch, seq] token tensors, got clean "
+            f"{tuple(clean.shape)} and corrupt {tuple(corrupt.shape)}"
+        )
+    if clean.shape[0] != corrupt.shape[0]:
+        raise ValueError(
+            "clean and corrupt must hold the same number of prompt pairs, got "
+            f"{clean.shape[0]} and {corrupt.shape[0]}"
+        )
+    if clean.shape[1] != corrupt.shape[1]:
+        raise ValueError(
+            "each clean/corrupt pair must tokenize to the same length; got clean "
+            f"length {clean.shape[1]} and corrupt length {corrupt.shape[1]}. "
+            "Attribution patching aligns activations position-by-position."
+        )
+
+    node_hook_names = _required_hook_names(int(model.cfg.n_layers))
+    batch = int(clean.shape[0])
+    totals: dict[Node, float] = {}
+
+    for index in range(batch):
+        clean_cache = cache_activation_and_gradient(
+            model, clean[index : index + 1], metric_fn, names_filter=node_hook_names
+        )
+        corrupt_cache = cache_activation_and_gradient(
+            model, corrupt[index : index + 1], metric_fn, names_filter=node_hook_names
+        )
+        nodes = enumerate_nodes(model, corrupt_cache)
+        for node, score in _node_effects(clean_cache, corrupt_cache, nodes).items():
+            totals[node] = totals.get(node, 0.0) + score
+
+    node_scores = {node: total / batch for node, total in totals.items()}
+    return AttributionResult(node_scores=node_scores)

--- a/transformer_lens/tools/analysis/attribution_patching.py
+++ b/transformer_lens/tools/analysis/attribution_patching.py
@@ -266,8 +266,9 @@ def cache_activation_and_gradient(
     tokens: torch.Tensor,
     metric_fn: MetricFn,
     names_filter: NamesFilter = None,
+    compute_gradient: bool = True,
 ) -> GradientCache:
-    """Run one forward and capture activations plus their metric-gradients.
+    """Run one forward and capture activations plus (optionally) their metric-gradients.
 
     Registers a forward hook and a backward hook at each cached point, runs one
     grad-enabled forward, then drives a single backward with
@@ -286,6 +287,12 @@ def cache_activation_and_gradient(
     keeps it off every parameter's ``.grad`` buffer — no caller grads clobbered, no
     model-sized buffer allocated.
 
+    With ``compute_gradient=False`` the backward is skipped entirely: only forward
+    hooks are registered, no backward is driven, and every cached point's gradient
+    is ``None``. Callers that read activations only (the clean pass of
+    :func:`attribution_patch`, which pairs these with the *corrupt* run's gradients)
+    use this to run a plain forward instead of a needless forward + backward.
+
     Args:
         model: A ``TransformerBridge`` (or compatible) exposing ``hook_dict`` and
             the ``hooks()`` context manager.
@@ -293,11 +300,15 @@ def cache_activation_and_gradient(
         metric_fn: Maps the model logits to a scalar to differentiate.
         names_filter: Restricts which hook points are cached (and have gradients
             retained). ``None`` caches every hook point.
+        compute_gradient: When ``True`` (default) capture gradients via backward
+            hooks. When ``False`` run an activation-only forward and leave every
+            gradient ``None``.
 
     Returns:
-        A :class:`GradientCache` with per-hook activations and gradients.
+        A :class:`GradientCache` with per-hook activations, and gradients when
+        ``compute_gradient`` is ``True`` (all ``None`` otherwise).
     """
-    if not torch.is_grad_enabled():
+    if compute_gradient and not torch.is_grad_enabled():
         raise ValueError(
             "cache_activation_and_gradient needs autograd, but gradient tracking "
             "is off (torch.no_grad(), set_grad_enabled(False), or inference mode)."
@@ -332,6 +343,21 @@ def cache_activation_and_gradient(
         return hook
 
     fwd_hooks = [(name, make_fwd_hook(name)) for name in names]
+
+    if not compute_gradient:
+        with model.hooks(fwd_hooks=fwd_hooks):
+            logits = model(tokens)
+            metric = metric_fn(logits)
+            if metric.dim() != 0:
+                raise ValueError(
+                    f"metric_fn must return a scalar tensor, got shape {tuple(metric.shape)}"
+                )
+        return GradientCache(
+            activations=activations,
+            gradients={name: None for name in activations},
+            metric=metric.detach(),
+        )
+
     bwd_hooks = [(name, make_bwd_hook(name)) for name in names]
 
     with model.hooks(fwd_hooks=fwd_hooks, bwd_hooks=bwd_hooks):
@@ -466,7 +492,11 @@ def attribution_patch(
 
     for index in range(batch):
         clean_cache = cache_activation_and_gradient(
-            model, clean[index : index + 1], metric_fn, names_filter=node_hook_names
+            model,
+            clean[index : index + 1],
+            metric_fn,
+            names_filter=node_hook_names,
+            compute_gradient=False,
         )
         corrupt_cache = cache_activation_and_gradient(
             model, corrupt[index : index + 1], metric_fn, names_filter=node_hook_names

--- a/transformer_lens/tools/analysis/attribution_patching.py
+++ b/transformer_lens/tools/analysis/attribution_patching.py
@@ -15,16 +15,16 @@ Only the ``TransformerBridge`` API is targeted; TransformerLens v4 deprecates
 Sign/direction convention (denoising form): the gradient is taken on the
 *corrupt* run and the estimate points *toward* the clean activation, so a
 positive score means patching that node from corrupt toward clean moves the
-metric in the positive direction. The oracle-parity test (PR5) maps this
-convention onto the pinned reference rather than assuming the two agree.
+metric in the positive direction. An oracle-parity test maps this convention
+onto a pinned reference rather than assuming the two agree.
 
 Memory note: gradients are retained only for hook points passing ``names_filter``.
 Retaining gradients at every hook point roughly doubles cache memory, so callers
 should filter to the hook families their analysis actually reads.
 
-Scope: this PR ships node granularity with plain attribution (``ig_steps=1``).
+Scope: this build ships node granularity with plain attribution (``ig_steps=1``).
 Edge scoring (EAP), the integrated-gradient path (EAP-IG, ``ig_steps>1``), and
-ablate-outside faithfulness land in follow-on PRs; their API is declared here —
+ablate-outside faithfulness are not implemented yet; their API is declared here —
 ``granularity="edge"`` and ``ig_steps>1`` raise :class:`NotImplementedError` — so
 downstream code can pin against a stable surface now.
 """
@@ -72,7 +72,7 @@ class Node:
 
     ``position`` is the sequence index the node is read at. The invariants above
     are enforced in ``__post_init__`` so a malformed key raises rather than
-    silently producing a wrong graph (Risk 1: the explicit-graph guard).
+    silently producing a wrong graph.
     """
 
     kind: NodeKind
@@ -131,13 +131,13 @@ class EdgeAttributionConfig:
     ``ig_steps`` exceeds 1. Collapsing them removes the invalid states (e.g.
     ``method="attribution", ig_steps=5``).
 
-    This substrate PR implements node granularity with plain attribution only.
+    This build implements node granularity with plain attribution only.
     ``granularity="edge"`` and ``ig_steps>1`` are accepted by the type but raise
     :class:`NotImplementedError` at construction, so downstream code can import and
-    reference this API now while the edge sweep (PR2) and the integrated-gradient
-    path (PR3) land later. When PR3 ships EAP-IG, the default flips to the
-    proposal's ``ig_steps=5`` (EAP-IG is the faithful default); until then the
-    default is the only executable value, ``ig_steps=1``.
+    reference this API now while edge scoring and the integrated-gradient path are
+    not implemented yet. Once EAP-IG lands, the default flips to ``ig_steps=5``
+    (EAP-IG is the faithful default); until then the default is the only executable
+    value, ``ig_steps=1``.
 
     Attributes:
         granularity: ``"node"`` or ``"edge"``. Defaults to ``"node"``.
@@ -152,13 +152,13 @@ class EdgeAttributionConfig:
             raise ValueError(f"ig_steps must be >= 1, got {self.ig_steps}")
         if self.granularity == "edge":
             raise NotImplementedError(
-                "granularity='edge' (EAP edge scoring) lands in PR2; this substrate "
-                "PR implements granularity='node' only."
+                "granularity='edge' (EAP edge scoring) is not implemented yet; this "
+                "build supports granularity='node' only."
             )
         if self.ig_steps > 1:
             raise NotImplementedError(
-                "ig_steps>1 (EAP-IG integrated gradients) lands in PR3; this substrate "
-                "PR implements ig_steps=1 (plain attribution) only."
+                "ig_steps>1 (EAP-IG integrated gradients) is not implemented yet; this "
+                "build supports ig_steps=1 (plain attribution) only."
             )
 
 
@@ -174,7 +174,7 @@ class AttributionResult:
             docstring).
         edge_scores: Per-edge effect estimate keyed by ``(source, destination)``.
             Declared here so the result API is stable across the PR series; it is
-            populated only from PR2 (edge sweep) and is empty for a node sweep.
+            populated only once edge scoring lands and is empty for a node sweep.
     """
 
     node_scores: dict[Node, float]
@@ -192,10 +192,10 @@ class AttributionResult:
         return ranked[:k]
 
     def top_edges(self, k: int = 10) -> list[tuple[Node, Node, float]]:
-        """The ``k`` highest-magnitude edges — populated from PR2's edge sweep."""
+        """The ``k`` highest-magnitude edges — populated once edge scoring lands."""
         raise NotImplementedError(
-            "edge scoring lands in PR2; run a node-granularity sweep and use "
-            "top_nodes() in this PR."
+            "edge scoring is not implemented yet; run a node-granularity sweep and "
+            "use top_nodes()."
         )
 
 
@@ -225,7 +225,7 @@ def enumerate_nodes(model: Any, cache: GradientCache) -> list[Node]:
 
     Raises:
         ValueError: if any required hook point is absent from ``cache`` — the
-            graph is never silently truncated (Risk 1).
+            graph is never silently truncated.
     """
     n_layers = int(model.cfg.n_layers)
     missing = [name for name in _required_hook_names(n_layers) if name not in cache.activations]
@@ -452,13 +452,13 @@ def attribution_patch(
     Sign/direction convention (denoising form): gradients are taken on the *corrupt*
     run and the estimate points *toward* the clean activation, so a positive score
     means patching that node from corrupt toward clean moves the metric in the
-    positive direction. PR5's oracle-parity test maps this convention onto the
-    pinned reference rather than assuming the two agree.
+    positive direction. An oracle-parity test maps this convention onto a pinned
+    reference rather than assuming the two agree.
 
     Dataset averaging: ``clean``/``corrupt`` may hold a batch of prompt pairs. Each
     pair is scored independently (per-example forward/backward, so its own
     reconstruction identity holds) and per-node scores are averaged across the batch
-    before ranking (proposal step 6).
+    before ranking.
 
     Args:
         model: A ``TransformerBridge`` (or compatible) exposing ``cfg.n_layers``,
@@ -472,14 +472,14 @@ def attribution_patch(
 
     Returns:
         An :class:`AttributionResult` whose ``node_scores`` are averaged over the
-        batch. ``edge_scores`` stays empty until PR2.
+        batch. ``edge_scores`` stays empty until edge scoring lands.
 
     Raises:
         ValueError: if ``clean``/``corrupt`` are not 2D, hold a different number of
             pairs, or a pair tokenizes to different lengths (activations must align
             position-by-position).
     """
-    del config  # node granularity + ig_steps=1 only this PR; enforced at construction.
+    del config  # node granularity + ig_steps=1 only; enforced at construction.
 
     if clean.ndim != 2 or corrupt.ndim != 2:
         raise ValueError(

--- a/transformer_lens/tools/analysis/attribution_patching.py
+++ b/transformer_lens/tools/analysis/attribution_patching.py
@@ -3,9 +3,9 @@
 Attribution patching estimates the causal effect of every model component on a
 task metric with a *gradient-based linearization* of activation patching: rather
 than one forward pass per intervention, it reads a single gradient cache. For a
-clean/corrupt prompt pair it runs a clean forward (for ``a_clean``), a corrupt
-forward with retained gradients plus a manual ``metric.backward()`` (for
-``a_corrupt`` and ``g = d(metric)/d(a)``), and scores each node with the
+clean/corrupt prompt pair it runs a clean forward (for ``a_clean``) and a corrupt
+forward whose backward hooks capture ``g = d(metric)/d(a)`` (for ``a_corrupt`` and
+its gradient), and scores each node with the
 first-order Taylor estimate ``effect(node) = (a_clean - a_corrupt) . g``. Scores
 over a batch of clean/corrupt pairs are averaged before ranking.
 
@@ -267,11 +267,24 @@ def cache_activation_and_gradient(
     metric_fn: MetricFn,
     names_filter: NamesFilter = None,
 ) -> GradientCache:
-    """Run one forward + one manual backward, caching activations and gradients.
+    """Run one forward and capture activations plus their metric-gradients.
 
+    Registers a forward hook and a backward hook at each cached point, runs one
+    grad-enabled forward, then drives a single backward with
+    :func:`torch.autograd.grad` to fire the backward hooks.
     ``run_with_cache(..., incl_bwd=True)`` only backpropagates the model's own
     scalar output, so a custom (non-scalar-output) metric such as a logit-diff
-    needs the backward call done by hand — that is what this helper does.
+    needs the backward driven here.
+
+    Gradients come from the backward hooks, not from ``.grad`` on the cached
+    tensors. ``TransformerBridge`` reshapes the tensor handed to a forward hook at
+    a converted point (``attn.hook_z``, ``hook_q/k/v``, ``hook_attn_out``), so that
+    tensor is a view the model's forward never consumes: ``retain_grad()`` on it is
+    inert and its ``.grad`` stays ``None``. A backward hook goes through the same
+    conversion and delivers the real gradient in canonical shape. Driving the
+    backward with :func:`torch.autograd.grad` instead of ``metric.backward()``
+    keeps it off every parameter's ``.grad`` buffer — no caller grads clobbered, no
+    model-sized buffer allocated.
 
     Args:
         model: A ``TransformerBridge`` (or compatible) exposing ``hook_dict`` and
@@ -297,32 +310,60 @@ def cache_activation_and_gradient(
 
     live: dict[str, torch.Tensor] = {}
     activations: dict[str, torch.Tensor] = {}
+    gradients: dict[str, Optional[torch.Tensor]] = {}
 
-    def make_hook(name: str) -> Callable[..., None]:
+    def make_fwd_hook(name: str) -> Callable[..., None]:
         def hook(tensor: torch.Tensor, *, hook: Any) -> None:
             del hook
             if isinstance(tensor, torch.Tensor):
-                tensor.retain_grad()
                 live[name] = tensor
                 activations[name] = tensor.detach().clone()
             return None
 
         return hook
 
-    fwd_hooks = [(name, make_hook(name)) for name in names]
+    def make_bwd_hook(name: str) -> Callable[..., None]:
+        def hook(grad: torch.Tensor, *, hook: Any) -> None:
+            del hook
+            if isinstance(grad, torch.Tensor):
+                gradients[name] = grad.detach().clone()
+            return None
 
-    model.zero_grad(set_to_none=True)
-    with model.hooks(fwd_hooks=fwd_hooks):
+        return hook
+
+    fwd_hooks = [(name, make_fwd_hook(name)) for name in names]
+    bwd_hooks = [(name, make_bwd_hook(name)) for name in names]
+
+    with model.hooks(fwd_hooks=fwd_hooks, bwd_hooks=bwd_hooks):
         logits = model(tokens)
+        metric = metric_fn(logits)
+        if metric.dim() != 0:
+            raise ValueError(
+                f"metric_fn must return a scalar tensor, got shape {tuple(metric.shape)}"
+            )
+        captured_names = [name for name in names if name in live]
+        # torch.autograd.grad only *drives* the backward; the gradients we keep are
+        # the converted-shape ones the backward hooks write into `gradients`. Unlike
+        # metric.backward() it touches no parameter `.grad` buffer.
+        returned = (
+            torch.autograd.grad(
+                metric,
+                inputs=[live[name] for name in captured_names],
+                allow_unused=True,
+                retain_graph=False,
+            )
+            if captured_names
+            else ()
+        )
 
-    metric = metric_fn(logits)
-    if metric.dim() != 0:
-        raise ValueError(f"metric_fn must return a scalar tensor, got shape {tuple(metric.shape)}")
-    metric.backward()
+    # The most-upstream cached point's own backward hook never fires — nothing
+    # requested is upstream of it, so the backward stops at it — but its cached
+    # tensor is on-path and unconverted, so torch.autograd.grad returns that
+    # gradient directly. Backfill any point the hooks missed from that return.
+    for name, grad in zip(captured_names, returned):
+        if gradients.get(name) is None:
+            gradients[name] = None if grad is None else grad.detach().clone()
 
-    gradients: dict[str, Optional[torch.Tensor]] = {
-        name: live[name].grad for name in names if name in live
-    }
     return GradientCache(activations=activations, gradients=gradients, metric=metric.detach())
 
 
@@ -366,8 +407,8 @@ def attribution_patch(
     """Estimate every node's causal effect on ``metric_fn`` in two forwards + one backward.
 
     For each clean/corrupt pair this runs a clean forward (for ``a_clean``) and a
-    corrupt forward with retained gradients plus a manual ``metric.backward()`` (for
-    ``a_corrupt`` and ``g = d(metric)/d(a)``), then scores each node with the
+    corrupt forward whose backward hooks capture ``g = d(metric)/d(a)`` (for
+    ``a_corrupt`` and its gradient), then scores each node with the
     first-order Taylor estimate ``effect(node) = (a_clean - a_corrupt) . g``.
 
     Sign/direction convention (denoising form): gradients are taken on the *corrupt*


### PR DESCRIPTION
---

### Summary

Adds `attribution_patching`, a new analysis tool under `transformer_lens/tools/analysis/`, together with its reusable substrate and public API. This first PR ships **node-level (first-order Taylor) attribution only**. The API surface (`granularity`, `ig_steps`) is designed here so it stays stable across the planned series — edge scoring (EAP), the integrated-gradient path (EAP-IG), ablate-outside faithfulness, oracle parity, and the demo land in follow-on PRs

Attribution patching estimates the causal effect of every residual-stream component on a task metric by reading a single gradient cache instead of running one forward pass per intervention. For a clean/corrupt prompt pair it runs a clean forward (for `a_clean`), a corrupt forward with retained gradients plus a manual `metric.backward()` (for `a_corrupt` and `g = d(metric)/d(a)`), and scores each node with the first-order estimate `effect(node) = (a_clean − a_corrupt) · g`. Per-node scores are averaged across a batch of clean/corrupt pairs before ranking.

Everything targets the `TransformerBridge` API exclusively; there is no new reference to `HookedTransformer`.

---

### What's included

- **Names-filtered gradient-cache substrate.** A helper runs a Bridge forward with a names filter, retains gradients only on the requested hook families, and invokes the user metric with a manual `metric.backward()` — necessary because `run_with_cache(..., incl_bwd=True)` only backprops the model's scalar output, not a custom logit-diff metric. Retaining gradients everywhere roughly doubles cache memory, so callers filter to the hook families their analysis reads.
- **Typed computational-graph node model.** A `Node` dataclass keyed by `(layer, position, head, kind)` with node families for embed / attn-head-out / mlp-out, enumerated from the Bridge hook graph. A missing required hook point raises rather than being silently skipped.
- **Config + result API.** `EdgeAttributionConfig` exposes `granularity` (`"node"` | `"edge"`) and `ig_steps` (int) only — there is deliberately no `method` field, which collapses the overlapping axes flagged in review; `ig_steps=1` is plain attribution/EAP. `AttributionResult` carries `node_scores` and `top_nodes(k=...)`. `granularity="edge"` and `ig_steps>1` raise`NotImplementedError` pointing at the follow-on PRs, so downstream code can pin against a stable surface now.
- **`attribution_patch` entry point** assembling two forwards and one manual backward, with token-length parity validation (mismatched clean/corrupt tokenization raises) and dataset averaging across a batch of pairs.
- **Pinned sign/direction convention** (denoising form): the gradient is taken on the corrupt run and the estimate points toward the clean activation, so a positive score means patching that node from corrupt toward clean moves the metric in the positive direction. The docstring notes a follow-on PR will map this convention onto the pinned oracle rather than assuming the two agree.
- **Linear-model reconstruction identity test.** A tiny `TransformerBridge` (chosen over a model-free stub so the real hook graph and cache plumbing are exercised end-to-end) is configured to be linear — identity MLP activation, a metric linear in the logits, frozen attention patterns, and LayerNorm scale treated as constant — so the first-order identity is exact. The test asserts summed node attributions equal `m(clean) − m(corrupt)` under tight `atol`, and asserts the documented sign/direction. Exact equality is a linear-network property and does not hold for a stock nonlinear config; the test documents this constraint.

---

### Files

- `transformer_lens/tools/analysis/attribution_patching.py` (new)
- `transformer_lens/tools/analysis/__init__.py` (exports `attribution_patch`, `EdgeAttributionConfig`, `AttributionResult`, `Node`; `__all__` updated)
- `tests/unit/tools/test_attribution_patching.py` (new)

---

### Scope / follow-ups

Node granularity only in this PR. The following land in follow-on PRs:

- Faithfulness default (corrupt-patch / ablate-outside)
- Edge scoring (EAP)
- Integrated gradients (EAP-IG, `ig_steps>1`)
- Oracle parity
- The uniquely-named demo notebook

Addresses part of #1742 — this PR covers node-granularity attribution patching; edge scoring (EAP) and integrated gradients (EAP-IG), which #1742 also asks for, are tracked as follow-on work above.

---

### Checklist

- [x] `make unit-test` green
- [x] `uv run mypy .` clean
- [x] `make format` applied
- [x] Linear-model reconstruction identity holds under exact equality
- [x] Token-length parity and missing-hook paths raise
- [x] API is `granularity` + `ig_steps` only; `edge` / `ig_steps>1` raise `NotImplementedError`
- [x] No new reference to `HookedTransformer`; all model interaction via `TransformerBridge`

---
