### PR TITLE
feat(svd_circuits): per-head QK/OV SVD with degeneracy guard

### DIFF
--- a/tests/unit/tools/test_svd_circuits.py
+++ b/tests/unit/tools/test_svd_circuits.py
@@ -5,6 +5,7 @@ degeneracy guard directly, so no model is loaded and no pretrained weights are d
 """
 
 import warnings
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -15,9 +16,45 @@ from transformer_lens.tools.analysis.svd_circuits import (
     RankReportRow,
     _degeneracy_blocks,
     _factored_head_svd,
+    decompose_head,
 )
 
 D_MODEL, D_HEAD = 12, 4
+
+
+class _StubAttn:
+    def __init__(self, W_Q, W_K, W_V, W_O):
+        self.W_Q, self.W_K, self.W_V, self.W_O = W_Q, W_K, W_V, W_O
+
+
+class _StubBlock:
+    def __init__(self, attn):
+        self.attn = attn
+
+
+class _StubModel:
+    """Model-free stand-in exposing cfg.n_layers/n_heads and blocks[i].attn.W_*.
+
+    W_K/W_V carry ``n_kv_heads`` rows (the grouped-query layout); W_Q/W_O carry
+    ``n_heads`` rows, matching the per-block shapes ``decompose_head`` reads.
+    """
+
+    def __init__(
+        self,
+        n_heads,
+        n_kv_heads,
+        n_layers=1,
+        d_model=D_MODEL,
+        d_head=D_HEAD,
+        seed=0,
+    ):
+        g = torch.Generator().manual_seed(seed)
+        W_Q = torch.randn(n_heads, d_model, d_head, generator=g)
+        W_K = torch.randn(n_kv_heads, d_model, d_head, generator=g)
+        W_V = torch.randn(n_kv_heads, d_model, d_head, generator=g)
+        W_O = torch.randn(n_heads, d_head, d_model, generator=g)
+        self.cfg = SimpleNamespace(n_layers=n_layers, n_heads=n_heads)
+        self.blocks = [_StubBlock(_StubAttn(W_Q, W_K, W_V, W_O)) for _ in range(n_layers)]
 
 
 # --------------------------------------------------------------------------- #
@@ -211,3 +248,79 @@ def test_degeneracy_blocks_groups_equal_run_directly():
 def test_degeneracy_blocks_on_well_separated_are_all_singletons():
     blocks = _degeneracy_blocks(torch.tensor([8.0, 4.0, 2.0, 1.0]), eps=1e-2)
     assert blocks == [[0], [1], [2], [3]]
+
+
+# --------------------------------------------------------------------------- #
+# decompose_head wiring and input guards (model-free, via _StubModel)
+# --------------------------------------------------------------------------- #
+def test_decompose_head_mha_reads_requested_head():
+    """MHA stub (n_heads == n_kv_heads): each head's OV decomposes its own W_V/W_O."""
+    model = _StubModel(n_heads=4, n_kv_heads=4)
+    attn = model.blocks[0].attn
+    for h in range(4):
+        result = decompose_head(model, layer=0, head=h, which=("OV",))
+        S_ref = torch.linalg.svd(attn.W_V[h] @ attn.W_O[h]).S
+        assert torch.allclose(result.OV.S, S_ref[:D_HEAD], atol=1e-4)
+
+
+def test_decompose_head_gqa_maps_query_to_kv_head():
+    """GQA stub (4 query heads, 2 kv heads): every head decomposes without IndexError,
+    and heads 0,1 recover kv head 0's W_K/W_V while heads 2,3 recover kv head 1's."""
+    model = _StubModel(n_heads=4, n_kv_heads=2)
+    attn = model.blocks[0].attn
+    n_heads = model.cfg.n_heads
+    n_kv_heads = attn.W_K.shape[0]
+    for h in range(n_heads):
+        result = decompose_head(model, layer=0, head=h, which=("QK", "OV"))
+        kv_head = h // (n_heads // n_kv_heads)
+        ov_ref = torch.linalg.svd(attn.W_V[kv_head] @ attn.W_O[h]).S
+        qk_ref = torch.linalg.svd(attn.W_Q[h] @ attn.W_K[kv_head].transpose(-1, -2)).S
+        assert torch.allclose(result.OV.S, ov_ref[:D_HEAD], atol=1e-4)
+        assert torch.allclose(result.QK.S, qk_ref[:D_HEAD], atol=1e-4)
+
+
+def test_decompose_head_qk_transpose_wiring():
+    """QK factors W_Q_h and W_K_h.T; res.QK.S matches svd(W_Q_h @ W_K_h.T)."""
+    model = _StubModel(n_heads=4, n_kv_heads=4)
+    attn = model.blocks[0].attn
+    result = decompose_head(model, layer=0, head=2, which=("QK",))
+    S_ref = torch.linalg.svd(attn.W_Q[2] @ attn.W_K[2].transpose(-1, -2)).S
+    assert torch.allclose(result.QK.S, S_ref[:D_HEAD], atol=1e-4)
+
+
+def test_decompose_head_which_filter():
+    """which=("OV",) returns only OV; which=("QK",) returns only QK."""
+    model = _StubModel(n_heads=2, n_kv_heads=2)
+    ov_only = decompose_head(model, layer=0, head=0, which=("OV",))
+    assert ov_only.OV is not None and ov_only.QK is None
+    qk_only = decompose_head(model, layer=0, head=0, which=("QK",))
+    assert qk_only.QK is not None and qk_only.OV is None
+
+
+def test_decompose_head_rejects_bad_layer():
+    model = _StubModel(n_heads=2, n_kv_heads=2, n_layers=1)
+    with pytest.raises(ValueError):
+        decompose_head(model, layer=1, head=0)
+
+
+def test_decompose_head_rejects_bad_head():
+    model = _StubModel(n_heads=2, n_kv_heads=2)
+    with pytest.raises(ValueError):
+        decompose_head(model, layer=0, head=2)
+
+
+def test_decompose_head_rejects_empty_which():
+    model = _StubModel(n_heads=2, n_kv_heads=2)
+    with pytest.raises(ValueError):
+        decompose_head(model, layer=0, head=0, which=())
+
+
+def test_decompose_head_rejects_unknown_which():
+    """An unknown which entry is rejected; the jaxtyping/beartype import hook enforced
+    by this suite's pytest config raises its own violation before the manual ValueError
+    guard runs, so the check is on the exception class name rather than ValueError."""
+    model = _StubModel(n_heads=2, n_kv_heads=2)
+    with pytest.raises(Exception) as exc_info:
+        decompose_head(model, layer=0, head=0, which=("QK", "XX"))
+    exc_name = type(exc_info.value).__name__
+    assert "TypeCheckError" in exc_name or "Beartype" in exc_name

--- a/tests/unit/tools/test_svd_circuits.py
+++ b/tests/unit/tools/test_svd_circuits.py
@@ -214,11 +214,39 @@ def test_near_but_not_equal_respects_eps():
 
 
 def test_null_run_grouped():
-    """A run of near-zero singular values forms one degenerate null block."""
+    """A spectrum the relative-gap rule cannot group (8e-3 is 40x above 2e-4) is grouped by
+    an explicit null_rtol wide enough to catch both as numerically null."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([1.0, 8e-3, 2e-4]),
+        which="OV",
+        layer=0,
+        head=0,
+        eps=1e-2,
+        null_rtol=1e-2,
+    )
+    assert res.degenerate_blocks() == [[1, 2]]
+    with pytest.raises(DegenerateDirectionError):
+        res.require_isolated(1)
+    with pytest.raises(DegenerateDirectionError):
+        res.require_isolated(2)
+
+
+def test_null_default_does_not_overgroup():
+    """With the default null_rtol, 8e-3 is not treated as null, so it is not over-grouped
+    with the tail direction the way the eps=1e-2 near-equal threshold used to."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([1.0, 8e-3, 2e-4]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    assert not res.is_degenerate(1)
+    assert not res.is_degenerate(2)
+
+
+def test_null_run_groups_true_null_tail():
+    """The default null_rtol still catches a genuinely near-zero tail as a null block."""
     res = _factored_head_svd(
         *_factored_with_spectrum([5.0, 1.0, 1e-9, 1e-9]), which="OV", layer=0, head=0, eps=1e-2
     )
-    assert res.is_degenerate(2) and res.is_degenerate(3)
+    assert res.degenerate_blocks() == [[2, 3]]
     with pytest.raises(DegenerateDirectionError):
         res.require_isolated(2)
     with pytest.raises(DegenerateDirectionError):
@@ -265,12 +293,12 @@ def test_degeneracy_blocks_partition_all_indices():
 # --------------------------------------------------------------------------- #
 def test_degeneracy_blocks_groups_equal_run_directly():
     """_degeneracy_blocks groups a repeated value and isolates the well-separated neighbours."""
-    blocks = _degeneracy_blocks(torch.tensor([5.0, 3.0, 3.0, 1.0]), eps=1e-2)
+    blocks = _degeneracy_blocks(torch.tensor([5.0, 3.0, 3.0, 1.0]), eps=1e-2, null_rtol=1e-2)
     assert blocks == [[0], [1, 2], [3]]
 
 
 def test_degeneracy_blocks_on_well_separated_are_all_singletons():
-    blocks = _degeneracy_blocks(torch.tensor([8.0, 4.0, 2.0, 1.0]), eps=1e-2)
+    blocks = _degeneracy_blocks(torch.tensor([8.0, 4.0, 2.0, 1.0]), eps=1e-2, null_rtol=1e-2)
     assert blocks == [[0], [1], [2], [3]]
 
 

--- a/tests/unit/tools/test_svd_circuits.py
+++ b/tests/unit/tools/test_svd_circuits.py
@@ -36,7 +36,8 @@ class _StubModel:
     """Model-free stand-in exposing cfg.n_layers/n_heads and blocks[i].attn.W_*.
 
     W_K/W_V carry ``n_kv_heads`` rows (the grouped-query layout); W_Q/W_O carry
-    ``n_heads`` rows, matching the per-block shapes ``decompose_head`` reads.
+    ``n_heads`` rows, matching the per-block shapes ``decompose_head`` reads. Each
+    layer draws its own weights so a read from the wrong layer is visible.
     """
 
     def __init__(
@@ -47,14 +48,27 @@ class _StubModel:
         d_model=D_MODEL,
         d_head=D_HEAD,
         seed=0,
+        dtype=torch.float32,
+        requires_grad=False,
     ):
         g = torch.Generator().manual_seed(seed)
-        W_Q = torch.randn(n_heads, d_model, d_head, generator=g)
-        W_K = torch.randn(n_kv_heads, d_model, d_head, generator=g)
-        W_V = torch.randn(n_kv_heads, d_model, d_head, generator=g)
-        W_O = torch.randn(n_heads, d_head, d_model, generator=g)
         self.cfg = SimpleNamespace(n_layers=n_layers, n_heads=n_heads)
-        self.blocks = [_StubBlock(_StubAttn(W_Q, W_K, W_V, W_O)) for _ in range(n_layers)]
+        self.blocks = []
+        for _ in range(n_layers):
+            shapes = [
+                (n_heads, d_model, d_head),
+                (n_kv_heads, d_model, d_head),
+                (n_kv_heads, d_model, d_head),
+                (n_heads, d_head, d_model),
+            ]
+            weights = [torch.randn(*shape, generator=g).to(dtype) for shape in shapes]
+            if requires_grad:
+                weights = [torch.nn.Parameter(w) for w in weights]
+            self.blocks.append(_StubBlock(_StubAttn(*weights)))
+
+
+def _reconstruct(res):
+    return res.U @ torch.diag(res.S) @ res.V.transpose(-2, -1)
 
 
 # --------------------------------------------------------------------------- #
@@ -100,8 +114,7 @@ def test_reconstruction_matches_materialized_matrix():
     """U @ diag(S) @ V.T rebuilds W_V @ W_O, sidestepping the U/V column-sign ambiguity."""
     W_V, W_O = _random_ov()
     res = _factored_head_svd(W_V, W_O, which="OV", layer=0, head=0, eps=1e-2)
-    reconstruction = res.U @ torch.diag(res.S) @ res.V.transpose(-2, -1)
-    assert torch.allclose(reconstruction, W_V @ W_O, atol=1e-4)
+    assert torch.allclose(_reconstruct(res), W_V @ W_O, atol=1e-4)
 
 
 def test_singular_values_sorted_descending():
@@ -191,6 +204,23 @@ def test_degenerate_error_message_points_to_block():
     assert "subspace" in message.lower()
 
 
+def test_refusal_message_names_the_rule_that_formed_the_block():
+    """A gap-formed block is refused for its eps gap; a null block is refused as null."""
+    gap = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="QK", layer=2, head=3, eps=1e-2
+    )
+    with pytest.raises(
+        DegenerateDirectionError, match=r"QK SVD of head L2H3.*eps=0\.01"
+    ) as gap_exc:
+        gap.require_isolated(2)
+    assert "null" not in str(gap_exc.value)
+    null = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 2e-9, 1e-9]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    with pytest.raises(DegenerateDirectionError, match="numerically null"):
+        null.require_isolated(1)
+
+
 def test_well_separated_spectrum_flags_nothing():
     """A well-separated spectrum (8, 4, 2, 1) has no degenerate block and no flagged row."""
     res = _factored_head_svd(
@@ -214,8 +244,8 @@ def test_near_but_not_equal_respects_eps():
 
 
 def test_null_run_grouped():
-    """A spectrum the relative-gap rule cannot group (8e-3 is 40x above 2e-4) is grouped by
-    an explicit null_rtol wide enough to catch both as numerically null."""
+    """Two directions the gap rule cannot group (8e-3 is 40x above 2e-4) form one null
+    block under a null_rtol wide enough to cover both."""
     res = _factored_head_svd(
         *_factored_with_spectrum([1.0, 8e-3, 2e-4]),
         which="OV",
@@ -232,8 +262,8 @@ def test_null_run_grouped():
 
 
 def test_null_default_does_not_overgroup():
-    """With the default null_rtol, 8e-3 is not treated as null, so it is not over-grouped
-    with the tail direction the way the eps=1e-2 near-equal threshold used to."""
+    """Under the default null_rtol, 8e-3 and 2e-4 are both far above the null cutoff and 40x
+    apart, so neither is degenerate."""
     res = _factored_head_svd(
         *_factored_with_spectrum([1.0, 8e-3, 2e-4]), which="OV", layer=0, head=0, eps=1e-2
     )
@@ -253,28 +283,37 @@ def test_null_run_groups_true_null_tail():
         res.require_isolated(3)
 
 
+def test_lone_null_direction_is_degenerate():
+    """A single null direction is refused on its own: its singular vector is an arbitrary
+    null-space vector even though no neighbour groups with it."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 1.0, 0.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    assert res.rank_report[3].is_null and res.is_degenerate(3)
+    assert res.degenerate_blocks() == [[3]]
+    with pytest.raises(DegenerateDirectionError, match="null"):
+        res.require_isolated(3)
+    assert all(res.require_isolated(i) is None for i in range(3))
+
+
 def test_degenerate_blocks_returns_equal_run():
-    """degenerate_blocks pins the actual grouping for a repeated value, defeating a
-    "return [] unconditionally" mutation that would otherwise slip through a test that
-    only checks non-degeneracy elsewhere."""
+    """degenerate_blocks returns the repeated-value run and nothing else."""
     res = _factored_head_svd(
         *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
     )
     assert res.degenerate_blocks() == [[1, 2]]
 
 
-def test_slow_decay_does_not_form_one_block():
-    """A spectrum decaying ~0.9% per step, just under eps=1e-2, no longer chains every
-    direction into one block spanning far more than eps: each block's spread is capped to
-    eps of its own anchor, so the slowly decaying tail breaks into several small blocks
-    instead of one, and the well-separated top direction stays isolated."""
+def test_slow_decay_forms_one_gap_separated_block():
+    """A tail decaying 0.9% per step has no eps=1e-2 gap anywhere inside it, so it is one
+    block, and only the well-separated top direction is isolated."""
     tail = [0.5 * (0.991**i) for i in range(7)]
     spectrum = [1.0] + tail
     res = _factored_head_svd(
         *_factored_with_spectrum(spectrum), which="OV", layer=0, head=0, eps=1e-2
     )
     assert res.require_isolated(0) is None
-    assert res.degenerate_blocks() == [[1, 2], [3, 4], [5, 6]]
+    assert res.degenerate_blocks() == [[1, 2, 3, 4, 5, 6, 7]]
 
 
 def test_degeneracy_blocks_partition_all_indices():
@@ -302,6 +341,24 @@ def test_degeneracy_blocks_on_well_separated_are_all_singletons():
     assert blocks == [[0], [1], [2], [3]]
 
 
+@pytest.mark.parametrize("seed", range(5))
+@pytest.mark.parametrize("eps", [1e-2, 5e-2])
+def test_every_block_boundary_is_an_eps_gap(seed, eps):
+    """Blocks end exactly where the spectrum has a relative gap of at least eps, so every
+    boundary is eps-separated and no singleton has a neighbour within eps."""
+    g = torch.Generator().manual_seed(seed)
+    S = torch.sort(torch.rand(64, generator=g) * 10 + 0.1, descending=True).values
+    S[10:20] = S[10]  # a planted exactly-equal run
+    blocks = _degeneracy_blocks(S, eps=eps, null_rtol=0.0)
+    gap = lambda i, j: 1.0 - float(S[j]) / float(S[i])  # i < j
+    assert [i for block in blocks for i in block] == list(range(64))
+    for left, right in zip(blocks, blocks[1:]):
+        assert gap(left[-1], right[0]) >= eps
+    for block in blocks:
+        for i, j in zip(block, block[1:]):
+            assert gap(i, j) < eps
+
+
 # --------------------------------------------------------------------------- #
 # decompose_head wiring and input guards (model-free, via _StubModel)
 # --------------------------------------------------------------------------- #
@@ -313,11 +370,12 @@ def test_decompose_head_mha_reads_requested_head():
         result = decompose_head(model, layer=0, head=h, which=("OV",))
         S_ref = torch.linalg.svd(attn.W_V[h] @ attn.W_O[h]).S
         assert torch.allclose(result.OV.S, S_ref[:D_HEAD], atol=1e-4)
+        assert torch.allclose(_reconstruct(result.OV), attn.W_V[h] @ attn.W_O[h], atol=1e-4)
 
 
 def test_decompose_head_gqa_maps_query_to_kv_head():
-    """GQA stub (4 query heads, 2 kv heads): every head decomposes without IndexError,
-    and heads 0,1 recover kv head 0's W_K/W_V while heads 2,3 recover kv head 1's."""
+    """GQA stub (4 query heads, 2 kv heads): each query head reads its own kv head, with
+    U/V orientation and the head identity pinned as well."""
     model = _StubModel(n_heads=4, n_kv_heads=2)
     attn = model.blocks[0].attn
     n_heads = model.cfg.n_heads
@@ -325,10 +383,25 @@ def test_decompose_head_gqa_maps_query_to_kv_head():
     for h in range(n_heads):
         result = decompose_head(model, layer=0, head=h, which=("QK", "OV"))
         kv_head = h // (n_heads // n_kv_heads)
-        ov_ref = torch.linalg.svd(attn.W_V[kv_head] @ attn.W_O[h]).S
-        qk_ref = torch.linalg.svd(attn.W_Q[h] @ attn.W_K[kv_head].transpose(-1, -2)).S
-        assert torch.allclose(result.OV.S, ov_ref[:D_HEAD], atol=1e-4)
-        assert torch.allclose(result.QK.S, qk_ref[:D_HEAD], atol=1e-4)
+        ov_ref = attn.W_V[kv_head] @ attn.W_O[h]
+        qk_ref = attn.W_Q[h] @ attn.W_K[kv_head].transpose(-1, -2)
+        assert torch.allclose(result.OV.S, torch.linalg.svd(ov_ref).S[:D_HEAD], atol=1e-4)
+        assert torch.allclose(result.QK.S, torch.linalg.svd(qk_ref).S[:D_HEAD], atol=1e-4)
+        assert torch.allclose(_reconstruct(result.OV), ov_ref, atol=1e-4)
+        assert torch.allclose(_reconstruct(result.QK), qk_ref, atol=1e-4)
+        assert (result.QK.which, result.QK.layer, result.QK.head) == ("QK", 0, h)
+        assert (result.OV.which, result.OV.layer, result.OV.head) == ("OV", 0, h)
+
+
+def test_decompose_head_reads_requested_layer():
+    """On a two-layer stub, layer 1's decomposition matches layer 1's weights, not layer 0's."""
+    model = _StubModel(n_heads=2, n_kv_heads=2, n_layers=2)
+    result = decompose_head(model, layer=1, head=1, which=("OV",))
+    own = model.blocks[1].attn.W_V[1] @ model.blocks[1].attn.W_O[1]
+    other = model.blocks[0].attn.W_V[1] @ model.blocks[0].attn.W_O[1]
+    assert torch.allclose(_reconstruct(result.OV), own, atol=1e-4)
+    assert not torch.allclose(_reconstruct(result.OV), other, atol=1e-2)
+    assert result.OV.layer == 1
 
 
 def test_decompose_head_qk_transpose_wiring():
@@ -338,6 +411,25 @@ def test_decompose_head_qk_transpose_wiring():
     result = decompose_head(model, layer=0, head=2, which=("QK",))
     S_ref = torch.linalg.svd(attn.W_Q[2] @ attn.W_K[2].transpose(-1, -2)).S
     assert torch.allclose(result.QK.S, S_ref[:D_HEAD], atol=1e-4)
+
+
+def test_decompose_head_detaches_from_model_weights():
+    """The returned factors carry no autograd graph back to the model's parameters."""
+    model = _StubModel(n_heads=2, n_kv_heads=2, requires_grad=True)
+    result = decompose_head(model, layer=0, head=0)
+    for res in (result.QK, result.OV):
+        for tensor in (res.U, res.S, res.V):
+            assert not tensor.requires_grad and tensor.grad_fn is None
+
+
+def test_decompose_head_keeps_float64_and_promotes_half():
+    """float64 weights stay float64 (and null_rtol follows), fp16 weights are promoted."""
+    result = decompose_head(_StubModel(n_heads=2, n_kv_heads=2, dtype=torch.float64), 0, 0)
+    assert result.OV.S.dtype == torch.float64
+    assert result.OV.null_rtol == pytest.approx(D_MODEL * torch.finfo(torch.float64).eps)
+    result = decompose_head(_StubModel(n_heads=2, n_kv_heads=2, dtype=torch.float16), 0, 0)
+    assert result.OV.S.dtype == torch.float32
+    assert result.OV.null_rtol == pytest.approx(D_MODEL * torch.finfo(torch.float32).eps)
 
 
 def test_decompose_head_which_filter():
@@ -368,11 +460,13 @@ def test_decompose_head_rejects_empty_which():
 
 
 def test_decompose_head_rejects_unknown_which():
-    """An unknown which entry is rejected; the jaxtyping/beartype import hook enforced
-    by this suite's pytest config raises its own violation before the manual ValueError
-    guard runs, so the check is on the exception class name rather than ValueError."""
     model = _StubModel(n_heads=2, n_kv_heads=2)
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(ValueError, match="which entries"):
         decompose_head(model, layer=0, head=0, which=("QK", "XX"))
-    exc_name = type(exc_info.value).__name__
-    assert "TypeCheckError" in exc_name or "Beartype" in exc_name
+
+
+def test_decompose_head_rejects_bare_string_which():
+    """A bare string is refused instead of being iterated into its characters."""
+    model = _StubModel(n_heads=2, n_kv_heads=2)
+    with pytest.raises(ValueError, match="sequence"):
+        decompose_head(model, layer=0, head=0, which="QK")

--- a/tests/unit/tools/test_svd_circuits.py
+++ b/tests/unit/tools/test_svd_circuits.py
@@ -1,0 +1,213 @@
+"""Unit tests for per-head QK/OV singular-vector decomposition.
+
+Model-free: they build synthetic weight tensors and exercise the factored SVD and the
+degeneracy guard directly, so no model is loaded and no pretrained weights are downloaded.
+"""
+
+import warnings
+
+import pytest
+import torch
+
+from transformer_lens.tools.analysis.svd_circuits import (
+    DegenerateDirectionError,
+    HeadSVD,
+    RankReportRow,
+    _degeneracy_blocks,
+    _factored_head_svd,
+)
+
+D_MODEL, D_HEAD = 12, 4
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic fixtures
+# --------------------------------------------------------------------------- #
+def _random_ov(seed=0):
+    """A non-degenerate OV factoring: W_V [d_model, d_head], W_O [d_head, d_model]."""
+    g = torch.Generator().manual_seed(seed)
+    W_V = torch.randn(D_MODEL, D_HEAD, generator=g)
+    W_O = torch.randn(D_HEAD, D_MODEL, generator=g)
+    return W_V, W_O
+
+
+def _factored_with_spectrum(spectrum, seed=0):
+    """Build (A, B) so that A @ B == U0 @ diag(s) @ V0.T with U0, V0 orthonormal columns.
+
+    ``spectrum`` is a descending sequence of singular values; passing a repeated value plants
+    an exactly-degenerate block, so the recovered SVD has a known, controllable spectrum.
+    """
+    s = torch.as_tensor(spectrum, dtype=torch.float32)
+    g = torch.Generator().manual_seed(seed)
+    U0, _ = torch.linalg.qr(torch.randn(D_MODEL, len(s), generator=g))
+    V0, _ = torch.linalg.qr(torch.randn(D_MODEL, len(s), generator=g))
+    root = s.sqrt()
+    A = U0 @ torch.diag(root)  # [d_model, r]
+    B = torch.diag(root) @ V0.transpose(-2, -1)  # [r, d_model]
+    return A, B
+
+
+# --------------------------------------------------------------------------- #
+# Oracle / correctness of the factored SVD
+# --------------------------------------------------------------------------- #
+def test_singular_values_match_torch_linalg_svd_on_ov():
+    """The factored OV SVD reproduces the singular values of the materialized W_V @ W_O."""
+    W_V, W_O = _random_ov()
+    S_ref = torch.linalg.svd(W_V @ W_O).S
+    res = _factored_head_svd(W_V, W_O, which="OV", layer=0, head=0, eps=1e-2)
+    assert isinstance(res, HeadSVD)
+    assert torch.allclose(res.S, S_ref[:D_HEAD], atol=1e-5)
+
+
+def test_reconstruction_matches_materialized_matrix():
+    """U @ diag(S) @ V.T rebuilds W_V @ W_O, sidestepping the U/V column-sign ambiguity."""
+    W_V, W_O = _random_ov()
+    res = _factored_head_svd(W_V, W_O, which="OV", layer=0, head=0, eps=1e-2)
+    reconstruction = res.U @ torch.diag(res.S) @ res.V.transpose(-2, -1)
+    assert torch.allclose(reconstruction, W_V @ W_O, atol=1e-4)
+
+
+def test_singular_values_sorted_descending():
+    W_V, W_O = _random_ov()
+    res = _factored_head_svd(W_V, W_O, which="OV", layer=0, head=0, eps=1e-2)
+    assert bool(torch.all(res.S[:-1] + 1e-6 >= res.S[1:]))
+
+
+def test_rank_bounded_by_d_head():
+    """A product of d_head-rank factors has at most d_head singular values, all reported."""
+    W_V, W_O = _random_ov()
+    res = _factored_head_svd(W_V, W_O, which="OV", layer=0, head=0, eps=1e-2)
+    assert res.S.shape[0] == D_HEAD
+    assert int((res.S > 1e-6).sum()) <= D_HEAD
+
+
+def test_qk_svd_matches_materialized():
+    """The QK path factors W_Q and W_K.T and matches torch.linalg.svd(W_Q @ W_K.T)."""
+    g = torch.Generator().manual_seed(1)
+    W_Q = torch.randn(D_MODEL, D_HEAD, generator=g)
+    W_K = torch.randn(D_MODEL, D_HEAD, generator=g)
+    S_ref = torch.linalg.svd(W_Q @ W_K.transpose(-1, -2)).S
+    res = _factored_head_svd(W_Q, W_K.transpose(-1, -2), which="QK", layer=0, head=0, eps=1e-2)
+    assert torch.allclose(res.S, S_ref[:D_HEAD], atol=1e-5)
+
+
+def test_uses_V_not_Vh_no_deprecation_warning():
+    """FactoredMatrix.Vh is a deprecated alias that warns; the decomposition must read .V only."""
+    W_V, W_O = _random_ov()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        _factored_head_svd(W_V, W_O, which="OV", layer=0, head=0, eps=1e-2)
+
+
+def test_rank_report_shape_and_ratio():
+    """Each direction gets one report row; sigma_ratio is sigma normalized by the top value."""
+    W_V, W_O = _random_ov()
+    res = _factored_head_svd(W_V, W_O, which="OV", layer=0, head=0, eps=1e-2)
+    assert len(res.rank_report) == D_HEAD
+    assert all(isinstance(row, RankReportRow) for row in res.rank_report)
+    top = float(res.S.max())
+    for row in res.rank_report:
+        assert row.sigma_ratio == pytest.approx(row.sigma / top, rel=1e-5)
+    assert res.rank_report[0].sigma_ratio == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------------------- #
+# Degeneracy guard: refuse per-direction attribution inside a degenerate block
+# --------------------------------------------------------------------------- #
+def test_degeneracy_block_flagged_on_equal_singular_values():
+    """Equal singular values (5, 3, 3, 1) make directions 1 and 2 rotation-ambiguous."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    assert res.is_degenerate(1) and res.is_degenerate(2)
+    assert not res.is_degenerate(0) and not res.is_degenerate(3)
+
+
+def test_block_of_returns_full_degenerate_run():
+    """block_of returns the whole degenerate run for a member, and a singleton otherwise."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    assert set(res.block_of(1)) == {1, 2} == set(res.block_of(2))
+    assert res.block_of(0) == [0]
+
+
+def test_require_isolated_raises_inside_block():
+    """require_isolated raises for a degenerate direction and returns None for an isolated one."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    with pytest.raises(DegenerateDirectionError):
+        res.require_isolated(1)
+    assert res.require_isolated(0) is None
+
+
+def test_degenerate_error_message_points_to_block():
+    """The refusal names the block indices and steers the caller to subspace attribution."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    with pytest.raises(DegenerateDirectionError) as excinfo:
+        res.require_isolated(1)
+    message = str(excinfo.value)
+    assert "1" in message and "2" in message
+    assert "subspace" in message.lower()
+
+
+def test_well_separated_spectrum_flags_nothing():
+    """A well-separated spectrum (8, 4, 2, 1) has no degenerate block and no flagged row."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([8.0, 4.0, 2.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    assert res.degenerate_blocks() == []
+    assert not any(row.is_degenerate for row in res.rank_report)
+
+
+def test_near_but_not_equal_respects_eps():
+    """A relative gap of 5e-3 groups under eps=1e-2 but stays isolated under eps=1e-3."""
+    spectrum = [3.0, 3.0 * (1 - 5e-3), 1.0, 0.5]
+    grouped = _factored_head_svd(
+        *_factored_with_spectrum(spectrum), which="OV", layer=0, head=0, eps=1e-2
+    )
+    assert grouped.is_degenerate(0) and grouped.is_degenerate(1)
+    separated = _factored_head_svd(
+        *_factored_with_spectrum(spectrum), which="OV", layer=0, head=0, eps=1e-3
+    )
+    assert not separated.is_degenerate(0) and not separated.is_degenerate(1)
+
+
+def test_null_run_grouped():
+    """A run of near-zero singular values forms one degenerate null block."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 1.0, 1e-9, 1e-9]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    assert res.is_degenerate(2) and res.is_degenerate(3)
+    with pytest.raises(DegenerateDirectionError):
+        res.require_isolated(2)
+    with pytest.raises(DegenerateDirectionError):
+        res.require_isolated(3)
+
+
+def test_degeneracy_blocks_partition_all_indices():
+    """Degenerate blocks plus the remaining singletons cover every direction exactly once."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    covered = [i for block in res.degenerate_blocks() for i in block]
+    singletons = [i for i in range(D_HEAD) if i not in covered]
+    assert sorted(covered + singletons) == list(range(D_HEAD))
+    assert len(covered + singletons) == D_HEAD  # no direction counted twice
+
+
+# --------------------------------------------------------------------------- #
+# Degeneracy grouping on a raw spectrum (fully model-free)
+# --------------------------------------------------------------------------- #
+def test_degeneracy_blocks_groups_equal_run_directly():
+    """_degeneracy_blocks groups a repeated value and isolates the well-separated neighbours."""
+    blocks = _degeneracy_blocks(torch.tensor([5.0, 3.0, 3.0, 1.0]), eps=1e-2)
+    assert blocks == [[0], [1, 2], [3]]
+
+
+def test_degeneracy_blocks_on_well_separated_are_all_singletons():
+    blocks = _degeneracy_blocks(torch.tensor([8.0, 4.0, 2.0, 1.0]), eps=1e-2)
+    assert blocks == [[0], [1], [2], [3]]

--- a/tests/unit/tools/test_svd_circuits.py
+++ b/tests/unit/tools/test_svd_circuits.py
@@ -225,6 +225,30 @@ def test_null_run_grouped():
         res.require_isolated(3)
 
 
+def test_degenerate_blocks_returns_equal_run():
+    """degenerate_blocks pins the actual grouping for a repeated value, defeating a
+    "return [] unconditionally" mutation that would otherwise slip through a test that
+    only checks non-degeneracy elsewhere."""
+    res = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    assert res.degenerate_blocks() == [[1, 2]]
+
+
+def test_slow_decay_does_not_form_one_block():
+    """A spectrum decaying ~0.9% per step, just under eps=1e-2, no longer chains every
+    direction into one block spanning far more than eps: each block's spread is capped to
+    eps of its own anchor, so the slowly decaying tail breaks into several small blocks
+    instead of one, and the well-separated top direction stays isolated."""
+    tail = [0.5 * (0.991**i) for i in range(7)]
+    spectrum = [1.0] + tail
+    res = _factored_head_svd(
+        *_factored_with_spectrum(spectrum), which="OV", layer=0, head=0, eps=1e-2
+    )
+    assert res.require_isolated(0) is None
+    assert res.degenerate_blocks() == [[1, 2], [3, 4], [5, 6]]
+
+
 def test_degeneracy_blocks_partition_all_indices():
     """Degenerate blocks plus the remaining singletons cover every direction exactly once."""
     res = _factored_head_svd(

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -211,12 +211,16 @@ def _head_weights(
 def _degeneracy_blocks(S: Float[torch.Tensor, "rank"], eps: float) -> List[List[int]]:
     """Group singular directions into contiguous blocks by their relative gap.
 
-    ``S`` holds singular values sorted in descending order. Direction ``i`` joins
-    the block of direction ``i - 1`` when their relative gap ``1 - S[i]/S[i-1]``
-    falls below ``eps``, or when both are in a near-zero (null) run relative to the
-    top singular value. A block of more than one direction is degenerate: its
-    directions are defined only up to a rotation within the block. ``_SIGMA_FLOOR``
-    keeps the ratios finite when a divisor is ~0.
+    ``S`` holds singular values sorted in descending order. Direction ``i`` joins the
+    open block when it is within relative gap ``eps`` of both the previous direction
+    and the block's anchor (its first, largest member), or when both directions sit in
+    a near-zero (null) run relative to the top singular value. The anchor constraint
+    bounds how far a block can spread: without it, a spectrum decaying by just under
+    ``eps`` at every step would chain every direction into one block whose extremes
+    differ by far more than ``eps``, purely because each gap-to-previous is individually
+    small. A block of more than one direction is degenerate: its directions are defined
+    only up to a rotation within the block. ``_SIGMA_FLOOR`` keeps the ratios finite when
+    a divisor is ~0.
     """
     n = int(S.shape[0])
     if n == 0:
@@ -227,9 +231,10 @@ def _degeneracy_blocks(S: Float[torch.Tensor, "rank"], eps: float) -> List[List[
     current = [0]
     for i in range(1, n):
         prev = max(values[i - 1], _SIGMA_FLOOR)
-        relative_gap = 1.0 - (values[i] / prev)
+        anchor = max(values[current[0]], _SIGMA_FLOOR)
+        near_equal = (1.0 - values[i] / prev) < eps and (1.0 - values[i] / anchor) < eps
         null_run = (values[i] / top) < eps and (values[i - 1] / top) < eps
-        if relative_gap < eps or null_run:
+        if near_equal or null_run:
             current.append(i)
         else:
             blocks.append(current)

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -190,15 +190,22 @@ def _head_weights(
 ]:
     """Return ``(W_Q_h, W_K_h, W_V_h, W_O_h)`` for one head as float tensors.
 
-    The upcast to ``float`` promotes fp16/bf16 weights before the SVD, where
-    reduced precision is a known source of instability.
+    Reads the single block's per-head weights rather than the full-model
+    ``W_Q``/``W_K``/``W_V``/``W_O`` stacks, so only one layer is materialized. On
+    grouped-query attention ``W_K``/``W_V`` carry one row per key-value head, so the
+    query head is mapped to its key-value head (query head ``h`` reads kv head
+    ``h // (n_heads // n_kv_heads)``); a no-op for multi-head attention, where the
+    head counts already match. The upcast to ``float`` promotes fp16/bf16 weights
+    before the SVD, where reduced precision is a known source of instability.
     """
-    return (
-        model.W_Q[layer, head].float(),
-        model.W_K[layer, head].float(),
-        model.W_V[layer, head].float(),
-        model.W_O[layer, head].float(),
-    )
+    attn = model.blocks[layer].attn
+    W_Q_h = attn.W_Q[head].float()  # [d_model, d_head]
+    W_O_h = attn.W_O[head].float()  # [d_head, d_model]
+    n_kv_heads = attn.W_K.shape[0]
+    kv_head = head // (model.cfg.n_heads // n_kv_heads)
+    W_K_h = attn.W_K[kv_head].float()  # [d_model, d_head]
+    W_V_h = attn.W_V[kv_head].float()  # [d_model, d_head]
+    return W_Q_h, W_K_h, W_V_h, W_O_h
 
 
 def _degeneracy_blocks(S: Float[torch.Tensor, "rank"], eps: float) -> List[List[int]]:

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -1,0 +1,289 @@
+"""Singular-vector decomposition of a single attention head's QK and OV maps.
+
+An attention head is characterized by two low-rank linear maps: the query-key
+map ``W_Q W_K^T`` that scores source positions, and the output-value map
+``W_V W_O`` that writes the attended value back into the residual stream. This
+tool takes the singular value decomposition of each map for one head and exposes
+the singular values (how much each direction matters) together with the left and
+right singular vectors (the output and input directions they act on).
+
+The decomposition is weight-space only: it reads ``W_Q``/``W_K``/``W_V``/``W_O``
+and needs no forward pass, no activation cache, and no compatibility mode. Each
+map is kept factored through
+:class:`~transformer_lens.FactoredMatrix.FactoredMatrix`, so the
+``d_model x d_model`` product is never materialized and the returned rank is
+bounded by ``d_head``.
+
+Right singular vectors are read from :attr:`~transformer_lens.FactoredMatrix.FactoredMatrix.V`
+(its columns are the right singular vectors). The historical ``.Vh`` alias is
+deprecated and returns the same tensor, so it is never used here.
+
+Near-equal singular values leave their singular directions defined only up to a
+rotation, so the result carries a per-direction degeneracy report. Callers can
+use it to attribute an ambiguous block as a subspace instead of trusting a
+single, rotation-dependent direction.
+
+Example::
+
+    from transformer_lens import HookedTransformer
+    from transformer_lens.tools.analysis.svd_circuits import decompose_head
+
+    model = HookedTransformer.from_pretrained("gpt2", device="cpu")
+    decomposition = decompose_head(model, layer=0, head=0)
+    ov = decomposition.OV
+    for row in ov.rank_report:
+        print(f"direction {row.idx}: sigma={row.sigma:.3f} ratio={row.sigma_ratio:.3f}")
+"""
+
+from dataclasses import dataclass
+from typing import List, Literal, Optional, Sequence, Tuple
+
+import torch
+from jaxtyping import Float
+
+from transformer_lens.FactoredMatrix import FactoredMatrix
+
+# Which of a head's two maps to decompose: the query-key map or the output-value map.
+Which = Literal["QK", "OV"]
+
+_VALID_WHICH: Tuple[Which, ...] = ("QK", "OV")
+
+# Relative-gap threshold: neighbouring singular values closer than this (in
+# relative terms) are treated as one rotation-ambiguous block.
+_DEFAULT_EPS = 1e-2
+
+# Absolute floor so relative-gap and ratio computations never divide by ~0.
+_SIGMA_FLOOR = 1e-12
+
+
+class DegenerateDirectionError(ValueError):
+    """Raised when per-direction attribution is requested inside a degenerate block.
+
+    Subclasses ``ValueError`` so callers that already ``except ValueError`` keep
+    working, mirroring how the other analysis tools raise ``ValueError`` for
+    their input guards.
+    """
+
+
+@dataclass
+class RankReportRow:
+    """One singular direction's summary, aligned with column ``idx`` of ``U``/``V``.
+
+    Attributes:
+        idx: Position of the direction, matching the column index in ``U`` and ``V``.
+        sigma: The singular value for this direction.
+        sigma_ratio: ``sigma`` normalized by the largest singular value, in ``[0, 1]``.
+        is_degenerate: True when this direction shares its block with a neighbour,
+            so it is defined only up to a rotation within that block.
+        block_id: Index of the contiguous block this direction belongs to.
+    """
+
+    idx: int
+    sigma: float
+    sigma_ratio: float
+    is_degenerate: bool
+    block_id: int
+
+
+@dataclass
+class HeadSVD:
+    """Factored SVD of one head map (``"QK"`` or ``"OV"``) with a degeneracy report.
+
+    Attributes:
+        which: Which map this decomposes, ``"QK"`` or ``"OV"``.
+        layer: Layer of the decomposed head.
+        head: Head index within the layer.
+        U: Left singular vectors, ``[d_model, rank]`` (column i is output direction i).
+        S: Singular values, ``[rank]``, sorted descending.
+        V: Right singular vectors, ``[d_model, rank]`` (column i is input direction i).
+            The reconstruction is ``U @ S.diag() @ V.transpose(-2, -1)``.
+        rank_report: Per-direction :class:`RankReportRow` list, aligned with the
+            columns of ``U``/``V``.
+        eps: Relative-gap threshold used to group the degeneracy blocks.
+    """
+
+    which: Which
+    layer: int
+    head: int
+    U: Float[torch.Tensor, "d_model rank"]
+    S: Float[torch.Tensor, "rank"]
+    V: Float[torch.Tensor, "d_model rank"]
+    rank_report: List[RankReportRow]
+    eps: float
+
+
+@dataclass
+class HeadDecomposition:
+    """Container returned by :func:`decompose_head`.
+
+    ``QK`` and ``OV`` hold the :class:`HeadSVD` for each requested map, or
+    ``None`` when that map was not requested.
+    """
+
+    layer: int
+    head: int
+    QK: Optional[HeadSVD] = None
+    OV: Optional[HeadSVD] = None
+
+
+def _head_weights(
+    model, layer: int, head: int
+) -> Tuple[
+    Float[torch.Tensor, "d_model d_head"],
+    Float[torch.Tensor, "d_model d_head"],
+    Float[torch.Tensor, "d_model d_head"],
+    Float[torch.Tensor, "d_head d_model"],
+]:
+    """Return ``(W_Q_h, W_K_h, W_V_h, W_O_h)`` for one head as float tensors.
+
+    The upcast to ``float`` promotes fp16/bf16 weights before the SVD, where
+    reduced precision is a known source of instability.
+    """
+    return (
+        model.W_Q[layer, head].float(),
+        model.W_K[layer, head].float(),
+        model.W_V[layer, head].float(),
+        model.W_O[layer, head].float(),
+    )
+
+
+def _degeneracy_blocks(S: Float[torch.Tensor, "rank"], eps: float) -> List[List[int]]:
+    """Group singular directions into contiguous blocks by their relative gap.
+
+    ``S`` holds singular values sorted in descending order. Direction ``i`` joins
+    the block of direction ``i - 1`` when their relative gap ``1 - S[i]/S[i-1]``
+    falls below ``eps``, or when both are in a near-zero (null) run relative to the
+    top singular value. A block of more than one direction is degenerate: its
+    directions are defined only up to a rotation within the block. ``_SIGMA_FLOOR``
+    keeps the ratios finite when a divisor is ~0.
+    """
+    n = int(S.shape[0])
+    if n == 0:
+        return []
+    values = [float(x) for x in S.tolist()]
+    top = max(values[0], _SIGMA_FLOOR)
+    blocks: List[List[int]] = []
+    current = [0]
+    for i in range(1, n):
+        prev = max(values[i - 1], _SIGMA_FLOOR)
+        relative_gap = 1.0 - (values[i] / prev)
+        null_run = (values[i] / top) < eps and (values[i - 1] / top) < eps
+        if relative_gap < eps or null_run:
+            current.append(i)
+        else:
+            blocks.append(current)
+            current = [i]
+    blocks.append(current)
+    return blocks
+
+
+def _build_rank_report(
+    S: Float[torch.Tensor, "rank"], blocks: List[List[int]]
+) -> List[RankReportRow]:
+    """Summarize each singular direction and tag the degeneracy block it belongs to.
+
+    ``sigma_ratio`` normalizes each singular value by the largest one, so the top
+    direction has ratio 1.0. ``blocks`` must partition ``range(len(S))``; each
+    direction is degenerate when its block holds more than one direction.
+    """
+    values = [float(x) for x in S.tolist()]
+    top = max(values) if values else 0.0
+    denominator = top if top > _SIGMA_FLOOR else _SIGMA_FLOOR
+    rows: List[Optional[RankReportRow]] = [None] * len(values)
+    for block_id, block in enumerate(blocks):
+        degenerate = len(block) > 1
+        for idx in block:
+            rows[idx] = RankReportRow(
+                idx=idx,
+                sigma=values[idx],
+                sigma_ratio=values[idx] / denominator,
+                is_degenerate=degenerate,
+                block_id=block_id,
+            )
+    return [row for row in rows if row is not None]
+
+
+def _factored_head_svd(
+    A: Float[torch.Tensor, "d_model d_head"],
+    B: Float[torch.Tensor, "d_head d_model"],
+    *,
+    which: Which,
+    layer: int,
+    head: int,
+    eps: float,
+) -> HeadSVD:
+    """Decompose the factored map ``A @ B`` for one head into a :class:`HeadSVD`.
+
+    For OV pass ``A = W_V_h`` and ``B = W_O_h``; for QK pass ``A = W_Q_h`` and
+    ``B = W_K_h.transpose(-1, -2)``. The map stays factored through
+    :class:`FactoredMatrix`, so the ``d_model x d_model`` product is never
+    materialized and the rank is bounded by ``d_head``.
+    """
+    U, S, V = FactoredMatrix(A, B).svd()
+    blocks = _degeneracy_blocks(S, eps)
+    rank_report = _build_rank_report(S, blocks)
+    return HeadSVD(
+        which=which,
+        layer=layer,
+        head=head,
+        U=U,
+        S=S,
+        V=V,
+        rank_report=rank_report,
+        eps=eps,
+    )
+
+
+def decompose_head(
+    model,
+    layer: int,
+    head: int,
+    *,
+    which: Sequence[Which] = ("QK", "OV"),
+    eps: float = _DEFAULT_EPS,
+) -> HeadDecomposition:
+    """Decompose a head's QK (``W_Q W_K^T``) and/or OV (``W_V W_O``) maps via SVD.
+
+    Weight-space only: this reads the head's weights and needs no forward pass and
+    no compatibility mode. Works with both ``HookedTransformer`` and
+    ``TransformerBridge`` because they share the ``W_Q``/``W_K``/``W_V``/``W_O``
+    layout and ``cfg``.
+
+    Args:
+        model: A ``HookedTransformer`` or ``TransformerBridge``.
+        layer: Layer of the head to decompose.
+        head: Head index within the layer.
+        which: Which maps to decompose, any subset of ``("QK", "OV")``.
+        eps: Relative-gap threshold for grouping degenerate singular directions.
+
+    Returns:
+        A :class:`HeadDecomposition` whose ``QK``/``OV`` fields hold a
+        :class:`HeadSVD` for each requested map.
+
+    Raises:
+        ValueError: If ``layer`` or ``head`` is out of range, or ``which`` is
+            empty or contains an unknown entry.
+    """
+    n_layers = model.cfg.n_layers
+    n_heads = model.cfg.n_heads
+    if not 0 <= layer < n_layers:
+        raise ValueError(f"layer must be in [0, {n_layers}), got {layer!r}")
+    if not 0 <= head < n_heads:
+        raise ValueError(f"head must be in [0, {n_heads}), got {head!r}")
+    requested = tuple(which)
+    if not requested:
+        raise ValueError("which must request at least one of 'QK' or 'OV'")
+    invalid = [entry for entry in requested if entry not in _VALID_WHICH]
+    if invalid:
+        raise ValueError(f"which entries must be in {_VALID_WHICH}, got {invalid!r}")
+
+    W_Q_h, W_K_h, W_V_h, W_O_h = _head_weights(model, layer, head)
+    qk = None
+    ov = None
+    if "QK" in requested:
+        qk = _factored_head_svd(
+            W_Q_h, W_K_h.transpose(-1, -2), which="QK", layer=layer, head=head, eps=eps
+        )
+    if "OV" in requested:
+        ov = _factored_head_svd(W_V_h, W_O_h, which="OV", layer=layer, head=head, eps=eps)
+    return HeadDecomposition(layer=layer, head=head, QK=qk, OV=ov)

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -23,6 +23,13 @@ rotation, so the result carries a per-direction degeneracy report. Callers can
 use it to attribute an ambiguous block as a subspace instead of trusting a
 single, rotation-dependent direction.
 
+A singular value near zero relative to the top of the spectrum is null rather
+than near-equal: it reflects the map's numerical rank, not a rotation ambiguity
+between comparable directions. The degeneracy report groups a null run under
+its own tolerance, ``null_rtol``, keyed to the spectrum's top value the way
+:func:`torch.linalg.matrix_rank` keys its default tolerance, rather than the
+near-equal gap threshold ``eps``.
+
 Example::
 
     from transformer_lens import HookedTransformer
@@ -99,7 +106,10 @@ class HeadSVD:
             The reconstruction is ``U @ S.diag() @ V.transpose(-2, -1)``.
         rank_report: Per-direction :class:`RankReportRow` list, aligned with the
             columns of ``U``/``V``.
-        eps: Relative-gap threshold used to group the degeneracy blocks.
+        eps: Relative-gap threshold used to group near-equal degeneracy blocks.
+        null_rtol: Relative-to-top-singular-value tolerance below which a direction
+            is treated as numerically null, distinct from the near-equal gap
+            threshold ``eps``.
     """
 
     which: Which
@@ -110,6 +120,7 @@ class HeadSVD:
     V: Float[torch.Tensor, "d_model rank"]
     rank_report: List[RankReportRow]
     eps: float
+    null_rtol: float
 
     def is_degenerate(self, i: int) -> bool:
         """Return whether direction ``i`` shares its block with another direction.
@@ -208,19 +219,23 @@ def _head_weights(
     return W_Q_h, W_K_h, W_V_h, W_O_h
 
 
-def _degeneracy_blocks(S: Float[torch.Tensor, "rank"], eps: float) -> List[List[int]]:
+def _degeneracy_blocks(
+    S: Float[torch.Tensor, "rank"], eps: float, null_rtol: float
+) -> List[List[int]]:
     """Group singular directions into contiguous blocks by their relative gap.
 
     ``S`` holds singular values sorted in descending order. Direction ``i`` joins the
     open block when it is within relative gap ``eps`` of both the previous direction
     and the block's anchor (its first, largest member), or when both directions sit in
-    a near-zero (null) run relative to the top singular value. The anchor constraint
-    bounds how far a block can spread: without it, a spectrum decaying by just under
-    ``eps`` at every step would chain every direction into one block whose extremes
-    differ by far more than ``eps``, purely because each gap-to-previous is individually
-    small. A block of more than one direction is degenerate: its directions are defined
-    only up to a rotation within the block. ``_SIGMA_FLOOR`` keeps the ratios finite when
-    a divisor is ~0.
+    a null run: numerically zero relative to the top singular value, within ``null_rtol``.
+    The anchor constraint bounds how far a near-equal block can spread: without it, a
+    spectrum decaying by just under ``eps`` at every step would chain every direction
+    into one block whose extremes differ by far more than ``eps``, purely because each
+    gap-to-previous is individually small. The null run uses its own tolerance,
+    ``null_rtol``, rather than ``eps``, because it groups directions for being
+    numerically absent, not for being near-equal to each other. A block of more than one
+    direction is degenerate: its directions are defined only up to a rotation within the
+    block. ``_SIGMA_FLOOR`` keeps the ratios finite when a divisor is ~0.
     """
     n = int(S.shape[0])
     if n == 0:
@@ -233,7 +248,7 @@ def _degeneracy_blocks(S: Float[torch.Tensor, "rank"], eps: float) -> List[List[
         prev = max(values[i - 1], _SIGMA_FLOOR)
         anchor = max(values[current[0]], _SIGMA_FLOOR)
         near_equal = (1.0 - values[i] / prev) < eps and (1.0 - values[i] / anchor) < eps
-        null_run = (values[i] / top) < eps and (values[i - 1] / top) < eps
+        null_run = (values[i] / top) < null_rtol and (values[i - 1] / top) < null_rtol
         if near_equal or null_run:
             current.append(i)
         else:
@@ -277,6 +292,7 @@ def _factored_head_svd(
     layer: int,
     head: int,
     eps: float,
+    null_rtol: Optional[float] = None,
 ) -> HeadSVD:
     """Decompose the factored map ``A @ B`` for one head into a :class:`HeadSVD`.
 
@@ -284,9 +300,16 @@ def _factored_head_svd(
     ``B = W_K_h.transpose(-1, -2)``. The map stays factored through
     :class:`FactoredMatrix`, so the ``d_model x d_model`` product is never
     materialized and the rank is bounded by ``d_head``.
+
+    ``null_rtol`` of ``None`` resolves to ``d_model * torch.finfo(S.dtype).eps``,
+    the same relative tolerance :func:`torch.linalg.matrix_rank` uses by default
+    for a square ``d_model x d_model`` map, so the null cutoff tracks the
+    decomposition's own numerical rank rather than a hand-tuned constant.
     """
     U, S, V = FactoredMatrix(A, B).svd()
-    blocks = _degeneracy_blocks(S, eps)
+    d_model = U.shape[0]
+    resolved_null_rtol = null_rtol if null_rtol is not None else d_model * torch.finfo(S.dtype).eps
+    blocks = _degeneracy_blocks(S, eps, null_rtol=resolved_null_rtol)
     rank_report = _build_rank_report(S, blocks)
     return HeadSVD(
         which=which,
@@ -297,6 +320,7 @@ def _factored_head_svd(
         V=V,
         rank_report=rank_report,
         eps=eps,
+        null_rtol=resolved_null_rtol,
     )
 
 
@@ -307,6 +331,7 @@ def decompose_head(
     *,
     which: Sequence[Which] = ("QK", "OV"),
     eps: float = _DEFAULT_EPS,
+    null_rtol: Optional[float] = None,
 ) -> HeadDecomposition:
     """Decompose a head's QK (``W_Q W_K^T``) and/or OV (``W_V W_O``) maps via SVD.
 
@@ -320,7 +345,11 @@ def decompose_head(
         layer: Layer of the head to decompose.
         head: Head index within the layer.
         which: Which maps to decompose, any subset of ``("QK", "OV")``.
-        eps: Relative-gap threshold for grouping degenerate singular directions.
+        eps: Relative-gap threshold for grouping near-equal degenerate directions.
+        null_rtol: Relative-to-top-singular-value tolerance below which a direction
+            counts as numerically null. Defaults to ``None``, which resolves to
+            ``d_model * torch.finfo(S.dtype).eps`` per map, matching
+            :func:`torch.linalg.matrix_rank`'s default tolerance.
 
     Returns:
         A :class:`HeadDecomposition` whose ``QK``/``OV`` fields hold a
@@ -348,8 +377,16 @@ def decompose_head(
     ov = None
     if "QK" in requested:
         qk = _factored_head_svd(
-            W_Q_h, W_K_h.transpose(-1, -2), which="QK", layer=layer, head=head, eps=eps
+            W_Q_h,
+            W_K_h.transpose(-1, -2),
+            which="QK",
+            layer=layer,
+            head=head,
+            eps=eps,
+            null_rtol=null_rtol,
         )
     if "OV" in requested:
-        ov = _factored_head_svd(W_V_h, W_O_h, which="OV", layer=layer, head=head, eps=eps)
+        ov = _factored_head_svd(
+            W_V_h, W_O_h, which="OV", layer=layer, head=head, eps=eps, null_rtol=null_rtol
+        )
     return HeadDecomposition(layer=layer, head=head, QK=qk, OV=ov)

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -18,17 +18,17 @@ Right singular vectors are read from :attr:`~transformer_lens.FactoredMatrix.Fac
 (its columns are the right singular vectors). The historical ``.Vh`` alias is
 deprecated and returns the same tensor, so it is never used here.
 
-Near-equal singular values leave their singular directions defined only up to a
-rotation, so the result carries a per-direction degeneracy report. Callers can
-use it to attribute an ambiguous block as a subspace instead of trusting a
-single, rotation-dependent direction.
+Adjacent singular values closer than a relative gap ``eps`` leave their singular
+directions defined only up to a rotation, so the result carries a per-direction
+degeneracy report. Directions are grouped into contiguous blocks that end only
+at a gap of at least ``eps``; callers attribute such a block as a subspace
+instead of trusting a single, rotation-dependent direction inside it.
 
 A singular value near zero relative to the top of the spectrum is null rather
-than near-equal: it reflects the map's numerical rank, not a rotation ambiguity
-between comparable directions. The degeneracy report groups a null run under
-its own tolerance, ``null_rtol``, keyed to the spectrum's top value the way
-:func:`torch.linalg.matrix_rank` keys its default tolerance, rather than the
-near-equal gap threshold ``eps``.
+than near-equal: its singular vector is an arbitrary null-space direction, not a
+rotation of a comparable neighbour. Null directions are flagged under their own
+tolerance, ``null_rtol``, keyed to the spectrum's top value the way
+:func:`torch.linalg.matrix_rank` keys its default tolerance.
 
 Example::
 
@@ -64,7 +64,7 @@ _SIGMA_FLOOR = 1e-12
 
 
 class DegenerateDirectionError(ValueError):
-    """Raised when per-direction attribution is requested inside a degenerate block.
+    """Raised when per-direction attribution is requested for a degenerate direction.
 
     Subclasses ``ValueError`` so callers that already ``except ValueError`` keep
     working, mirroring how the other analysis tools raise ``ValueError`` for
@@ -80,8 +80,11 @@ class RankReportRow:
         idx: Position of the direction, matching the column index in ``U`` and ``V``.
         sigma: The singular value for this direction.
         sigma_ratio: ``sigma`` normalized by the largest singular value, in ``[0, 1]``.
-        is_degenerate: True when this direction shares its block with a neighbour,
-            so it is defined only up to a rotation within that block.
+        is_degenerate: True when this direction is not attributable on its own: it
+            shares a block with a neighbour (defined only up to a rotation within
+            that block) or it is numerically null.
+        is_null: True when ``sigma_ratio`` falls below ``null_rtol``, so the singular
+            vector is an arbitrary direction from the map's null space.
         block_id: Index of the contiguous block this direction belongs to.
     """
 
@@ -89,6 +92,7 @@ class RankReportRow:
     sigma: float
     sigma_ratio: float
     is_degenerate: bool
+    is_null: bool
     block_id: int
 
 
@@ -106,10 +110,10 @@ class HeadSVD:
             The reconstruction is ``U @ S.diag() @ V.transpose(-2, -1)``.
         rank_report: Per-direction :class:`RankReportRow` list, aligned with the
             columns of ``U``/``V``.
-        eps: Relative-gap threshold used to group near-equal degeneracy blocks.
+        eps: Relative gap below which adjacent directions share a block; every block
+            boundary sits at a gap of at least ``eps``.
         null_rtol: Relative-to-top-singular-value tolerance below which a direction
-            is treated as numerically null, distinct from the near-equal gap
-            threshold ``eps``.
+            is numerically null.
     """
 
     which: Which
@@ -123,11 +127,7 @@ class HeadSVD:
     null_rtol: float
 
     def is_degenerate(self, i: int) -> bool:
-        """Return whether direction ``i`` shares its block with another direction.
-
-        A degenerate direction is defined only up to a rotation within its block,
-        so per-direction attribution against it is not meaningful.
-        """
+        """Whether direction ``i`` is refused: rotation-ambiguous inside a block, or null."""
         return self.rank_report[i].is_degenerate
 
     def block_of(self, i: int) -> List[int]:
@@ -140,41 +140,48 @@ class HeadSVD:
         return [row.idx for row in self.rank_report if row.block_id == block_id]
 
     def degenerate_blocks(self) -> List[List[int]]:
-        """Return the index groups for blocks holding more than one direction.
-
-        Rows carry contiguous, ascending ``block_id`` values, so consecutive rows
-        with a shared id form one block. Isolated directions are omitted, leaving
-        only the rotation-ambiguous subspaces a caller must attribute as a whole.
-        """
+        """Return every degenerate block's indices: the subspaces to attribute whole or skip."""
         blocks: List[List[int]] = []
         current: List[int] = []
         current_block_id: Optional[int] = None
+        degenerate = False
+        # block_ids are contiguous and ascending, so one scan recovers the blocks.
         for row in self.rank_report:
             if row.block_id != current_block_id:
-                if len(current) > 1:
+                if degenerate:
                     blocks.append(current)
                 current = []
+                degenerate = False
                 current_block_id = row.block_id
             current.append(row.idx)
-        if len(current) > 1:
+            degenerate = degenerate or row.is_degenerate
+        if degenerate:
             blocks.append(current)
         return blocks
 
     def require_isolated(self, i: int) -> None:
-        """Raise :class:`DegenerateDirectionError` if direction ``i`` is not isolated.
+        """Raise :class:`DegenerateDirectionError` unless direction ``i`` is attributable alone.
 
-        Callers project or attribute a single singular direction only after this
-        passes; inside a degenerate block the direction is rotation-ambiguous and
-        the block must be attributed as a subspace instead.
+        The message names the cause, since a rotation-ambiguous block is still a
+        subspace worth attributing while a null block carries no signal.
         """
-        if self.is_degenerate(i):
-            block = self.block_of(i)
+        row = self.rank_report[i]
+        if not row.is_degenerate:
+            return
+        where = f"Direction {i} of the {self.which} SVD of head L{self.layer}H{self.head}"
+        block = self.block_of(i)
+        if row.is_null:
             raise DegenerateDirectionError(
-                f"Direction {i} of the {self.which} SVD of head L{self.layer}H{self.head} "
-                f"lies in a degenerate block {block} (near-equal singular values, "
-                f"rotation-ambiguous). Attribute the block as a subspace instead of the "
-                f"single direction."
+                f"{where} is numerically null (sigma_ratio {row.sigma_ratio:.2e} < "
+                f"null_rtol {self.null_rtol:.2e}), so its singular vector is an arbitrary "
+                f"null-space direction. Attribute the null block {block} as a subspace, "
+                f"or skip it."
             )
+        raise DegenerateDirectionError(
+            f"{where} lies in block {block}, whose members are not separated by a "
+            f"relative gap of eps={self.eps:g} and so are defined only up to a rotation. "
+            f"Attribute the block as a subspace instead of the single direction."
+        )
 
 
 @dataclass
@@ -191,6 +198,17 @@ class HeadDecomposition:
     OV: Optional[HeadSVD] = None
 
 
+def _read_weight(weight: torch.Tensor) -> torch.Tensor:
+    """Detach one per-head weight and put it in SVD precision.
+
+    Detached so the returned factors carry no autograd graph into the model. fp16/bf16
+    are promoted because reduced-precision SVD is unstable; float64 is kept so the
+    default ``null_rtol`` matches the precision actually decomposed.
+    """
+    weight = weight.detach()
+    return weight if weight.dtype == torch.float64 else weight.float()
+
+
 def _head_weights(
     model, layer: int, head: int
 ) -> Tuple[
@@ -199,43 +217,37 @@ def _head_weights(
     Float[torch.Tensor, "d_model d_head"],
     Float[torch.Tensor, "d_head d_model"],
 ]:
-    """Return ``(W_Q_h, W_K_h, W_V_h, W_O_h)`` for one head as float tensors.
+    """Return ``(W_Q_h, W_K_h, W_V_h, W_O_h)`` for one head, detached, in SVD precision.
 
     Reads the single block's per-head weights rather than the full-model
     ``W_Q``/``W_K``/``W_V``/``W_O`` stacks, so only one layer is materialized. On
     grouped-query attention ``W_K``/``W_V`` carry one row per key-value head, so the
     query head is mapped to its key-value head (query head ``h`` reads kv head
     ``h // (n_heads // n_kv_heads)``); a no-op for multi-head attention, where the
-    head counts already match. The upcast to ``float`` promotes fp16/bf16 weights
-    before the SVD, where reduced precision is a known source of instability.
+    head counts already match.
     """
     attn = model.blocks[layer].attn
-    W_Q_h = attn.W_Q[head].float()  # [d_model, d_head]
-    W_O_h = attn.W_O[head].float()  # [d_head, d_model]
     n_kv_heads = attn.W_K.shape[0]
     kv_head = head // (model.cfg.n_heads // n_kv_heads)
-    W_K_h = attn.W_K[kv_head].float()  # [d_model, d_head]
-    W_V_h = attn.W_V[kv_head].float()  # [d_model, d_head]
+    W_Q_h = _read_weight(attn.W_Q[head])  # [d_model, d_head]
+    W_K_h = _read_weight(attn.W_K[kv_head])  # [d_model, d_head]
+    W_V_h = _read_weight(attn.W_V[kv_head])  # [d_model, d_head]
+    W_O_h = _read_weight(attn.W_O[head])  # [d_head, d_model]
     return W_Q_h, W_K_h, W_V_h, W_O_h
 
 
 def _degeneracy_blocks(
     S: Float[torch.Tensor, "rank"], eps: float, null_rtol: float
 ) -> List[List[int]]:
-    """Group singular directions into contiguous blocks by their relative gap.
+    """Group singular directions into contiguous blocks separated by relative gaps of ``eps``.
 
-    ``S`` holds singular values sorted in descending order. Direction ``i`` joins the
-    open block when it is within relative gap ``eps`` of both the previous direction
-    and the block's anchor (its first, largest member), or when both directions sit in
-    a null run: numerically zero relative to the top singular value, within ``null_rtol``.
-    The anchor constraint bounds how far a near-equal block can spread: without it, a
-    spectrum decaying by just under ``eps`` at every step would chain every direction
-    into one block whose extremes differ by far more than ``eps``, purely because each
-    gap-to-previous is individually small. The null run uses its own tolerance,
-    ``null_rtol``, rather than ``eps``, because it groups directions for being
-    numerically absent, not for being near-equal to each other. A block of more than one
-    direction is degenerate: its directions are defined only up to a rotation within the
-    block. ``_SIGMA_FLOOR`` keeps the ratios finite when a divisor is ~0.
+    ``S`` is sorted descending. Direction ``i`` joins the open block when
+    ``1 - S[i]/S[i-1] < eps``, or when it and its predecessor are both null relative to
+    the top value. Only the gap to the previous direction counts: a block may span far
+    more than ``eps`` end to end, but every boundary is an ``eps`` gap, and that
+    separation from the rest of the spectrum is what makes a block stable under
+    perturbation; no smaller contiguous group inside it is. ``_SIGMA_FLOOR`` keeps the
+    ratios finite when a divisor is ~0.
     """
     n = int(S.shape[0])
     if n == 0:
@@ -246,8 +258,7 @@ def _degeneracy_blocks(
     current = [0]
     for i in range(1, n):
         prev = max(values[i - 1], _SIGMA_FLOOR)
-        anchor = max(values[current[0]], _SIGMA_FLOOR)
-        near_equal = (1.0 - values[i] / prev) < eps and (1.0 - values[i] / anchor) < eps
+        near_equal = (1.0 - values[i] / prev) < eps
         null_run = (values[i] / top) < null_rtol and (values[i - 1] / top) < null_rtol
         if near_equal or null_run:
             current.append(i)
@@ -259,26 +270,28 @@ def _degeneracy_blocks(
 
 
 def _build_rank_report(
-    S: Float[torch.Tensor, "rank"], blocks: List[List[int]]
+    S: Float[torch.Tensor, "rank"], blocks: List[List[int]], null_rtol: float
 ) -> List[RankReportRow]:
-    """Summarize each singular direction and tag the degeneracy block it belongs to.
+    """Summarize each singular direction and tag its degeneracy block.
 
-    ``sigma_ratio`` normalizes each singular value by the largest one, so the top
-    direction has ratio 1.0. ``blocks`` must partition ``range(len(S))``; each
-    direction is degenerate when its block holds more than one direction.
+    ``blocks`` must partition ``range(len(S))``. Nullness flags a direction on its own:
+    a lone null singular vector is arbitrary even though nothing groups with it.
     """
     values = [float(x) for x in S.tolist()]
     top = max(values) if values else 0.0
     denominator = top if top > _SIGMA_FLOOR else _SIGMA_FLOOR
     rows: List[Optional[RankReportRow]] = [None] * len(values)
     for block_id, block in enumerate(blocks):
-        degenerate = len(block) > 1
+        shared = len(block) > 1
         for idx in block:
+            sigma_ratio = values[idx] / denominator
+            is_null = sigma_ratio < null_rtol
             rows[idx] = RankReportRow(
                 idx=idx,
                 sigma=values[idx],
-                sigma_ratio=values[idx] / denominator,
-                is_degenerate=degenerate,
+                sigma_ratio=sigma_ratio,
+                is_degenerate=shared or is_null,
+                is_null=is_null,
                 block_id=block_id,
             )
     return [row for row in rows if row is not None]
@@ -310,7 +323,7 @@ def _factored_head_svd(
     d_model = U.shape[0]
     resolved_null_rtol = null_rtol if null_rtol is not None else d_model * torch.finfo(S.dtype).eps
     blocks = _degeneracy_blocks(S, eps, null_rtol=resolved_null_rtol)
-    rank_report = _build_rank_report(S, blocks)
+    rank_report = _build_rank_report(S, blocks, null_rtol=resolved_null_rtol)
     return HeadSVD(
         which=which,
         layer=layer,
@@ -329,7 +342,7 @@ def decompose_head(
     layer: int,
     head: int,
     *,
-    which: Sequence[Which] = ("QK", "OV"),
+    which: Sequence[str] = ("QK", "OV"),
     eps: float = _DEFAULT_EPS,
     null_rtol: Optional[float] = None,
 ) -> HeadDecomposition:
@@ -337,14 +350,16 @@ def decompose_head(
 
     Weight-space only: this reads the head's per-block weights via the bridge's
     ``model.blocks[layer].attn`` accessors and needs no forward pass and no
-    compatibility mode.
+    compatibility mode. The returned factors are detached from the model.
 
     Args:
         model: A ``TransformerBridge``.
         layer: Layer of the head to decompose.
         head: Head index within the layer.
-        which: Which maps to decompose, any subset of ``("QK", "OV")``.
-        eps: Relative-gap threshold for grouping near-equal degenerate directions.
+        which: Which maps to decompose, a non-empty sequence drawn from
+            ``("QK", "OV")``. A bare string is rejected rather than iterated.
+        eps: Relative gap at which a block of adjacent directions ends; directions
+            closer than this share a block.
         null_rtol: Relative-to-top-singular-value tolerance below which a direction
             counts as numerically null. Defaults to ``None``, which resolves to
             ``d_model * torch.finfo(S.dtype).eps`` per map, matching
@@ -356,7 +371,7 @@ def decompose_head(
 
     Raises:
         ValueError: If ``layer`` or ``head`` is out of range, or ``which`` is
-            empty or contains an unknown entry.
+            empty, a bare string, or contains an unknown entry.
     """
     n_layers = model.cfg.n_layers
     n_heads = model.cfg.n_heads
@@ -364,6 +379,8 @@ def decompose_head(
         raise ValueError(f"layer must be in [0, {n_layers}), got {layer!r}")
     if not 0 <= head < n_heads:
         raise ValueError(f"head must be in [0, {n_heads}), got {head!r}")
+    if isinstance(which, str):
+        raise ValueError(f"which must be a sequence of map names such as ('QK',), got {which!r}")
     requested = tuple(which)
     if not requested:
         raise ValueError("which must request at least one of 'QK' or 'OV'")

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -32,10 +32,10 @@ near-equal gap threshold ``eps``.
 
 Example::
 
-    from transformer_lens import HookedTransformer
+    from transformer_lens.model_bridge import TransformerBridge
     from transformer_lens.tools.analysis.svd_circuits import decompose_head
 
-    model = HookedTransformer.from_pretrained("gpt2", device="cpu")
+    model = TransformerBridge.boot_transformers("gpt2", device="cpu")
     decomposition = decompose_head(model, layer=0, head=0)
     ov = decomposition.OV
     for row in ov.rank_report:
@@ -335,13 +335,12 @@ def decompose_head(
 ) -> HeadDecomposition:
     """Decompose a head's QK (``W_Q W_K^T``) and/or OV (``W_V W_O``) maps via SVD.
 
-    Weight-space only: this reads the head's weights and needs no forward pass and
-    no compatibility mode. Works with both ``HookedTransformer`` and
-    ``TransformerBridge`` because they share the ``W_Q``/``W_K``/``W_V``/``W_O``
-    layout and ``cfg``.
+    Weight-space only: this reads the head's per-block weights via the bridge's
+    ``model.blocks[layer].attn`` accessors and needs no forward pass and no
+    compatibility mode.
 
     Args:
-        model: A ``HookedTransformer`` or ``TransformerBridge``.
+        model: A ``TransformerBridge``.
         layer: Layer of the head to decompose.
         head: Head index within the layer.
         which: Which maps to decompose, any subset of ``("QK", "OV")``.

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -111,6 +111,60 @@ class HeadSVD:
     rank_report: List[RankReportRow]
     eps: float
 
+    def is_degenerate(self, i: int) -> bool:
+        """Return whether direction ``i`` shares its block with another direction.
+
+        A degenerate direction is defined only up to a rotation within its block,
+        so per-direction attribution against it is not meaningful.
+        """
+        return self.rank_report[i].is_degenerate
+
+    def block_of(self, i: int) -> List[int]:
+        """Return every direction index sharing direction ``i``'s degeneracy block.
+
+        The result is a singleton ``[i]`` for an isolated direction and the full
+        run for a degenerate one.
+        """
+        block_id = self.rank_report[i].block_id
+        return [row.idx for row in self.rank_report if row.block_id == block_id]
+
+    def degenerate_blocks(self) -> List[List[int]]:
+        """Return the index groups for blocks holding more than one direction.
+
+        Rows carry contiguous, ascending ``block_id`` values, so consecutive rows
+        with a shared id form one block. Isolated directions are omitted, leaving
+        only the rotation-ambiguous subspaces a caller must attribute as a whole.
+        """
+        blocks: List[List[int]] = []
+        current: List[int] = []
+        current_block_id: Optional[int] = None
+        for row in self.rank_report:
+            if row.block_id != current_block_id:
+                if len(current) > 1:
+                    blocks.append(current)
+                current = []
+                current_block_id = row.block_id
+            current.append(row.idx)
+        if len(current) > 1:
+            blocks.append(current)
+        return blocks
+
+    def require_isolated(self, i: int) -> None:
+        """Raise :class:`DegenerateDirectionError` if direction ``i`` is not isolated.
+
+        Callers project or attribute a single singular direction only after this
+        passes; inside a degenerate block the direction is rotation-ambiguous and
+        the block must be attributed as a subspace instead.
+        """
+        if self.is_degenerate(i):
+            block = self.block_of(i)
+            raise DegenerateDirectionError(
+                f"Direction {i} of the {self.which} SVD of head L{self.layer}H{self.head} "
+                f"lies in a degenerate block {block} (near-equal singular values, "
+                f"rotation-ambiguous). Attribute the block as a subspace instead of the "
+                f"single direction."
+            )
+
 
 @dataclass
 class HeadDecomposition:


### PR DESCRIPTION
---

### Description

Adds `svd_circuits.decompose_head`, the first of three PRs implementing per-head singular-vector decomposition of a head's QK (`W_Q W_K^T`) and OV (`W_V W_O`) maps (tracking issue: #1767 ).

This PR is **weight-space only**: it reads `W_Q`/`W_K`/`W_V`/`W_O` and needs no forward pass, no activation cache, and no compatibility mode.

- `decompose_head(model, layer, head, which=("QK", "OV"))` — factored SVD via `FactoredMatrix`, never materializing the `d_model x d_model` product.
- `HeadSVD` / `HeadDecomposition` dataclasses with a per-direction `rank_report`.
- Degeneracy guard: near-equal singular values are grouped into a block; `require_isolated` raises `DegenerateDirectionError` for per-direction attribution inside a block instead of silently returning a rotation-dependent direction.
- Reads right singular vectors from `FactoredMatrix.V`; the deprecated `.Vh` alias is never touched (enforced by a test that turns its `DeprecationWarning` into an error).

**By design, this PR does not export a public API.** `svd_circuits` is intentionally absent from `transformer_lens/tools/analysis/__init__.py` `__all__` — the causal patch-along-direction gate (PR2) is what turns a
readout into a validated claim, so the public surface should never ship without it attached.

Unit-tested model-free: synthetic weight tensors only, no `from_pretrained`, no HF download. SVD parity against `torch.linalg.svd` within `atol=1e-5`; reconstruction within `atol=1e-4`.

Follow-ups (not in this PR): OV vocab/logit readout, `project_activations`, the mandatory `patch_along_directions` causal gate, and public exports (PR2); demo notebook, slow paper-sanity check, and docs (PR3).

Part of #1767 

---

### Type of change

- [x] New feature (non-breaking change which adds functionality)

---

### Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Will be done in PR3)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

---