### PR TITLE
Fix JacobianLens dictionary cache invalidation

### DIFF
--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -28,6 +28,7 @@ from transformer_lens.tools.analysis import (
     solve_coordinate_patch,
 )
 from transformer_lens.utilities.activation_functions import apply_softcap
+from transformer_lens.utilities.parameter_swap import temporarily_swap_parameter
 
 D_MODEL = 6
 N_LAYERS = 4
@@ -1351,8 +1352,7 @@ class TestRegistry:
 
 
 def test_lens_vector_dictionary_matches_lens_vectors_and_caches(toy_model: _ToyBridge) -> None:
-    """The full-vocabulary dictionary equals lens_vectors over every token, is cached per
-    (layer, device), and is released by clear_device_cache."""
+    """The dictionary matches lens_vectors, caches unchanged weights, and can be cleared."""
     torch.manual_seed(0)
     d_model = toy_model.cfg.d_model
     layer = 1
@@ -1369,6 +1369,107 @@ def test_lens_vector_dictionary_matches_lens_vectors_and_caches(toy_model: _ToyB
     assert lens.lens_vector_dictionary(toy_model, layer) is dictionary
     lens.clear_device_cache()
     assert lens.lens_vector_dictionary(toy_model, layer) is not dictionary
+
+
+def test_lens_vector_dictionary_invalidates_after_in_place_weight_update(
+    toy_model: _ToyBridge,
+) -> None:
+    lens = JacobianLens({1: torch.eye(D_MODEL)}, n_prompts=1, d_model=D_MODEL)
+    original = lens.lens_vector_dictionary(toy_model, 1)
+
+    with torch.no_grad():
+        toy_model.unembed.weight.copy_(2 * toy_model.unembed.weight)
+
+    updated = lens.lens_vector_dictionary(toy_model, 1)
+    assert updated is not original
+    torch.testing.assert_close(
+        updated,
+        lens.lens_vectors(toy_model, list(range(D_VOCAB)), 1),
+    )
+
+
+def test_lens_vector_dictionary_invalidates_after_optimizer_step(toy_model: _ToyBridge) -> None:
+    lens = JacobianLens({1: torch.eye(D_MODEL)}, n_prompts=1, d_model=D_MODEL)
+    original = lens.lens_vector_dictionary(toy_model, 1)
+    optimizer = torch.optim.SGD([toy_model.unembed.weight], lr=0.1)
+    toy_model.unembed.weight.grad = torch.ones_like(toy_model.unembed.weight)
+
+    optimizer.step()
+
+    updated = lens.lens_vector_dictionary(toy_model, 1)
+    assert updated is not original
+    torch.testing.assert_close(
+        updated,
+        lens.lens_vectors(toy_model, list(range(D_VOCAB)), 1),
+    )
+
+
+def test_lens_vector_dictionary_does_not_cross_model_instances(toy_model: _ToyBridge) -> None:
+    lens = JacobianLens({1: torch.eye(D_MODEL)}, n_prompts=1, d_model=D_MODEL)
+    first = lens.lens_vector_dictionary(toy_model, 1)
+    other_model = _ToyBridge()
+    with torch.no_grad():
+        other_model.unembed.weight.add_(1)
+
+    second = lens.lens_vector_dictionary(other_model, 1)
+
+    assert second is not first
+    torch.testing.assert_close(
+        second,
+        lens.lens_vectors(other_model, list(range(D_VOCAB)), 1),
+    )
+
+
+def test_lens_vector_dictionary_invalidates_after_parameter_replacement(
+    toy_model: _ToyBridge,
+) -> None:
+    lens = JacobianLens({1: torch.eye(D_MODEL)}, n_prompts=1, d_model=D_MODEL)
+    original = lens.lens_vector_dictionary(toy_model, 1)
+    toy_model.unembed.weight = nn.Parameter(2 * toy_model.unembed.weight.detach())
+
+    updated = lens.lens_vector_dictionary(toy_model, 1)
+
+    assert updated is not original
+    torch.testing.assert_close(
+        updated,
+        lens.lens_vectors(toy_model, list(range(D_VOCAB)), 1),
+    )
+
+
+def test_lens_vector_dictionary_tracks_temporary_parameter_swap(toy_model: _ToyBridge) -> None:
+    lens = JacobianLens({1: torch.eye(D_MODEL)}, n_prompts=1, d_model=D_MODEL)
+    baseline = lens.lens_vector_dictionary(toy_model, 1)
+    replacement = 2 * toy_model.unembed.weight.detach()
+
+    with temporarily_swap_parameter(toy_model.unembed.weight, replacement):
+        swapped = lens.lens_vector_dictionary(toy_model, 1)
+        assert swapped is not baseline
+        torch.testing.assert_close(
+            swapped,
+            lens.lens_vectors(toy_model, list(range(D_VOCAB)), 1),
+        )
+
+    restored = lens.lens_vector_dictionary(toy_model, 1)
+    assert restored is not swapped
+    torch.testing.assert_close(restored, baseline)
+
+
+def test_decompose_uses_current_token_labels_after_unembedding_row_swap(
+    toy_model: _ToyBridge,
+) -> None:
+    lens = JacobianLens({1: torch.eye(D_MODEL)}, n_prompts=1, d_model=D_MODEL)
+    lens.lens_vector_dictionary(toy_model, 1)
+    replacement = toy_model.unembed.weight.detach().clone()
+    replacement[[0, 1]] = replacement[[1, 0]]
+
+    with temporarily_swap_parameter(toy_model.unembed.weight, replacement):
+        current_token_zero = toy_model.W_U[:, 0].detach().clone()
+        result = lens.decompose(toy_model, current_token_zero, layer=1, k=1)
+
+    assert result.support.tolist() == [0]
+    torch.testing.assert_close(
+        result.non_j_space_component, torch.zeros(D_MODEL), atol=1e-6, rtol=0
+    )
 
 
 def test_lens_vector_dictionary_rejects_unfitted_layer(toy_model: _ToyBridge) -> None:

--- a/tests/unit/tools/test_jacobian_lens.py
+++ b/tests/unit/tools/test_jacobian_lens.py
@@ -1164,6 +1164,7 @@ def test_lens_vector_dictionary_matches_lens_vectors_and_caches(toy_model: _ToyB
     # cached: the same object is returned on a repeat call, and clearing releases it
     assert lens.lens_vector_dictionary(toy_model, layer) is dictionary
     lens.clear_device_cache()
+    assert lens._unembedding_snapshots == {}
     assert lens.lens_vector_dictionary(toy_model, layer) is not dictionary
 
 
@@ -1256,6 +1257,32 @@ def test_lens_vector_dictionary_tracks_temporary_parameter_swap() -> None:
     restored = lens.lens_vector_dictionary(toy_model, 1)
     assert restored is not swapped
     torch.testing.assert_close(restored, baseline)
+
+
+def test_unembedding_snapshot_is_shared_across_layers_and_invalidates_all() -> None:
+    toy_model = _ToyBridge()
+    lens = JacobianLens(
+        {0: torch.eye(D_MODEL), 1: torch.eye(D_MODEL)}, n_prompts=1, d_model=D_MODEL
+    )
+    device = torch.device("cpu")
+    first_layer_zero = lens.lens_vector_dictionary(toy_model, 0)
+    first_layer_one = lens.lens_vector_dictionary(toy_model, 1)
+    snapshot = lens._unembedding_snapshots[device]
+
+    assert len(lens._unembedding_snapshots) == 1
+    assert lens.lens_vector_dictionary(toy_model, 0) is first_layer_zero
+    assert lens._unembedding_snapshots[device] is snapshot
+
+    with torch.no_grad():
+        toy_model.unembed.weight.data.add_(1)
+
+    updated_layer_zero = lens.lens_vector_dictionary(toy_model, 0)
+
+    assert updated_layer_zero is not first_layer_zero
+    assert lens._unembedding_snapshots[device] is not snapshot
+    assert (1, device) not in lens._dictionary_cache
+    updated_layer_one = lens.lens_vector_dictionary(toy_model, 1)
+    assert updated_layer_one is not first_layer_one
 
 
 def test_decompose_detects_data_row_swap_without_a_version_change() -> None:

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -64,6 +64,7 @@ import warnings
 from dataclasses import dataclass
 from importlib.metadata import version
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from weakref import ref
 
 import torch
 from jaxtyping import Float, Int
@@ -213,6 +214,29 @@ class JacobianLensReadout:
         return out
 
 
+@dataclass(frozen=True)
+class _UnembeddingFingerprint:
+    model_ref: Any
+    data_ptr: int
+    version: int
+    shape: Tuple[int, ...]
+    stride: Tuple[int, ...]
+    dtype: torch.dtype
+    device: torch.device
+
+
+def _unembedding_fingerprint(model: Any, unembed: torch.Tensor) -> _UnembeddingFingerprint:
+    return _UnembeddingFingerprint(
+        model_ref=ref(model),
+        data_ptr=unembed.data_ptr(),
+        version=unembed._version,
+        shape=tuple(unembed.shape),
+        stride=tuple(unembed.stride()),
+        dtype=unembed.dtype,
+        device=unembed.device,
+    )
+
+
 class JacobianLens:
     """A fitted Jacobian lens: one transport matrix per source layer.
 
@@ -255,7 +279,9 @@ class JacobianLens:
         self.d_model = int(d_model)
         self.metadata: Dict[str, Any] = dict(metadata or {})
         self._device_jacobians: Dict[Tuple[int, torch.device], torch.Tensor] = {}
-        self._dictionary_cache: Dict[Tuple[int, torch.device], torch.Tensor] = {}
+        self._dictionary_cache: Dict[
+            Tuple[int, torch.device], Tuple[_UnembeddingFingerprint, torch.Tensor]
+        ] = {}
 
     @property
     def source_layers(self) -> List[int]:
@@ -832,9 +858,9 @@ class JacobianLens:
         """Full-vocabulary J-lens dictionary at ``layer``: ``[d_vocab, d_model]``.
 
         Row ``t`` is the J-lens vector ``v_t = J[layer]^T W_U[:, t]`` -- this is
-        :meth:`lens_vectors` over the entire vocabulary. The result is cached per
-        (layer, device) so a sparse decomposition can reuse it; :meth:`clear_device_cache`
-        releases it.
+        :meth:`lens_vectors` over the entire vocabulary. The result is cached while the
+        model's unembedding is unchanged so a sparse decomposition can reuse it;
+        :meth:`clear_device_cache` releases it.
 
         The dictionary is vocabulary-sized and cached on the model's device
         (``d_vocab * d_model`` fp32 values, on the order of gigabytes for a large
@@ -849,13 +875,16 @@ class JacobianLens:
         """
         self.validate_model(model)
         layer = _normalize_layer(layer, model.cfg.n_layers)
-        device = torch.device(model.W_U.device)
-        cached = self._dictionary_cache.get((layer, device))
-        if cached is None:
+        unembed = model.W_U
+        device = torch.device(unembed.device)
+        fingerprint = _unembedding_fingerprint(model, unembed)
+        entry = self._dictionary_cache.get((layer, device))
+        if entry is None or entry[0] != fingerprint:
             matrix = self._matrix_on(layer, device)  # [d_model, d_model]
-            cached = (matrix.T @ model.W_U.float()).T  # [d_vocab, d_model]
-            self._dictionary_cache[(layer, device)] = cached
-        return cached
+            dictionary = (matrix.T @ unembed.float()).T  # [d_vocab, d_model]
+            entry = (fingerprint, dictionary)
+            self._dictionary_cache[(layer, device)] = entry
+        return entry[1]
 
     @torch.no_grad()
     def decompose(

--- a/transformer_lens/tools/analysis/jacobian_lens.py
+++ b/transformer_lens/tools/analysis/jacobian_lens.py
@@ -60,7 +60,6 @@ Example::
     print(result.top_tokens(model.tokenizer, k=5)[8][-1])  # layer 8, final position
 """
 
-import hashlib
 import warnings
 from dataclasses import dataclass
 from importlib.metadata import version
@@ -225,25 +224,6 @@ class JacobianLensReadout:
         return out
 
 
-@dataclass(frozen=True)
-class _UnembeddingFingerprint:
-    digest: bytes
-    shape: Tuple[int, ...]
-    dtype: torch.dtype
-    device: torch.device
-
-
-def _unembedding_fingerprint(unembed: torch.Tensor) -> _UnembeddingFingerprint:
-    """Hash contents because ``.data`` writes bypass PyTorch's version counter."""
-    raw_bytes = unembed.detach().contiguous().cpu().view(torch.uint8).numpy()
-    return _UnembeddingFingerprint(
-        digest=hashlib.blake2b(memoryview(raw_bytes), digest_size=16).digest(),
-        shape=tuple(unembed.shape),
-        dtype=unembed.dtype,
-        device=unembed.device,
-    )
-
-
 class JacobianLens:
     """A fitted Jacobian lens: one transport matrix per source layer.
 
@@ -286,9 +266,8 @@ class JacobianLens:
         self.d_model = int(d_model)
         self.metadata: Dict[str, Any] = dict(metadata or {})
         self._device_jacobians: Dict[Tuple[int, torch.device], torch.Tensor] = {}
-        self._dictionary_cache: Dict[
-            Tuple[int, torch.device], Tuple[_UnembeddingFingerprint, torch.Tensor]
-        ] = {}
+        self._dictionary_cache: Dict[Tuple[int, torch.device], torch.Tensor] = {}
+        self._unembedding_snapshots: Dict[torch.device, torch.Tensor] = {}
 
     @property
     def source_layers(self) -> List[int]:
@@ -677,10 +656,10 @@ class JacobianLens:
     # ------------------------------------------------------------------ #
 
     def clear_device_cache(self) -> None:
-        """Release lazily cached Jacobian copies and full-vocabulary dictionaries on
-        accelerator devices."""
+        """Release cached Jacobians, dictionaries, and unembedding snapshots on devices."""
         self._device_jacobians.clear()
         self._dictionary_cache.clear()
+        self._unembedding_snapshots.clear()
 
     def _matrix_on(self, layer: int, device: Union[str, torch.device]) -> torch.Tensor:
         """Return one cached fp32 Jacobian copy for a layer/device pair."""
@@ -871,7 +850,8 @@ class JacobianLens:
 
         The dictionary is vocabulary-sized and cached on the model's device
         (``d_vocab * d_model`` fp32 values, on the order of gigabytes for a large
-        vocabulary), one entry per requested layer.
+        vocabulary), one entry per requested layer. One detached copy of ``W_U`` is
+        retained per device to detect changes without transferring weights to the host.
 
         Args:
             model: The model supplying ``W_U``.
@@ -884,14 +864,20 @@ class JacobianLens:
         layer = _normalize_layer(layer, model.cfg.n_layers)
         unembed = model.W_U
         device = torch.device(unembed.device)
-        fingerprint = _unembedding_fingerprint(unembed)
-        entry = self._dictionary_cache.get((layer, device))
-        if entry is None or entry[0] != fingerprint:
+        snapshot = self._unembedding_snapshots.get(device)
+        if snapshot is None or not torch.equal(snapshot, unembed):
+            self._unembedding_snapshots[device] = unembed.detach().clone()
+            stale_keys = [key for key in self._dictionary_cache if key[1] == device]
+            for key in stale_keys:
+                del self._dictionary_cache[key]
+
+        key = (layer, device)
+        dictionary = self._dictionary_cache.get(key)
+        if dictionary is None:
             matrix = self._matrix_on(layer, device)  # [d_model, d_model]
             dictionary = (matrix.T @ unembed.float()).T  # [d_vocab, d_model]
-            entry = (fingerprint, dictionary)
-            self._dictionary_cache[(layer, device)] = entry
-        return entry[1]
+            self._dictionary_cache[key] = dictionary
+        return dictionary
 
     @torch.no_grad()
     def decompose(


### PR DESCRIPTION
# Description

`JacobianLens.lens_vector_dictionary()` previously cached a full-vocabulary dictionary only by layer and device. Reusing the lens after an optimizer step, an in-place or temporary unembedding edit, a parameter replacement, or with another compatible model could therefore return a stale dictionary and silently attach residual directions to the wrong token labels.

This change retains one detached `W_U` snapshot per device and compares it with the current unembedding using on-device `torch.equal`. Unchanged weights retain the existing object-level dictionary cache hit; a content change invalidates every cached layer on that device. This covers `.data` writes that bypass PyTorch's version counter and parameter replacements after allocator address reuse, without copying weights to the host or hashing them on every cache lookup.

The regression coverage verifies cache hits for unchanged weights and invalidation after `copy_()`, an optimizer step, `.data` mutation without a version increment, whole-parameter replacement after the old parameter has been released, temporary parameter swapping in both directions, and reuse with a second compatible model. It also verifies that one snapshot is shared across layers, a change invalidates every layer on the affected device, and an unembedding row swap cannot make decomposition return the old token label with zero residual.

Fixes #1765

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Not applicable.

# Validation

- `uv run --no-cache --no-sync pytest tests/unit/tools/test_jacobian_lens.py tests/unit/tools/test_jacobian_lens_coordinate_patch_hooks.py -q` — 122 passed
- `uv run --no-cache --no-sync mypy .` — success across 397 source files
- pycln, isort, Black, and `git diff --check` — passed for the affected surface

The complete `make test-pr` surface was not run locally.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes — only the affected unit-test surface was run
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility