### PR TITLE
Require eval mode for JacobianLens fitting

### DIFF
--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -124,6 +124,7 @@ class _ToyBridge(TransformerBridge):
         self.blocks = nn.ModuleList(blocks)
         self.ln_final = nn.Identity()
         self.unembed = nn.Linear(D_MODEL, D_VOCAB, bias=False, dtype=dtype)
+        self.eval()
 
     @property
     def W_U(self) -> torch.Tensor:
@@ -281,6 +282,57 @@ def test_toy_model_satisfies_raw_bridge_contract(toy_model: _ToyBridge) -> None:
     assert toy_model.compatibility_mode is False
     assert toy_model._weights_processed is False
     assert set(toy_model.hook_dict) == {f"blocks.{layer}.hook_out" for layer in range(N_LAYERS)}
+
+
+def test_fit_rejects_model_in_training_mode() -> None:
+    model = _ToyBridge()
+    model.train()
+
+    with pytest.raises(ValueError, match=r"model\.eval\(\)"):
+        JacobianLens.fit(
+            model,
+            ["a toy prompt"],
+            corpus=CORPUS,
+            skip_first_positions=SKIP_FIRST,
+            show_progress=False,
+        )
+    assert model.training is True
+
+
+def test_fit_rejects_nested_submodule_in_training_mode() -> None:
+    model = _ToyBridge()
+    model.blocks[1].train()
+    assert model.training is False
+
+    with pytest.raises(ValueError, match=r"model\.eval\(\)"):
+        JacobianLens.fit(
+            model,
+            ["a toy prompt"],
+            corpus=CORPUS,
+            skip_first_positions=SKIP_FIRST,
+            show_progress=False,
+        )
+    assert model.training is False
+    assert model.blocks[1].training is True
+
+
+def test_fit_rejects_hidden_original_model_submodule_in_training_mode() -> None:
+    model = _ToyBridge()
+    original_model = nn.Sequential(nn.Linear(D_MODEL, D_MODEL))
+    original_model.eval()
+    original_model[0].train()
+    model.original_model = original_model
+
+    with pytest.raises(ValueError, match="original_model"):
+        JacobianLens.fit(
+            model,
+            ["a toy prompt"],
+            corpus=CORPUS,
+            skip_first_positions=SKIP_FIRST,
+            show_progress=False,
+        )
+    assert original_model.training is False
+    assert original_model[0].training is True
 
 
 def test_fit_recovers_closed_form_jacobians(

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -1416,7 +1416,8 @@ class JacobianLens:
             model: A raw ``TransformerBridge``. Model parameters are temporarily
                 frozen (``requires_grad=False``) during fitting and restored
                 after. Cotangents and activation gradients use the model dtype;
-                fit with a float32 model for the highest-fidelity estimator.
+                fit with a float32 model for the highest-fidelity estimator. The
+                model and all of its submodules must be in evaluation mode.
             prompts: Prompt strings. Prompts too short to contain a valid
                 position (``seq_len <= skip_first_positions + 1``) are skipped
                 with a warning and do not count toward ``n_prompts``.
@@ -1438,10 +1439,11 @@ class JacobianLens:
 
         Raises:
             TypeError: If model is not a ``TransformerBridge``.
-            ValueError: On compatibility mode, invalid provenance or layer
-                indices, or if no prompt was long enough to fit on.
+            ValueError: On compatibility mode, training mode, invalid provenance
+                or layer indices, or if no prompt was long enough to fit on.
         """
         _require_raw_bridge(model)
+        _require_eval_mode_for_fit(model)
         if not isinstance(corpus, str) or not corpus.strip():
             raise ValueError("corpus must be a non-empty provenance identifier")
         n_layers = model.cfg.n_layers
@@ -1627,6 +1629,32 @@ def _require_raw_bridge(model: Any) -> None:
             f"got W_U input width {unembed_width} for d_model={model.cfg.d_model}. "
             "Architectures with a final output projection are not yet supported."
         )
+
+
+def _require_eval_mode_for_fit(model: Any) -> None:
+    """Reject stochastic training state without mutating the caller's model."""
+    training_modules: Dict[int, str] = {}
+    roots = (("", model), ("original_model", getattr(model, "original_model", None)))
+    for prefix, root in roots:
+        if not isinstance(root, torch.nn.Module):
+            continue
+        for name, module in root.named_modules():
+            if not module.training:
+                continue
+            qualified_name = ".".join(part for part in (prefix, name) if part)
+            training_modules.setdefault(id(module), qualified_name or "<root>")
+    if not training_modules:
+        return
+
+    names = list(training_modules.values())
+    preview = ", ".join(names[:3])
+    if len(names) > 3:
+        preview += f", and {len(names) - 3} more"
+    raise ValueError(
+        "JacobianLens.fit() requires the model and all submodules to be in "
+        f"evaluation mode; found training mode at {preview}. Call model.eval() "
+        "before fitting."
+    )
 
 
 def _validate_metadata(metadata: Dict[str, Any]) -> None:


### PR DESCRIPTION
# Description

Fixes #1762.

`JacobianLens.fit()` documents deterministic fitting, but an active training-mode module can apply different dropout realizations to the replicated batch rows used for different Jacobian output dimensions. That silently assembles rows from different stochastic executions, so the result is not the Jacobian of any single forward pass and can change substantially with `dim_batch`.

This change makes fitting fail fast unless the Bridge and every submodule are in evaluation mode. The check covers both the Bridge module tree and its deliberately unregistered `original_model`, reports an actionable `model.eval()` message, and does not mutate the caller's training state. The public docstring now records the requirement.

The regression tests cover a training root model, a training nested Bridge module under an eval root, and a training nested module inside the hidden original model. They also verify that every mixed training state remains unchanged after the error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (affected unit file: 104 passed; full repository suite was not rerun)
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

## Validation

- `uv run --no-cache --no-sync pytest tests/unit/tools/test_jacobian_lens.py -q`: 104 passed
- focused training-state regression surface after final assertions: 3 passed
- pinned pycln, isort, and Black on both changed Python files
- `uv run --no-cache --no-sync mypy .`: success across 396 source files
- `git diff --check`
