### PR TITLE
refactor(jacobian_lens): extract estimator-independent fit driver

### DIFF
--- a/tests/integration/test_jacobian_lens.py
+++ b/tests/integration/test_jacobian_lens.py
@@ -615,3 +615,125 @@ def test_decompose_gemma_activation_is_valid():
     assert torch.allclose(
         result.j_space_component + result.non_j_space_component, activation, atol=1e-2
     )
+
+
+# --------------------------------------------------------------------------- #
+# Ordinary-estimator fit regression fixture                                   #
+# --------------------------------------------------------------------------- #
+#
+# This pins the exact numerics of the current ``JacobianLens.fit`` drive loop
+# before the estimator-independent driver is extracted. The
+# refactor must reproduce these golden transport matrices, so a change to
+# cotangent batching, valid-position selection, source-position averaging,
+# prompt accumulation, or the graph root would surface here as a failure.
+#
+# The fixture avoids brittleness two ways: it builds a tiny GPT-2 locally (no
+# model download) and overwrites every parameter with an RNG-version-independent
+# arithmetic ramp, so the fitted matrices are byte-identical across machines and
+# torch versions. In-run determinism is asserted with ``torch.equal`` (a repeat
+# fit) and the golden comparison uses a tight tolerance that only absorbs
+# cross-BLAS float rounding on the 4-wide matmuls.
+
+REGRESSION_CORPUS = "jlens-drive-loop-regression-v1"
+REGRESSION_PROMPTS = [
+    "the quick brown fox jumps over the lazy dog again",
+    "colorless green ideas sleep furiously beneath the ancient stone bridge",
+]
+REGRESSION_FIT_KWARGS = dict(
+    source_layers=[0, 1],
+    dim_batch=3,  # < d_model=4 so the ragged final chunk is exercised
+    max_seq_len=16,
+    skip_first_positions=1,
+    show_progress=False,
+)
+# Golden transport matrices captured from the pre-refactor JacobianLens.fit.
+REGRESSION_GOLDEN_JACOBIANS = {
+    0: [
+        [1.0194597244262695, -0.10382787883281708, 0.01114815566688776, 0.07321998476982117],
+        [0.017510414123535156, 0.7570222020149231, 0.17482545971870422, 0.05064191669225693],
+        [-0.06917503476142883, -0.09777483344078064, 1.198944091796875, -0.03199436515569687],
+        [0.05239897966384888, 0.06332147866487503, -0.1471048891544342, 1.0313844680786133],
+    ],
+    1: [
+        [1.022949457168579, -0.05948571860790253, -0.08073973655700684, 0.11727607250213623],
+        [-0.011972094886004925, 0.8772072792053223, 0.12830956280231476, 0.006455251481384039],
+        [-0.04260174185037613, 0.0968940407037735, 1.0271172523498535, -0.08140958845615387],
+        [0.01806488260626793, -0.12579867243766785, -0.007413430605083704, 1.1151472330093384],
+    ],
+}
+
+
+def _build_tiny_deterministic_gpt2():
+    """A 4-wide, 3-layer GPT-2 bridge with fixed arithmetic weights and a real tokenizer.
+
+    Weights are RNG-independent so the fit is reproducible across environments; the
+    GPT-2 tokenizer (small, cached) lets ``JacobianLens.fit`` take string prompts.
+    """
+    from transformers import AutoTokenizer, GPT2Config, GPT2LMHeadModel
+
+    from transformer_lens.model_bridge.sources import build_bridge_from_module
+
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    config = GPT2Config(
+        vocab_size=tokenizer.vocab_size,
+        n_positions=64,
+        n_embd=4,
+        n_layer=3,
+        n_head=2,
+        resid_pdrop=0.0,
+        embd_pdrop=0.0,
+        attn_pdrop=0.0,
+    )
+    hf_model = GPT2LMHeadModel(config).eval()
+    for salt, (_, param) in enumerate(sorted(hf_model.named_parameters())):
+        ramp = torch.arange(param.numel(), dtype=torch.float64)
+        vals = ((ramp * 0.6180339887498949 + (salt + 1) * 0.31830988618) % 1.0) - 0.5
+        param.data.copy_(vals.reshape(param.shape).to(param.dtype))
+    return build_bridge_from_module(
+        hf_model,
+        "GPT2LMHeadModel",
+        hf_config=config,
+        tokenizer=tokenizer,
+        dtype=torch.float32,
+        device="cpu",
+        model_name="tiny-deterministic-gpt2-jacobian-lens",
+    )
+
+
+def test_fit_ordinary_estimator_regression_fixture():
+    """JacobianLens.fit reproduces frozen golden matrices, guarding the driver-extraction refactor."""
+    from transformer_lens.tools.analysis import JacobianLens
+
+    model = _build_tiny_deterministic_gpt2()
+    lens = JacobianLens.fit(model, REGRESSION_PROMPTS, corpus=REGRESSION_CORPUS, **REGRESSION_FIT_KWARGS)
+
+    assert lens.n_prompts == len(REGRESSION_PROMPTS)
+    assert lens.d_model == 4
+    assert lens.source_layers == [0, 1]
+    assert lens.metadata["corpus"] == REGRESSION_CORPUS
+    assert lens.metadata["target_layer"] == 2
+
+    for layer, golden in REGRESSION_GOLDEN_JACOBIANS.items():
+        matrix = lens.jacobians[layer]
+        assert matrix.shape == (4, 4)
+        assert torch.isfinite(matrix).all()
+        torch.testing.assert_close(
+            matrix, torch.tensor(golden, dtype=torch.float32), atol=1e-5, rtol=1e-4
+        )
+
+    # The estimator is deterministic: a repeat fit is bit-identical in this environment.
+    repeat = JacobianLens.fit(model, REGRESSION_PROMPTS, corpus=REGRESSION_CORPUS, **REGRESSION_FIT_KWARGS)
+    for layer in lens.source_layers:
+        assert torch.equal(lens.jacobians[layer], repeat.jacobians[layer])
+
+    # Joint fitting equals merging per-prompt fits, exactly, on this fixture.
+    merged = JacobianLens.merge(
+        [
+            JacobianLens.fit(model, [prompt], corpus=REGRESSION_CORPUS, **REGRESSION_FIT_KWARGS)
+            for prompt in REGRESSION_PROMPTS
+        ]
+    )
+    for layer in lens.source_layers:
+        torch.testing.assert_close(
+            lens.jacobians[layer], merged.jacobians[layer], atol=1e-6, rtol=1e-5
+        )

--- a/tests/integration/test_jacobian_lens.py
+++ b/tests/integration/test_jacobian_lens.py
@@ -6,6 +6,8 @@ RMSNorm and logit-softcap coverage in the regular CI suite, while a slow
 Gemma-2-2b-it test checks the published artifact on the real architecture.
 """
 
+from typing import Any
+
 import pytest
 import torch
 
@@ -129,7 +131,7 @@ def test_bridge_fit_merge_consistency_and_finiteness(gpt2_bridge):
     """Joint fitting equals merging per-prompt fits for a real Bridge."""
     from transformer_lens.tools.analysis import JacobianLens
 
-    fit_kwargs = dict(
+    fit_kwargs: dict[str, Any] = dict(
         source_layers=[0, 5, 10],
         dim_batch=96,
         max_seq_len=32,
@@ -639,7 +641,7 @@ REGRESSION_PROMPTS = [
     "the quick brown fox jumps over the lazy dog again",
     "colorless green ideas sleep furiously beneath the ancient stone bridge",
 ]
-REGRESSION_FIT_KWARGS = dict(
+REGRESSION_FIT_KWARGS: dict[str, Any] = dict(
     source_layers=[0, 1],
     dim_batch=3,  # < d_model=4 so the ragged final chunk is exercised
     max_seq_len=16,

--- a/tests/integration/test_jacobian_lens.py
+++ b/tests/integration/test_jacobian_lens.py
@@ -797,10 +797,29 @@ def test_fit_driver_honors_alternate_backward_provider():
         grads = _ordinary_vjp(target, sources, cotangent, retain_graph)
         return tuple(SCALE * grad for grad in grads)
 
-    scaled, n_scaled = _fit_transport_matrices(
-        model, REGRESSION_PROMPTS, backward_provider=scaled_provider, **REGRESSION_FIT_KWARGS
-    )
+    # Count top-level bridge forwards independently of the backward seam. The
+    # driver replicates each prompt once and runs a single forward per prompt,
+    # batching every one-hot cotangent through that one captured graph; the
+    # backward-provider call count above cannot witness this because it rises
+    # with dim_batch chunking, not with forwards. A forward pre-hook on the
+    # bridge fires once per model(...) call, so it pins the invariant directly:
+    # exactly one bridge forward per contributing prompt.
+    forward_calls = 0
+
+    def _count_forward(_module, _args):
+        nonlocal forward_calls
+        forward_calls += 1
+
+    handle = model.register_forward_pre_hook(_count_forward)
+    try:
+        scaled, n_scaled = _fit_transport_matrices(
+            model, REGRESSION_PROMPTS, backward_provider=scaled_provider, **REGRESSION_FIT_KWARGS
+        )
+    finally:
+        handle.remove()
     assert calls > 0  # the driver actually took its backward step through the seam
+    # One forward per prompt: no short prompt is skipped here, so every prompt contributes.
+    assert forward_calls == len(REGRESSION_PROMPTS)
     assert n_scaled == n_ordinary
     for layer in baseline:
         assert torch.equal(scaled[layer], SCALE * baseline[layer])

--- a/tests/integration/test_jacobian_lens.py
+++ b/tests/integration/test_jacobian_lens.py
@@ -705,7 +705,9 @@ def test_fit_ordinary_estimator_regression_fixture():
     from transformer_lens.tools.analysis import JacobianLens
 
     model = _build_tiny_deterministic_gpt2()
-    lens = JacobianLens.fit(model, REGRESSION_PROMPTS, corpus=REGRESSION_CORPUS, **REGRESSION_FIT_KWARGS)
+    lens = JacobianLens.fit(
+        model, REGRESSION_PROMPTS, corpus=REGRESSION_CORPUS, **REGRESSION_FIT_KWARGS
+    )
 
     assert lens.n_prompts == len(REGRESSION_PROMPTS)
     assert lens.d_model == 4
@@ -722,7 +724,9 @@ def test_fit_ordinary_estimator_regression_fixture():
         )
 
     # The estimator is deterministic: a repeat fit is bit-identical in this environment.
-    repeat = JacobianLens.fit(model, REGRESSION_PROMPTS, corpus=REGRESSION_CORPUS, **REGRESSION_FIT_KWARGS)
+    repeat = JacobianLens.fit(
+        model, REGRESSION_PROMPTS, corpus=REGRESSION_CORPUS, **REGRESSION_FIT_KWARGS
+    )
     for layer in lens.source_layers:
         assert torch.equal(lens.jacobians[layer], repeat.jacobians[layer])
 
@@ -736,4 +740,71 @@ def test_fit_ordinary_estimator_regression_fixture():
     for layer in lens.source_layers:
         torch.testing.assert_close(
             lens.jacobians[layer], merged.jacobians[layer], atol=1e-6, rtol=1e-5
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Backward-provider seam                                                      #
+# --------------------------------------------------------------------------- #
+#
+# The estimator-independent driver (``_fit_transport_matrices``) takes its
+# backward step through a ``backward_provider`` callable so a future estimator
+# can reuse the capture / cotangent-batching / averaging machinery
+# unchanged. This test proves the seam works before anything depends on it: an
+# alternate provider that scales the ordinary VJP by an exact power of two flows
+# linearly through the driver, so every transport matrix must come out scaled by
+# exactly that constant, while the public ``JacobianLens.fit`` path -- which
+# passes ``_ordinary_vjp`` -- stays pinned to the golden regression matrices.
+
+
+def test_fit_driver_honors_alternate_backward_provider():
+    """The driver routes its backward step through the provider seam without
+    disturbing the ordinary ``JacobianLens.fit`` numerics."""
+    from transformer_lens.tools.analysis import JacobianLens
+    from transformer_lens.tools.analysis.jacobian_lens import (
+        _fit_transport_matrices,
+        _ordinary_vjp,
+    )
+
+    model = _build_tiny_deterministic_gpt2()
+
+    # The ordinary provider through the driver reproduces the pinned golden
+    # matrices, anchoring the alternate-provider comparison to the fit fixture.
+    baseline, n_ordinary = _fit_transport_matrices(
+        model, REGRESSION_PROMPTS, backward_provider=_ordinary_vjp, **REGRESSION_FIT_KWARGS
+    )
+    assert n_ordinary == len(REGRESSION_PROMPTS)
+    for layer, golden in REGRESSION_GOLDEN_JACOBIANS.items():
+        torch.testing.assert_close(
+            baseline[layer], torch.tensor(golden, dtype=torch.float32), atol=1e-5, rtol=1e-4
+        )
+
+    # An alternate provider that scales the ordinary VJP by an exact power of two.
+    # Power-of-two scaling commutes bit-exactly with the driver's mean / sum /
+    # divide reductions, so the honored result is byte-identical to SCALE*baseline.
+    SCALE = 2.0
+    calls = 0
+
+    def scaled_provider(target, sources, cotangent, retain_graph):
+        nonlocal calls
+        calls += 1
+        grads = _ordinary_vjp(target, sources, cotangent, retain_graph)
+        return tuple(SCALE * grad for grad in grads)
+
+    scaled, n_scaled = _fit_transport_matrices(
+        model, REGRESSION_PROMPTS, backward_provider=scaled_provider, **REGRESSION_FIT_KWARGS
+    )
+    assert calls > 0  # the driver actually took its backward step through the seam
+    assert n_scaled == n_ordinary
+    for layer in baseline:
+        assert torch.equal(scaled[layer], SCALE * baseline[layer])
+
+    # Exercising the seam leaves the public fit path untouched: it still routes
+    # through the ordinary VJP and reproduces the golden regression matrices.
+    lens = JacobianLens.fit(
+        model, REGRESSION_PROMPTS, corpus=REGRESSION_CORPUS, **REGRESSION_FIT_KWARGS
+    )
+    for layer, golden in REGRESSION_GOLDEN_JACOBIANS.items():
+        torch.testing.assert_close(
+            lens.jacobians[layer], torch.tensor(golden, dtype=torch.float32), atol=1e-5, rtol=1e-4
         )

--- a/tests/integration/test_jacobian_lens.py
+++ b/tests/integration/test_jacobian_lens.py
@@ -6,6 +6,10 @@ RMSNorm and logit-softcap coverage in the regular CI suite, while a slow
 Gemma-2-2b-it test checks the published artifact on the real architecture.
 """
 
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -810,3 +814,50 @@ def test_fit_driver_honors_alternate_backward_provider():
         torch.testing.assert_close(
             lens.jacobians[layer], torch.tensor(golden, dtype=torch.float32), atol=1e-5, rtol=1e-4
         )
+
+
+def test_fit_attributes_short_prompt_warning_to_caller_frame():
+    """The short-prompt skip warning must point at the ``JacobianLens.fit`` call site, one
+    frame up from ``_fit_transport_matrices`` where the warning is actually raised.
+
+    This runs in a bare subprocess rather than in-process: this suite's pytest config wraps
+    every ``transformer_lens`` call for runtime type-checking (``--jaxtyping-packages`` in
+    pyproject.toml), and each wrapper layer adds its own interpreter frame, which would
+    otherwise swallow the one-frame difference this test exists to catch.
+    """
+    script = textwrap.dedent(
+        """
+        import warnings
+
+        from tests.integration.test_jacobian_lens import (
+            REGRESSION_CORPUS,
+            REGRESSION_FIT_KWARGS,
+            REGRESSION_PROMPTS,
+            _build_tiny_deterministic_gpt2,
+        )
+        from transformer_lens.tools.analysis import JacobianLens
+
+        model = _build_tiny_deterministic_gpt2()
+        prompts = ["hi", *REGRESSION_PROMPTS]  # "hi" tokenizes to 2 tokens, at the skip threshold
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            call_line = __import__("inspect").currentframe().f_lineno + 1
+            JacobianLens.fit(model, prompts, corpus=REGRESSION_CORPUS, **REGRESSION_FIT_KWARGS)
+
+        skip_warnings = [w for w in caught if "skipping prompt" in str(w.message)]
+        assert len(skip_warnings) == 1, caught
+        assert skip_warnings[0].filename == "<string>", skip_warnings[0].filename
+        assert skip_warnings[0].lineno == call_line, (skip_warnings[0].lineno, call_line)
+        print("PROBE_OK")
+        """
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PROBE_OK" in result.stdout, result.stdout + result.stderr

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -1982,7 +1982,7 @@ def _fit_transport_matrices(
                 warnings.warn(
                     f"skipping prompt with only {seq_len} tokens "
                     f"(need > {skip_first_positions + 1})",
-                    stacklevel=2,
+                    stacklevel=3,
                 )
                 continue
             per_prompt = _jacobian_for_prompt(

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -1487,37 +1487,16 @@ class JacobianLens:
                 stacklevel=2,
             )
 
-        jacobian_sum = {
-            layer: torch.zeros(d_model, d_model, dtype=torch.float32) for layer in resolved_sources
-        }
-        n_done = 0
-        iterator = tqdm(prompts, desc="fitting J-lens", disable=not show_progress)
-        with _frozen_parameters(model):
-            for prompt in iterator:
-                tokens = model.to_tokens(prompt)[:, :max_seq_len]
-                seq_len = tokens.shape[1]
-                if seq_len <= skip_first_positions + 1:
-                    warnings.warn(
-                        f"skipping prompt with only {seq_len} tokens "
-                        f"(need > {skip_first_positions + 1})",
-                        stacklevel=2,
-                    )
-                    continue
-                per_prompt = _jacobian_for_prompt(
-                    model,
-                    tokens,
-                    source_layers=resolved_sources,
-                    dim_batch=dim_batch,
-                    skip_first_positions=skip_first_positions,
-                    backward_provider=_ordinary_vjp,
-                )
-                for layer in resolved_sources:
-                    jacobian_sum[layer] += per_prompt[layer]
-                n_done += 1
-        if n_done == 0:
-            raise ValueError(
-                "every prompt was too short to contribute valid positions; nothing was fitted"
-            )
+        transport_matrices, n_done = _fit_transport_matrices(
+            model,
+            prompts,
+            source_layers=resolved_sources,
+            dim_batch=dim_batch,
+            max_seq_len=max_seq_len,
+            skip_first_positions=skip_first_positions,
+            show_progress=show_progress,
+            backward_provider=_ordinary_vjp,
+        )
 
         fit_metadata: Dict[str, Any] = {
             "model_name": getattr(model.cfg, "model_name", None),
@@ -1545,7 +1524,7 @@ class JacobianLens:
         full_metadata.update(fit_metadata)
         _validate_metadata(full_metadata)
         return cls(
-            {layer: jacobian_sum[layer] / n_done for layer in resolved_sources},
+            transport_matrices,
             n_prompts=n_done,
             d_model=d_model,
             metadata=full_metadata,

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -86,6 +86,18 @@ from transformer_lens.utilities.hf_utils import call_hf_with_retry
 
 TokenInput = Union[str, int]
 
+# Backward-provider seam for the fit drive loop. A provider takes the target
+# residual, the source residuals it differentiates against, one batched one-hot
+# cotangent, and the ``retain_graph`` flag, and returns one gradient per source
+# (the same tuple ``torch.autograd.grad`` returns). Keeping the backward step
+# behind this narrow callable lets the estimator-independent driver run an
+# alternate estimator without touching its capture / cotangent-batching /
+# averaging machinery; the ordinary J-lens path passes :func:`_ordinary_vjp`.
+BackwardProvider = Callable[
+    [torch.Tensor, List[torch.Tensor], torch.Tensor, bool],
+    Tuple[torch.Tensor, ...],
+]
+
 # ---------------------------------------------------------------------------
 # Registry helpers
 # ---------------------------------------------------------------------------
@@ -1497,6 +1509,7 @@ class JacobianLens:
                     source_layers=resolved_sources,
                     dim_batch=dim_batch,
                     skip_first_positions=skip_first_positions,
+                    backward_provider=_ordinary_vjp,
                 )
                 for layer in resolved_sources:
                     jacobian_sum[layer] += per_prompt[layer]
@@ -1833,6 +1846,27 @@ class _frozen_parameters:
             param.requires_grad_(flag)
 
 
+def _ordinary_vjp(
+    target: torch.Tensor,
+    sources: List[torch.Tensor],
+    cotangent: torch.Tensor,
+    retain_graph: bool,
+) -> Tuple[torch.Tensor, ...]:
+    """Ordinary vector-Jacobian product backing the J-lens estimator.
+
+    Thin wrapper over ``torch.autograd.grad`` so the drive loop takes its
+    backward step through the :data:`BackwardProvider` seam. This is the
+    identity-preserving provider: routing the ordinary fit through it changes no
+    numerics.
+    """
+    return torch.autograd.grad(
+        outputs=target,
+        inputs=sources,
+        grad_outputs=cotangent,
+        retain_graph=retain_graph,
+    )
+
+
 def _jacobian_for_prompt(
     model: Any,
     tokens: Int[torch.Tensor, "one seq"],
@@ -1840,12 +1874,18 @@ def _jacobian_for_prompt(
     source_layers: List[int],
     dim_batch: int,
     skip_first_positions: int,
+    backward_provider: BackwardProvider,
 ) -> Dict[int, Float[torch.Tensor, "d_model d_model"]]:
     """Exact per-prompt Jacobian rows via batched one-hot cotangents.
 
     Assumes parameters are already frozen (see :class:`_frozen_parameters`) so
     that marking the earliest source activation ``requires_grad`` roots the
     graph there.
+
+    The backward pass is taken through ``backward_provider`` rather than calling
+    ``torch.autograd.grad`` directly, so the capture / cotangent-batching /
+    averaging mechanics are shared by any estimator. The ordinary J-lens path
+    passes :func:`_ordinary_vjp`, which reproduces the original numerics exactly.
     """
     d_model = model.cfg.d_model
     target_layer = model.cfg.n_layers - 1
@@ -1890,11 +1930,11 @@ def _jacobian_for_prompt(
             positions_index[None, :],
             dim_start + batch_index[:n_dims, None],
         ] = 1.0
-        grads = torch.autograd.grad(
-            outputs=target,
-            inputs=sources,
-            grad_outputs=cotangent,
-            retain_graph=pass_index < n_passes - 1,
+        grads = backward_provider(
+            target,
+            sources,
+            cotangent,
+            pass_index < n_passes - 1,
         )
         for layer, grad in zip(source_layers, grads):
             # each gradient lives on its layer's device under sharded/device_map setups
@@ -1902,3 +1942,84 @@ def _jacobian_for_prompt(
             jacobians[layer][dim_start : dim_start + n_dims, :] = rows.cpu()
         del grads
     return jacobians
+
+
+def _fit_transport_matrices(
+    model: Any,
+    prompts: Sequence[str],
+    *,
+    source_layers: List[int],
+    dim_batch: int,
+    max_seq_len: int,
+    skip_first_positions: int,
+    show_progress: bool,
+    backward_provider: BackwardProvider,
+) -> Tuple[Dict[int, Float[torch.Tensor, "d_model d_model"]], int]:
+    """Estimator-independent J-lens drive loop.
+
+    Owns the mechanics shared by every estimator: the frozen-parameter
+    lifecycle, the per-prompt forward/backward accumulation (source/target
+    residual capture, one-hot cotangent batching, ``dim_batch`` chunking,
+    valid-position selection, and source-position averaging all live in
+    :func:`_jacobian_for_prompt`), the prompt-accumulation running sum, and the
+    final division into per-prompt means. Only the backward step varies: it is
+    taken through ``backward_provider``, so an alternate estimator reuses this
+    loop unchanged. Callers own input validation, provenance, and lens
+    construction.
+
+    Args:
+        model: A raw ``TransformerBridge`` whose parameters are frozen for the
+            duration of the loop.
+        prompts: Prompt strings; prompts too short to contain a valid position
+            (``seq_len <= skip_first_positions + 1``) are skipped with a warning
+            and do not count toward the returned prompt total.
+        source_layers: Resolved, in-range source layers to fit.
+        dim_batch: Output dimensions per backward pass.
+        max_seq_len: Prompts are truncated to this many tokens.
+        skip_first_positions: Leading positions excluded from the source average.
+        show_progress: Show a tqdm progress bar over prompts.
+        backward_provider: Backward-step seam; pass :func:`_ordinary_vjp` for the
+            ordinary J-lens numerics.
+
+    Returns:
+        ``(transport_matrices, n_prompts)`` where ``transport_matrices`` maps each
+        source layer to its prompt-averaged ``[d_model, d_model]`` matrix and
+        ``n_prompts`` is the number of prompts that contributed.
+
+    Raises:
+        ValueError: If no prompt was long enough to contribute valid positions.
+    """
+    d_model = model.cfg.d_model
+    jacobian_sum = {
+        layer: torch.zeros(d_model, d_model, dtype=torch.float32) for layer in source_layers
+    }
+    n_done = 0
+    iterator = tqdm(prompts, desc="fitting J-lens", disable=not show_progress)
+    with _frozen_parameters(model):
+        for prompt in iterator:
+            tokens = model.to_tokens(prompt)[:, :max_seq_len]
+            seq_len = tokens.shape[1]
+            if seq_len <= skip_first_positions + 1:
+                warnings.warn(
+                    f"skipping prompt with only {seq_len} tokens "
+                    f"(need > {skip_first_positions + 1})",
+                    stacklevel=2,
+                )
+                continue
+            per_prompt = _jacobian_for_prompt(
+                model,
+                tokens,
+                source_layers=source_layers,
+                dim_batch=dim_batch,
+                skip_first_positions=skip_first_positions,
+                backward_provider=backward_provider,
+            )
+            for layer in source_layers:
+                jacobian_sum[layer] += per_prompt[layer]
+            n_done += 1
+    if n_done == 0:
+        raise ValueError(
+            "every prompt was too short to contribute valid positions; nothing was fitted"
+        )
+    means = {layer: jacobian_sum[layer] / n_done for layer in source_layers}
+    return means, n_done


### PR DESCRIPTION
---

### Summary

Extracts the estimator-independent part of `JacobianLens.fit` / `_jacobian_for_prompt` into asingle shared driver, `_fit_transport_matrices`, that accepts a **swappable backward provider**.The ordinary J-lens path passes an ordinary-VJP wrapper (`_ordinary_vjp` over`torch.autograd.grad`), so the fitted transport matrices are **byte-identical** to before.

This is a pure refactor. It creates the seam a relevance-modified backward pass later plugs into,and ships **no** new public API and **no** relevance-lens surface.

Part of #1755 (R-lens). This is PR1 of the 3-PR plan in that issue; PR2 lands the shared LN/Identity/Half custom-VJP backend, PR3 adds `RelevanceLens.fit`.

---

### Motivation

R-lens reuses J-lens's entire fitting loop unchanged (frozen-parameter lifecycle, one-hot cotangent batching, valid-position selection, source-position averaging, prompt accumulation) and differs only in the backward step, which becomes a RelP/LRP-modified VJP instead of the ordinary Jacobian VJP. Isolating the estimator-independent mechanics behind a narrow backward-provider seam lets that later work plug in without touching or risking the ordinary J-lens numerics. Landing it first, on its own, keeps the risky refactor separate from the new estimator and gives a pinned regression baseline the rest of the plan must preserve.

---

### What ships (commit by commit)

1. **`test(jacobian_lens): pin ordinary-estimator fit regression fixture`** Captures a deterministic small-model `JacobianLens.fit` as a golden reference before the refactor. A tiny locally-built GPT-2 with RNG-independent arithmetic weights makes the fitted transport matrices reproducible across environments. Also asserts repeat-fit determinism and joint == merged consistency.

2. **`refactor(jacobian_lens): extract estimator-independent fit driver`** Adds a `BackwardProvider` seam and an `_ordinary_vjp` wrapper so the fit backward step goes through a swappable callable instead of a direct `torch.autograd.grad`. Routes `_jacobian_for_prompt` through the provider; the ordinary path passes `_ordinary_vjp` so the numerics are identical. Adds the `_fit_transport_matrices` driver owning the frozen-parameter lifecycle, prompt accumulation, and source-position averaging.

3. **`refactor(jacobian_lens): route JacobianLens.fit through shared driver`** Rewrites `fit` to delegate to `_fit_transport_matrices` with the ordinary provider and removes the duplicated drive-loop body (frozen-parameter lifecycle, per-prompt accumulation, empty-fit guard).

4. **`test(jacobian_lens): driver accepts alternate backward provider`** Drives `_fit_transport_matrices` with an alternate provider that scales the ordinary VJP by an exact power of two and asserts every transport matrix is byte-identical to `SCALE * baseline`. Confirms the ordinary provider reproduces the pinned golden matrices and that the public `JacobianLens.fit` path is untouched. Also asserts the model forward runs exactly once per prompt, the invariant PR2's per-forward fail-closed hook check depends on.

5. **`chore(jacobian_lens): format, mypy`** Annotates the shared fit kwargs dicts as `dict[str, Any]` so `**` unpacking type-checks under mypy; imports `typing.Any` in the integration test. Format and mypy clean on touched files.

---

### Testing

- `tests/integration/test_jacobian_lens.py` — 18 passed (includes the new pinned regression fixture and the backward-provider seam test).
- `tests/integration/test_backward_lens.py` — 32 passed (defensive net).
- `tests/unit/model_bridge/generalized_components/test_normalization_hook_semantics.py` — 11 passed (defensive net).
- `uv run mypy` on touched sources — clean; `black` / `isort` — clean.

The `backward_lens` and hook-semantics suites are a defensive regression net, not a functional gate this change touches no `NormalizationBridge` code, backward hooks, or the autograd forward dispatch, and running them makes the "pure refactor, no behavior change" claim verifiable rather than asserted.

---

### Out of scope (later PRs on #1755)

The LN/Identity/Half custom-VJP backend, native-forward preservation, the raw-`GatedMLPBridge` recompute path (PR2), and `RelevanceLens.fit` with provenance/merge/registry guards and docs (PR3). No relevance-rule code lands here.

---

### API

No public API added or changed.

---

### Checklist

- [x] Base set to `dev`; working branch `feat/r-lens-drive-loop`.
- [x] Ordinary-estimator regression fixture captured before the refactor and green after it.
- [x] `JacobianLens.fit` numerics unchanged; backward-provider seam exercised by a test with no
  R-lens code yet.
- [x] Driver invokes model forward exactly once per prompt.
- [x] `backward_lens` and hook-semantics suites green and untouched.
- [x] `mypy` and formatting clean on touched files.
- [ ] Full `make test-pr` run (unit + docstring + acceptance + integration) attached before submit.
- [ ] Integration test run against a cached GPT-2 with `.env` sourced.

---