### PR TITLE
fix(demos): port direct path patching demo to TransformerBridge

### DIFF
--- a/demos/direct_path_patching_ioi.ipynb
+++ b/demos/direct_path_patching_ioi.ipynb
@@ -62,8 +62,8 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "from transformer_lens import HookedTransformer\n",
-    "from transformer_lens.direct_path_patching import get_act_patch_direct_path"
+    "from transformer_lens.model_bridge import TransformerBridge\n",
+    "from transformer_lens.tools.analysis.direct_path_patching import get_act_patch_direct_path"
    ]
   },
   {
@@ -79,12 +79,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = HookedTransformer.from_pretrained(\n",
-    "    \"gpt2\",\n",
-    "    center_unembed=True,\n",
-    "    center_writing_weights=True,\n",
-    "    fold_ln=True,\n",
-    ")\n",
+    "model = TransformerBridge.boot_transformers(\"gpt2\")\n",
+    "model.enable_compatibility_mode()\n",
     "model.eval()\n",
     "print(f\"Loaded GPT-2 small: {model.cfg.n_layers} layers, {model.cfg.n_heads} heads\")"
    ]

--- a/makefile
+++ b/makefile
@@ -60,6 +60,7 @@ notebook-test:
 	$(RUN) pytest --nbval-sanitize-with demos/doc_sanitize.cfg demos/Stable_Lm.ipynb $(RERUN_ARGS)
 	$(RUN) pytest --nbval-sanitize-with demos/doc_sanitize.cfg demos/SVD_Interpreter_Demo.ipynb $(RERUN_ARGS)
 	$(RUN) pytest --nbval-sanitize-with demos/doc_sanitize.cfg demos/Tracr_to_Transformer_Lens_Demo.ipynb $(RERUN_ARGS)
+	$(RUN) pytest --nbval-sanitize-with demos/doc_sanitize.cfg demos/direct_path_patching_ioi.ipynb $(RERUN_ARGS)
 
 	# Contains failing cells
 


### PR DESCRIPTION
# Description

Fixes the broken `demos/direct_path_patching_ioi.ipynb` notebook and aligns it with TransformerLens v4:
- Updates the import to `from transformer_lens.tools.analysis.direct_path_patching import get_act_patch_direct_path` (reflecting its location in `tools/analysis`).
- Migrates model loading from deprecated `HookedTransformer.from_pretrained` to `TransformerBridge.boot_transformers("gpt2")` with `enable_compatibility_mode()`.
- Adds `demos/direct_path_patching_ioi.ipynb` to `makefile` under `notebook-test` so CI catches future regressions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility