### PR TITLE
feat(svd_circuits): singular-direction readout, projection, and causal patch gate

### DIFF
--- a/tests/integration/test_svd_circuits.py
+++ b/tests/integration/test_svd_circuits.py
@@ -1,0 +1,66 @@
+"""Integration test: OV vocab readout and the causal patch gate on a real GPT-2 head.
+
+The only file in the ``svd_circuits`` suite that downloads a pretrained model. Drives the
+whole read-then-patch path against layer 9 head 9 (the paper's canonical name-mover head) on
+a minimal IOI-style prompt, to check that the readout and the causal gate agree on a real
+Bridge rather than only on the unit suite's synthetic and tiny-model fixtures.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from transformer_lens.model_bridge import TransformerBridge
+from transformer_lens.tools.analysis.svd_circuits import (
+    decompose_head,
+    patch_along_directions,
+    vocab_readout,
+)
+
+CLEAN_PROMPT = "When Mary and John went to the store, John gave a drink to"
+LAYER, HEAD = 9, 9
+
+
+@pytest.fixture(scope="module")
+def gpt2_bridge():
+    model = TransformerBridge.boot_transformers("gpt2", device="cpu", dtype=torch.float32)
+    model.enable_compatibility_mode()
+    return model
+
+
+def _logit_diff_metric(model):
+    mary_token = model.to_single_token(" Mary")
+    john_token = model.to_single_token(" John")
+
+    def metric(logits: torch.Tensor) -> float:
+        return float(logits[0, -1, mary_token] - logits[0, -1, john_token])
+
+    return metric
+
+
+def test_svd_circuits_readout_and_patch_gate_on_name_mover_head(gpt2_bridge) -> None:
+    decomposition = decompose_head(gpt2_bridge, layer=LAYER, head=HEAD, which=("OV",))
+    ov = decomposition.OV
+    assert ov is not None
+
+    readout = vocab_readout(gpt2_bridge, ov, k=10)
+    assert readout.shape == (gpt2_bridge.cfg.d_vocab, 10)
+    assert torch.isfinite(readout).all()
+
+    # Pick the first non-degenerate direction rather than assuming index 0 is isolated.
+    top_direction = next(row.idx for row in ov.rank_report if not row.is_degenerate)
+
+    prompt = gpt2_bridge.to_tokens(CLEAN_PROMPT)
+    metric = _logit_diff_metric(gpt2_bridge)
+
+    result = patch_along_directions(gpt2_bridge, ov, prompt, metric, keep=[top_direction])
+
+    assert result.retained == [top_direction]
+    assert math.isfinite(result.original_metric)
+    assert math.isfinite(result.patched_metric)
+    assert math.isfinite(result.delta_metric)
+    assert math.isfinite(result.baseline_delta_metric)
+    assert isinstance(result.gated, bool)

--- a/tests/unit/tools/test_svd_circuits.py
+++ b/tests/unit/tools/test_svd_circuits.py
@@ -16,10 +16,13 @@ import torch
 from transformer_lens.tools.analysis.svd_circuits import (
     DegenerateDirectionError,
     HeadSVD,
+    LogitSignature,
     RankReportRow,
     _degeneracy_blocks,
     _factored_head_svd,
     decompose_head,
+    logit_signature,
+    vocab_readout,
 )
 
 D_MODEL, D_HEAD = 12, 4
@@ -529,3 +532,59 @@ def test_ov_output_direction_matches_svd_interpreter(tiny_bridge):
     projected_via_U = ov.U[:, 0] @ W_U
     assert not torch.allclose(projected_via_U, reference[:, 0, 0], atol=1e-2)
     assert not torch.allclose(projected_via_U, -reference[:, 0, 0], atol=1e-2)
+
+
+# --------------------------------------------------------------------------- #
+# vocab_readout / logit_signature (OV output-direction readout)
+# --------------------------------------------------------------------------- #
+def test_vocab_readout_shape_and_which_guard():
+    """vocab_readout returns [d_vocab, k] for OV, and rejects QK input and out-of-range k."""
+    ov = _factored_head_svd(*_random_ov(), which="OV", layer=0, head=0, eps=1e-2)
+    vocab_size = 20
+    model = SimpleNamespace(W_U=torch.randn(D_MODEL, vocab_size))
+
+    result = vocab_readout(model, ov, k=3)
+    assert result.shape == (vocab_size, 3)
+
+    qk = _factored_head_svd(
+        *_factored_with_spectrum([8.0, 4.0, 2.0, 1.0]), which="QK", layer=0, head=0, eps=1e-2
+    )
+    with pytest.raises(ValueError, match="OV"):
+        vocab_readout(model, qk, k=1)
+
+    with pytest.raises(ValueError, match="k must be"):
+        vocab_readout(model, ov, k=D_HEAD + 1)
+
+
+def test_vocab_readout_raises_without_compatibility_mode(tiny_bridge):
+    """A TransformerBridge without compatibility mode enabled refuses to project through W_U."""
+    decomposition = decompose_head(tiny_bridge, layer=0, head=0, which=("OV",))
+    with pytest.raises(ValueError, match="enable_compatibility_mode"):
+        vocab_readout(tiny_bridge, decomposition.OV)
+
+
+def test_logit_signature_matches_manual_projection():
+    """logit_signature's reconstruction matches a hand-computed S[i] * V[:, i] projection."""
+    ov = _factored_head_svd(
+        *_factored_with_spectrum([8.0, 4.0, 2.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    vocab_size = 16
+    W_U = torch.randn(D_MODEL, vocab_size)
+    model = SimpleNamespace(W_U=W_U)
+    token_ids = torch.tensor([1, 5, 9])
+
+    result = logit_signature(model, ov, direction=0, tokens=token_ids)
+    assert isinstance(result, LogitSignature)
+    expected = (ov.S[0] * ov.V[:, 0]) @ W_U[:, token_ids]
+    assert torch.allclose(result.values, expected, atol=1e-5)
+    assert result.direction == 0
+
+
+def test_logit_signature_raises_on_degenerate_direction():
+    """A rotation-ambiguous direction's 'signature' is not attributable, so this must raise."""
+    ov = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    model = SimpleNamespace(W_U=torch.randn(D_MODEL, 8))
+    with pytest.raises(DegenerateDirectionError):
+        logit_signature(model, ov, direction=1, tokens=torch.tensor([0]))

--- a/tests/unit/tools/test_svd_circuits.py
+++ b/tests/unit/tools/test_svd_circuits.py
@@ -1,11 +1,14 @@
 """Unit tests for per-head QK/OV singular-vector decomposition.
 
-Model-free: they build synthetic weight tensors and exercise the factored SVD and the
-degeneracy guard directly, so no model is loaded and no pretrained weights are downloaded.
+Mostly model-free: most tests build synthetic weight tensors and exercise the factored SVD
+and the degeneracy guard directly, so no model is loaded and no pretrained weights are
+downloaded. A few tests instantiate a tiny, randomly-initialized TransformerBridge (CPU-only,
+no Hub access) where a real per-head decomposition is needed for a cross-check.
 """
 
 import warnings
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -470,3 +473,59 @@ def test_decompose_head_rejects_bare_string_which():
     model = _StubModel(n_heads=2, n_kv_heads=2)
     with pytest.raises(ValueError, match="sequence"):
         decompose_head(model, layer=0, head=0, which="QK")
+
+
+# --------------------------------------------------------------------------- #
+# OV output-direction convention (cross-check against SVDInterpreter)
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module")
+def tiny_bridge():
+    """Tiny GPT-2 bridge: MHA (n_heads == n_kv_heads), CPU-only, no Hub access."""
+    from transformers import GPT2Config, GPT2LMHeadModel
+
+    from transformer_lens.config.transformer_bridge_config import (
+        TransformerBridgeConfig,
+    )
+    from transformer_lens.model_bridge import TransformerBridge
+    from transformer_lens.model_bridge.supported_architectures.gpt2 import (
+        GPT2ArchitectureAdapter,
+    )
+
+    torch.manual_seed(0)
+    hf_model = GPT2LMHeadModel(
+        GPT2Config(n_embd=32, n_layer=1, n_head=2, vocab_size=64, n_positions=32)
+    ).eval()
+    cfg = TransformerBridgeConfig(
+        d_model=32,
+        d_head=16,
+        n_heads=2,
+        n_layers=1,
+        n_ctx=32,
+        d_vocab=64,
+        architecture="GPT2LMHeadModel",
+    )
+    return TransformerBridge(hf_model, GPT2ArchitectureAdapter(cfg), tokenizer=MagicMock())
+
+
+def test_ov_output_direction_matches_svd_interpreter(tiny_bridge):
+    """OV's write/vocab-readout direction is ``.V``, not ``.U`` - checked against the
+    already-shipped ``SVDInterpreter``, not just internal self-consistency, so the
+    assertion cannot pass under either U/V labeling by construction."""
+    from transformer_lens.SVDInterpreter import SVDInterpreter
+
+    layer, head = 0, 0
+    decomposition = decompose_head(tiny_bridge, layer, head, which=("OV",))
+    ov = decomposition.OV
+    W_U = tiny_bridge.W_U
+
+    interpreter = SVDInterpreter(tiny_bridge)
+    reference = interpreter.get_singular_vectors("OV", layer, head_index=head, num_vectors=1)
+
+    projected_via_V = ov.V[:, 0] @ W_U
+    assert torch.allclose(projected_via_V, reference[:, 0, 0], atol=1e-4) or torch.allclose(
+        projected_via_V, -reference[:, 0, 0], atol=1e-4
+    )
+
+    projected_via_U = ov.U[:, 0] @ W_U
+    assert not torch.allclose(projected_via_U, reference[:, 0, 0], atol=1e-2)
+    assert not torch.allclose(projected_via_U, -reference[:, 0, 0], atol=1e-2)

--- a/tests/unit/tools/test_svd_circuits.py
+++ b/tests/unit/tools/test_svd_circuits.py
@@ -6,6 +6,7 @@ downloaded. A few tests instantiate a tiny, randomly-initialized TransformerBrid
 no Hub access) where a real per-head decomposition is needed for a cross-check.
 """
 
+import math
 import warnings
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -18,11 +19,13 @@ from transformer_lens.tools.analysis.svd_circuits import (
     DegenerateDirectionError,
     HeadSVD,
     LogitSignature,
+    PatchResult,
     RankReportRow,
     _degeneracy_blocks,
     _factored_head_svd,
     decompose_head,
     logit_signature,
+    patch_along_directions,
     project_activations,
     vocab_readout,
 )
@@ -641,6 +644,146 @@ def test_project_activations_restores_use_attn_result(tiny_bridge):
         for initial in (False, True):
             tiny_bridge.set_use_attn_result(initial)
             project_activations(tiny_bridge, decomposition.OV, torch.tensor([[5, 63, 7, 9]]))
+            assert tiny_bridge.cfg.use_attn_result == initial
+    finally:
+        tiny_bridge.set_use_attn_result(original)
+
+
+# --------------------------------------------------------------------------- #
+# patch_along_directions (mandatory causal gate)
+# --------------------------------------------------------------------------- #
+class _PatchStubModel:
+    """Model-free stand-in for patch_along_directions' run_with_hooks/metric protocol.
+
+    Exposes a single fixed per-head "hook_result" activation that a hook can intercept
+    exactly as ``run_with_hooks`` would present it (the hook receives the activation and
+    a hook object, and returns the replacement), then reduces it to a scalar the same
+    way for the unmodified, patched, and baseline calls, so the block guard and gating
+    arithmetic can be tested without a real forward pass.
+    """
+
+    def __init__(self, d_model, n_heads, pos=3, seed=0):
+        g = torch.Generator().manual_seed(seed)
+        self.cfg = SimpleNamespace(use_attn_result=False)
+        self._result = torch.randn(1, pos, n_heads, d_model, generator=g)
+        self._readout = torch.randn(d_model, generator=g)
+
+    def set_use_attn_result(self, value):
+        self.cfg.use_attn_result = value
+
+    def _logits(self, result):
+        return result.sum(dim=2) @ self._readout  # [batch, pos]
+
+    def __call__(self, prompt):
+        return self._logits(self._result)
+
+    def run_with_hooks(self, prompt, fwd_hooks):
+        activation = self._result
+        for name, hook_fn in fwd_hooks:
+            activation = hook_fn(activation, hook=SimpleNamespace(name=name))
+        return self._logits(activation)
+
+
+def test_patch_along_directions_which_guard():
+    """QK has no write direction to reconstruct onto, so a QK HeadSVD is refused."""
+    qk = _factored_head_svd(
+        *_factored_with_spectrum([8.0, 4.0, 2.0, 1.0]), which="QK", layer=0, head=0, eps=1e-2
+    )
+    with pytest.raises(ValueError, match="OV"):
+        patch_along_directions(SimpleNamespace(), qk, "prompt", lambda logits: 0.0, keep=[0])
+
+
+def test_patch_along_directions_requires_keep_xor_ablate():
+    """Passing both keep and ablate, or neither, is refused before any model access."""
+    ov = _factored_head_svd(
+        *_factored_with_spectrum([8.0, 4.0, 2.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    metric = lambda logits: 0.0
+    with pytest.raises(ValueError, match="exactly one"):
+        patch_along_directions(SimpleNamespace(), ov, "prompt", metric, keep=[0], ablate=[1])
+    with pytest.raises(ValueError, match="exactly one"):
+        patch_along_directions(SimpleNamespace(), ov, "prompt", metric)
+
+
+def test_patch_along_directions_rejects_partial_degenerate_block():
+    """keep must take a degenerate block whole or not at all; a partial slice is refused,
+    and the whole block plus an isolated direction is accepted."""
+    ov = _factored_head_svd(
+        *_factored_with_spectrum([5.0, 3.0, 3.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    metric = lambda logits: 0.0
+    with pytest.raises(DegenerateDirectionError):
+        patch_along_directions(SimpleNamespace(), ov, "prompt", metric, keep=[0, 1])
+
+    stub = _PatchStubModel(d_model=D_MODEL, n_heads=1)
+    result = patch_along_directions(
+        stub, ov, "prompt", lambda logits: float(logits.sum()), keep=[0, 1, 2]
+    )
+    assert isinstance(result, PatchResult)
+    assert result.retained == [0, 1, 2]
+
+
+def test_patch_along_directions_reports_delta_and_restores_use_attn_result():
+    """delta_metric is patched minus original metric, gated follows the documented
+    comparison against baseline_delta_metric, and use_attn_result is restored after."""
+    ov = _factored_head_svd(
+        *_factored_with_spectrum([8.0, 4.0, 2.0, 1.0]), which="OV", layer=0, head=0, eps=1e-2
+    )
+    stub = _PatchStubModel(d_model=D_MODEL, n_heads=1)
+    metric = lambda logits: float(logits.sum())
+    for initial in (False, True):
+        stub.set_use_attn_result(initial)
+        result = patch_along_directions(
+            stub, ov, "prompt", metric, keep=[0], rng=torch.Generator().manual_seed(0)
+        )
+        assert result.delta_metric == pytest.approx(result.patched_metric - result.original_metric)
+        assert math.isfinite(result.baseline_delta_metric)
+        expected_gated = abs(result.delta_metric) > abs(result.baseline_delta_metric)
+        assert result.gated == expected_gated
+        assert stub.cfg.use_attn_result == initial
+
+
+def test_patch_along_directions_discriminates_causal_direction(tiny_bridge):
+    """Ablating the head's strongest OV direction should move a metric aligned with that
+    direction materially more than ablating its weakest, least load-bearing direction."""
+    layer, head = 0, 0
+    decomposition = decompose_head(tiny_bridge, layer, head, which=("OV",))
+    ov = decomposition.OV
+    strong = ov.rank_report[0].idx
+    weak = ov.rank_report[-1].idx
+    assert not ov.is_degenerate(strong)
+    assert not ov.is_degenerate(weak)
+
+    target_token = int((ov.V[:, strong] @ tiny_bridge.W_U).argmax())
+    prompt = torch.tensor([[5, 63, 7, 9]])
+
+    def metric(logits):
+        return logits[0, -1, target_token].item()
+
+    strong_result = patch_along_directions(
+        tiny_bridge, ov, prompt, metric, ablate=[strong], rng=torch.Generator().manual_seed(0)
+    )
+    weak_result = patch_along_directions(
+        tiny_bridge, ov, prompt, metric, ablate=[weak], rng=torch.Generator().manual_seed(0)
+    )
+    assert isinstance(strong_result, PatchResult)
+    assert math.isfinite(strong_result.baseline_delta_metric)
+    assert math.isfinite(weak_result.baseline_delta_metric)
+    assert abs(strong_result.delta_metric) > abs(weak_result.delta_metric)
+
+
+def test_patch_along_directions_restores_use_attn_result(tiny_bridge):
+    """use_attn_result is restored to its prior value regardless of what it started as."""
+    decomposition = decompose_head(tiny_bridge, 0, 0, which=("OV",))
+    ov = decomposition.OV
+    metric = lambda logits: float(logits.sum())
+    original = tiny_bridge.cfg.use_attn_result
+    try:
+        for initial in (False, True):
+            tiny_bridge.set_use_attn_result(initial)
+            patch_along_directions(
+                tiny_bridge, ov, torch.tensor([[5, 63, 7, 9]]), metric, keep=[ov.rank_report[0].idx]
+            )
             assert tiny_bridge.cfg.use_attn_result == initial
     finally:
         tiny_bridge.set_use_attn_result(original)

--- a/tests/unit/tools/test_svd_circuits.py
+++ b/tests/unit/tools/test_svd_circuits.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 
 from transformer_lens.tools.analysis.svd_circuits import (
+    ActivationProjection,
     DegenerateDirectionError,
     HeadSVD,
     LogitSignature,
@@ -22,6 +23,7 @@ from transformer_lens.tools.analysis.svd_circuits import (
     _factored_head_svd,
     decompose_head,
     logit_signature,
+    project_activations,
     vocab_readout,
 )
 
@@ -507,7 +509,11 @@ def tiny_bridge():
         d_vocab=64,
         architecture="GPT2LMHeadModel",
     )
-    return TransformerBridge(hf_model, GPT2ArchitectureAdapter(cfg), tokenizer=MagicMock())
+    tokenizer = MagicMock()
+    # A real tokenizer isn't available (no-download fixture), but to_str_tokens's return
+    # value is jaxtyped-checked as List[str], so batch_decode must return actual strings.
+    tokenizer.batch_decode = lambda tokens_list, **kwargs: [str(ids[0]) for ids in tokens_list]
+    return TransformerBridge(hf_model, GPT2ArchitectureAdapter(cfg), tokenizer=tokenizer)
 
 
 def test_ov_output_direction_matches_svd_interpreter(tiny_bridge):
@@ -588,3 +594,53 @@ def test_logit_signature_raises_on_degenerate_direction():
     model = SimpleNamespace(W_U=torch.randn(D_MODEL, 8))
     with pytest.raises(DegenerateDirectionError):
         logit_signature(model, ov, direction=1, tokens=torch.tensor([0]))
+
+
+# --------------------------------------------------------------------------- #
+# project_activations (per-position firing coefficients in the OV output basis)
+# --------------------------------------------------------------------------- #
+def test_project_activations_which_guard():
+    """QK has no write direction to project onto, so a QK HeadSVD is refused."""
+    qk = _factored_head_svd(
+        *_factored_with_spectrum([8.0, 4.0, 2.0, 1.0]), which="QK", layer=0, head=0, eps=1e-2
+    )
+    with pytest.raises(ValueError, match="OV"):
+        project_activations(SimpleNamespace(), qk, "hello world")
+
+
+def test_project_activations_reconstructs_head_output(tiny_bridge):
+    """Coefficients recovered against V reconstruct the actual cached hook_result slice."""
+    layer, head = 0, 0
+    decomposition = decompose_head(tiny_bridge, layer, head, which=("OV",))
+    # A raw token tensor, not a string: tiny_bridge's tokenizer is a MagicMock and cannot
+    # tokenize text, but a token-id tensor bypasses that path entirely.
+    prompt = torch.tensor([[5, 63, 7, 9]])
+
+    projection = project_activations(tiny_bridge, decomposition.OV, prompt)
+    assert isinstance(projection, ActivationProjection)
+    assert projection.head_svd is decomposition.OV
+
+    previous = tiny_bridge.cfg.use_attn_result
+    tiny_bridge.set_use_attn_result(True)
+    try:
+        _, cache = tiny_bridge.run_with_cache(prompt)
+    finally:
+        tiny_bridge.set_use_attn_result(previous)
+    expected = cache[("result", layer, "attn")][0, :, head, :]
+
+    reconstructed = projection.coefficients @ decomposition.OV.V.transpose(-2, -1)
+    assert torch.allclose(reconstructed, expected, atol=1e-4)
+    assert projection.str_tokens == tiny_bridge.to_str_tokens(prompt)
+
+
+def test_project_activations_restores_use_attn_result(tiny_bridge):
+    """use_attn_result is restored to its prior value regardless of what it started as."""
+    decomposition = decompose_head(tiny_bridge, 0, 0, which=("OV",))
+    original = tiny_bridge.cfg.use_attn_result
+    try:
+        for initial in (False, True):
+            tiny_bridge.set_use_attn_result(initial)
+            project_activations(tiny_bridge, decomposition.OV, torch.tensor([[5, 63, 7, 9]]))
+            assert tiny_bridge.cfg.use_attn_result == initial
+    finally:
+        tiny_bridge.set_use_attn_result(original)

--- a/transformer_lens/tools/analysis/__init__.py
+++ b/transformer_lens/tools/analysis/__init__.py
@@ -22,6 +22,10 @@ Tools:
       anchored coordinate patching (offline and dynamic/hooked).
     - projection_kernel: Basis-invariant subspace overlap and TransformerBridge
       attention-head OQ/OK/OV affinity.
+    - svd_circuits: Per-head QK/OV singular-vector decomposition with a
+      degeneracy guard, OV vocab and logit readout, per-position activation
+      projection onto singular directions, and a mandatory causal patch gate
+      that reconstructs a head's output onto a chosen singular subspace.
 """
 
 from transformer_lens.tools.analysis.attribution_patching import (
@@ -76,8 +80,23 @@ from transformer_lens.tools.analysis.projection_kernel import (
     projection_kernel,
     random_projection_kernel_moments,
 )
+from transformer_lens.tools.analysis.svd_circuits import (
+    ActivationProjection,
+    DegenerateDirectionError,
+    HeadDecomposition,
+    HeadSVD,
+    LogitSignature,
+    PatchResult,
+    RankReportRow,
+    decompose_head,
+    logit_signature,
+    patch_along_directions,
+    project_activations,
+    vocab_readout,
+)
 
 __all__ = [
+    "ActivationProjection",
     "AttentionHeadRef",
     "AttributionResult",
     "BackwardLens",
@@ -85,33 +104,44 @@ __all__ = [
     "BackwardLensMatrixResult",
     "BackwardLensResult",
     "CoordinatePatch",
+    "DegenerateDirectionError",
     "DirectLogitAttribution",
     "EdgeAttributionConfig",
     "HeadAffinityPair",
     "HeadAffinityResult",
+    "HeadDecomposition",
+    "HeadSVD",
     "JSpaceDecomposition",
     "JSpaceOccupancy",
     "JSpaceVarianceProfile",
     "JacobianLens",
     "JacobianLensReadout",
     "LinearGradientFactors",
+    "LogitSignature",
     "Node",
+    "PatchResult",
     "ProjectedFactor",
     "ProjectionKernelResult",
     "RandomSubspaceReference",
+    "RankReportRow",
     "SubspaceBasis",
     "VocabularyRanking",
     "WeightLayout",
     "attention_head_subspace_affinity",
     "attribution_patch",
+    "decompose_head",
     "direct_logit_attribution",
     "estimate_occupancy",
     "get_act_patch_direct_path",
     "get_act_patch_direct_path_all_sources",
     "get_sparse_decomposition",
+    "logit_signature",
     "orthonormal_subspace",
+    "patch_along_directions",
+    "project_activations",
     "projection_kernel",
     "random_projection_kernel_moments",
     "solve_coordinate_patch",
     "solve_coordinate_patch_positions",
+    "vocab_readout",
 ]

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -52,7 +52,7 @@ Example::
 """
 
 from dataclasses import dataclass
-from typing import List, Literal, Optional, Sequence, Tuple
+from typing import List, Literal, Optional, Sequence, Tuple, Union
 
 import torch
 from jaxtyping import Float
@@ -420,3 +420,116 @@ def decompose_head(
             W_V_h, W_O_h, which="OV", layer=layer, head=head, eps=eps, null_rtol=null_rtol
         )
     return HeadDecomposition(layer=layer, head=head, QK=qk, OV=ov)
+
+
+def _validate_bridge_compatibility(model) -> None:
+    """Reject a ``TransformerBridge`` whose ``W_U`` would give a silently wrong projection.
+
+    ``HookedTransformer`` always has the final LayerNorm folded into ``W_U``, so this
+    only fires for ``TransformerBridge``. Mirrors the compatibility-mode check other
+    unembedding-touching analysis tools already run, without any hybrid-architecture
+    restriction: projecting a rank-1 OV direction through ``W_U`` does not depend on
+    the block-layout assumptions that check exists for elsewhere.
+    """
+    # Lazy import - keeps the module importable without the bridge as a hard dependency.
+    from transformer_lens.model_bridge import TransformerBridge
+
+    if not isinstance(model, TransformerBridge):
+        return
+    if not getattr(model, "compatibility_mode", False):
+        raise ValueError(
+            "Projecting an OV direction through W_U on a TransformerBridge requires "
+            "compatibility mode, so that LayerNorm weights are folded into W_U. Call "
+            "`model.enable_compatibility_mode()` after loading the bridge, then retry."
+        )
+
+
+def vocab_readout(
+    model, head_svd: HeadSVD, *, k: int = 10
+) -> Float[torch.Tensor, "d_vocab k"]:
+    """Project the top-k OV output directions through the unembedding.
+
+    Requires ``head_svd.which == "OV"``: QK produces no write direction to project
+    (see the module docstring). On a ``TransformerBridge``, compatibility mode must
+    be enabled so ``W_U`` carries the folded final LayerNorm weights;
+    ``HookedTransformer`` always has this folding applied.
+
+    Does not call ``head_svd.require_isolated``: a degenerate direction's vocab
+    readout is still a well-defined projection, unlike a per-direction causal claim,
+    so it is not gated here. The contract that no direction is reported without a
+    passing causal patch is enforced by :func:`patch_along_directions`.
+
+    Args:
+        model: A ``TransformerBridge`` (with compatibility mode enabled) or a
+            ``HookedTransformer``; only its ``W_U`` is read.
+        head_svd: An OV :class:`HeadSVD` from :func:`decompose_head`.
+        k: Number of top singular directions to project.
+
+    Returns:
+        ``W_U.T @ head_svd.V[:, :k]``, shape ``[d_vocab, k]``: column i is
+        direction i's projection through the unembedding.
+
+    Raises:
+        ValueError: If ``head_svd.which != "OV"``, if ``k`` is not in
+            ``(0, rank]``, or if ``model`` is a ``TransformerBridge`` without
+            compatibility mode enabled.
+    """
+    if head_svd.which != "OV":
+        raise ValueError(f"vocab_readout requires an OV HeadSVD, got which={head_svd.which!r}")
+    rank = head_svd.V.shape[1]
+    if not 0 < k <= rank:
+        raise ValueError(f"k must be in (0, {rank}], got {k!r}")
+    _validate_bridge_compatibility(model)
+    return model.W_U.T @ head_svd.V[:, :k].float()
+
+
+@dataclass
+class LogitSignature:
+    """Rank-1-reconstruction logit effect for one OV direction, per requested token.
+
+    Attributes:
+        direction: Which ``HeadSVD`` column this reconstructs.
+        values: Signed logit contribution, aligned with the requested tokens.
+    """
+
+    direction: int
+    values: Float[torch.Tensor, "token"]
+
+
+def logit_signature(
+    model,
+    head_svd: HeadSVD,
+    direction: int,
+    tokens: Union[int, Sequence[int], torch.Tensor],
+) -> LogitSignature:
+    """Signed logit effect of one OV direction's rank-1 reconstruction on the given tokens.
+
+    Pure weight-space computation: reconstructs the head's OV output along a single
+    singular direction (``S[direction] * V[:, direction]``, never ``U`` - see the
+    module docstring) and projects it through ``W_U`` restricted to ``tokens``. Runs
+    no forward pass and builds no cache.
+
+    Args:
+        model: A ``TransformerBridge`` (with compatibility mode enabled) or a
+            ``HookedTransformer``; only its ``W_U`` is read.
+        head_svd: An OV :class:`HeadSVD` from :func:`decompose_head`.
+        direction: Column index of the singular direction to reconstruct.
+        tokens: Token id(s) to read the logit effect for.
+
+    Returns:
+        A :class:`LogitSignature` with one value per requested token.
+
+    Raises:
+        ValueError: If ``head_svd.which != "OV"``, or if ``model`` is a
+            ``TransformerBridge`` without compatibility mode enabled.
+        DegenerateDirectionError: If ``direction`` is not attributable alone (see
+            :meth:`HeadSVD.require_isolated`).
+    """
+    if head_svd.which != "OV":
+        raise ValueError(f"logit_signature requires an OV HeadSVD, got which={head_svd.which!r}")
+    head_svd.require_isolated(direction)
+    _validate_bridge_compatibility(model)
+    token_ids = torch.as_tensor(tokens, dtype=torch.long).reshape(-1)
+    reconstruction = (head_svd.S[direction] * head_svd.V[:, direction]).float()
+    values = reconstruction @ model.W_U[:, token_ids]
+    return LogitSignature(direction=direction, values=values)

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -5,7 +5,7 @@ map ``W_Q W_K^T`` that scores source positions, and the output-value map
 ``W_V W_O`` that writes the attended value back into the residual stream. This
 tool takes the singular value decomposition of each map for one head and exposes
 the singular values (how much each direction matters) together with the left and
-right singular vectors (the output and input directions they act on).
+right singular vectors that span the map's input and output spaces.
 
 The decomposition is weight-space only: it reads ``W_Q``/``W_K``/``W_V``/``W_O``
 and needs no forward pass, no activation cache, and no compatibility mode. Each
@@ -14,9 +14,18 @@ map is kept factored through
 ``d_model x d_model`` product is never materialized and the returned rank is
 bounded by ``d_head``.
 
-Right singular vectors are read from :attr:`~transformer_lens.FactoredMatrix.FactoredMatrix.V`
-(its columns are the right singular vectors). The historical ``.Vh`` alias is
-deprecated and returns the same tensor, so it is never used here.
+For a factored map ``A @ B`` (``A: [ldim, mdim]``, ``B: [mdim, rdim]``), the SVD's
+``U`` columns live in ``A``'s input space (``ldim``) and ``V`` columns live in
+``B``'s output space (``rdim``): feeding ``x = U[:, i]`` through the map gives
+``x @ (A @ B) == S[i] * V[:, i]``, never the reverse. For OV (``A = W_V_h``,
+``B = W_O_h``), ``U``'s columns are therefore the value-computation *input*
+directions this head reads from the residual stream, and ``V``'s columns are the
+*output* directions it writes back into the residual stream - the ones to
+project through ``W_U`` for a vocab or logit readout. For QK (``A = W_Q_h``,
+``B = W_K_h.transpose(-1, -2)``), both ``U`` (destination/query-read) and ``V``
+(source/key-read) are read directions; QK only ever produces a scalar attention
+score, so neither is a write direction. The historical ``.Vh`` alias returns the
+same tensor as ``.V`` and is never used here.
 
 Adjacent singular values closer than a relative gap ``eps`` leave their singular
 directions defined only up to a rotation, so the result carries a per-direction
@@ -104,10 +113,15 @@ class HeadSVD:
         which: Which map this decomposes, ``"QK"`` or ``"OV"``.
         layer: Layer of the decomposed head.
         head: Head index within the layer.
-        U: Left singular vectors, ``[d_model, rank]`` (column i is output direction i).
+        U: Left singular vectors, ``[d_model, rank]``: column i is the map's input
+            direction i (for OV, the residual-stream direction this head's value
+            computation reads from; for QK, the destination/query-read direction).
         S: Singular values, ``[rank]``, sorted descending.
-        V: Right singular vectors, ``[d_model, rank]`` (column i is input direction i).
-            The reconstruction is ``U @ S.diag() @ V.transpose(-2, -1)``.
+        V: Right singular vectors, ``[d_model, rank]``: column i is the map's output
+            direction i for OV (the residual-stream direction this head writes into,
+            the one to project through ``W_U``), or the source/key-read direction for
+            QK (QK produces no write direction). The reconstruction is
+            ``U @ S.diag() @ V.transpose(-2, -1)``.
         rank_report: Per-direction :class:`RankReportRow` list, aligned with the
             columns of ``U``/``V``.
         eps: Relative gap below which adjacent directions share a block; every block

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -52,7 +52,7 @@ Example::
 """
 
 from dataclasses import dataclass
-from typing import List, Literal, Optional, Sequence, Tuple, Union
+from typing import Callable, List, Literal, Optional, Sequence, Tuple, Union
 
 import torch
 from jaxtyping import Float
@@ -597,3 +597,182 @@ def project_activations(
     coefficients = result @ head_svd.V
     str_tokens = model.to_str_tokens(prompt)
     return ActivationProjection(head_svd=head_svd, coefficients=coefficients, str_tokens=str_tokens)
+
+
+def _validate_retained_blocks(head_svd: HeadSVD, retained: Sequence[int]) -> None:
+    """Raise if ``retained`` splits a degenerate block instead of keeping it whole or empty.
+
+    A degenerate block's members are defined only up to a rotation (or, for a null
+    block, arbitrary null-space vectors), so attributing a causal effect to part of the
+    block while dropping the rest would let a caller route around the guard
+    :meth:`HeadSVD.require_isolated` already enforces per direction.
+    """
+    retained_set = set(retained)
+    for block in head_svd.degenerate_blocks():
+        block_set = set(block)
+        overlap = retained_set & block_set
+        if overlap and overlap != block_set:
+            raise DegenerateDirectionError(
+                f"retained directions {sorted(overlap)} split block {sorted(block_set)} of "
+                f"the {head_svd.which} SVD of head L{head_svd.layer}H{head_svd.head}, whose "
+                f"members are not separated by a relative gap of eps={head_svd.eps:g} or are "
+                f"jointly null. Keep or ablate the whole block, not part of it."
+            )
+
+
+def _resolve_retained(
+    head_svd: HeadSVD, keep: Optional[Sequence[int]], ablate: Optional[Sequence[int]]
+) -> List[int]:
+    """Resolve ``keep``/``ablate`` to the sorted list of retained direction indices.
+
+    Exactly one of ``keep``/``ablate`` must be given; ``ablate``'s complement over the
+    map's full rank becomes the retained set. Raises :class:`DegenerateDirectionError`
+    if the result would split a degenerate block (see :func:`_validate_retained_blocks`).
+    """
+    if (keep is None) == (ablate is None):
+        raise ValueError("patch_along_directions requires exactly one of keep or ablate")
+    rank = head_svd.V.shape[1]
+    if keep is not None:
+        retained = sorted(set(keep))
+    else:
+        assert ablate is not None
+        ablate_set = set(ablate)
+        retained = [i for i in range(rank) if i not in ablate_set]
+    _validate_retained_blocks(head_svd, retained)
+    return retained
+
+
+def _make_subspace_hook(head: int, projector: Float[torch.Tensor, "d_model d_model"]):
+    """Build a ``hook_result`` hook that reconstructs one head's output onto ``span(projector)``.
+
+    Leaves every other head's slice of the ``[batch, pos, head_index, d_model]`` tensor
+    untouched. Clones before mutating so the hook never writes into the activation the
+    forward pass itself is still using.
+    """
+
+    def hook_fn(activation: torch.Tensor, hook) -> torch.Tensor:
+        activation = activation.clone()
+        activation[:, :, head, :] = activation[:, :, head, :] @ projector.to(activation.dtype)
+        return activation
+
+    return hook_fn
+
+
+@dataclass
+class PatchResult:
+    """Result of causally patching a head's output onto a chosen OV singular subspace.
+
+    Attributes:
+        head_svd: The OV decomposition patched against.
+        retained: Direction indices whose span the head's output was reconstructed
+            onto; the complement was zeroed.
+        original_metric: Metric value on the unmodified prompt.
+        patched_metric: Metric value after the subspace reconstruction.
+        delta_metric: ``patched_metric - original_metric``.
+        baseline_delta_metric: ``delta_metric`` from reconstructing onto a random
+            subspace of the same rank as ``retained``, instead of the requested one.
+        gated: True only if ``abs(delta_metric)`` exceeds ``abs(baseline_delta_metric)``
+            (or an explicit threshold, if one was passed): a subfunction is causally
+            load-bearing only if it beats an equally-sized random subspace, not merely
+            "moves the metric at all".
+    """
+
+    head_svd: HeadSVD
+    retained: List[int]
+    original_metric: float
+    patched_metric: float
+    delta_metric: float
+    baseline_delta_metric: float
+    gated: bool
+
+
+@torch.no_grad()
+def patch_along_directions(
+    model,
+    head_svd: HeadSVD,
+    prompt: Union[str, torch.Tensor],
+    metric: Callable[[torch.Tensor], float],
+    *,
+    keep: Optional[Sequence[int]] = None,
+    ablate: Optional[Sequence[int]] = None,
+    threshold: Optional[float] = None,
+    rng: Optional[torch.Generator] = None,
+) -> PatchResult:
+    """Causally validate a claimed OV subfunction by reconstructing the head's output onto it.
+
+    Requires ``head_svd.which == "OV"``: this reconstructs the write/output basis
+    ``V``, and QK has no such vector (see the module docstring). Runs the prompt three
+    times with ``use_attn_result`` enabled: once unmodified, once with the head's
+    ``hook_result`` slice reconstructed onto ``span(head_svd.V[:, retained])``, and once
+    onto a random orthonormal subspace of the same width, so a moved metric can be
+    compared against the effect of an equally-sized but arbitrary subspace instead of
+    being read as significant on its own. Restores the model's prior ``use_attn_result``
+    setting afterward.
+
+    Args:
+        model: A ``TransformerBridge`` or ``HookedTransformer``.
+        head_svd: An OV :class:`HeadSVD` from :func:`decompose_head`.
+        prompt: A single prompt: a string or a ``[1, pos]`` token tensor.
+        metric: A function from the model's logits to a scalar.
+        keep: Direction indices to retain; the rest are zeroed. Exactly one of
+            ``keep``/``ablate`` must be given.
+        ablate: Direction indices to zero; the rest are retained.
+        threshold: Explicit gate threshold. Defaults to ``None``, which uses
+            ``abs(baseline_delta_metric)`` instead.
+        rng: Optional generator for the random baseline subspace, for reproducibility.
+
+    Returns:
+        A :class:`PatchResult` describing the patched, baseline, and original metrics.
+
+    Raises:
+        ValueError: If ``head_svd.which != "OV"``, or if ``keep``/``ablate`` are both
+            given or both omitted.
+        DegenerateDirectionError: If the retained directions split a degenerate block
+            (see :func:`_validate_retained_blocks`).
+    """
+    if head_svd.which != "OV":
+        raise ValueError(
+            f"patch_along_directions requires an OV HeadSVD, got which={head_svd.which!r}"
+        )
+    retained = _resolve_retained(head_svd, keep, ablate)
+
+    V = head_svd.V
+    kept_projector = V[:, retained] @ V[:, retained].transpose(-2, -1)
+
+    d_model = V.shape[0]
+    width = len(retained)
+    random_input = torch.randn(d_model, width, generator=rng, dtype=V.dtype)
+    random_basis, _ = torch.linalg.qr(random_input)
+    baseline_projector = random_basis @ random_basis.transpose(-2, -1)
+
+    hook_name = f"blocks.{head_svd.layer}.attn.hook_result"
+    previous = getattr(model.cfg, "use_attn_result", False)
+    model.set_use_attn_result(True)
+    try:
+        original_metric = float(metric(model(prompt)))
+        patched_logits = model.run_with_hooks(
+            prompt, fwd_hooks=[(hook_name, _make_subspace_hook(head_svd.head, kept_projector))]
+        )
+        patched_metric = float(metric(patched_logits))
+        baseline_logits = model.run_with_hooks(
+            prompt,
+            fwd_hooks=[(hook_name, _make_subspace_hook(head_svd.head, baseline_projector))],
+        )
+        baseline_metric = float(metric(baseline_logits))
+    finally:
+        model.set_use_attn_result(previous)
+
+    delta_metric = patched_metric - original_metric
+    baseline_delta_metric = baseline_metric - original_metric
+    gate_threshold = abs(baseline_delta_metric) if threshold is None else threshold
+    gated = abs(delta_metric) > gate_threshold
+
+    return PatchResult(
+        head_svd=head_svd,
+        retained=retained,
+        original_metric=original_metric,
+        patched_metric=patched_metric,
+        delta_metric=delta_metric,
+        baseline_delta_metric=baseline_delta_metric,
+        gated=gated,
+    )

--- a/transformer_lens/tools/analysis/svd_circuits.py
+++ b/transformer_lens/tools/analysis/svd_circuits.py
@@ -444,9 +444,7 @@ def _validate_bridge_compatibility(model) -> None:
         )
 
 
-def vocab_readout(
-    model, head_svd: HeadSVD, *, k: int = 10
-) -> Float[torch.Tensor, "d_vocab k"]:
+def vocab_readout(model, head_svd: HeadSVD, *, k: int = 10) -> Float[torch.Tensor, "d_vocab k"]:
     """Project the top-k OV output directions through the unembedding.
 
     Requires ``head_svd.which == "OV"``: QK produces no write direction to project
@@ -533,3 +531,69 @@ def logit_signature(
     reconstruction = (head_svd.S[direction] * head_svd.V[:, direction]).float()
     values = reconstruction @ model.W_U[:, token_ids]
     return LogitSignature(direction=direction, values=values)
+
+
+@dataclass
+class ActivationProjection:
+    """Per-position coefficients of a head's actual output in its OV output basis.
+
+    Attributes:
+        head_svd: The OV decomposition this was projected against.
+        coefficients: ``[pos, rank]``; ``coefficients[:, i]`` is the signed amount of
+            singular direction ``i`` (``head_svd.V[:, i]``) present in the head's actual
+            output at each position. Summing ``coefficients[:, i] * head_svd.V[:, i]``
+            over ``i`` reconstructs the head's real per-position output to numerical
+            precision, since ``V``'s columns are orthonormal and this projects onto the
+            exact basis the head writes in.
+        str_tokens: Tokenized prompt, aligned with the position axis, for display.
+    """
+
+    head_svd: HeadSVD
+    coefficients: Float[torch.Tensor, "pos rank"]
+    str_tokens: List[str]
+
+
+def project_activations(
+    model, head_svd: HeadSVD, prompt: Union[str, torch.Tensor]
+) -> ActivationProjection:
+    """Project a head's actual per-position output onto its OV singular directions.
+
+    Requires ``head_svd.which == "OV"``: this projects onto the write/output basis
+    ``V``, and QK has no such vector (see the module docstring). Runs a real forward
+    pass with ``use_attn_result`` enabled to read the per-head output
+    (``hook_result``), then projects it onto ``head_svd.V``. Restores the model's
+    prior ``use_attn_result`` setting afterward, since flipping that config flag as a
+    side effect of a read-only analysis call would surprise a caller who already had
+    hooks or a cache built around its prior state.
+
+    Args:
+        model: A ``TransformerBridge`` or ``HookedTransformer``.
+        head_svd: An OV :class:`HeadSVD` from :func:`decompose_head`.
+        prompt: A single prompt (not a batch): a string or a ``[1, pos]`` token tensor.
+
+    Returns:
+        An :class:`ActivationProjection` with the per-position coefficients.
+
+    Raises:
+        ValueError: If ``head_svd.which != "OV"``, or if ``prompt`` is not a single
+            (batch-size-1) prompt.
+    """
+    if head_svd.which != "OV":
+        raise ValueError(
+            f"project_activations requires an OV HeadSVD, got which={head_svd.which!r}"
+        )
+    previous = getattr(model.cfg, "use_attn_result", False)
+    model.set_use_attn_result(True)
+    try:
+        _, cache = model.run_with_cache(prompt)
+    finally:
+        model.set_use_attn_result(previous)
+    result = cache[("result", head_svd.layer, "attn")][..., head_svd.head, :]
+    if result.shape[0] != 1:
+        raise ValueError(
+            f"project_activations requires a single prompt, got batch={result.shape[0]}"
+        )
+    result = result.squeeze(0).to(head_svd.V.dtype)
+    coefficients = result @ head_svd.V
+    str_tokens = model.to_str_tokens(prompt)
+    return ActivationProjection(head_svd=head_svd, coefficients=coefficients, str_tokens=str_tokens)


### PR DESCRIPTION
---

### Description

Adds the causal-validation layer on top of PR1's per-head QK/OV SVD (#1768): a direction can now be read out to vocab/logit space, projected against a real forward pass, and, critically, causally patched before any subfunction claim is accepted. Second of three PRs implementing per-head singular-vector decomposition of a head's QK (`W_Q W_K^T`) and OV (`W_V W_O`) maps (tracking issue: #1767).

- `vocab_readout(model, head_svd, k=10)` — projects the top-k OV output directions (`HeadSVD.V`) through the unembedding, gated on `TransformerBridge` compatibility mode.
- `logit_signature(model, head_svd, direction, tokens)` — signed logit effect of one OV direction's rank-1 reconstruction; requires the direction to pass `require_isolated` first, since a rotation-ambiguous or null direction's signature is not attributable to it alone.
- `project_activations(model, head_svd, prompt)` — per-position firing coefficients of a head's actual `hook_result` output against its `V` basis; summing the coefficients against `V` reconstructs the real output to numerical precision, since both read the same basis the head actually writes in.
- `patch_along_directions(model, head_svd, prompt, metric, keep=..., ablate=...)` — the mandatory causal gate. Reconstructs or ablates a head's output onto a chosen span of `V` directions via a direct `hook_result` hook, and reports `delta_metric` against an equally-sized random-subspace baseline (`gated` is true only when the requested subspace beats that baseline, not merely when the metric moves at all). Degenerate blocks reported by `HeadSVD.degenerate_blocks()` must be kept or dropped whole; a caller cannot route around `require_isolated` by hand-picking part of a rotation-ambiguous block through `keep`/`ablate`.
- Public exports: `decompose_head`, `project_activations`, `patch_along_directions`, `vocab_readout`, `logit_signature`, and their supporting types now ship from `transformer_lens.tools.analysis` — the first time this module is part of the public API, by design, so a readout was never importable without the causal gate attached to it.
- `tests/integration/test_svd_circuits.py` (new): exercises `vocab_readout` and `patch_along_directions` end to end against GPT-2 small's layer 9 head 9 (name-mover head) on an IOI-style prompt.

**Correctness fix folded in first:** `HeadSVD`'s docstring had the OV output direction backwards — `U`'s columns are the value-computation input space, `V`'s are the residual-stream output space this head writes into and the one to project through `W_U`. The swap never raised a shape error because both spaces are `d_model`-dimensional, so every downstream readout, projection, or patch would have silently used the wrong basis. Fixed first, with a regression test that cross-checks against the already-shipped `SVDInterpreter` (which projects the OV map the other way already), so the assertion cannot pass under either labeling.

Two implementation notes for anyone diffing this against the original proposal:
- `vocab_readout` does not wrap `SVDInterpreter.get_singular_vectors`. That method indexes `W_V`/`W_K` with a raw query-head index, which is wrong on grouped-query models (the same bug PR1 already fixed for this module's own weight reads). `vocab_readout` reuses PR1's already-kv-mapped `HeadSVD.V` and projects it through `W_U` directly instead of introducing a second, buggy SVD path.
- `patch_along_directions` calls `model.run_with_hooks` directly rather than `generic_activation_patch`. That helper is built for a clean-vs-corrupted two-run sweep over an index grid; this tool is a single-prompt reconstruct/ablate on a live projection, which does not fit the sweep shape.

Unit-tested with a tiny no-download `TransformerBridge` (real forward passes, no Hub access) for projection/patch behavior, plus model-free tests for the pure weight-space math. Integration test downloads `gpt2-small`.

PR3 (docs, demo notebook, slow multi-head oracle-parity check) follows this one.

Part of #1767

---

### Type of change

- [x] New feature (non-breaking change which adds functionality)

---

### Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (will be done in PR3)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

---