### PR TITLE
Clarify quantized dtype ownership; keep the whole-model skip (#1743)

### DIFF
--- a/tests/unit/utilities/test_multi_gpu_unit.py
+++ b/tests/unit/utilities/test_multi_gpu_unit.py
@@ -300,9 +300,20 @@ class TestMaybeCastFloatingParams:
         assert model.weight.dtype == torch.bfloat16
 
     def test_skips_quantized_model(self):
-        """Quantized models should NOT have their params cast."""
-        from types import SimpleNamespace
+        """An active quantizer means HF owns the storage dtypes, so nothing is cast.
 
+        The skip is whole-model deliberately. ``from_pretrained`` is responsible for
+        applying the requested dtype to ordinary floating parameters before this helper
+        runs, and TransformerLens must not second-guess quantizer-owned storage
+        afterward. Any parameter still off the requested dtype here may be
+        quantizer-owned, and dtype alone cannot distinguish ownership safely (see
+        ``test_itemsize_guard_does_not_identify_quantizer_owned_scales``). transformers
+        draws the same line itself: ``.to(dtype=...)`` raises for bitsandbytes and
+        GPTQ models, ``.half()`` / ``.float()`` for any quantized model.
+
+        See: https://github.com/TransformerLensOrg/TransformerLens/issues/1713
+        See: https://github.com/TransformerLensOrg/TransformerLens/issues/1743
+        """
         from transformer_lens.utilities.multi_gpu import maybe_cast_floating_params
 
         model = nn.Linear(4, 4)
@@ -311,6 +322,28 @@ class TestMaybeCastFloatingParams:
 
         maybe_cast_floating_params(model, torch.bfloat16)
         assert model.weight.dtype == torch.float32  # NOT cast
+
+    @pytest.mark.parametrize("scale_fmt", ["ue8m0", "float"])
+    def test_preserves_quantizer_owned_scales_of_any_width(self, scale_fmt):
+        """Both widths of ``weight_scale_inv`` survive, which the dtype guard cannot do.
+
+        The ordinary parameter is set up as the loader would have delivered it, at the
+        requested dtype, so the correct outcome for the whole model is that nothing
+        moves. Under ``scale_fmt="float"`` the scale is float32, so this fails outright
+        if the cast is ever re-enabled behind only the one-byte-float guard.
+        """
+        from transformer_lens.utilities.multi_gpu import maybe_cast_floating_params
+
+        model = nn.Module()
+        model.quantized = _fp8_linear(scale_fmt)
+        model.ln_weight = nn.Parameter(torch.ones(4, dtype=torch.bfloat16))
+        model.config = SimpleNamespace(quantization_config=SimpleNamespace(quant_method="fp8"))
+
+        before = {name: param.dtype for name, param in model.named_parameters()}
+        maybe_cast_floating_params(model, torch.bfloat16)
+
+        assert {name: param.dtype for name, param in model.named_parameters()} == before
+        assert model.quantized.weight_scale_inv.dtype == before["quantized.weight_scale_inv"]
 
     def test_skips_model_without_config(self):
         """Models without a config attribute should be cast (no quantization)."""

--- a/tests/unit/utilities/test_multi_gpu_unit.py
+++ b/tests/unit/utilities/test_multi_gpu_unit.py
@@ -135,6 +135,31 @@ class TestGetDeviceForBlockIndex:
         assert result.type == "cpu"
 
 
+def _fp8_linear(scale_fmt: str) -> nn.Module:
+    """A real transformers finegrained-FP8 ``Linear``, or skip if the integration moved."""
+    integration = pytest.importorskip(
+        "transformers.integrations.finegrained_fp8",
+        reason="requires transformers' finegrained-FP8 integration",
+    )
+    fp8_linear = getattr(integration, "FP8Linear", None)
+    if fp8_linear is None:
+        pytest.skip("transformers.integrations.finegrained_fp8.FP8Linear is unavailable")
+    return fp8_linear(
+        in_features=128,
+        out_features=128,
+        block_size=(128, 128),
+        activation_scheme="static",
+        scale_fmt=scale_fmt,
+        has_bias=True,
+    )
+
+
+# Quantizer-owned storage on FP8Linear: the packed weight and its scales. ``bias`` is
+# excluded on purpose -- HF keeps biases in the model's compute dtype, so a bias is an
+# ordinary parameter that the quantizer does not own.
+_FP8_OWNED_PARAMS = ("weight", "weight_scale_inv", "activation_scale")
+
+
 class TestCastFloatingParamsToDtype:
     """Regression tests for cast_floating_params_to_dtype.
 
@@ -211,6 +236,46 @@ class TestCastFloatingParamsToDtype:
         assert model.standard_weight.dtype == torch.bfloat16
         assert model.fp8_scale.dtype == torch.float8_e4m3fn
         assert model.packed_weight.dtype == torch.int8
+
+    @pytest.mark.parametrize("scale_fmt", ["ue8m0", "float"])
+    def test_itemsize_guard_does_not_identify_quantizer_owned_scales(self, scale_fmt):
+        """``itemsize < 2`` is a narrow-float guard, not an ownership test.
+
+        Transformers picks ``weight_scale_inv``'s storage dtype from the checkpoint's
+        ``scale_fmt``: a one-byte UE8M0 float for "ue8m0", float32 for "float" (the
+        default). Both spell the same quantizer-owned scale, and ``activation_scale``
+        is float32 under either format. So a one-byte test protects some quantizer-owned
+        scales and silently rewrites others, which is why the cast has to be gated on
+        the model having no active quantizer rather than on per-parameter dtype.
+
+        See: https://github.com/TransformerLensOrg/TransformerLens/issues/1743
+        """
+        target = torch.bfloat16
+        module = _fp8_linear(scale_fmt)
+        before = {name: param.dtype for name, param in module.named_parameters()}
+        cast_floating_params_to_dtype(module, target)
+        after = {name: param.dtype for name, param in module.named_parameters()}
+
+        owned = {name: before[name] for name in _FP8_OWNED_PARAMS if name in before}
+        assert owned, "FP8Linear exposed none of its quantizer-owned parameters"
+        # Mirror the cast's whole predicate, not dtype width alone: it rewrites a
+        # parameter only when that parameter is floating, wider than one byte and not
+        # already at the target. (Its fourth condition, meta, cannot apply to this
+        # materialized fixture.) Deriving the set this way stays correct if
+        # transformers moves `weight` to a wide packed-integer storage like GPTQ's
+        # int32, which the cast is right to skip.
+        eligible = {
+            name
+            for name, dtype in owned.items()
+            if dtype.is_floating_point and dtype.itemsize >= 2 and dtype != target
+        }
+        assert eligible, "expected a quantizer-owned float wider than one byte"
+        rewritten = {name for name, dtype in owned.items() if after[name] != dtype}
+        assert rewritten == eligible, (
+            "the cast should rewrite exactly those quantizer-owned parameters eligible "
+            f"under its dtype-only predicate: rewritten={sorted(rewritten)} "
+            f"eligible={sorted(eligible)}"
+        )
 
 
 class TestMaybeCastFloatingParams:

--- a/tests/unit/utilities/test_multi_gpu_unit.py
+++ b/tests/unit/utilities/test_multi_gpu_unit.py
@@ -345,6 +345,48 @@ class TestMaybeCastFloatingParams:
         assert {name: param.dtype for name, param in model.named_parameters()} == before
         assert model.quantized.weight_scale_inv.dtype == before["quantized.weight_scale_inv"]
 
+    def test_casts_once_hf_releases_quantizer_ownership(self):
+        """The guard is a hand-off, not a permanent opt-out.
+
+        ``HfQuantizer.postprocess_model`` calls ``remove_quantization_config`` when a
+        checkpoint is loaded with ``dequantize=True``, which deletes
+        ``config.quantization_config``. ``quantization_method`` then returns None and
+        normalization resumes. That is what stops the whole-model guard from stranding a
+        genuinely dequantized checkpoint in its load dtype.
+        """
+        from transformer_lens.utilities.multi_gpu import maybe_cast_floating_params
+
+        model = nn.Linear(4, 4)
+        model.weight = nn.Parameter(torch.zeros(4, 4, dtype=torch.float32))
+        model.config = SimpleNamespace(quantization_config=SimpleNamespace(quant_method="mxfp4"))
+
+        maybe_cast_floating_params(model, torch.bfloat16)
+        assert model.weight.dtype == torch.float32
+
+        del model.config.quantization_config  # what remove_quantization_config does
+        maybe_cast_floating_params(model, torch.bfloat16)
+        assert model.weight.dtype == torch.bfloat16
+
+    def test_hf_still_clears_quantization_config_when_dequantizing(self):
+        """Pins the upstream behaviour the whole-model guard is calibrated against.
+
+        If transformers ever stops deleting ``quantization_config`` on a dequantized
+        load, ``quantization_method`` would keep reporting a method for a model whose
+        storage the quantizer no longer owns, and the guard really would be too broad.
+        Fail here rather than silently stranding those checkpoints.
+        """
+        base = pytest.importorskip("transformers.quantizers.base")
+
+        model = nn.Linear(4, 4)
+        model.config = SimpleNamespace(quantization_config=SimpleNamespace(quant_method="mxfp4"))
+        model.is_quantized = True
+        # Called unbound: remove_quantization_config only touches `model`, and building
+        # a real quantizer would need a live quantization config per method.
+        base.HfQuantizer.remove_quantization_config(None, model)
+
+        assert not hasattr(model.config, "quantization_config")
+        assert model.is_quantized is False
+
     def test_skips_model_without_config(self):
         """Models without a config attribute should be cast (no quantization)."""
         from transformer_lens.utilities.multi_gpu import maybe_cast_floating_params

--- a/tests/unit/utilities/test_multi_gpu_unit.py
+++ b/tests/unit/utilities/test_multi_gpu_unit.py
@@ -144,6 +144,10 @@ def _fp8_linear(scale_fmt: str) -> nn.Module:
     fp8_linear = getattr(integration, "FP8Linear", None)
     if fp8_linear is None:
         pytest.skip("transformers.integrations.finegrained_fp8.FP8Linear is unavailable")
+    # ue8m0 scales go through _get_ue8m0_dtype, which raises rather than falling back
+    # when torch has no float8_e8m0fnu. pyproject allows torch>=2.6; this needs 2.7.
+    if scale_fmt == "ue8m0" and not hasattr(torch, "float8_e8m0fnu"):
+        pytest.skip("torch < 2.7")
     return fp8_linear(
         in_features=128,
         out_features=128,
@@ -155,8 +159,11 @@ def _fp8_linear(scale_fmt: str) -> nn.Module:
 
 
 # Quantizer-owned storage on FP8Linear: the packed weight and its scales. ``bias`` is
-# excluded on purpose -- HF keeps biases in the model's compute dtype, so a bias is an
-# ordinary parameter that the quantizer does not own.
+# excluded because the FP8 quantizers do not claim it: ``param_needs_quantization``
+# returns False for ``tensor_name == "bias"`` in both quantizer_finegrained_fp8.py and
+# quantizer_fbgemm_fp8.py. (Its storage dtype is not uniform either; fbgemm-FP8 hardcodes
+# a float32 bias while forcing the model to bfloat16, so "biases follow the compute
+# dtype" would be the wrong reason to exclude it.)
 _FP8_OWNED_PARAMS = ("weight", "weight_scale_inv", "activation_scale")
 
 
@@ -243,10 +250,11 @@ class TestCastFloatingParamsToDtype:
 
         Transformers picks ``weight_scale_inv``'s storage dtype from the checkpoint's
         ``scale_fmt``: a one-byte UE8M0 float for "ue8m0", float32 for "float" (the
-        default). Both spell the same quantizer-owned scale, and ``activation_scale``
-        is float32 under either format. So a one-byte test protects some quantizer-owned
-        scales and silently rewrites others, which is why the cast has to be gated on
-        the model having no active quantizer rather than on per-parameter dtype.
+        default). Both spell the same quantizer-owned scale. ``activation_scale``, which
+        this fixture requests via ``activation_scheme="static"``, is float32 under
+        either format. So a one-byte test protects some quantizer-owned scales and
+        silently rewrites others, which is why the cast has to be gated on the model
+        having no active quantizer rather than on per-parameter dtype.
 
         See: https://github.com/TransformerLensOrg/TransformerLens/issues/1743
         """
@@ -327,15 +335,20 @@ class TestMaybeCastFloatingParams:
     def test_preserves_quantizer_owned_scales_of_any_width(self, scale_fmt):
         """Both widths of ``weight_scale_inv`` survive, which the dtype guard cannot do.
 
-        The ordinary parameter is set up as the loader would have delivered it, at the
-        requested dtype, so the correct outcome for the whole model is that nothing
-        moves. Under ``scale_fmt="float"`` the scale is float32, so this fails outright
-        if the cast is ever re-enabled behind only the one-byte-float guard.
+        Every ordinary parameter is normalised to the target dtype in the fixture, so
+        the only thing this test can fail on is quantizer-owned storage. Under
+        ``scale_fmt="float"`` the scale is float32, so it fails outright if the cast is
+        ever re-enabled behind only the one-byte-float guard.
         """
         from transformer_lens.utilities.multi_gpu import maybe_cast_floating_params
 
         model = nn.Module()
         model.quantized = _fp8_linear(scale_fmt)
+        # FP8Linear allocates its bias at float32, but the quantizer does not claim it
+        # (see _FP8_OWNED_PARAMS), so it is not what this test is about. Normalise it to
+        # the target, or the assertion below also fires on a narrowing that correctly
+        # casts ordinary parameters, which this test's name disclaims.
+        model.quantized.bias = nn.Parameter(model.quantized.bias.to(torch.bfloat16))
         model.ln_weight = nn.Parameter(torch.ones(4, dtype=torch.bfloat16))
         model.config = SimpleNamespace(quantization_config=SimpleNamespace(quant_method="fp8"))
 
@@ -374,15 +387,40 @@ class TestMaybeCastFloatingParams:
         load, ``quantization_method`` would keep reporting a method for a model whose
         storage the quantizer no longer owns, and the guard really would be too broad.
         Fail here rather than silently stranding those checkpoints.
+
+        Drives ``postprocess_model`` rather than ``remove_quantization_config``: it is
+        the dequantize branch in the former that this design relies on, and calling the
+        latter directly would still pass if that branch were dropped.
         """
         base = pytest.importorskip("transformers.quantizers.base")
 
+        class _DequantizingQuantizer(base.HfQuantizer):
+            """Minimal quantizer standing in for any ``dequantize=True`` load."""
+
+            requires_calibration = False
+
+            def __init__(self):
+                self.quantization_config = SimpleNamespace(quant_method="mxfp4", dequantize=True)
+                self.pre_quantized = True
+
+            def _process_model_before_weight_loading(self, model, **kwargs):
+                return model
+
+            def _process_model_after_weight_loading(self, model, **kwargs):
+                return model
+
+            def is_serializable(self, safe_serialization=None):
+                return True
+
+            @property
+            def is_trainable(self):
+                return False
+
         model = nn.Linear(4, 4)
-        model.config = SimpleNamespace(quantization_config=SimpleNamespace(quant_method="mxfp4"))
+        model.config = SimpleNamespace()
         model.is_quantized = True
-        # Called unbound: remove_quantization_config only touches `model`, and building
-        # a real quantizer would need a live quantization config per method.
-        base.HfQuantizer.remove_quantization_config(None, model)
+
+        _DequantizingQuantizer().postprocess_model(model)
 
         assert not hasattr(model.config, "quantization_config")
         assert model.is_quantized is False

--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -847,8 +847,11 @@ def boot(
         # Cast params to dtype; preserve float32 buffers (e.g., RotaryEmbedding.inv_freq).
         # Use module-level alignment so Accelerate can temporarily materialize offloaded
         # parameters before we touch them.
-        # Skip dtype normalization entirely when model has an active quantizer: the
-        # quantizer owns specific dtypes (e.g., FP8 scales) that must not be overwritten.
+        # Skip dtype normalization entirely when the model has an active quantizer.
+        # `dtype` already went into from_pretrained above, which is the component
+        # responsible for applying it to ordinary floating parameters; anything still
+        # off the requested dtype here may be quantizer-owned storage, whose width is
+        # the quantizer's to choose (FP8 *or* float32 scales).
         from transformer_lens.utilities.multi_gpu import maybe_cast_floating_params
 
         maybe_cast_floating_params(hf_model, dtype)

--- a/transformer_lens/model_bridge/sources/transformers.py
+++ b/transformer_lens/model_bridge/sources/transformers.py
@@ -848,10 +848,12 @@ def boot(
         # Use module-level alignment so Accelerate can temporarily materialize offloaded
         # parameters before we touch them.
         # Skip dtype normalization entirely when the model has an active quantizer.
-        # `dtype` already went into from_pretrained above, which is the component
-        # responsible for applying it to ordinary floating parameters; anything still
-        # off the requested dtype here may be quantizer-owned storage, whose width is
-        # the quantizer's to choose (FP8 *or* float32 scales).
+        # from_pretrained settled the load dtype above, and on a quantized checkpoint
+        # that is the quantizer's effective dtype rather than necessarily the requested
+        # one (HfQuantizer.update_dtype lets AWQ, fbgemm-FP8 and FP-Quant override it;
+        # AWQ keys off CUDA/XPU being available at all, not off placement).
+        # Re-casting would overwrite those choices along with quantizer-owned storage,
+        # whose width is the quantizer's to choose (FP8 *or* float32 scales).
         from transformer_lens.utilities.multi_gpu import maybe_cast_floating_params
 
         maybe_cast_floating_params(hf_model, dtype)

--- a/transformer_lens/utilities/multi_gpu.py
+++ b/transformer_lens/utilities/multi_gpu.py
@@ -256,8 +256,9 @@ def cast_floating_params_to_dtype(model: nn.Module, dtype: torch.dtype) -> None:
 
     The one-byte-float skip below is a backstop against the worst corruption, not an
     ownership test. Quantizer-owned scales are float32 as often as FP8: transformers'
-    finegrained-FP8 integration picks between the two by ``scale_fmt``, and its
-    ``activation_scale`` is float32 either way. A dtype cannot say who owns a tensor.
+    finegrained-FP8 stores ``weight_scale_inv`` as float32 unless the checkpoint asks
+    for ue8m0 scales, and fbgemm-FP8 stores its scales as float32 outright. A dtype
+    cannot say who owns a tensor.
     See: https://github.com/TransformerLensOrg/TransformerLens/issues/1743
     """
     from accelerate.utils import align_module_device
@@ -281,24 +282,18 @@ def cast_floating_params_to_dtype(model: nn.Module, dtype: torch.dtype) -> None:
 def maybe_cast_floating_params(model: nn.Module, dtype: torch.dtype) -> None:
     """Cast floating params to dtype, skipping models with active quantization.
 
-    The skip is whole-model on purpose, and it is a division of responsibility rather
-    than a loss. ``from_pretrained`` is the component that applies the requested dtype
-    to ordinary floating parameters, and it has already run by this point; whatever is
-    still not at the requested dtype afterward may be quantizer-owned storage, and
-    dtype alone cannot distinguish ownership safely. (bitsandbytes 4-bit and 8-bit
-    checkpoints were checked and matched that division: every ordinary floating
-    parameter, embeddings and layernorms and quantized-layer biases alike, arrived
-    already converted. Not every quantization backend was reachable to test, which is
-    a further reason to leave the loader's result alone rather than re-derive it.)
+    The skip is whole-model on purpose. ``from_pretrained`` has already settled the
+    load dtype by this point, and on a quantized checkpoint that is the quantizer's
+    *effective* dtype, not necessarily the requested one: quantizers may override it
+    in ``HfQuantizer.update_dtype`` (AWQ downgrades bfloat16 to float16 whenever CUDA
+    or XPU is available, whatever the placement; fbgemm-FP8 and FP-Quant force
+    bfloat16). Re-casting here would overwrite those
+    deliberate choices along with genuinely quantizer-owned storage, and dtype alone
+    cannot tell the two apart.
 
-    transformers draws the same line itself:
-    ``PreTrainedModel.to(dtype=...)`` raises for bitsandbytes and GPTQ models, and
-    ``.half()`` / ``.float()`` raise for any quantized model ("the model has already
-    been casted to the correct dtype"), all gated on the same whole-model
-    ``is_quantized`` flag. The gate also releases in step with HF: a dequantized load
-    has its ``quantization_config`` deleted by
-    ``HfQuantizer.remove_quantization_config``, so ``quantization_method`` returns None
-    and normalization resumes.
+    The gate releases in step with HF: a dequantized load has its
+    ``quantization_config`` deleted by ``HfQuantizer.remove_quantization_config``, so
+    ``quantization_method`` returns None and normalization resumes.
 
     See: https://github.com/TransformerLensOrg/TransformerLens/issues/1713
     See: https://github.com/TransformerLensOrg/TransformerLens/issues/1743

--- a/transformer_lens/utilities/multi_gpu.py
+++ b/transformer_lens/utilities/multi_gpu.py
@@ -251,8 +251,14 @@ def is_mixed_cpu_gpu(values: Any) -> bool:
 def cast_floating_params_to_dtype(model: nn.Module, dtype: torch.dtype) -> None:
     """Cast materialized floating parameters while preserving Accelerate offload hooks.
 
-    Skips one-byte floats (FP8 dtypes like float8_e8m0fnu) which are quantizer-owned
-    scale parameters — casting them corrupts the quantization format.
+    Only safe on a model with no active quantizer; go through
+    ``maybe_cast_floating_params`` for anything that came out of ``from_pretrained``.
+
+    The one-byte-float skip below is a backstop against the worst corruption, not an
+    ownership test. Quantizer-owned scales are float32 as often as FP8: transformers'
+    finegrained-FP8 integration picks between the two by ``scale_fmt``, and its
+    ``activation_scale`` is float32 either way. A dtype cannot say who owns a tensor.
+    See: https://github.com/TransformerLensOrg/TransformerLens/issues/1743
     """
     from accelerate.utils import align_module_device
 
@@ -263,8 +269,10 @@ def cast_floating_params_to_dtype(model: nn.Module, dtype: torch.dtype) -> None:
                     continue
                 if param.device.type == "meta":
                     continue
-                # Skip one-byte floats (FP8 scale tensors): they are quantizer-owned
-                # and casting them breaks the weight/scale pair relationship.
+                # Backstop, not an ownership test. One-byte floats are the case
+                # where a cast is silently unrecoverable, so they are refused even
+                # here; wider quantizer-owned scales exist and are NOT caught, which
+                # is why callers gate on the model's quantizer instead of on dtype.
                 if param.dtype.itemsize < 2:
                     continue
                 param.data = param.data.to(dtype=dtype)
@@ -273,11 +281,27 @@ def cast_floating_params_to_dtype(model: nn.Module, dtype: torch.dtype) -> None:
 def maybe_cast_floating_params(model: nn.Module, dtype: torch.dtype) -> None:
     """Cast floating params to dtype, skipping models with active quantization.
 
-    When a model has an active quantization_config, the quantizer owns specific
-    dtypes (e.g., FP8 scales) that must not be overwritten. This helper wraps
-    the cast with that check.
+    The skip is whole-model on purpose, and it is a division of responsibility rather
+    than a loss. ``from_pretrained`` is the component that applies the requested dtype
+    to ordinary floating parameters, and it has already run by this point; whatever is
+    still not at the requested dtype afterward may be quantizer-owned storage, and
+    dtype alone cannot distinguish ownership safely. (bitsandbytes 4-bit and 8-bit
+    checkpoints were checked and matched that division: every ordinary floating
+    parameter, embeddings and layernorms and quantized-layer biases alike, arrived
+    already converted. Not every quantization backend was reachable to test, which is
+    a further reason to leave the loader's result alone rather than re-derive it.)
+
+    transformers draws the same line itself:
+    ``PreTrainedModel.to(dtype=...)`` raises for bitsandbytes and GPTQ models, and
+    ``.half()`` / ``.float()`` raise for any quantized model ("the model has already
+    been casted to the correct dtype"), all gated on the same whole-model
+    ``is_quantized`` flag. The gate also releases in step with HF: a dequantized load
+    has its ``quantization_config`` deleted by
+    ``HfQuantizer.remove_quantization_config``, so ``quantization_method`` returns None
+    and normalization resumes.
 
     See: https://github.com/TransformerLensOrg/TransformerLens/issues/1713
+    See: https://github.com/TransformerLensOrg/TransformerLens/issues/1743
     """
     from transformer_lens.utilities.quantization import quantization_method
 


### PR DESCRIPTION
## Description

Fixes #1743, by correcting its premise rather than its proposed fix.

#1743 is right about the mechanism: `maybe_cast_floating_params` skips dtype normalization for an entire model the moment a `quantization_config` is present. Its proposed fix is to drop that call-site guard and rely on the `itemsize < 2` check inside `cast_floating_params_to_dtype`. That would reintroduce #1713.

`itemsize < 2` is not an ownership test. transformers' finegrained-FP8 picks `weight_scale_inv`'s storage dtype from the checkpoint:

```python
sf_dtype = _get_ue8m0_dtype() if scale_fmt == "ue8m0" else torch.float32
```

Same parameter, same quantizer, same role, two widths, and **float32 is the default**. `activation_scale` is float32 under either format, and fbgemm-fp8 stores `weight_scale` and its expert scales as float32 `nn.Parameter`s. Running the merged `cast_floating_params_to_dtype` against a real `FP8Linear` rewrites the float32 `weight_scale_inv` to bf16, which is #1713's corruption in a scale format the guard cannot see. It also corrupts `activation_scale` on `ue8m0` checkpoints, so even #1713's own format is not fully protected by dtype alone.

| `scale_fmt` | quantizer-owned params rewritten by the cast |
| --- | --- |
| `"ue8m0"` | `activation_scale` (float32) |
| `"float"` (default) | `weight_scale_inv`, `activation_scale` (both float32) |

Nothing is lost by skipping. `from_pretrained` settles the load dtype before this
helper runs, and on a quantized checkpoint that is the quantizer's *effective* dtype
rather than necessarily the requested one: nine quantizers override it in
`HfQuantizer.update_dtype` (AWQ downgrades bfloat16 to float16 whenever CUDA or XPU is
available, whatever the placement; fbgemm-FP8 and FP-Quant force bfloat16). Re-casting
here would overwrite those deliberate choices along with quantizer-owned storage.

On bitsandbytes, which overrides nothing, every ordinary floating parameter arrives at
the requested dtype already: 4-bit pre-quantized and 8-bit on-the-fly both show 0
mismatches, including with a deliberately conflicting `config.dtype=float32`. On the
4-bit checkpoint that is 100 distinct floating tensors against 48 packed `Params4bit`
(a naive module walk reports 101, because GPT-2 ties `wte.weight` and `lm_head.weight`).

This also matches the line transformers draws itself: `PreTrainedModel.to(dtype=...)` raises for bitsandbytes and GPTQ, and `.half()` / `.float()` raise for any quantized model ("the model has already been casted to the correct dtype"), all gated on the same whole-model `is_quantized` flag. And the gate releases in step with HF: `HfQuantizer.postprocess_model` calls `remove_quantization_config` on a dequantized load, deleting `config.quantization_config`, so `quantization_method` returns None and normalization resumes. That is the one way the guard could have been genuinely too broad, and it isn't.

**No runtime behavior change.** The contribution is corrected rationale plus regression tests for the actual ownership invariant. The previous docstring claimed the `itemsize < 2` branch skips "quantizer-owned scale parameters", which is false and is what made removing the call-site guard look safe.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Tests

- `test_itemsize_guard_does_not_identify_quantizer_owned_scales[ue8m0|float]` uses a real `FP8Linear`. The expected set is derived from the cast's own predicate (floating, `itemsize >= 2`, not already at target) rather than dtype width, so it stays correct if transformers moves `weight` to wide packed-integer storage like GPTQ's int32.
- `test_preserves_quantizer_owned_scales_of_any_width[ue8m0|float]`: both scale widths survive an active quantizer. The float32 side fails outright if the cast is ever re-enabled behind only the one-byte guard.
- `test_skips_quantized_model`: restored, with the evidence for why.
- `test_casts_once_hf_releases_quantizer_ownership`: casting resumes once ownership is released.
- `test_hf_still_clears_quantization_config_when_dequantizing`: pins the upstream behavior this design depends on, so a transformers change fails loudly instead of silently stranding dequantized checkpoints.

Anti-tautology check: applying #1743's proposed fix fails 4 of these tests.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

`make unit-test`: 5581 passed. The 8 failures are pre-existing on `dev` and reproduce unchanged at `b652cfa8` in a clean worktree. 6 are CPU/CUDA device-mixing failures that pass under `CUDA_VISIBLE_DEVICES=""` (CI runs CPU-only per `tests/QUARANTINES.md`), and 2 are `test_attention.py` bitsandbytes stub tests that CI skips via `skipif(not is_bitsandbytes_available())`. `uv run mypy .` clean, `black` / `isort` / `pycln` clean.

