### PR TITLE
Fix IOIDataset BOS handling

### DIFF
--- a/tests/unit/test_evals_ioi.py
+++ b/tests/unit/test_evals_ioi.py
@@ -1,18 +1,34 @@
-"""Tests for IOIDataset in transformer_lens/evals.py.
-
-Regression test for https://github.com/TransformerLensOrg/TransformerLens/issues/515
-"""
+"""Tests for IOIDataset and ioi_eval in transformer_lens/evals.py."""
 
 from unittest.mock import MagicMock
 
-from transformer_lens.evals import IOIDataset
+import torch
+
+from transformer_lens.evals import IOIDataset, ioi_eval
 
 
 def _make_tokenizer():
     """Minimal mock tokenizer sufficient for IOIDataset."""
     tok = MagicMock()
-    tok.encode.side_effect = lambda text: [1, 2, 3]
+    tok.encode.side_effect = lambda text, add_special_tokens=True: [1, 2, 3]
     tok.bos_token_id = 0
+    return tok
+
+
+def _make_automatic_bos_tokenizer():
+    """Tokenizer stub whose default encode path inserts a BOS token."""
+    tok = MagicMock()
+    tok.bos_token_id = 0
+
+    def encode(text, add_special_tokens=True):
+        if text.startswith(" "):
+            payload = [30 if text.strip() == "Alice" else 31]
+        else:
+            target = 30 if text.split()[-1] == "Alice" else 31
+            payload = [10, 20, target]
+        return ([tok.bos_token_id] if add_special_tokens else []) + payload
+
+    tok.encode.side_effect = encode
     return tok
 
 
@@ -63,3 +79,60 @@ def test_ioi_dataset_symmetric():
     tokenizer = _make_tokenizer()
     dataset = IOIDataset(tokenizer, num_samples=10, symmetric=True)
     assert len(dataset.samples) == 10
+
+
+def test_ioi_dataset_prepend_bos_is_the_only_source_of_special_tokens():
+    tokenizer = _make_automatic_bos_tokenizer()
+    with_bos = IOIDataset(
+        tokenizer,
+        templates=["[A] met [B] and [A]"],
+        names=["Alice", "Bob"],
+        nouns={},
+        num_samples=1,
+        prepend_bos=True,
+        seed=0,
+    )[0]
+    without_bos = IOIDataset(
+        tokenizer,
+        templates=["[A] met [B] and [A]"],
+        names=["Alice", "Bob"],
+        nouns={},
+        num_samples=1,
+        prepend_bos=False,
+        seed=0,
+    )[0]
+
+    assert with_bos["prompt"].tolist() == [0, 10, 20, 31]
+    assert without_bos["prompt"].tolist() == [10, 20, 31]
+    for item in (with_bos, without_bos):
+        assert {tuple(item["IO"].tolist()), tuple(item["S"].tolist())} == {(30,), (31,)}
+
+
+def test_ioi_eval_reads_logits_before_the_first_answer_token():
+    tokenizer = _make_automatic_bos_tokenizer()
+    dataset = IOIDataset(
+        tokenizer,
+        templates=["[A] met [B] and [A]"],
+        names=["Alice", "Bob"],
+        nouns={},
+        num_samples=1,
+        prepend_bos=True,
+        seed=0,
+    )
+
+    class PositionSensitiveModel:
+        def __call__(self, tokens, return_type):
+            assert return_type == "logits"
+            logits = torch.zeros(tokens.shape[0], tokens.shape[1], 32)
+            for row, prompt in enumerate(tokens):
+                answer = int(prompt[-1])
+                distractor = 31 if answer == 30 else 30
+                logits[row, 2, answer] = 1
+                logits[row, 2, distractor] = -1
+                logits[row, 3, answer] = -1
+                logits[row, 3, distractor] = 1
+            return logits
+
+    result = ioi_eval(PositionSensitiveModel(), dataset=dataset, batch_size=1, tokenizer=tokenizer)
+
+    assert result == {"Logit Difference": 2.0, "Accuracy": 1.0}

--- a/transformer_lens/evals.py
+++ b/transformer_lens/evals.py
@@ -391,14 +391,14 @@ class IOIDataset(Dataset):
 
     def __getitem__(self, idx):
         sample = self.samples[idx]
-        prompt = self.tokenizer.encode(sample["text"])
+        prompt = self.tokenizer.encode(sample["text"], add_special_tokens=False)
         if self.prepend_bos:
             prompt = [self.tokenizer.bos_token_id] + prompt
 
         return {
             "prompt": torch.LongTensor(prompt),
-            "IO": torch.LongTensor(self.tokenizer.encode(sample["IO"])),
-            "S": torch.LongTensor(self.tokenizer.encode(sample["S"])),
+            "IO": torch.LongTensor(self.tokenizer.encode(sample["IO"], add_special_tokens=False)),
+            "S": torch.LongTensor(self.tokenizer.encode(sample["S"], add_special_tokens=False)),
         }
 
     def get_sample(self, symmetric=False) -> List[Dict[str, str]]:

--- a/transformer_lens/evals.py
+++ b/transformer_lens/evals.py
@@ -367,7 +367,8 @@ class IOIDataset(Dataset):
             nouns: Dict mapping placeholder names to lists of nouns. Defaults to built-in nouns.
             num_samples: Number of samples to generate.
             symmetric: If True, generate both orderings of each name pair.
-            prepend_bos: If True, prepend the BOS token to each prompt.
+            prepend_bos: If True, prepend one BOS token to each prompt. Tokenizer-added special
+                tokens are disabled, so False leaves the prompt without a BOS.
             seed: Optional random seed for reproducibility. If None, the current
                 random state is used (samples will vary across runs).
         """


### PR DESCRIPTION
# Description

`IOIDataset` previously called `tokenizer.encode()` with automatic special-token insertion enabled and then manually prepended a BOS. TransformerLens tokenizers configured to add BOS therefore produced two leading BOS tokens by default, while `prepend_bos=False` still left one BOS in place. Automatic BOS tokens in the IO/S label encodings also shifted the first differing-token index used by `ioi_eval()`, causing the default evaluation path to read logits one position too late.

This change encodes prompts and labels with `add_special_tokens=False`, leaving the existing `prepend_bos` branch as the sole source of a prompt BOS. The parameter documentation now states that contract.

Regression tests model a tokenizer that automatically inserts BOS, cover both values of `prepend_bos`, verify that IO/S contain only content tokens, and use position-sensitive logits to confirm that `ioi_eval()` reads the prediction immediately before the first answer token.

No new dependencies are required.

Fixes #1772

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Screenshots

Not applicable.

# Validation

- `uv run --no-cache --no-sync pytest tests/unit/test_evals_ioi.py -q` — 7 passed
- `uv run --no-cache --no-sync mypy .` — success across 398 source files
- pycln, isort, Black, and `git diff --check` — passed for the affected surface

The complete unit-test suite was not run locally.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes — only the affected unit-test file was run
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility